### PR TITLE
Build GitHub release in “Generate stats” workflow

### DIFF
--- a/.github/workflows/stats-comment.yml
+++ b/.github/workflows/stats-comment.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
 
-      - name: Build
-        uses: ./.github/workflows/actions/build
+      - name: Build npm package and GitHub release
+        run: |
+          npm run build:package --workspace govuk-frontend
+          npm run build:release --workspace govuk-frontend
 
       - name: Add comment to PR
         uses: actions/github-script@v7.0.1
@@ -29,12 +31,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { commentStats } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
+
             // PR information
             const issueNumber = ${{ github.event.pull_request.number }}
             const commit = '${{ github.event.pull_request.head.sha }}'
+
             const options = {
               path: '${{ github.workspace }}',
               titleText: ':clipboard: Stats',
               markerText: 'stats'
             }
+
             await commentStats({ github, context, commit }, issueNumber, options)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -305,11 +305,11 @@ jobs:
 
   generate-stats:
     name: Stats comment
-    needs: [install, build]
+    needs: [install]
 
     permissions:
       pull-requests: write
 
     # Run existing "Stats comment" workflow
-    # (after install and build have been cached)
+    # (after only install has been cached)
     uses: ./.github/workflows/stats-comment.yml

--- a/docs/examples/webpack/babel.config.js
+++ b/docs/examples/webpack/babel.config.js
@@ -4,7 +4,8 @@
  * @type {import('@babel/core').ConfigFunction}
  */
 module.exports = function (api) {
-  const isBrowser = !api.env('test')
+  // Assume browser environment via webpack 'web' target
+  const isBrowser = api.caller((caller) => caller?.target === 'web')
 
   // Apply Browserslist environment for supported targets
   // https://github.com/browserslist/browserslist#configuring-for-different-environments

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -4,7 +4,10 @@
  * @type {import('@babel/core').ConfigFunction}
  */
 module.exports = function (api) {
-  const isBrowser = !api.env('test')
+  // Assume browser environment via Rollup plugin
+  const isBrowser = api.caller(
+    (caller) => caller?.name === '@rollup/plugin-babel'
+  )
 
   // Apply Browserslist environment for supported targets
   // https://github.com/browserslist/browserslist#configuring-for-different-environments

--- a/packages/govuk-frontend/postcss.config.mjs
+++ b/packages/govuk-frontend/postcss.config.mjs
@@ -1,11 +1,8 @@
-import { pkg } from '@govuk-frontend/config'
 import autoprefixer from 'autoprefixer'
 import cssnano from 'cssnano'
 import cssnanoPresetDefault from 'cssnano-preset-default'
 import postcss from 'postcss'
 import scss from 'postcss-scss'
-
-const { NODE_ENV } = process.env
 
 /**
  * PostCSS config
@@ -13,20 +10,21 @@ const { NODE_ENV } = process.env
  * @param {import('postcss-load-config').ConfigContext} [ctx] - Context options
  * @returns {import('postcss-load-config').Config} PostCSS Config
  */
-export default ({ env = NODE_ENV, to = '' } = {}) => ({
+export default ({ to = '' } = {}) => ({
   plugins: [
     // Add vendor prefixes
     autoprefixer({ env: 'stylesheets' }),
 
     // Add GOV.UK Frontend release version
-    ['test', 'production'].includes(env) && {
+    {
       postcssPlugin: 'govuk-frontend-version',
       Declaration: {
         // Find CSS declaration for version, update value
         // https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md
         // https://postcss.org/api/#declaration
-        '--govuk-frontend-version': (decl) => {
-          decl.value = `"${pkg.version}"`
+        '--govuk-frontend-version': async (decl) => {
+          const config = await import('@govuk-frontend/config')
+          decl.value = `"${config.version}"`
         }
       }
     },

--- a/packages/govuk-frontend/rollup.publish.config.mjs
+++ b/packages/govuk-frontend/rollup.publish.config.mjs
@@ -1,4 +1,4 @@
-import { pkg } from '@govuk-frontend/config'
+import config from '@govuk-frontend/config'
 import { babel } from '@rollup/plugin-babel'
 import replace from '@rollup/plugin-replace'
 import { defineConfig } from 'rollup'
@@ -59,7 +59,7 @@ export default defineConfig(({ i: input }) => ({
       preventAssignment: true,
 
       // Add GOV.UK Frontend release version
-      development: pkg.version
+      development: config.version
     }),
     babel({
       babelHelpers: 'bundled'

--- a/packages/govuk-frontend/rollup.release.config.mjs
+++ b/packages/govuk-frontend/rollup.release.config.mjs
@@ -1,4 +1,4 @@
-import { pkg } from '@govuk-frontend/config'
+import config from '@govuk-frontend/config'
 import { babel } from '@rollup/plugin-babel'
 import replace from '@rollup/plugin-replace'
 import terser from '@rollup/plugin-terser'
@@ -59,7 +59,7 @@ export default defineConfig(({ i: input }) => ({
       preventAssignment: true,
 
       // Add GOV.UK Frontend release version
-      development: pkg.version
+      development: config.version
     }),
     babel({
       babelHelpers: 'bundled'

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -1,6 +1,6 @@
 import { join } from 'path'
 
-import { pkg } from '@govuk-frontend/config'
+import { pkg, version } from '@govuk-frontend/config'
 import { files, npm, scripts, styles, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
@@ -35,7 +35,7 @@ export default (options) =>
         filePath({ dir, name }) {
           return join(
             dir,
-            `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.js`
+            `${name.replace(/^all/, pkg.name)}-${version}.min.js`
           )
         }
       })
@@ -51,7 +51,7 @@ export default (options) =>
 
         // Rename using package name (versioned) and `*.min.css` extension
         filePath({ dir }) {
-          return join(dir, `${pkg.name}-${pkg.version}.min.css`)
+          return join(dir, `${pkg.name}-${version}.min.css`)
         }
       })
     ),

--- a/shared/config/index.js
+++ b/shared/config/index.js
@@ -1,5 +1,9 @@
 const pkg = require('govuk-frontend/package.json')
 
+// Node.js environment with default
+// https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production
+const { NODE_ENV = 'development' } = process.env
+
 /**
  * Config
  */
@@ -7,9 +11,20 @@ const paths = require('./paths')
 const ports = require('./ports')
 const urls = require('./urls')
 
+/**
+ * GOV.UK Frontend release version
+ *
+ * The version export identifies development builds using NODE_ENV by default
+ * unlike test and production builds which use the release pkg.version number
+ */
+const version = ['test', 'production'].includes(NODE_ENV)
+  ? pkg.version // Use release version
+  : NODE_ENV // or default to build type
+
 module.exports = {
   paths,
   pkg,
   ports,
-  urls
+  urls,
+  version
 }

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'fs/promises'
 import { dirname, join, parse } from 'path'
 
-import { pkg } from '@govuk-frontend/config'
+import config from '@govuk-frontend/config'
 import cpy from 'cpy'
 import slash from 'slash'
 
@@ -17,7 +17,7 @@ export async function version(assetPath, options) {
 
     // Add package version
     async fileContents() {
-      return pkg.version
+      return config.version
     }
   })
 }


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/4147 by running `npm run build:release` in GitHub Actions

This now means we see the PR stats impact on [committed files in **./dist**](https://github.com/alphagov/govuk-frontend/tree/main/dist) too

## Development build output
Because [Node.js assumes a development environment by default](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production) I've ensured Babel, PostCSS and Rollup make their `NODE_ENV=development` version numbers and filenames obvious in the PR stats comment:

```patch
- const version="5.0.0-beta.2";function mergeConfigs(...t){function flattenObject(t){const e={};return function flattenLoop(t,i){
+ const version="development";function mergeConfigs(...t){function flattenObject(t){const e={};return function flattenLoop(t,i){
```

### Before

GitHub release committed assets use version numbers

```console
dist/govuk-frontend-5.0.0-beta.2.min.css
dist/govuk-frontend-5.0.0-beta.2.min.js
```

### After

GitHub release development builds use `NODE_ENV`

```console
dist/govuk-frontend-development.min.css
dist/govuk-frontend-development.min.js
```