### PR TITLE
Fix Skip link hash fragment check for Exit this page

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.njk
@@ -20,3 +20,19 @@
     redirectUrl: "https://www.gov.uk/"
   }) }}
 {% endblock %}
+
+{% block bodyEnd %}
+  <script type="module" src="/javascripts/govuk-frontend.min.js"></script>
+  <script type="module">
+    import { ExitThisPage, SkipLink } from '/javascripts/govuk-frontend.min.js'
+
+    const $skipLinks = document.querySelectorAll('[data-module="govuk-skip-link"]')
+    const $exitThisPage = document.querySelector('[data-module="govuk-exit-this-page"]')
+
+    $skipLinks.forEach(($skipLink) => {
+      new SkipLink($skipLink)
+    })
+
+    new ExitThisPage($exitThisPage)
+  </script>
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -36,18 +36,7 @@ export class SkipLink extends GOVUKFrontendComponent {
     }
 
     this.$module = $module
-    this.$linkedElement = this.getLinkedElement()
 
-    this.$module.addEventListener('click', () => this.focusLinkedElement())
-  }
-
-  /**
-   * Get linked element
-   *
-   * @private
-   * @returns {HTMLElement} $linkedElement - Target of the skip link
-   */
-  getLinkedElement() {
     const linkedElementId = getFragmentFromUrl(this.$module.hash)
 
     // Check for link hash fragment
@@ -68,7 +57,9 @@ export class SkipLink extends GOVUKFrontendComponent {
       })
     }
 
-    return $linkedElement
+    this.$linkedElement = $linkedElement
+
+    this.$module.addEventListener('click', () => this.focusLinkedElement())
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -39,6 +39,12 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     const hash = this.$module.hash
     const href = this.$module.getAttribute('href') ?? ''
+    const url = new window.URL(this.$module.href)
+
+    // Check for external link URL and return early
+    if (url.origin !== window.location.origin) {
+      return
+    }
 
     const linkedElementId = getFragmentFromUrl(hash)
 
@@ -73,6 +79,10 @@ export class SkipLink extends GOVUKFrontendComponent {
    * @private
    */
   focusLinkedElement() {
+    if (!this.$linkedElement) {
+      return
+    }
+
     if (!this.$linkedElement.getAttribute('tabindex')) {
       // Set the element tabindex to -1 so it can be focused with JavaScript.
       this.$linkedElement.setAttribute('tabindex', '-1')
@@ -101,6 +111,10 @@ export class SkipLink extends GOVUKFrontendComponent {
    * @private
    */
   removeFocusProperties() {
+    if (!this.$linkedElement) {
+      return
+    }
+
     this.$linkedElement.removeAttribute('tabindex')
     this.$linkedElement.classList.remove('govuk-skip-link-focused-element')
   }

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -39,7 +39,24 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     const hash = this.$module.hash
     const href = this.$module.getAttribute('href') ?? ''
-    const url = new window.URL(this.$module.href)
+
+    /** @type {URL | undefined} */
+    let url
+
+    /**
+     * Check for valid link URL
+     *
+     * {@link https://caniuse.com/url}
+     * {@link https://url.spec.whatwg.org}
+     *
+     */
+    try {
+      url = new window.URL(this.$module.href)
+    } catch (error) {
+      throw new ElementError(
+        `Skip link: Target link (\`href="${href}"\`) is invalid`
+      )
+    }
 
     // Check for external link URL and return early
     if (url.origin !== window.location.origin) {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -66,9 +66,11 @@ export class SkipLink extends GOVUKFrontendComponent {
     const linkedElementId = getFragmentFromUrl(hash)
 
     // Check for link hash fragment
-    if (!linkedElementId) {
+    if (!linkedElementId || url.pathname !== window.location.pathname) {
       throw new ElementError(
-        `Skip link: Target link (\`href="${href}"\`) has no hash fragment`
+        !linkedElementId
+          ? `Skip link: Target link (\`href="${href}"\`) has no hash fragment`
+          : `Skip link: Target link (\`href="${href}"\`) must stay on page (\`${window.location.pathname}\`)`
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -58,19 +58,20 @@ export class SkipLink extends GOVUKFrontendComponent {
       )
     }
 
-    // Check for external link URL and return early
-    if (url.origin !== window.location.origin) {
+    // Return early for external URLs or links to other pages
+    if (
+      url.origin !== window.location.origin ||
+      url.pathname !== window.location.pathname
+    ) {
       return
     }
 
     const linkedElementId = getFragmentFromUrl(hash)
 
-    // Check for link hash fragment
-    if (!linkedElementId || url.pathname !== window.location.pathname) {
+    // Check link path matching current page
+    if (!linkedElementId) {
       throw new ElementError(
-        !linkedElementId
-          ? `Skip link: Target link (\`href="${href}"\`) has no hash fragment`
-          : `Skip link: Target link (\`href="${href}"\`) must stay on page (\`${window.location.pathname}\`)`
+        `Skip link: Target link (\`href="${href}"\`) has no hash fragment`
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -37,12 +37,15 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    const linkedElementId = getFragmentFromUrl(this.$module.hash)
+    const hash = this.$module.hash
+    const href = this.$module.getAttribute('href') ?? ''
+
+    const linkedElementId = getFragmentFromUrl(hash)
 
     // Check for link hash fragment
     if (!linkedElementId) {
       throw new ElementError(
-        'Skip link: Root element (`$module`) attribute (`href`) has no URL fragment'
+        `Skip link: Target link (\`href="${href}"\`) has no hash fragment`
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -76,6 +76,33 @@ describe('Skip Link', () => {
       })
     })
 
+    it('can return early without errors when linking to another page (without hash fragment)', async () => {
+      await render(page, 'skip-link', {
+        context: {
+          text: 'Exit this page',
+          href: '/clear-session-data'
+        }
+      })
+    })
+
+    it('can return early without errors when linking to another page (with hash fragment)', async () => {
+      await render(page, 'skip-link', {
+        context: {
+          text: 'Skip to main content',
+          href: '/somewhere-else#main-content'
+        }
+      })
+    })
+
+    it('can return early without errors when linking to the current page (with hash fragment)', async () => {
+      await render(page, 'skip-link', {
+        context: {
+          text: 'Skip to main content',
+          href: '#content'
+        }
+      })
+    })
+
     it('can throw a SupportError if appropriate', async () => {
       await expect(
         render(page, 'skip-link', examples.default, {
@@ -146,31 +173,14 @@ describe('Skip Link', () => {
         render(page, 'skip-link', {
           context: {
             text: 'Skip to main content',
-            href: 'this-element-does-not-exist'
+            href: '/components/skip-link/preview'
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Target link (`href="this-element-does-not-exist"`) has no hash fragment'
-        }
-      })
-    })
-
-    it('throws when the href links to another page', async () => {
-      await expect(
-        render(page, 'skip-link', {
-          context: {
-            text: 'Skip to main content',
-            href: '/somewhere-else#main-content'
-          }
-        })
-      ).rejects.toMatchObject({
-        cause: {
-          name: 'ElementError',
-          message:
-            'Skip link: Target link (`href="/somewhere-else#main-content"`) must stay on page (`/components/skip-link/preview`)'
+            'Skip link: Target link (`href="/components/skip-link/preview"`) has no hash fragment'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -157,5 +157,22 @@ describe('Skip Link', () => {
         }
       })
     })
+
+    it('throws when the href links to another page', async () => {
+      await expect(
+        render(page, 'skip-link', {
+          context: {
+            text: 'Skip to main content',
+            href: '/somewhere-else#main-content'
+          }
+        })
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Skip link: Target link (`href="/somewhere-else#main-content"`) must stay on page (`/components/skip-link/preview`)'
+        }
+      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -67,6 +67,15 @@ describe('Skip Link', () => {
   })
 
   describe('errors at instantiation', () => {
+    it('can return early without errors for external href', async () => {
+      await render(page, 'skip-link', {
+        context: {
+          text: 'Exit this page',
+          href: 'https://www.bbc.co.uk/weather'
+        }
+      })
+    })
+
     it('can throw a SupportError if appropriate', async () => {
       await expect(
         render(page, 'skip-link', examples.default, {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -144,7 +144,7 @@ describe('Skip Link', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Root element (`$module`) attribute (`href`) has no URL fragment'
+            'Skip link: Target link (`href="this-element-does-not-exist"`) has no hash fragment'
         }
       })
     })


### PR DESCRIPTION
This PR ensures we ignore Skip link focus handling when linking to other pages

I noticed we throw an error on [Skip link `href: "https://www.gov.uk/"` for **Exit this page**](https://govuk-frontend-review.herokuapp.com/examples/exit-this-page-with-skiplink)

```console
Skip link: Root element (`$module`) attribute (`href`) has no URL fragment
```

For the guidance see [Skip link "**Adding the secondary link**" guidance](https://design-system.service.gov.uk/components/exit-this-page/#adding-the-secondary-link)

### Total bundle size
`all.mjs` ~69.41 KiB~ 69.9 KiB

It's good to note the file size increase due to the new errors, but see #4535 for ideas

## Hash fragment is missing

Since multiple skip links can exist on a page, the error message now includes `getAttribute('href')` from the source HTML attribute to help developer users identify which link is missing a hash fragment

### Before

```console
Skip link: Root element (`$module`) attribute (`href`) has no URL fragment
```

### After

```console
Skip link: Target link (`href="https://example.service.gov.uk"`) has no hash fragment
```

## Invalid URL error message

To skip external URLs we need to compare `location.origin` but this requires a valid URL

I've added a new error message should URL parsing fail:

```console
Skip link: Target link (`href="example.service.gov.uk"`) is invalid
```