### PR TITLE
Fix shared task `styles.compile()` when loadPaths don’t exist yet

### DIFF
--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -72,7 +72,9 @@ function componentNameToConfigName(componentName) {
  * @param {Pick<PackageOptions, "modulePath" | "moduleRoot">} [options] - Package resolution options
  * @returns {string} Path to installed npm package entry
  */
-function packageResolveToPath(packageEntry, { modulePath, moduleRoot } = {}) {
+function packageResolveToPath(packageEntry, options = {}) {
+  const { modulePath, moduleRoot } = options
+
   const packagePath = require.resolve(packageEntry, {
     paths: [moduleRoot ?? paths.root]
   })
@@ -106,10 +108,9 @@ function packageResolveToPath(packageEntry, { modulePath, moduleRoot } = {}) {
  * @param {PackageOptions} [options] - Package resolution options
  * @returns {string} Path to installed npm package field
  */
-function packageTypeToPath(
-  packageName,
-  { modulePath, moduleRoot, type = 'commonjs' } = {}
-) {
+function packageTypeToPath(packageName, options = {}) {
+  const { modulePath, moduleRoot, type = 'commonjs' } = options
+
   const packageEntry = `${packageName}/package.json`
   const packageField = type === 'module' ? 'module' : 'main'
 

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -68,6 +68,17 @@ function componentNameToConfigName(componentName) {
  * Once the package entry is resolved, the option `modulePath` can be used to
  * append a new path relative to the package entry, for example `i18n.mjs`
  *
+ * @example
+ * Resolving components relative to a default package entry
+ *
+ * - GOV.UK Frontend v4 './govuk/components/accordion/accordion.mjs'
+ * - GOV.UK Frontend v5 './dist/govuk/components/accordion/accordion.mjs'
+ *
+ * ```mjs
+ * const templatePath = packageResolveToPath('govuk-frontend', {
+ *   modulePath: `components/accordion/accordion.mjs`
+ * })
+ * ```
  * @param {string} packageEntry - Installed npm package entry, for example `govuk-frontend/src/govuk/all.mjs`
  * @param {Pick<PackageOptions, "modulePath" | "moduleRoot">} [options] - Package resolution options
  * @returns {string} Path to installed npm package entry
@@ -93,17 +104,6 @@ function packageResolveToPath(packageEntry, options = {}) {
  *
  * {@link https://github.com/alphagov/govuk-frontend/issues/3755}
  *
- * @example
- * Resolving components relative to a default package entry
- *
- * - GOV.UK Frontend v4 './govuk/components/accordion/accordion.mjs'
- * - GOV.UK Frontend v5 './dist/govuk/components/accordion/accordion.mjs'
- *
- * ```mjs
- * const templatePath = packageResolveToPath('govuk-frontend', {
- *   modulePath: `components/accordion/accordion.mjs`
- * })
- * ```
  * @param {string} packageName - Installed npm package name
  * @param {PackageOptions} [options] - Package resolution options
  * @returns {string} Path to installed npm package field

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -3,7 +3,7 @@ import { join, parse } from 'path'
 
 import { paths } from '@govuk-frontend/config'
 import { getListing } from '@govuk-frontend/lib/files'
-import { packageResolveToPath } from '@govuk-frontend/lib/names'
+import { packageTypeToPath } from '@govuk-frontend/lib/names'
 import chalk from 'chalk'
 import PluginError from 'plugin-error'
 import postcss from 'postcss'
@@ -90,7 +90,7 @@ export async function compileStylesheet([
       // Resolve @imports via
       loadPaths: [
         // Remove `govuk/` suffix using `modulePath`
-        packageResolveToPath('govuk-frontend', {
+        packageTypeToPath('govuk-frontend', {
           modulePath: '../',
           moduleRoot: basePath
         }),


### PR DESCRIPTION
This PR fixes a bug where a newly cloned repo can't run:

```
npm install
npm run build:release
```

I've tweaked a bit of awful Prettier formatting and added some better comments too

## Problem

For our [Sass `loadPaths`](https://sass-lang.com/documentation/js-api/interfaces/options/#loadPaths) we use `require.resolve()` via [`packageResolveToPath()`](https://github.com/alphagov/govuk-frontend/blob/2cdcb65570aba21e9babb2b692e3585aa606fac0/shared/lib/names.js#L75) to locate `govuk-frontend`

But Node.js throws “Cannot find module” since `npm run build:package` hasn't been run yet

## Solution

We can use the ~`packageResolveToPath()`~ [`packageTypeToPath()`](https://github.com/alphagov/govuk-frontend/blob/2cdcb65570aba21e9babb2b692e3585aa606fac0/shared/lib/names.js#L109) helper instead

This helper was added when Node.js v17 couldn't use `require.resolve()` in https://github.com/alphagov/govuk-frontend/issues/3755