### PR TITLE
Skip or delete PR diff comments when empty

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -68,7 +68,8 @@ jobs:
               {
                 path: '${{ github.workspace }}/.cache/diff/dist/other.diff',
                 titleText: 'Other changes to GitHub release',
-                markerText: 'dist/other.diff'
+                markerText: 'dist/other.diff',
+                skipEmpty: true
               }
             ]
 

--- a/.github/workflows/diff-change-to-package.yaml
+++ b/.github/workflows/diff-change-to-package.yaml
@@ -58,17 +58,20 @@ jobs:
               {
                 path: '${{ github.workspace }}/.cache/diff/package/js.diff',
                 titleText: 'JavaScript changes to npm package',
-                markerText: 'package/js.diff'
+                markerText: 'package/js.diff',
+                skipEmpty: true
               },
               {
                 path: '${{ github.workspace }}/.cache/diff/package/css.diff',
                 titleText: 'Stylesheets changes to npm package',
-                markerText: 'package/css.diff'
+                markerText: 'package/css.diff',
+                skipEmpty: true
               },
               {
                 path: '${{ github.workspace }}/.cache/diff/package/other.diff',
                 titleText: 'Other changes to npm package',
-                markerText: 'package/other.diff'
+                markerText: 'package/other.diff',
+                skipEmpty: true
               }
             ]
 

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -54,9 +54,10 @@ export async function commentDiff(
   // Read diff from previous step
   const diffText = await readFile(path, 'utf8')
 
-  // Skip comment for empty diff
+  // Skip or delete comment for empty diff
   if (!diffText && skipEmpty) {
     console.log(`Skipping GitHub comment for ${basename(path)}`)
+    await deleteComment(githubActionContext, issueNumber, markerText)
     return
   }
 
@@ -246,6 +247,34 @@ function githubActionRunUrl(context) {
   const { runId, repo } = context
 
   return `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}/attempts/${process.env.GITHUB_RUN_ATTEMPT}`
+}
+
+/**
+ * Delete GitHub issue comment with marker `<!-- Example -->`
+ *
+ * @param {Pick<GithubActionContext, "github" | "context">} githubActionContext
+ * @param {number} issueNumber
+ * @param {Comment["markerText"]} markerText
+ */
+export async function deleteComment(
+  { github, context },
+  issueNumber,
+  markerText
+) {
+  const { issues } = github.rest
+
+  // Find first match for marker
+  const comment = await getComment({ github, context }, issueNumber, markerText)
+
+  // Delete comment
+  if (comment) {
+    await issues.deleteComment({
+      issue_number: issueNumber,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: comment.id
+    })
+  }
 }
 
 /**

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -176,8 +176,7 @@ export async function comment(
   /**
    * Find GitHub issue comment with marker `<!-- Example -->`
    */
-  const comments = await github.paginate(issues.listComments, parameters)
-  const comment = comments.find(({ body }) => !!body?.includes(markerText))
+  const comment = await getComment({ github, context }, issueNumber, markerText)
 
   /**
    * Update GitHub issue comment (or create new)
@@ -250,6 +249,28 @@ function githubActionRunUrl(context) {
 }
 
 /**
+ * Find GitHub issue comment with marker `<!-- Example -->`
+ *
+ * @param {Pick<GithubActionContext, "github" | "context">} githubActionContext
+ * @param {number} issueNumber
+ * @param {Comment["markerText"]} markerText
+ * @returns {Promise<IssueCommentData | undefined>} GitHub comment
+ */
+export async function getComment({ github, context }, issueNumber, markerText) {
+  const { issues } = github.rest
+
+  // Find all GitHub issue comments
+  const comments = await github.paginate(issues.listComments, {
+    issue_number: issueNumber,
+    owner: context.repo.owner,
+    repo: context.repo.repo
+  })
+
+  // Find first match for marker
+  return comments.find(({ body }) => !!body?.includes(markerText))
+}
+
+/**
  * @param {number} prNumber - The PR number
  * @param {string} path - URL path
  * @returns {URL} - The Review App preview URL
@@ -283,4 +304,5 @@ function getReviewAppUrl(prNumber, path = '/') {
 /**
  * @typedef {import('@octokit/plugin-rest-endpoint-methods').RestEndpointMethodTypes["issues"]} IssuesEndpoint
  * @typedef {IssuesEndpoint["listComments"]["parameters"]} IssueCommentsListParams
+ * @typedef {IssuesEndpoint["getComment"]["response"]["data"]} IssueCommentData
  */

--- a/.github/workflows/scripts/package.json
+++ b/.github/workflows/scripts/package.json
@@ -7,8 +7,9 @@
     "npm": "^10.1.0"
   },
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@govuk-frontend/lib": "*",
-    "@govuk-frontend/stats": "*"
+    "@govuk-frontend/stats": "*",
+    "outdent": "^0.8.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,10 @@
     ".github/workflows/scripts": {
       "name": "@govuk-frontend/workflow-scripts",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@govuk-frontend/lib": "*",
-        "@govuk-frontend/stats": "*"
+        "@govuk-frontend/stats": "*",
+        "outdent": "^0.8.0"
       },
       "engines": {
         "node": "^20.9.0",


### PR DESCRIPTION
This PR addresses some of the review comments in https://github.com/alphagov/govuk-frontend/pull/4511#pullrequestreview-1754871951

## Skipping empty GitHub diff comments

We no longer post "No diff changes found." comments, except for:

1. **JavaScript changes to GitHub release**
2. **Stylesheets changes to GitHub release**

This reduces comment noise for day-to-day PRs but keeps the important two for GitHub releases

<img width="643" alt="Empty comments" src="https://github.com/alphagov/govuk-frontend/assets/415517/59a142b5-ab8a-4b05-8fb5-a943c0bfbcae">

## Deleting outdated GitHub diff comments

What if a PR had a diff and a comment was added

But another push results in no diff, so we'd be left with an outdated comment that was already posted

With the comment now out of date, we now remove it via [GitHub REST API `issues.deleteComment`](https://octokit.github.io/rest.js/v20#issues-delete-comment)