### PR TITLE
Serve non-minified files for iFrame resizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15263,9 +15263,9 @@
       ]
     },
     "node_modules/iframe-resizer": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.7.tgz",
-      "integrity": "sha512-a3EGVScU9NtUpj6lWvGhVw3EfOw5AopRs5xGsQU385kWdgQt++OsD6PCnTV+8YkgBu/g28rLIh0EztFg9UQr1Q==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.9.tgz",
+      "integrity": "sha512-MCt+V/THB4a9OcAdrWo5NsI2CRpeMM4ijhTfiLtsdgDJXWYXf62Ve8yO8rKGmYNs991zty/EolYOxActlkfU+A==",
       "engines": {
         "node": ">=0.8.0"
       },
@@ -30491,7 +30491,7 @@
         "front-matter": "^4.0.2",
         "govuk-frontend": "*",
         "highlight.js": "^11.9.0",
-        "iframe-resizer": "^4.3.7",
+        "iframe-resizer": "^4.3.9",
         "js-beautify": "^1.14.11",
         "marked": "^10.0.0",
         "marked-linkify-it": "^3.1.6",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -33,7 +33,7 @@
     "front-matter": "^4.0.2",
     "govuk-frontend": "*",
     "highlight.js": "^11.9.0",
-    "iframe-resizer": "^4.3.7",
+    "iframe-resizer": "^4.3.9",
     "js-beautify": "^1.14.11",
     "marked": "^10.0.0",
     "marked-linkify-it": "^3.1.6",

--- a/packages/govuk-frontend-review/src/views/component-preview.njk
+++ b/packages/govuk-frontend-review/src/views/component-preview.njk
@@ -16,5 +16,5 @@
 {% endblock %}
 
 {% block scripts %}
-  <script type="module" src="/vendor/iframe-resizer/iframeResizer.contentWindow.min.js"></script>
+  <script type="module" src="/vendor/iframe-resizer/iframeResizer.contentWindow.js"></script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/layouts/layout.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/layout.njk
@@ -11,7 +11,7 @@
 {% block bodyEnd %}
   {{ super() }}
   {% block scripts %}
-    <script type="module" src="/vendor/iframe-resizer/iframeResizer.min.js"></script>
+    <script type="module" src="/vendor/iframe-resizer/iframeResizer.js"></script>
     <script type="module">
       const $examples = document.querySelectorAll('.js-component-preview')
 


### PR DESCRIPTION
Testing an alternative route to [bundling iframe-resizer in the review app](https://github.com/alphagov/govuk-frontend/pull/4489), for solving iframe-resized having removed its minified files from the bundle.

Downside is slightly larger files served to the browser, but it avoids us the setup of a build process for the JavaScript of the review app.