### PR TITLE
Organise and add tests for Review app "Full page examples"

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -275,8 +275,10 @@ export default async () => {
     }
   )
 
-  // Full page example views
-  routes.fullPageExamples(app)
+  /**
+   * Full page example routes
+   */
+  app.use('/full-page-examples', routes.fullPageExamples)
 
   /**
    * Page not found handler

--- a/packages/govuk-frontend-review/src/common/lib/files.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.mjs
@@ -56,6 +56,7 @@ export async function getFullPageExamples() {
  * @typedef {object} FullPageExample
  * @property {string} name - Example name
  * @property {string} path - Example directory name
+ * @property {string} title - Example title
  * @property {string} [scenario] - Description explaining the example
  * @property {string} [notes] - Additional notes about the example
  */

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -1,48 +1,40 @@
+import express from 'express'
+
 import { getFullPageExamples } from '../common/lib/files.mjs'
 import * as routes from '../views/full-page-examples/index.mjs'
 
+const router = express.Router()
 const fullPageExamples = await getFullPageExamples()
 const fullPageExampleNames = fullPageExamples.map(({ path }) => path)
 
 /**
- * @param {import('express').Application} app
+ * Full page examples index
  */
-export default (app) => {
-  routes.cookieBannerEssentialCookies(app)
-  routes.cookieBannerServerSide(app)
-  routes.haveYouChangedYourName(app)
-  routes.feedback(app)
-  routes.howDoYouWantToSignIn(app)
-  routes.search(app)
-  routes.passportDetails(app)
-  routes.updateYourAccountDetails(app)
-  routes.uploadYourPhoto(app)
-  routes.uploadYourPhotoSuccess(app)
-  routes.whatIsYourAddress(app)
-  routes.whatIsYourNationality(app)
-  routes.whatIsYourPostcode(app)
-  routes.whatWasTheLastCountryYouVisited(app)
-
-  /**
-   * Full page examples index
-   */
-  app.get('/full-page-examples', async (req, res) => {
-    res.render('full-page-examples/index', {
-      fullPageExamples
-    })
+router.get('/', (req, res) => {
+  res.render('full-page-examples/index', {
+    fullPageExamples
   })
+})
 
-  /**
-   * Full page example
-   */
-  app.get('/full-page-examples/:exampleName', (req, res, next) => {
-    const { exampleName } = req.params
-
-    // No matching example so continue to page not found
-    if (!fullPageExampleNames.includes(exampleName)) {
-      return next()
-    }
-
-    res.render(`full-page-examples/${exampleName}/index`)
-  })
+/**
+ * Full page example custom handling
+ */
+for (const route of Object.values(routes)) {
+  router.use(route)
 }
+
+/**
+ * Full page example
+ */
+router.get('/:exampleName', (req, res, next) => {
+  const { exampleName } = req.params
+
+  // No matching example so continue to page not found
+  if (!fullPageExampleNames.includes(exampleName)) {
+    return next()
+  }
+
+  res.render(`full-page-examples/${exampleName}/index`)
+})
+
+export default router

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -39,18 +39,17 @@ router.param(
 )
 
 /**
- * Full page examples index
+ * Full page example name handler
+ *
+ * Empty handler ensures `router.param()` matches above to populate
+ * `res.locals.example` before routes with custom handling are run
  */
-router.get('/', (req, res) => {
-  res.render('full-page-examples/index', {
-    fullPageExamples
-  })
-})
+router.all('/:exampleName', (req, res, next) => next())
 
 /**
  * Full page example and 404 handler
  */
-router.all('/:exampleName', (req, res, next) => {
+router.get('/:exampleName', (req, res, next) => {
   const { exampleName } = req.params
 
   // Check for known examples
@@ -62,11 +61,20 @@ router.all('/:exampleName', (req, res, next) => {
   )
 
   // Continue to page not found or next matching route
-  if (!hasExample || hasRouter || req.method !== 'GET') {
+  if (!hasExample || hasRouter) {
     return next()
   }
 
   res.render(`full-page-examples/${exampleName}/index`)
+})
+
+/**
+ * Full page examples index
+ */
+router.get('/', (req, res) => {
+  res.render('full-page-examples/index', {
+    fullPageExamples
+  })
 })
 
 /**

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -8,12 +8,53 @@ const fullPageExamples = await getFullPageExamples()
 const fullPageExampleNames = fullPageExamples.map(({ path }) => path)
 
 /**
+ * Handle parameter :exampleName
+ *
+ * Adds context for full page examples for `{{ example.title }}` etc
+ */
+router.param(
+  'exampleName',
+
+  /**
+   * @param {import('express').Request} req
+   * @param {import('express').Response} res
+   * @param {import('express').NextFunction} next
+   * @param {string} exampleName
+   */
+  (req, res, next, exampleName) => {
+    const example = fullPageExamples.find(
+      (example) => example.path === exampleName
+    )
+
+    // Update response locals
+    res.locals.example = example
+
+    next()
+  }
+)
+
+/**
  * Full page examples index
  */
 router.get('/', (req, res) => {
   res.render('full-page-examples/index', {
     fullPageExamples
   })
+})
+
+/**
+ * Full page example 404 handler
+ */
+router.all('/:exampleName', (req, res, next) => {
+  const { exampleName } = req.params
+
+  // No matching example so flag as page not found
+  // for other routes mounted to '/:exampleName'
+  if (!fullPageExampleNames.includes(exampleName)) {
+    res.status(404)
+  }
+
+  next()
 })
 
 /**
@@ -30,7 +71,7 @@ router.get('/:exampleName', (req, res, next) => {
   const { exampleName } = req.params
 
   // No matching example so continue to page not found
-  if (!fullPageExampleNames.includes(exampleName)) {
+  if (res.statusCode !== 200) {
     return next()
   }
 

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -7,11 +7,6 @@ const router = express.Router()
 const fullPageExamples = await getFullPageExamples()
 const fullPageExampleNames = fullPageExamples.map(({ path }) => path)
 
-// Full page examples, custom handlers
-const fullPageExampleRoutes = Object.values(routes).flatMap(({ stack }) =>
-  stack.map(({ route }) => route)
-)
-
 /**
  * Handle parameter :exampleName
  *
@@ -47,28 +42,6 @@ router.param(
 router.all('/:exampleName', (req, res, next) => next())
 
 /**
- * Full page example and 404 handler
- */
-router.get('/:exampleName', (req, res, next) => {
-  const { exampleName } = req.params
-
-  // Check for known examples
-  const hasExample = fullPageExampleNames.includes(exampleName)
-
-  // Check for named custom examples with GET handlers
-  const hasRouter = fullPageExampleRoutes.some(
-    ({ path, methods }) => methods.get && path === `/${exampleName}`
-  )
-
-  // Continue to page not found or next matching route
-  if (!hasExample || hasRouter) {
-    return next()
-  }
-
-  res.render(`full-page-examples/${exampleName}/index`)
-})
-
-/**
  * Full page examples index
  */
 router.get('/', (req, res) => {
@@ -83,5 +56,22 @@ router.get('/', (req, res) => {
 for (const route of Object.values(routes)) {
   router.use(route)
 }
+
+/**
+ * Full page example and 404 handler
+ */
+router.get('/:exampleName', (req, res, next) => {
+  const { exampleName } = req.params
+
+  // Check for known examples
+  const hasExample = fullPageExampleNames.includes(exampleName)
+
+  // No matching example so continue to page not found
+  if (!hasExample) {
+    return next()
+  }
+
+  res.render(`full-page-examples/${exampleName}/index`)
+})
 
 export default router

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs
@@ -1,35 +1,36 @@
+import { join } from 'path'
+
+import { paths } from '@govuk-frontend/config'
 import { getProperty, goTo } from '@govuk-frontend/helpers/puppeteer'
+import { getDirectories } from '@govuk-frontend/lib/files'
+
+import { getFullPageExamples } from '../common/lib/files.mjs'
 
 describe('Full page examples', () => {
-  describe.each([
-    {
-      title:
-        '2018’s oddest requests from Brits abroad: ‘Strictly’, vampires and sausages',
-      path: '/full-page-examples/announcements'
-    },
-    {
-      title: 'UK bank holidays',
-      path: '/full-page-examples/bank-holidays'
-    },
-    {
-      title: 'Check your answers - Temporary events notice',
-      path: '/full-page-examples/check-your-answers'
-    },
-    {
-      title: 'Apply online for a UK passport',
-      path: '/full-page-examples/start-page'
-    }
-  ])('$title', ({ title, path }) => {
-    it('should load correctly', async () => {
-      await goTo(page, path)
+  it('should load correctly', async () => {
+    const exampleNamesFullPage = await getDirectories(
+      join(paths.app, 'src/views/full-page-examples')
+    )
 
-      const $title = await page.$('title')
+    // Full page examples have additional context
+    const fullPageExamples = await getFullPageExamples()
 
-      // Check the page responded correctly
-      await expect(getProperty($title, 'textContent')).resolves.toEqual(
-        `${title} - GOV.UK`
+    // Check the page responded correctly
+    for (const exampleName of exampleNamesFullPage) {
+      await goTo(page, `/full-page-examples/${exampleName}`)
+
+      // Look for full page example context
+      const example = fullPageExamples.find(
+        (example) => example.path === exampleName
       )
-    })
+
+      // Find title text
+      const $title = await page.$('title')
+      const titleText = await getProperty($title, 'textContent')
+
+      // Check for matching title
+      expect(titleText).toEqual(`${example.title} - GOV.UK`)
+    }
   })
 })
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
@@ -1,4 +1,5 @@
 ---
+title: '2018’s oddest requests from Brits abroad: ‘Strictly’, vampires and sausages'
 scenario: You want to read this article about '2018’s oddest requests from Brits abroad'.
 notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausages-2018s-oddest-requests-from-brits-abroad
 ---
@@ -7,7 +8,7 @@ notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausage
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% set pageTitle = "2018’s oddest requests from Brits abroad: ‘Strictly’, vampires and sausages" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
@@ -1,4 +1,5 @@
 ---
+title: UK bank holidays
 scenario: |
   You want to know when the next bank holiday will be.
 
@@ -18,7 +19,7 @@ notes: |
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% set pageTitle = "UK bank holidays" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Coronavirus (COVID‑19)
 name: Campaign page
 scenario: |
   You want to know the latest updates on the coronavirus pandemic.
@@ -14,7 +15,7 @@ notes: Based on https://www.gov.uk/coronavirus
 {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
 
-{% set pageTitle = "Coronavirus (COVID‑19)" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block head %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Check your answers - Temporary events notice
 scenario: |
   As part of an online service, you are asked to check your answers before
   you send your application.
@@ -17,14 +18,12 @@ notes: The links to change your answers are not functional.
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Check your answers" %}
-{% set serviceName = "Temporary events notice" %}
-
-{% block pageTitle %}{{ pageTitle }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
   {{ govukHeader({
-    serviceName: serviceName
+    serviceName: "Temporary events notice"
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Child maintenance
 scenario: |
   You are a user looking for information on child maintenance.
 
@@ -24,7 +25,7 @@ scenario: |
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
-{% set pageTitle = "Child maintenance" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block skipLink %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/confirm-delete/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/confirm-delete/index.njk
@@ -1,10 +1,13 @@
+---
+title: Are you sure you want to delete Josh Lyman’s account?
+---
 {% extends "layouts/full-page-example.njk" %}
 
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set homepage_url = "/" %}
-{% set pageTitle = "Are you sure you want to delete Josh Lyman’s account?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block content %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Apply online for a UK passport
 name: Cookie banner (client side)
 scenario: You need to make a choice about whether to accept cookies or not.
 
@@ -21,7 +22,7 @@ notes: |
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
-{% set pageTitle = "Apply online for a UK passport" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% set html %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
@@ -1,13 +1,11 @@
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/cookie-banner-essential-cookies',
-    (req, res) => {
-      res.render('./full-page-examples/cookie-banner-essential-cookies/index', {
-        cookies: req.body.cookies
-      })
-    }
-  )
-}
+import express from 'express'
+
+const router = express.Router()
+
+router.post('/cookie-banner-essential-cookies', (req, res) => {
+  res.render('./full-page-examples/update-your-account-details/confirm', {
+    cookies: req.body.cookies
+  })
+})
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
@@ -4,13 +4,10 @@
 export default (app) => {
   app.post(
     '/full-page-examples/cookie-banner-essential-cookies',
-    (request, response) => {
-      response.render(
-        './full-page-examples/cookie-banner-essential-cookies/index',
-        {
-          cookies: request.body.cookies
-        }
-      )
+    (req, res) => {
+      res.render('./full-page-examples/cookie-banner-essential-cookies/index', {
+        cookies: req.body.cookies
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Apply online for a UK passport
 name: Cookie banner (essential cookies)
 scenario: You are told about essential cookies, with a choice to hide the banner.
 
@@ -19,7 +20,7 @@ notes: |
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
-{% set pageTitle = "Apply online for a UK passport" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block bodyStart %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.mjs
@@ -2,13 +2,10 @@
  * @param {import('express').Application} app
  */
 export default (app) => {
-  app.post(
-    '/full-page-examples/cookie-banner-server-side',
-    (request, response) => {
-      response.render('./full-page-examples/cookie-banner-server-side/index', {
-        cookies: request.body.cookies,
-        currentUrl: request.url
-      })
-    }
-  )
+  app.post('/full-page-examples/cookie-banner-server-side', (req, res) => {
+    res.render('./full-page-examples/cookie-banner-server-side/index', {
+      cookies: req.body.cookies,
+      currentUrl: req.url
+    })
+  })
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.mjs
@@ -1,11 +1,11 @@
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post('/full-page-examples/cookie-banner-server-side', (req, res) => {
-    res.render('./full-page-examples/cookie-banner-server-side/index', {
-      cookies: req.body.cookies,
-      currentUrl: req.url
-    })
+import express from 'express'
+
+const router = express.Router()
+
+router.post('/cookie-banner-server-side', (req, res) => {
+  res.render('./full-page-examples/cookie-banner-server-side/index', {
+    cookies: req.body.cookies
   })
-}
+})
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Apply online for a UK passport
 name: Cookie banner (server side with progressive enhancement)
 scenario: You need to make a choice about whether to accept cookies or not.
 
@@ -23,7 +24,7 @@ notes: |
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
-{% set pageTitle = "Apply online for a UK passport" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block bodyStart %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
@@ -1,79 +1,79 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/feedback',
+const router = express.Router()
 
-    body('what-were-you-trying-to-do')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter what you were trying to do')
-      .isLength({ max: 100 })
-      .withMessage('What were you trying to do must be 100 characters or less'),
+router.post(
+  '/feedback',
 
-    body('detail')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter details of your question, problem or feedback')
-      .isLength({ max: 300 })
-      .withMessage(
-        'Details of your question, problem or feedback must be 300 characters or less'
-      ),
+  body('what-were-you-trying-to-do')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter what you were trying to do')
+    .isLength({ max: 100 })
+    .withMessage('What were you trying to do must be 100 characters or less'),
 
-    body('do-you-want-a-reply')
-      .not()
-      .isEmpty()
-      .withMessage('Select yes if you want a reply'),
+  body('detail')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter details of your question, problem or feedback')
+    .isLength({ max: 300 })
+    .withMessage(
+      'Details of your question, problem or feedback must be 300 characters or less'
+    ),
 
-    body('name').custom((value, { req }) => {
-      // See https://github.com/express-validator/express-validator/pull/658
-      const wantsReply = req.body['do-you-want-a-reply'] === 'yes'
-      if (!wantsReply) {
-        return true
-      }
-      if (!value) {
-        throw new Error('Enter your name')
-      }
+  body('do-you-want-a-reply')
+    .not()
+    .isEmpty()
+    .withMessage('Select yes if you want a reply'),
+
+  body('name').custom((value, { req }) => {
+    // See https://github.com/express-validator/express-validator/pull/658
+    const wantsReply = req.body['do-you-want-a-reply'] === 'yes'
+    if (!wantsReply) {
       return true
-    }),
-
-    body('email').custom((value, { req }) => {
-      // See https://github.com/express-validator/express-validator/pull/658
-      const wantsReply = req.body['do-you-want-a-reply'] === 'yes'
-      if (!wantsReply) {
-        return true
-      }
-      if (!value) {
-        throw new Error('Enter your email address')
-      }
-      if (!value.includes('@')) {
-        throw new Error(
-          'Enter an email address in the correct format, like name@example.com'
-        )
-      }
-      return true
-    }),
-
-    (req, res) => {
-      const viewPath = './full-page-examples/feedback'
-      const errors = formatValidationErrors(validationResult(req))
-
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
-
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
     }
-  )
-}
+    if (!value) {
+      throw new Error('Enter your name')
+    }
+    return true
+  }),
+
+  body('email').custom((value, { req }) => {
+    // See https://github.com/express-validator/express-validator/pull/658
+    const wantsReply = req.body['do-you-want-a-reply'] === 'yes'
+    if (!wantsReply) {
+      return true
+    }
+    if (!value) {
+      throw new Error('Enter your email address')
+    }
+    if (!value.includes('@')) {
+      throw new Error(
+        'Enter an email address in the correct format, like name@example.com'
+      )
+    }
+    return true
+  }),
+
+  (req, res) => {
+    const viewPath = './full-page-examples/feedback'
+    const errors = formatValidationErrors(validationResult(req))
+
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
+    }
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
@@ -8,77 +8,69 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/feedback',
-    [
-      body('what-were-you-trying-to-do')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter what you were trying to do')
-        .isLength({ max: 100 })
-        .withMessage(
-          'What were you trying to do must be 100 characters or less'
-        ),
 
-      body('detail')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter details of your question, problem or feedback')
-        .isLength({ max: 300 })
-        .withMessage(
-          'Details of your question, problem or feedback must be 300 characters or less'
-        ),
+    body('what-were-you-trying-to-do')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter what you were trying to do')
+      .isLength({ max: 100 })
+      .withMessage('What were you trying to do must be 100 characters or less'),
 
-      body('do-you-want-a-reply')
-        .not()
-        .isEmpty()
-        .withMessage('Select yes if you want a reply'),
+    body('detail')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter details of your question, problem or feedback')
+      .isLength({ max: 300 })
+      .withMessage(
+        'Details of your question, problem or feedback must be 300 characters or less'
+      ),
 
-      body('name').custom((value, { req: request }) => {
-        // See https://github.com/express-validator/express-validator/pull/658
-        const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
-        if (!wantsReply) {
-          return true
-        }
-        if (!value) {
-          throw new Error('Enter your name')
-        }
+    body('do-you-want-a-reply')
+      .not()
+      .isEmpty()
+      .withMessage('Select yes if you want a reply'),
+
+    body('name').custom((value, { req }) => {
+      // See https://github.com/express-validator/express-validator/pull/658
+      const wantsReply = req.body['do-you-want-a-reply'] === 'yes'
+      if (!wantsReply) {
         return true
-      }),
+      }
+      if (!value) {
+        throw new Error('Enter your name')
+      }
+      return true
+    }),
 
-      body('email').custom((value, { req: request }) => {
-        // See https://github.com/express-validator/express-validator/pull/658
-        const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
-        if (!wantsReply) {
-          return true
-        }
-        if (!value) {
-          throw new Error('Enter your email address')
-        }
-        if (!value.includes('@')) {
-          throw new Error(
-            'Enter an email address in the correct format, like name@example.com'
-          )
-        }
+    body('email').custom((value, { req }) => {
+      // See https://github.com/express-validator/express-validator/pull/658
+      const wantsReply = req.body['do-you-want-a-reply'] === 'yes'
+      if (!wantsReply) {
         return true
-      })
-    ],
+      }
+      if (!value) {
+        throw new Error('Enter your email address')
+      }
+      if (!value.includes('@')) {
+        throw new Error(
+          'Enter an email address in the correct format, like name@example.com'
+        )
+      }
+      return true
+    }),
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render('./full-page-examples/feedback/index', {
+        return res.render('./full-page-examples/feedback/index', {
           errors,
           errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
+          values: req.body // In production this should sanitized.
         })
       }
-      response.render('./full-page-examples/feedback/confirm')
+      res.render('./full-page-examples/feedback/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
@@ -62,15 +62,18 @@ export default (app) => {
     }),
 
     (req, res) => {
+      const viewPath = './full-page-examples/feedback'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render('./full-page-examples/feedback/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: req.body // In production this should sanitized.
-        })
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/feedback/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Send your feedback - Verify
 scenario: |
   You have used a service called GOV.UK Verify and wish to report an issue.
 
@@ -27,8 +28,8 @@ notes: Based on https://www.signin.service.gov.uk/feedback
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% set pageTitle = "Send your feedback" %}
-{% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - Verify - GOV.UK{% endblock %}
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
   {{ govukHeader({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
@@ -1,32 +1,32 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/have-you-changed-your-name',
+const router = express.Router()
 
-    body('changed-name')
-      .not()
-      .isEmpty()
-      .withMessage('Select if you have changed your name'),
+router.post(
+  '/have-you-changed-your-name',
 
-    (req, res) => {
-      const viewPath = './full-page-examples/have-you-changed-your-name'
-      const errors = formatValidationErrors(validationResult(req))
+  body('changed-name')
+    .not()
+    .isEmpty()
+    .withMessage('Select if you have changed your name'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/have-you-changed-your-name'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
@@ -8,31 +8,25 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/have-you-changed-your-name',
-    [
-      body('changed-name')
-        .not()
-        .isEmpty()
-        .withMessage('Select if you have changed your name')
-    ],
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('changed-name')
+      .not()
+      .isEmpty()
+      .withMessage('Select if you have changed your name'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render(
+        return res.render(
           './full-page-examples/have-you-changed-your-name/index',
           {
             errors,
             errorSummary: Object.values(errors),
-            values: request.body // In production this should sanitized.
+            values: req.body // In production this should sanitized.
           }
         )
       }
-      response.render('./full-page-examples/have-you-changed-your-name/confirm')
+      res.render('./full-page-examples/have-you-changed-your-name/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
@@ -15,18 +15,18 @@ export default (app) => {
       .withMessage('Select if you have changed your name'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/have-you-changed-your-name'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render(
-          './full-page-examples/have-you-changed-your-name/index',
-          {
-            errors,
-            errorSummary: Object.values(errors),
-            values: req.body // In production this should sanitized.
-          }
-        )
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/have-you-changed-your-name/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Have you changed your name?
 scenario: |
   As part of an online service, you are asked if you have changed your name.
 
@@ -16,7 +17,7 @@ scenario: |
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Have you changed your name?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
@@ -1,32 +1,29 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/how-do-you-want-to-sign-in',
+const router = express.Router()
 
-    body('sign-in')
-      .not()
-      .isEmpty()
-      .withMessage('Select how you want to sign in'),
+router.post(
+  '/how-do-you-want-to-sign-in',
 
-    (req, res) => {
-      const viewPath = './full-page-examples/how-do-you-want-to-sign-in'
-      const errors = formatValidationErrors(validationResult(req))
+  body('sign-in').not().isEmpty().withMessage('Select how you want to sign in'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/how-do-you-want-to-sign-in'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
@@ -15,18 +15,18 @@ export default (app) => {
       .withMessage('Select how you want to sign in'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/how-do-you-want-to-sign-in'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render(
-          './full-page-examples/how-do-you-want-to-sign-in/index',
-          {
-            errors,
-            errorSummary: Object.values(errors),
-            values: req.body // In production this should sanitized.
-          }
-        )
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/how-do-you-want-to-sign-in/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
@@ -8,31 +8,25 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/how-do-you-want-to-sign-in',
-    [
-      body('sign-in')
-        .not()
-        .isEmpty()
-        .withMessage('Select how you want to sign in')
-    ],
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('sign-in')
+      .not()
+      .isEmpty()
+      .withMessage('Select how you want to sign in'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render(
+        return res.render(
           './full-page-examples/how-do-you-want-to-sign-in/index',
           {
             errors,
             errorSummary: Object.values(errors),
-            values: request.body // In production this should sanitized.
+            values: req.body // In production this should sanitized.
           }
         )
       }
-      response.render('./full-page-examples/how-do-you-want-to-sign-in/confirm')
+      res.render('./full-page-examples/how-do-you-want-to-sign-in/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
@@ -1,4 +1,5 @@
 ---
+title: How do you want to sign in?
 scenario: |
   As part of an online service, you are asked to select how you want to sign in.
 
@@ -17,7 +18,7 @@ notes: Based on https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-i
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% set pageTitle = "How do you want to sign in?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
@@ -8,42 +8,36 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/passport-details',
-    [
-      body('passport-number')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your passport number'),
 
-      body('expiry-day')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your expiry day'),
+    body('passport-number')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your passport number'),
 
-      body('expiry-month')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your expiry month'),
+    body('expiry-day')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your expiry day'),
 
-      body('expiry-year')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your expiry year')
-    ],
+    body('expiry-month')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your expiry month'),
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('expiry-year')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your expiry year'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
 
       if (!errors) {
-        return response.render('./full-page-examples/passport-details/confirm')
+        return res.render('./full-page-examples/passport-details/confirm')
       }
 
       // If any of the date inputs error apply a general error.
@@ -80,10 +74,10 @@ export default (app) => {
         )
       }
 
-      response.render('./full-page-examples/passport-details/index', {
+      res.render('./full-page-examples/passport-details/index', {
         errors,
         errorSummary,
-        values: request.body // In production this should sanitized.
+        values: req.body // In production this should sanitized.
       })
     }
   )

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
@@ -34,10 +34,11 @@ export default (app) => {
       .withMessage('Enter your expiry year'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/passport-details'
       const errors = formatValidationErrors(validationResult(req))
 
       if (!errors) {
-        return res.render('./full-page-examples/passport-details/confirm')
+        return res.render(`${viewPath}/confirm`)
       }
 
       // If any of the date inputs error apply a general error.
@@ -74,7 +75,7 @@ export default (app) => {
         )
       }
 
-      res.render('./full-page-examples/passport-details/index', {
+      res.render(`${viewPath}/index`, {
         errors,
         errorSummary,
         values: req.body // In production this should sanitized.

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
@@ -1,85 +1,86 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/passport-details',
+const router = express.Router()
 
-    body('passport-number')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your passport number'),
+router.post(
+  '/passport-details',
 
-    body('expiry-day')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your expiry day'),
+  body('passport-number')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your passport number'),
 
-    body('expiry-month')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your expiry month'),
+  body('expiry-day')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your expiry day'),
 
-    body('expiry-year')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your expiry year'),
+  body('expiry-month')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your expiry month'),
 
-    (req, res) => {
-      const viewPath = './full-page-examples/passport-details'
-      const errors = formatValidationErrors(validationResult(req))
+  body('expiry-year')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your expiry year'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/passport-details'
+    const errors = formatValidationErrors(validationResult(req))
 
-      // If any of the date inputs error apply a general error.
-      const expiryNamePrefix = 'expiry'
-      const expiryErrors = Object.values(errors).filter((error) =>
-        error.id.includes(`${expiryNamePrefix}-`)
-      )
-      if (expiryErrors.length) {
-        const firstExpiryErrorId = expiryErrors[0].id
-        // Get the first error message and merge it into a single error message.
-        errors[expiryNamePrefix] = {
-          id: expiryNamePrefix,
-          href: `#${firstExpiryErrorId}`,
-          value: '',
-          text: ''
-        }
-
-        // Construct a single error message based on all three error messages.
-        errors[expiryNamePrefix].text = 'Enter your expiry '
-        if (expiryErrors.length === 3) {
-          errors[expiryNamePrefix].text += 'date'
-        } else {
-          errors[expiryNamePrefix].text += expiryErrors
-            .map((error) => error.text.replace('Enter your expiry ', ''))
-            .join(' and ')
-        }
-      }
-
-      let errorSummary = Object.values(errors)
-      if (expiryErrors) {
-        // Remove all other errors from the summary so we only have one message that links to the expiry input.
-        errorSummary = errorSummary.filter(
-          (error) => !error.id.includes(`${expiryNamePrefix}-`)
-        )
-      }
-
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary,
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    // If any of the date inputs error apply a general error.
+    const expiryNamePrefix = 'expiry'
+    const expiryErrors = Object.values(errors).filter((error) =>
+      error.id.includes(`${expiryNamePrefix}-`)
+    )
+
+    if (expiryErrors.length) {
+      const firstExpiryErrorId = expiryErrors[0].id
+      // Get the first error message and merge it into a single error message.
+      errors[expiryNamePrefix] = {
+        id: expiryNamePrefix,
+        href: `#${firstExpiryErrorId}`,
+        value: '',
+        text: ''
+      }
+
+      // Construct a single error message based on all three error messages.
+      errors[expiryNamePrefix].text = 'Enter your expiry '
+      if (expiryErrors.length === 3) {
+        errors[expiryNamePrefix].text += 'date'
+      } else {
+        errors[expiryNamePrefix].text += expiryErrors
+          .map((error) => error.text.replace('Enter your expiry ', ''))
+          .join(' and ')
+      }
+    }
+
+    let errorSummary = Object.values(errors)
+    if (expiryErrors) {
+      // Remove all other errors from the summary so we only have one message that links to the expiry input.
+      errorSummary = errorSummary.filter(
+        (error) => !error.id.includes(`${expiryNamePrefix}-`)
+      )
+    }
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary,
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Passport details
 scenario: |
   As part of an online service, you are asked to provide your passport details.
 
@@ -17,7 +18,7 @@ scenario: |
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Passport details" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
@@ -1,9 +1,14 @@
-import { readFile } from 'fs/promises'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 
+import { paths } from '@govuk-frontend/config'
 import shuffleSeed from 'shuffle-seed'
 
 const { documents } = JSON.parse(
-  await readFile(new URL('data.json', import.meta.url), 'utf8')
+  readFileSync(
+    join(paths.app, 'src/views/full-page-examples/search/data.json'),
+    'utf8'
+  )
 )
 
 /**

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 
 import { paths } from '@govuk-frontend/config'
+import express from 'express'
 import shuffleSeed from 'shuffle-seed'
 
 const { documents } = JSON.parse(
@@ -11,42 +12,35 @@ const { documents } = JSON.parse(
   )
 )
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.get(
-    '/full-page-examples/search',
+const router = express.Router()
 
-    (req, res) => {
-      const { query } = req
+router.get('/search', (req, res) => {
+  const { query } = req
 
-      query.search ??= 'driving'
-      query.order ??= 'most-viewed'
+  query.search ??= 'driving'
+  query.order ??= 'most-viewed'
 
-      // Shuffle the documents based on the query string, to simulate different responses.
-      const seed = JSON.stringify(query)
-      const shuffledDocuments = shuffleSeed.shuffle(documents, seed)
+  // Shuffle the documents based on the query string, to simulate different responses.
+  const seed = JSON.stringify(query)
+  const shuffledDocuments = shuffleSeed.shuffle(documents, seed)
 
-      const total = '128124'
+  const total = '128124'
 
-      // Shuffle the total based on the query string
-      const randomizedTotal = shuffleSeed
-        .shuffle(total.split(''), seed)
-        .join('')
+  // Shuffle the total based on the query string
+  const randomizedTotal = shuffleSeed.shuffle(total.split(''), seed).join('')
 
-      res.render('./full-page-examples/search/index', {
-        documents: shuffledDocuments,
-        order: query.order,
+  res.render('./full-page-examples/search/index', {
+    documents: shuffledDocuments,
+    order: query.order,
 
-        // Make the total more readable
-        total: Number(randomizedTotal).toLocaleString('en', {
-          useGrouping: true
-        }),
+    // Make the total more readable
+    total: Number(randomizedTotal).toLocaleString('en', {
+      useGrouping: true
+    }),
 
-        // In production this should be sanitized
-        values: query
-      })
-    }
-  )
-}
+    // In production this should be sanitized
+    values: query
+  })
+})
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
@@ -18,12 +18,8 @@ export default (app) => {
   app.get(
     '/full-page-examples/search',
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     */
-    (request, response) => {
-      const { query } = request
+    (req, res) => {
+      const { query } = req
 
       query.search ??= 'driving'
       query.order ??= 'most-viewed'
@@ -39,7 +35,7 @@ export default (app) => {
         .shuffle(total.split(''), seed)
         .join('')
 
-      response.render('./full-page-examples/search/index', {
+      res.render('./full-page-examples/search/index', {
         documents: shuffledDocuments,
         order: query.order,
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Search
 scenario: |
   You would like to find relevant articles by sorting the results and filtering
   by the organisation(s) that published the articles.
@@ -25,7 +26,7 @@ notes: |
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
-{% set pageTitle = "Search" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block head %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Technology - Service Manual
 name: Topic page (Service Manual)
 scenario: |
   You would like to access information on a given topic, perhaps by finding out
@@ -13,7 +14,7 @@ notes: The links within each section are not functional.
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
 
-{% set pageTitle = "Technology - Service Manual" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Apply online for a UK passport
 scenario: |
   You want to apply for a passport.
 
@@ -16,7 +17,7 @@ notes: The buttons and links on this page are not functional.
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
-{% set pageTitle = "Apply online for a UK passport" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/task-list/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/task-list/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Apply for teacher training
 scenario: |
   You want to apply for a teacher training course
 
@@ -15,7 +16,7 @@ notes: The buttons and links on this page are not functional.
 {% from "govuk/components/task-list/macro.njk" import govukTaskList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Apply for teacher training" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/travel-guidance/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/travel-guidance/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Entry requirements - Narnia travel advice
 scenario: You want to read guidance about the entry requirements for travelling to Narnia.
 notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requirements
 ---
@@ -7,7 +8,7 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
-{% set pageTitle = "Entry requirements - Narnia travel advice" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -8,46 +8,37 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/update-your-account-details',
-    [
-      body('email')
-        .exists()
-        .isEmail()
-        .withMessage(
-          'Enter an email address in the correct format, like name@example.com'
-        )
-        .not()
-        .isEmpty()
-        .withMessage('Enter your email address'),
 
-      body('password')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your password')
-    ],
+    body('email')
+      .exists()
+      .isEmail()
+      .withMessage(
+        'Enter an email address in the correct format, like name@example.com'
+      )
+      .not()
+      .isEmpty()
+      .withMessage('Enter your email address'),
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('password')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your password'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
 
       if (!errors) {
-        return response.render(
+        return res.render(
           './full-page-examples/update-your-account-details/confirm'
         )
       }
 
-      response.render(
-        './full-page-examples/update-your-account-details/index',
-        {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        }
-      )
+      res.render('./full-page-examples/update-your-account-details/index', {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -1,43 +1,39 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/update-your-account-details',
+const router = express.Router()
 
-    body('email')
-      .exists()
-      .isEmail()
-      .withMessage(
-        'Enter an email address in the correct format, like name@example.com'
-      )
-      .not()
-      .isEmpty()
-      .withMessage('Enter your email address'),
+router.post(
+  '/update-your-account-details',
 
-    body('password')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your password'),
+  body('email')
+    .exists()
+    .isEmail()
+    .withMessage(
+      'Enter an email address in the correct format, like name@example.com'
+    )
+    .not()
+    .isEmpty()
+    .withMessage('Enter your email address'),
 
-    (req, res) => {
-      const viewPath = './full-page-examples/update-your-account-details'
-      const errors = formatValidationErrors(validationResult(req))
+  body('password').exists().not().isEmpty().withMessage('Enter your password'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/update-your-account-details'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -26,15 +26,14 @@ export default (app) => {
       .withMessage('Enter your password'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/update-your-account-details'
       const errors = formatValidationErrors(validationResult(req))
 
       if (!errors) {
-        return res.render(
-          './full-page-examples/update-your-account-details/confirm'
-        )
+        return res.render(`${viewPath}/confirm`)
       }
 
-      res.render('./full-page-examples/update-your-account-details/index', {
+      res.render(`${viewPath}/index`, {
         errors,
         errorSummary: Object.values(errors),
         values: req.body // In production this should sanitized.

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Update your account details
 scenario: |
   As part of an online service, you wish to update your account details.
 
@@ -14,7 +15,7 @@ scenario: |
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Update your account details" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.mjs
@@ -1,17 +1,15 @@
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/upload-your-photo-success',
+import express from 'express'
 
-    (req, res) => {
-      return res.render(
-        './full-page-examples/upload-your-photo-success/index',
-        {
-          isSuccess: true
-        }
-      )
-    }
-  )
-}
+const router = express.Router()
+
+router.post(
+  '/upload-your-photo-success',
+
+  (req, res) => {
+    res.render('./full-page-examples/upload-your-photo-success/index', {
+      isSuccess: true
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.mjs
@@ -5,13 +5,8 @@ export default (app) => {
   app.post(
     '/full-page-examples/upload-your-photo-success',
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      return response.render(
+    (req, res) => {
+      return res.render(
         './full-page-examples/upload-your-photo-success/index',
         {
           isSuccess: true

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Upload your photo
 scenario: |
   As part of an online service, you are asked to upload your photo.
 
@@ -16,7 +17,8 @@ scenario: |
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% block pageTitle %}Upload your photo - GOV.UK{% endblock %}
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
   {{ govukHeader({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -17,15 +17,18 @@ export default (app) => {
       .withMessage('Select I accept the terms and conditions'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/upload-your-photo'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render('./full-page-examples/upload-your-photo/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: req.body // In production this should sanitized.
-        })
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/upload-your-photo/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -8,30 +8,24 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/upload-your-photo',
-    [
-      body('photo').exists().not().isEmpty().withMessage('Select a photo'),
 
-      body('terms-and-conditions')
-        .not()
-        .isEmpty()
-        .withMessage('Select I accept the terms and conditions')
-    ],
+    body('photo').exists().not().isEmpty().withMessage('Select a photo'),
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('terms-and-conditions')
+      .not()
+      .isEmpty()
+      .withMessage('Select I accept the terms and conditions'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render('./full-page-examples/upload-your-photo/index', {
+        return res.render('./full-page-examples/upload-your-photo/index', {
           errors,
           errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
+          values: req.body // In production this should sanitized.
         })
       }
-      response.render('./full-page-examples/upload-your-photo/confirm')
+      res.render('./full-page-examples/upload-your-photo/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -1,34 +1,34 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/upload-your-photo',
+const router = express.Router()
 
-    body('photo').exists().not().isEmpty().withMessage('Select a photo'),
+router.post(
+  '/upload-your-photo',
 
-    body('terms-and-conditions')
-      .not()
-      .isEmpty()
-      .withMessage('Select I accept the terms and conditions'),
+  body('photo').exists().not().isEmpty().withMessage('Select a photo'),
 
-    (req, res) => {
-      const viewPath = './full-page-examples/upload-your-photo'
-      const errors = formatValidationErrors(validationResult(req))
+  body('terms-and-conditions')
+    .not()
+    .isEmpty()
+    .withMessage('Select I accept the terms and conditions'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/upload-your-photo'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Upload your photo
 scenario: |
   As part of an online service, you are asked to upload your photo.
 
@@ -18,7 +19,7 @@ scenario: |
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% set pageTitle = "Upload your photo" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
@@ -1,51 +1,51 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/what-is-your-address',
+const router = express.Router()
 
-    body('address-line-1')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your building and street'),
+router.post(
+  '/what-is-your-address',
 
-    body('address-town')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your town and city'),
+  body('address-line-1')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your building and street'),
 
-    body('address-county')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your county'),
+  body('address-town')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your town and city'),
 
-    body('address-postcode')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your postcode'),
+  body('address-county')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your county'),
 
-    (req, res) => {
-      const viewPath = './full-page-examples/what-is-your-address'
-      const errors = formatValidationErrors(validationResult(req))
+  body('address-postcode')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your postcode'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/what-is-your-address'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
@@ -8,50 +8,41 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-address',
-    [
-      body('address-line-1')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your building and street'),
 
-      body('address-town')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your town and city'),
+    body('address-line-1')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your building and street'),
 
-      body('address-county')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your county'),
+    body('address-town')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your town and city'),
 
-      body('address-postcode')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your postcode')
-    ],
+    body('address-county')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your county'),
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('address-postcode')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your postcode'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render(
-          './full-page-examples/what-is-your-address/index',
-          {
-            errors,
-            errorSummary: Object.values(errors),
-            values: request.body // In production this should sanitized.
-          }
-        )
+        return res.render('./full-page-examples/what-is-your-address/index', {
+          errors,
+          errorSummary: Object.values(errors),
+          values: req.body // In production this should sanitized.
+        })
       }
-      response.render('./full-page-examples/what-is-your-address/confirm')
+      res.render('./full-page-examples/what-is-your-address/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
@@ -34,15 +34,18 @@ export default (app) => {
       .withMessage('Enter your postcode'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/what-is-your-address'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render('./full-page-examples/what-is-your-address/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: req.body // In production this should sanitized.
-        })
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/what-is-your-address/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.njk
@@ -1,4 +1,5 @@
 ---
+title: What is your home address?
 scenario: |
   As part of an online service, you are asked to provide your address.
 
@@ -17,7 +18,7 @@ scenario: |
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "What is your home address?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
@@ -38,18 +38,18 @@ export default (app) => {
     }),
 
     (req, res) => {
+      const viewPath = './full-page-examples/what-is-your-nationality'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render(
-          './full-page-examples/what-is-your-nationality/index',
-          {
-            errors,
-            errorSummary: Object.values(errors),
-            values: req.body // In production this should sanitized.
-          }
-        )
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/what-is-your-nationality/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
@@ -8,54 +8,48 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-nationality',
-    [
-      body('confirm-nationality').custom((value, { req: request }) => {
-        // See https://github.com/express-validator/express-validator/pull/658
-        const cannotProvideNationality =
-          !!request.body['details-cannot-provide-nationality']
-        // If the user cannot provide their nationality and has given us separate details
-        // then do not show an error for the nationality fields.
-        if (cannotProvideNationality) {
-          return true
-        }
-        if (!value) {
-          throw new Error('Select your nationality or nationalities')
-        }
-        return true
-      }),
 
-      body('country-name').custom((value, { req: request }) => {
-        // See https://github.com/express-validator/express-validator/pull/658
-        const confirmedNationality = request.body['confirm-nationality'] || []
-        // If the other country option is selected and there's no value.
-        if (
-          confirmedNationality.includes('other-country-nationality') &&
-          !value
-        ) {
-          throw new Error('Enter your country')
-        }
+    body('confirm-nationality').custom((value, { req }) => {
+      // See https://github.com/express-validator/express-validator/pull/658
+      const cannotProvideNationality =
+        !!req.body['details-cannot-provide-nationality']
+      // If the user cannot provide their nationality and has given us separate details
+      // then do not show an error for the nationality fields.
+      if (cannotProvideNationality) {
         return true
-      })
-    ],
+      }
+      if (!value) {
+        throw new Error('Select your nationality or nationalities')
+      }
+      return true
+    }),
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('country-name').custom((value, { req }) => {
+      // See https://github.com/express-validator/express-validator/pull/658
+      const confirmedNationality = req.body['confirm-nationality'] || []
+      // If the other country option is selected and there's no value.
+      if (
+        confirmedNationality.includes('other-country-nationality') &&
+        !value
+      ) {
+        throw new Error('Enter your country')
+      }
+      return true
+    }),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render(
+        return res.render(
           './full-page-examples/what-is-your-nationality/index',
           {
             errors,
             errorSummary: Object.values(errors),
-            values: request.body // In production this should sanitized.
+            values: req.body // In production this should sanitized.
           }
         )
       }
-      response.render('./full-page-examples/what-is-your-nationality/confirm')
+      res.render('./full-page-examples/what-is-your-nationality/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
@@ -1,55 +1,52 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/what-is-your-nationality',
+const router = express.Router()
 
-    body('confirm-nationality').custom((value, { req }) => {
-      // See https://github.com/express-validator/express-validator/pull/658
-      const cannotProvideNationality =
-        !!req.body['details-cannot-provide-nationality']
-      // If the user cannot provide their nationality and has given us separate details
-      // then do not show an error for the nationality fields.
-      if (cannotProvideNationality) {
-        return true
-      }
-      if (!value) {
-        throw new Error('Select your nationality or nationalities')
-      }
+router.post(
+  '/what-is-your-nationality',
+
+  body('confirm-nationality').custom((value, { req }) => {
+    // See https://github.com/express-validator/express-validator/pull/658
+    const cannotProvideNationality =
+      !!req.body['details-cannot-provide-nationality']
+    // If the user cannot provide their nationality and has given us separate details
+    // then do not show an error for the nationality fields.
+    if (cannotProvideNationality) {
       return true
-    }),
-
-    body('country-name').custom((value, { req }) => {
-      // See https://github.com/express-validator/express-validator/pull/658
-      const confirmedNationality = req.body['confirm-nationality'] || []
-      // If the other country option is selected and there's no value.
-      if (
-        confirmedNationality.includes('other-country-nationality') &&
-        !value
-      ) {
-        throw new Error('Enter your country')
-      }
-      return true
-    }),
-
-    (req, res) => {
-      const viewPath = './full-page-examples/what-is-your-nationality'
-      const errors = formatValidationErrors(validationResult(req))
-
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
-
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
     }
-  )
-}
+    if (!value) {
+      throw new Error('Select your nationality or nationalities')
+    }
+    return true
+  }),
+
+  body('country-name').custom((value, { req }) => {
+    // See https://github.com/express-validator/express-validator/pull/658
+    const confirmedNationality = req.body['confirm-nationality'] || []
+    // If the other country option is selected and there's no value.
+    if (confirmedNationality.includes('other-country-nationality') && !value) {
+      throw new Error('Enter your country')
+    }
+    return true
+  }),
+
+  (req, res) => {
+    const viewPath = './full-page-examples/what-is-your-nationality'
+    const errors = formatValidationErrors(validationResult(req))
+
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
+    }
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.njk
@@ -1,4 +1,5 @@
 ---
+title: What is your nationality?
 scenario: |
   As part of an online service, you are asked to provide your nationality.
 
@@ -24,7 +25,7 @@ scenario: |
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% set pageTitle = "What is your nationality?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
@@ -1,33 +1,33 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/what-is-your-postcode',
+const router = express.Router()
 
-    body('address-postcode')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter your home postcode'),
+router.post(
+  '/what-is-your-postcode',
 
-    (req, res) => {
-      const viewPath = './full-page-examples/what-is-your-postcode'
-      const errors = formatValidationErrors(validationResult(req))
+  body('address-postcode')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter your home postcode'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath = './full-page-examples/what-is-your-postcode'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
@@ -16,15 +16,18 @@ export default (app) => {
       .withMessage('Enter your home postcode'),
 
     (req, res) => {
+      const viewPath = './full-page-examples/what-is-your-postcode'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render('./full-page-examples/what-is-your-postcode/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: req.body // In production this should sanitized.
-        })
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render('./full-page-examples/what-is-your-postcode/confirm')
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
@@ -8,32 +8,23 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-postcode',
-    [
-      body('address-postcode')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter your home postcode')
-    ],
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('address-postcode')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter your home postcode'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render(
-          './full-page-examples/what-is-your-postcode/index',
-          {
-            errors,
-            errorSummary: Object.values(errors),
-            values: request.body // In production this should sanitized.
-          }
-        )
+        return res.render('./full-page-examples/what-is-your-postcode/index', {
+          errors,
+          errorSummary: Object.values(errors),
+          values: req.body // In production this should sanitized.
+        })
       }
-      response.render('./full-page-examples/what-is-your-postcode/confirm')
+      res.render('./full-page-examples/what-is-your-postcode/confirm')
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.njk
@@ -1,4 +1,5 @@
 ---
+title: What is your home postcode?
 scenario: |
   As part of an online service, you are asked to provide your postcode.
 
@@ -15,7 +16,7 @@ scenario: |
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% set pageTitle = "What is your home postcode?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
@@ -8,32 +8,26 @@ import { formatValidationErrors } from '../../../utils.mjs'
 export default (app) => {
   app.post(
     '/full-page-examples/what-was-the-last-country-you-visited',
-    [
-      body('last-visited-country')
-        .exists()
-        .not()
-        .isEmpty()
-        .withMessage('Enter the last country you visited')
-    ],
 
-    /**
-     * @param {import('express').Request} request
-     * @param {import('express').Response} response
-     * @returns {void}
-     */
-    (request, response) => {
-      const errors = formatValidationErrors(validationResult(request))
+    body('last-visited-country')
+      .exists()
+      .not()
+      .isEmpty()
+      .withMessage('Enter the last country you visited'),
+
+    (req, res) => {
+      const errors = formatValidationErrors(validationResult(req))
       if (errors) {
-        return response.render(
+        return res.render(
           './full-page-examples/what-was-the-last-country-you-visited/index',
           {
             errors,
             errorSummary: Object.values(errors),
-            values: request.body // In production this should sanitized.
+            values: req.body // In production this should sanitized.
           }
         )
       }
-      response.render(
+      res.render(
         './full-page-examples/what-was-the-last-country-you-visited/confirm'
       )
     }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
@@ -1,34 +1,34 @@
+import express from 'express'
 import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
-/**
- * @param {import('express').Application} app
- */
-export default (app) => {
-  app.post(
-    '/full-page-examples/what-was-the-last-country-you-visited',
+const router = express.Router()
 
-    body('last-visited-country')
-      .exists()
-      .not()
-      .isEmpty()
-      .withMessage('Enter the last country you visited'),
+router.post(
+  '/what-was-the-last-country-you-visited',
 
-    (req, res) => {
-      const viewPath =
-        './full-page-examples/what-was-the-last-country-you-visited'
-      const errors = formatValidationErrors(validationResult(req))
+  body('last-visited-country')
+    .exists()
+    .not()
+    .isEmpty()
+    .withMessage('Enter the last country you visited'),
 
-      if (!errors) {
-        return res.render(`${viewPath}/confirm`)
-      }
+  (req, res) => {
+    const viewPath =
+      './full-page-examples/what-was-the-last-country-you-visited'
+    const errors = formatValidationErrors(validationResult(req))
 
-      res.render(`${viewPath}/index`, {
-        errors,
-        errorSummary: Object.values(errors),
-        values: req.body // In production this should sanitized.
-      })
+    if (!errors) {
+      return res.render(`${viewPath}/confirm`)
     }
-  )
-}
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: req.body // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
@@ -16,20 +16,19 @@ export default (app) => {
       .withMessage('Enter the last country you visited'),
 
     (req, res) => {
+      const viewPath =
+        './full-page-examples/what-was-the-last-country-you-visited'
       const errors = formatValidationErrors(validationResult(req))
-      if (errors) {
-        return res.render(
-          './full-page-examples/what-was-the-last-country-you-visited/index',
-          {
-            errors,
-            errorSummary: Object.values(errors),
-            values: req.body // In production this should sanitized.
-          }
-        )
+
+      if (!errors) {
+        return res.render(`${viewPath}/confirm`)
       }
-      res.render(
-        './full-page-examples/what-was-the-last-country-you-visited/confirm'
-      )
+
+      res.render(`${viewPath}/index`, {
+        errors,
+        errorSummary: Object.values(errors),
+        values: req.body // In production this should sanitized.
+      })
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
@@ -1,4 +1,5 @@
 ---
+title: What was the last country you visited?
 scenario: |
   As part of an online service, you are asked to provide the last country you visited.
 
@@ -16,7 +17,7 @@ scenario: |
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% set pageTitle = "What was the last country you visited?" %}
+{% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block beforeContent %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
@@ -1,4 +1,5 @@
 ---
+title: Work history - Apply for teacher training
 scenario: |
   As part of an online service, you are providing information about previous jobs
   in the form of multiple job records. You are provided a page to check the records
@@ -20,14 +21,12 @@ notes: The links to change your answers are not functional.
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Work history" %}
-{% set serviceName = "Apply for teacher training" %}
-
-{% block pageTitle %}{{ pageTitle }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
   {{ govukHeader({
-    serviceName: serviceName
+    serviceName: "Apply for teacher training"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
Like we do for middleware, this PR organises [Full page examples](https://govuk-frontend-review.herokuapp.com/full-page-examples) routes into `express.Router()` exports

I've replaced our [previous tests](https://github.com/alphagov/govuk-frontend/blob/73f3be39d9a6843815fc38c1e1709be232a9258b/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs#L3-L21) with a loop that renders and checks against newly added `title` front matter:

```patch
  ---
+ title: What is your nationality?
  scenario: |
    As part of an online service, you are asked to provide your nationality.
```