### PR TITLE
Move `setFocus()` to common utilities

### DIFF
--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -69,7 +69,7 @@ module.exports = {
             require: {
               ClassDeclaration: true,
               ClassExpression: true,
-              FunctionExpression: true,
+              FunctionExpression: false,
               MethodDefinition: true
             }
           }

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -134,6 +134,52 @@ export function getFragmentFromUrl(url) {
 }
 
 /**
+ * Move focus to element
+ *
+ * Sets tabindex to -1 to make the element programmatically focusable,
+ * but removes it on blur as the element doesn't need to be focused again.
+ *
+ * @private
+ * @template {HTMLElement} FocusElement
+ * @param {FocusElement} $element - HTML element
+ * @param {object} [options] - Handler options
+ * @param {function(this: FocusElement): void} [options.onFocus] - Callback on focus
+ * @param {function(this: FocusElement): void} [options.onBlur] - Callback on blur
+ */
+export function setFocus($element, options = {}) {
+  const isFocusable = $element.getAttribute('tabindex')
+
+  if (!isFocusable) {
+    $element.setAttribute('tabindex', '-1')
+  }
+
+  /**
+   * Handle element focus
+   */
+  function onFocus() {
+    $element.addEventListener('blur', onBlur, { once: true })
+  }
+
+  /**
+   * Handle element blur
+   */
+  function onBlur() {
+    options.onBlur?.call($element)
+
+    if (!isFocusable) {
+      $element.removeAttribute('tabindex')
+    }
+  }
+
+  // Add listener to reset element on blur, after focus
+  $element.addEventListener('focus', onFocus, { once: true })
+
+  // Focus element
+  options.onFocus?.call($element)
+  $element.focus()
+}
+
+/**
  * Checks if GOV.UK Frontend is supported on this page
  *
  * Some browsers will load and run our JavaScript but GOV.UK Frontend

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -143,7 +143,7 @@ export function getFragmentFromUrl(url) {
  * @template {HTMLElement} FocusElement
  * @param {FocusElement} $element - HTML element
  * @param {object} [options] - Handler options
- * @param {function(this: FocusElement): void} [options.onFocus] - Callback on focus
+ * @param {function(this: FocusElement): void} [options.onBeforeFocus] - Callback before focus
  * @param {function(this: FocusElement): void} [options.onBlur] - Callback on blur
  */
 export function setFocus($element, options = {}) {
@@ -175,7 +175,7 @@ export function setFocus($element, options = {}) {
   $element.addEventListener('focus', onFocus, { once: true })
 
   // Focus element
-  options.onFocus?.call($element)
+  options.onBeforeFocus?.call($element)
   $element.focus()
 }
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -1,4 +1,8 @@
-import { getFragmentFromUrl, mergeConfigs } from '../../common/index.mjs'
+import {
+  getFragmentFromUrl,
+  mergeConfigs,
+  setFocus
+} from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
@@ -44,29 +48,14 @@ export class ErrorSummary extends GOVUKFrontendComponent {
       normaliseDataset($module.dataset)
     )
 
-    this.setFocus()
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
-  }
-
-  /**
-   * Focus the error summary
-   *
-   * @private
-   */
-  setFocus() {
-    if (this.config.disableAutoFocus) {
-      return
+    /**
+     * Focus the error summary
+     */
+    if (!this.config.disableAutoFocus) {
+      setFocus(this.$module)
     }
 
-    // Set tabindex to -1 to make the element programmatically focusable, but
-    // remove it on blur as the error summary doesn't need to be focused again.
-    this.$module.setAttribute('tabindex', '-1')
-
-    this.$module.addEventListener('blur', () => {
-      this.$module.removeAttribute('tabindex')
-    })
-
-    this.$module.focus()
+    this.$module.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,4 +1,4 @@
-import { mergeConfigs } from '../../common/index.mjs'
+import { mergeConfigs, setFocus } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
@@ -41,43 +41,23 @@ export class NotificationBanner extends GOVUKFrontendComponent {
       normaliseDataset($module.dataset)
     )
 
-    this.setFocus()
-  }
-
-  /**
-   * Focus the element
-   *
-   * If `role="alert"` is set, focus the element to help some assistive
-   * technologies prioritise announcing it.
-   *
-   * You can turn off the auto-focus functionality by setting
-   * `data-disable-auto-focus="true"` in the component HTML. You might wish to
-   * do this based on user research findings, or to avoid a clash with another
-   * element which should be focused when the page loads.
-   *
-   * @private
-   */
-  setFocus() {
-    if (this.config.disableAutoFocus) {
-      return
+    /**
+     * Focus the notification banner
+     *
+     * If `role="alert"` is set, focus the element to help some assistive
+     * technologies prioritise announcing it.
+     *
+     * You can turn off the auto-focus functionality by setting
+     * `data-disable-auto-focus="true"` in the component HTML. You might wish to
+     * do this based on user research findings, or to avoid a clash with another
+     * element which should be focused when the page loads.
+     */
+    if (
+      this.$module.getAttribute('role') === 'alert' &&
+      !this.config.disableAutoFocus
+    ) {
+      setFocus(this.$module)
     }
-
-    if (this.$module.getAttribute('role') !== 'alert') {
-      return
-    }
-
-    // Set tabindex to -1 to make the element focusable with JavaScript. Remove
-    // the tabindex on blur as the component doesn't need to be focusable after
-    // the page has loaded.
-    if (!this.$module.getAttribute('tabindex')) {
-      this.$module.setAttribute('tabindex', '-1')
-
-      this.$module.addEventListener('blur', () => {
-        this.$module.removeAttribute('tabindex')
-      })
-    }
-
-    this.$module.focus()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -88,7 +88,7 @@ export class SkipLink extends GOVUKFrontendComponent {
      */
     this.$module.addEventListener('click', () =>
       setFocus($linkedElement, {
-        onFocus() {
+        onBeforeFocus() {
           $linkedElement.classList.add('govuk-skip-link-focused-element')
         },
         onBlur() {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -89,10 +89,10 @@ export class SkipLink extends GOVUKFrontendComponent {
     this.$module.addEventListener('click', () =>
       setFocus($linkedElement, {
         onFocus() {
-          this.classList.add('govuk-skip-link-focused-element')
+          $linkedElement.classList.add('govuk-skip-link-focused-element')
         },
         onBlur() {
-          this.classList.remove('govuk-skip-link-focused-element')
+          $linkedElement.classList.remove('govuk-skip-link-focused-element')
         }
       })
     )

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,4 +1,4 @@
-import { getFragmentFromUrl } from '../../common/index.mjs'
+import { getFragmentFromUrl, setFocus } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
@@ -10,12 +10,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 export class SkipLink extends GOVUKFrontendComponent {
   /** @private */
   $module
-
-  /** @private */
-  $linkedElement
-
-  /** @private */
-  linkedElementListener = false
 
   /**
    * @param {Element | null} $module - HTML element to use for skip link
@@ -86,57 +80,22 @@ export class SkipLink extends GOVUKFrontendComponent {
       })
     }
 
-    this.$linkedElement = $linkedElement
-
-    this.$module.addEventListener('click', () => this.focusLinkedElement())
-  }
-
-  /**
-   * Focus the linked element
-   *
-   * Set tabindex and helper CSS class. Set listener to remove them on blur.
-   *
-   * @private
-   */
-  focusLinkedElement() {
-    if (!this.$linkedElement) {
-      return
-    }
-
-    if (!this.$linkedElement.getAttribute('tabindex')) {
-      // Set the element tabindex to -1 so it can be focused with JavaScript.
-      this.$linkedElement.setAttribute('tabindex', '-1')
-      this.$linkedElement.classList.add('govuk-skip-link-focused-element')
-
-      // Add listener for blur on the focused element (unless the listener has
-      // previously been added)
-      if (!this.linkedElementListener) {
-        this.$linkedElement.addEventListener('blur', () =>
-          this.removeFocusProperties()
-        )
-        this.linkedElementListener = true
-      }
-    }
-
-    this.$linkedElement.focus()
-  }
-
-  /**
-   * Remove the tabindex that makes the linked element focusable because the
-   * element only needs to be focusable until it has received programmatic focus
-   * and a screen reader has announced it.
-   *
-   * Remove the CSS class that removes the native focus styles.
-   *
-   * @private
-   */
-  removeFocusProperties() {
-    if (!this.$linkedElement) {
-      return
-    }
-
-    this.$linkedElement.removeAttribute('tabindex')
-    this.$linkedElement.classList.remove('govuk-skip-link-focused-element')
+    /**
+     * Focus the linked element on click
+     *
+     * Adds a helper CSS class to hide native focus styles,
+     * but removes it on blur to restore native focus styles
+     */
+    this.$module.addEventListener('click', () =>
+      setFocus($linkedElement, {
+        onFocus() {
+          this.classList.add('govuk-skip-link-focused-element')
+        },
+        onBlur() {
+          this.classList.remove('govuk-skip-link-focused-element')
+        }
+      })
+    )
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -334,7 +334,6 @@ export class I18n {
    * @type {{ [key: string]: (count: number) => PluralRule }}
    */
   static pluralRules = {
-    /* eslint-disable jsdoc/require-jsdoc */
     arabic(n) {
       if (n === 0) {
         return 'zero'
@@ -436,7 +435,6 @@ export class I18n {
       }
       return 'other'
     }
-    /* eslint-enable jsdoc/require-jsdoc */
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/2501 by moving our last bit of duplicated code to a common utility

* https://github.com/alphagov/govuk-frontend/issues/2501

>We only really had two big duplicated things:
>
>1. Different `getFragmentFromUrl()` implementations across **Error summary**, **Skip link** and **Tabs**
>2. Different `setFocus()` implementations across **Error summary**, **Notification banner**, **Skip link**


## Component `setFocus()` method

This PR picked up item 2) above and moved `setFocus()` to a common utility for:

1. Error summary
2. Notification banner
3. Skip link

Their implementations did vary slightly:

1. Skip link target focus is configured on every click, but skipped if `tabindex` is present
1. Notification banner focus is configured once, but skipped if `tabindex` is present
1. Error summary focus is configured once once, but never skipped
1. All three components add a `blur` listener to remove `tabindex`
1. Only Skip link prevents multiple `blur` listeners being added
1. Only Skip link toggles class `govuk-skip-link-focused-element` (see below)
1. Only Skip link calls it ~`setFocus()`~ `focusLinkedElement()`

### Skip link class toggle

Unlike other components that had `setFocus()` duplicated, **Skip link** toggles the `govuk-skip-link-focused-element` class on the target element in addition to managing the `tabindex` attribute

You'll see I've added `onFocus` and `onBlur` callbacks to the `setFocus()` utility to support this:

```mjs
/**
 * Focus the linked element on click
 *
 * Adds a helper CSS class to hide native focus styles,
 * but removes it on blur to restore native focus styles
 */
this.$module.addEventListener('click', () =>
  setFocus($linkedElement, {
    onBeforeFocus() {
      $linkedElement.classList.add('govuk-skip-link-focused-element')
    },
    onBlur() {
      $linkedElement.classList.remove('govuk-skip-link-focused-element')
    }
  })
)
```

### Total bundle size
`all.mjs` ~69.9 KiB~ 69.5 KiB