### PR TITLE
Test Percy “cannot finalize” fix in v1.27.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,7 +3809,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.27.4.tgz",
       "integrity": "sha512-vhPcdtmJlvTYJ5VOqiVzo02ujdtBFNw1/Bj+2ybiZgn7PkCDPFcITfXoWWPea319EIibGC4ZHjWHctRBgtW/tQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -30655,14 +30655,6 @@
       "engines": {
         "node": "^20.9.0",
         "npm": "^10.1.0"
-      },
-      "peerDependencies": {
-        "@percy/sdk-utils": "^1.26.2"
-      },
-      "peerDependenciesMeta": {
-        "@percy/sdk-utils": {
-          "optional": true
-        }
       }
     },
     "shared/tasks/node_modules/chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@actions/github": "^6.0.0",
         "@jest/environment": "^29.5.0",
         "@octokit/rest": "20.0.2",
+        "@percy/core": "^1.27.4",
         "@types/browser-sync": "^2.27.5",
         "@types/express": "^4.17.21",
         "@types/gulp": "^4.0.17",
@@ -3238,7 +3239,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -3251,7 +3252,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3260,7 +3261,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -3713,7 +3714,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.27.4.tgz",
       "integrity": "sha512-1F8ulTJhfk4/Lgj1Cn0blaRd8vTRJDxahAGseTbfrnZ2PHsftPZ65/5nCHPtpdD/2CE8N5COBQscGTMQQO+hBA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@percy/env": "1.27.4",
         "@percy/logger": "1.27.4"
@@ -3726,7 +3727,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.27.4.tgz",
       "integrity": "sha512-mlgiOdzdSfUSx9FskVIjmbT/iHbTif0Ow5evZQJTT1W0xgHOBWDCZyhINdsqulSBw+K1PNhHsu1J0h2ijxF4uA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@percy/logger": "1.27.4",
         "ajv": "^8.6.2",
@@ -3741,7 +3742,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.27.4.tgz",
       "integrity": "sha512-WdsA4zlPgXl9xj+a5WW2wA20iU6VTDmRq5sgsYNSuPzZfQB2I5Cecgvb55p86dhlUTbPJrC76daQKzDTGe0hfA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@percy/client": "1.27.4",
@@ -3767,13 +3768,13 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.27.4.tgz",
       "integrity": "sha512-pwPDx3e9y7uRobVlEya8xu3BB3GeXbC74kQ6pPM/wFYDwi/Dg8DJywCsj5Nko/7QuhXP02rYgatkbREOIRxDnA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@percy/env": {
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.27.4.tgz",
       "integrity": "sha512-Xl2VUpljOrlCvAp/+KfmN9NUcTGpRdXPa1U9zSIyBnV/oAksp3/CK5EPpKZX/f8xUUkTp78UPaG99sEMA8VvXQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@percy/logger": "1.27.4"
       },
@@ -3785,7 +3786,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.27.4.tgz",
       "integrity": "sha512-AwXqYaDkHaq1TPkP+ByB8rjvH9ddvkAH9tFd2kmq8AeFFXZ0amAPSbm6u090OUtdHWjRmKQK9JjSouBxEh0aRw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=14"
       }
@@ -3809,7 +3810,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.27.4.tgz",
       "integrity": "sha512-vhPcdtmJlvTYJ5VOqiVzo02ujdtBFNw1/Bj+2ybiZgn7PkCDPFcITfXoWWPea319EIibGC4ZHjWHctRBgtW/tQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=14"
       }
@@ -3818,7 +3819,7 @@
       "version": "1.27.4",
       "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.27.4.tgz",
       "integrity": "sha512-pZOOYns8Fikh2qlbxO16DxFEnCrnFIoLpE7iz4M9jXxOfk16VZF1PWknMChSr5NqG2I9k2OMjizUE2j8zvtl2Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@percy/config": "1.27.4",
         "@percy/sdk-utils": "1.27.4"
@@ -5529,7 +5530,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8408,7 +8409,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -12287,7 +12288,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fast-fifo": {
       "version": "1.3.0",
@@ -12299,7 +12300,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -12342,7 +12343,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -13248,7 +13249,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -15379,7 +15380,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18748,7 +18749,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -20563,7 +20564,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -22530,7 +22531,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22597,7 +22598,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
       "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -23826,7 +23827,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -23934,7 +23935,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -24453,7 +24454,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24691,7 +24692,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -24707,7 +24708,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -24722,7 +24723,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -24732,7 +24733,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -24752,7 +24753,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -24836,7 +24837,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -29204,7 +29205,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -30349,7 +30350,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@actions/github": "^6.0.0",
         "@jest/environment": "^29.5.0",
         "@octokit/rest": "20.0.2",
-        "@percy/core": "^1.27.4",
+        "@percy/core": "^1.27.5",
         "@types/browser-sync": "^2.27.5",
         "@types/express": "^4.17.21",
         "@types/gulp": "^4.0.17",
@@ -3578,20 +3578,20 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
     },
     "node_modules/@percy/cli": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.27.4.tgz",
-      "integrity": "sha512-eIM44ejCMFc/S2W7X0htV+lvvmf63x5CaBpsSoQ9LRc/W02zHVAwQYdFFUowZEK6G1EwJEPIUnDxuuEx9PLG5A==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.27.5.tgz",
+      "integrity": "sha512-pgxhM6p5J6gT9sjx1+dVBU48UkrPr/h4H3Oy1bq4UkJyf/cSQwIw6MRSjnAnU/hq7hXpEx6VSeW1MMYhh3JHeQ==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-app": "1.27.4",
-        "@percy/cli-build": "1.27.4",
-        "@percy/cli-command": "1.27.4",
-        "@percy/cli-config": "1.27.4",
-        "@percy/cli-exec": "1.27.4",
-        "@percy/cli-snapshot": "1.27.4",
-        "@percy/cli-upload": "1.27.4",
-        "@percy/client": "1.27.4",
-        "@percy/logger": "1.27.4"
+        "@percy/cli-app": "1.27.5",
+        "@percy/cli-build": "1.27.5",
+        "@percy/cli-command": "1.27.5",
+        "@percy/cli-config": "1.27.5",
+        "@percy/cli-exec": "1.27.5",
+        "@percy/cli-snapshot": "1.27.5",
+        "@percy/cli-upload": "1.27.5",
+        "@percy/client": "1.27.5",
+        "@percy/logger": "1.27.5"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -3601,39 +3601,39 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.27.4.tgz",
-      "integrity": "sha512-av/s6K2QmQgq4SCQQ+3lmteNHeQtIpMeBjMfSgxs9zeBoPVOMx5hXrdsi6l7ChvOLXyYfzl/TbEuwrSDXiA8mw==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.27.5.tgz",
+      "integrity": "sha512-PD4zPi//Wd7Qi6N/KzzyyftQ/v1bG0i8R1sLUvgwIyePutsGLQISba4naBowAdaUytfcAjgwxTlM2okx77I69Q==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.27.4",
-        "@percy/cli-exec": "1.27.4"
+        "@percy/cli-command": "1.27.5",
+        "@percy/cli-exec": "1.27.5"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.27.4.tgz",
-      "integrity": "sha512-tzCAcV0sAw608Gr/Q6NtPvVkA8dnIehMzvEXNIN3WP9DkprOgu7MYuexN0fZXf4vSroDWYXT87pHYP8YrrnDag==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.27.5.tgz",
+      "integrity": "sha512-KrYoqPCN2HJmTVm2S8oC6mdHbaOA4giK9m+RkIYzhvJgQ6OXYJ9u2B+bJYpckXLgMlyCw1Z6K4WW0sN/WCrQxQ==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.27.4"
+        "@percy/cli-command": "1.27.5"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.27.4.tgz",
-      "integrity": "sha512-YDKeeOr1MvksDOnc2ZKQ/XuERGrWwzuT/vWZ9it8L+0SyPj28UbklDu0e9zBgPsSDfxJlIvsWXRuHNGHsweKXg==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.27.5.tgz",
+      "integrity": "sha512-VqOKCj1CgDh/yhNs2WK6GPyS5Rfpm+yJ/evISWUHtpbmac4JcFHMFUz/hiSo2T1bZEuzCz9meZi567ze45sf5g==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.27.4",
-        "@percy/core": "1.27.4",
-        "@percy/logger": "1.27.4"
+        "@percy/config": "1.27.5",
+        "@percy/core": "1.27.5",
+        "@percy/logger": "1.27.5"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -3643,24 +3643,24 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.27.4.tgz",
-      "integrity": "sha512-wFtQwPw4LEqpcZ6ac6WtejyGrvrrzzLdyvXNvsCPQLE47qXnXVXJ+E99k9KGcjavtUuPxrbWtX996Fz9Fb5hoQ==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.27.5.tgz",
+      "integrity": "sha512-1UA+wob8AqlkWDW6fqxm25NdoGNX4h4X1Koi+Cp17zieOpkfOG6AVUDJEWAxUxoN/gzk92zc+zDBTRgttEf4yA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.27.4"
+        "@percy/cli-command": "1.27.5"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.27.4.tgz",
-      "integrity": "sha512-aSDLvzXXdwJso+p5iI4iTOa7AYzgFdRoqY9ij/R5aAL9juNkvG5QatB1bkUNbJabKFe16t7iigt4eJnlS0R13A==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.27.5.tgz",
+      "integrity": "sha512-MnvOtDyhP8E/N0KwGVb6bp7DwWadPdy1lHsmc5Kry3ZY6fVKJWRE9t9WfeDRkjUEAZgwaxtNxBetLRXFCjblEA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.27.4",
+        "@percy/cli-command": "1.27.5",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -3684,12 +3684,12 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.27.4.tgz",
-      "integrity": "sha512-dDT2UpeP6X5NcMdj3AKLhHGmnobwzlXsHa52C+ne3kg3HSZgaXH9OsNY866Xe7onvcsZxvnRKDYHmWW6kC3cKQ==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.27.5.tgz",
+      "integrity": "sha512-yUc8QvoKVS0vCzv8ixBt45/k8thrQVbeoOrAF8J+K0cM8so1j7ZEXyuQm4hByrPTovREsXUE84mBOB+F+UKgLg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.27.4",
+        "@percy/cli-command": "1.27.5",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -3697,12 +3697,12 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.27.4.tgz",
-      "integrity": "sha512-+4mcEOUydFubyMWVzQjPV79sL1Jar95SR7Yr7Vp4FBoE0iq0CbaHoJtyOWDfwvHYYp4rRjVMxpY0ha3jnmF0mA==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.27.5.tgz",
+      "integrity": "sha512-Hu+WYMIPr5Bov/FqU7h9ykhufK4fM3xC3HnepULxC+sjx6R4iBbZqkfFFAjTO6gPaepNXxSlIpGOzrw3EeUgTw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.27.4",
+        "@percy/cli-command": "1.27.5",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -3711,25 +3711,25 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.27.4.tgz",
-      "integrity": "sha512-1F8ulTJhfk4/Lgj1Cn0blaRd8vTRJDxahAGseTbfrnZ2PHsftPZ65/5nCHPtpdD/2CE8N5COBQscGTMQQO+hBA==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.27.5.tgz",
+      "integrity": "sha512-C3WdSADXTMOFn362e7ctUA/pCdXT7f+nuSKwWPnOW8+2a4Z+qV6zr1VHubr3acIVfjENqc2z5t2tP0Lf8liJAg==",
       "devOptional": true,
       "dependencies": {
-        "@percy/env": "1.27.4",
-        "@percy/logger": "1.27.4"
+        "@percy/env": "1.27.5",
+        "@percy/logger": "1.27.5"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.27.4.tgz",
-      "integrity": "sha512-mlgiOdzdSfUSx9FskVIjmbT/iHbTif0Ow5evZQJTT1W0xgHOBWDCZyhINdsqulSBw+K1PNhHsu1J0h2ijxF4uA==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.27.5.tgz",
+      "integrity": "sha512-c84ptxyWjOA/58GgYqxVvnM4pa/qDux3uHlpskdiC1gfTkG7A0R+EjH0SMYCP+HNYG0f/denLhczkjBU31JnnA==",
       "devOptional": true,
       "dependencies": {
-        "@percy/logger": "1.27.4",
+        "@percy/logger": "1.27.5",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -3739,17 +3739,17 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.27.4.tgz",
-      "integrity": "sha512-WdsA4zlPgXl9xj+a5WW2wA20iU6VTDmRq5sgsYNSuPzZfQB2I5Cecgvb55p86dhlUTbPJrC76daQKzDTGe0hfA==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.27.5.tgz",
+      "integrity": "sha512-dJzhDGm+2EM3XBTcJFQoUZ/sD+t4Tlq2zu89wKuInUy6d9omNRMuyU+C2+6mbPQy9ZnARENFCDqGZFHfkVvAPw==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@percy/client": "1.27.4",
-        "@percy/config": "1.27.4",
-        "@percy/dom": "1.27.4",
-        "@percy/logger": "1.27.4",
-        "@percy/webdriver-utils": "1.27.4",
+        "@percy/client": "1.27.5",
+        "@percy/config": "1.27.5",
+        "@percy/dom": "1.27.5",
+        "@percy/logger": "1.27.5",
+        "@percy/webdriver-utils": "1.27.5",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -3765,27 +3765,27 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.27.4.tgz",
-      "integrity": "sha512-pwPDx3e9y7uRobVlEya8xu3BB3GeXbC74kQ6pPM/wFYDwi/Dg8DJywCsj5Nko/7QuhXP02rYgatkbREOIRxDnA==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.27.5.tgz",
+      "integrity": "sha512-x+yuP78vmiZlrIjqCP1Jx8+nFUth3VXxIwybZE8kl5lOO87xMhJKr6r/oF2aJA2Z3BfbsE9qoEEz9W/4GIk7/w==",
       "devOptional": true
     },
     "node_modules/@percy/env": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.27.4.tgz",
-      "integrity": "sha512-Xl2VUpljOrlCvAp/+KfmN9NUcTGpRdXPa1U9zSIyBnV/oAksp3/CK5EPpKZX/f8xUUkTp78UPaG99sEMA8VvXQ==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.27.5.tgz",
+      "integrity": "sha512-mzmqFz26N0FNpPzAJVpufSUntwxp2uJmWkHjI/MuZRZx3hckp+K09fv7wbX29BkAvfyEtvO7YZHWcSRdAM33Bg==",
       "devOptional": true,
       "dependencies": {
-        "@percy/logger": "1.27.4"
+        "@percy/logger": "1.27.5"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.27.4.tgz",
-      "integrity": "sha512-AwXqYaDkHaq1TPkP+ByB8rjvH9ddvkAH9tFd2kmq8AeFFXZ0amAPSbm6u090OUtdHWjRmKQK9JjSouBxEh0aRw==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.27.5.tgz",
+      "integrity": "sha512-Dk0s6yKTTzjP7P4zFDF6wLeO+t6A19MRPVXcRebV2G7sOTZAfZMugeatShhNvVGw7PZ3Suynvu2A+byiMF7vtQ==",
       "devOptional": true,
       "engines": {
         "node": ">=14"
@@ -3807,22 +3807,22 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.27.4.tgz",
-      "integrity": "sha512-vhPcdtmJlvTYJ5VOqiVzo02ujdtBFNw1/Bj+2ybiZgn7PkCDPFcITfXoWWPea319EIibGC4ZHjWHctRBgtW/tQ==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.27.5.tgz",
+      "integrity": "sha512-MoL/PegKdx9xPgxmvG3xuEMBUYwKO3s/8CnqFXvLNURc5Es6XRqCol7SDI/scsQSpkOaUKc/0rYhmMCRQOt+EA==",
       "devOptional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.27.4.tgz",
-      "integrity": "sha512-pZOOYns8Fikh2qlbxO16DxFEnCrnFIoLpE7iz4M9jXxOfk16VZF1PWknMChSr5NqG2I9k2OMjizUE2j8zvtl2Q==",
+      "version": "1.27.5",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.27.5.tgz",
+      "integrity": "sha512-wfMbc9KAMBP9UaLMa5nXzR8ddOM4adDu/rSpcEOIQ8JWCHtYbmcaOIK7HEgOyEekY8O8wQ4SVRJ0OdaVxBrGYw==",
       "devOptional": true,
       "dependencies": {
-        "@percy/config": "1.27.4",
-        "@percy/sdk-utils": "1.27.4"
+        "@percy/config": "1.27.5",
+        "@percy/sdk-utils": "1.27.5"
       },
       "engines": {
         "node": ">=14"
@@ -30505,7 +30505,7 @@
       "devDependencies": {
         "@govuk-frontend/helpers": "*",
         "@govuk-frontend/tasks": "*",
-        "@percy/cli": "^1.27.4",
+        "@percy/cli": "^1.27.5",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "autoprefixer": "^10.4.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30504,6 +30504,7 @@
       "devDependencies": {
         "@govuk-frontend/helpers": "*",
         "@govuk-frontend/tasks": "*",
+        "@percy/cli": "^1.27.4",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "autoprefixer": "^10.4.16",
@@ -30636,7 +30637,6 @@
         "@govuk-frontend/helpers": "*",
         "@govuk-frontend/lib": "*",
         "@npmcli/run-script": "^7.0.2",
-        "@percy/cli": "^1.27.4",
         "@percy/puppeteer": "^2.0.2",
         "chalk": "^5.3.0",
         "cpy": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@actions/github": "^6.0.0",
     "@jest/environment": "^29.5.0",
     "@octokit/rest": "20.0.2",
+    "@percy/core": "^1.27.4",
     "@types/browser-sync": "^2.27.5",
     "@types/express": "^4.17.21",
     "@types/gulp": "^4.0.17",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@actions/github": "^6.0.0",
     "@jest/environment": "^29.5.0",
     "@octokit/rest": "20.0.2",
-    "@percy/core": "^1.27.4",
+    "@percy/core": "^1.27.5",
     "@types/browser-sync": "^2.27.5",
     "@types/express": "^4.17.21",
     "@types/gulp": "^4.0.17",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@govuk-frontend/helpers": "*",
     "@govuk-frontend/tasks": "*",
+    "@percy/cli": "^1.27.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.16",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@govuk-frontend/helpers": "*",
     "@govuk-frontend/tasks": "*",
-    "@percy/cli": "^1.27.4",
+    "@percy/cli": "^1.27.5",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.16",

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -7,7 +7,6 @@ import {
 } from '@govuk-frontend/lib/components'
 import { filterPath } from '@govuk-frontend/lib/files'
 import percySnapshot from '@percy/puppeteer'
-import { waitForPercyIdle } from '@percy/sdk-utils'
 import puppeteer from 'puppeteer'
 
 /**
@@ -69,9 +68,6 @@ export async function screenshots() {
 
   // Close browser
   await browser.close()
-
-  // Wait for Percy to finish
-  return waitForPercyIdle()
 }
 
 /**

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -13,7 +13,6 @@
     "@govuk-frontend/helpers": "*",
     "@govuk-frontend/lib": "*",
     "@npmcli/run-script": "^7.0.2",
-    "@percy/cli": "^1.27.4",
     "@percy/puppeteer": "^2.0.2",
     "chalk": "^5.3.0",
     "cpy": "^11.0.0",

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -28,13 +28,5 @@
     "sass-embedded": "^1.69.5",
     "slash": "^5.1.0",
     "yargs-parser": "^21.1.1"
-  },
-  "peerDependencies": {
-    "@percy/sdk-utils": "^1.26.2"
-  },
-  "peerDependenciesMeta": {
-    "@percy/sdk-utils": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
The GitHub discussion for our Percy problems (https://github.com/alphagov/govuk-frontend/pull/3036, https://github.com/alphagov/govuk-frontend/pull/3670, https://github.com/alphagov/govuk-frontend/pull/3767) has been updated

* https://github.com/percy/cli/discussions/1137

They've asked for volunteers to [trial `v1.27.6-alpha.0`](https://github.com/percy/cli/discussions/1137#discussioncomment-7658807) which [fixes a race condition](https://github.com/percy/cli/pull/1440)

This PR removes our [`waitForPercyIdle()` workaround](https://github.com/percy/cli/discussions/1137#discussioncomment-6113954) and gives it a go

**Update:** The fix was added to [`v1.27.5`](https://github.com/percy/cli/releases/tag/v1.27.5)