### PR TITLE
[SPIKE] Enable Terser ES module aware minification

### DIFF
--- a/packages/govuk-frontend/rollup.release.config.mjs
+++ b/packages/govuk-frontend/rollup.release.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig(({ i: input }) => ({
      */
     plugins: [
       terser({
+        ecma: 2015,
         format: { comments: false },
         mangle: {
           keep_classnames: true,
@@ -37,6 +38,7 @@ export default defineConfig(({ i: input }) => ({
           // non-function string constants like `export { version }`
           reserved: Object.keys(GOVUKFrontend)
         },
+        module: true,
 
         // Include sources content from source maps to inspect
         // GOV.UK Frontend and other dependencies' source code


### PR DESCRIPTION
We forgot to enable Terser `module: true` now we use [ES modules for `govuk-frontend.min.js` ](https://github.com/alphagov/govuk-frontend/pull/3726)

Adding this config change to see what the diff looks like

**Surprise:** Nothing