### PR TITLE
[SPIKE] Password input component - hybrid approach

### DIFF
--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -137,6 +137,10 @@ describe('GOV.UK Prototype Kit config', () => {
           macroName: 'govukPanel'
         },
         {
+          importFrom: 'govuk/components/password-input/macro.njk',
+          macroName: 'govukPasswordInput'
+        },
+        {
           importFrom: 'govuk/components/phase-banner/macro.njk',
           macroName: 'govukPhaseBanner'
         },

--- a/packages/govuk-frontend/src/govuk/all.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.jsdom.test.mjs
@@ -14,6 +14,7 @@ jest.mock(`./components/error-summary/error-summary.mjs`)
 jest.mock(`./components/exit-this-page/exit-this-page.mjs`)
 jest.mock(`./components/header/header.mjs`)
 jest.mock(`./components/notification-banner/notification-banner.mjs`)
+jest.mock(`./components/password-input/password-input.mjs`)
 jest.mock(`./components/radios/radios.mjs`)
 jest.mock(`./components/skip-link/skip-link.mjs`)
 jest.mock(`./components/tabs/tabs.mjs`)
@@ -27,7 +28,8 @@ describe('initAll', () => {
     'character-count',
     'error-summary',
     'exit-this-page',
-    'notification-banner'
+    'notification-banner',
+    'password-input'
   ]
 
   afterEach(() => {

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -10,6 +10,7 @@ import { ErrorSummary } from './components/error-summary/error-summary.mjs'
 import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs'
 import { Header } from './components/header/header.mjs'
 import { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
+import { PasswordInput } from './components/password-input/password-input.mjs'
 import { Radios } from './components/radios/radios.mjs'
 import { SkipLink } from './components/skip-link/skip-link.mjs'
 import { Tabs } from './components/tabs/tabs.mjs'
@@ -41,6 +42,7 @@ function initAll(config) {
     [ExitThisPage, config.exitThisPage],
     [Header],
     [NotificationBanner, config.notificationBanner],
+    [PasswordInput, config.passwordInput],
     [Radios],
     [SkipLink],
     [Tabs]
@@ -81,6 +83,7 @@ export {
   ExitThisPage,
   Header,
   NotificationBanner,
+  PasswordInput,
   Radios,
   SkipLink,
   Tabs
@@ -96,6 +99,7 @@ export {
  * @property {ErrorSummaryConfig} [errorSummary] - Error Summary config
  * @property {ExitThisPageConfig} [exitThisPage] - Exit This Page config
  * @property {NotificationBannerConfig} [notificationBanner] - Notification Banner config
+ * @property {PasswordInputConfig} [passwordInput] - Password input config
  */
 
 /**
@@ -110,6 +114,7 @@ export {
  * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageConfig} ExitThisPageConfig
  * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageTranslations} ExitThisPageTranslations
  * @typedef {import('./components/notification-banner/notification-banner.mjs').NotificationBannerConfig} NotificationBannerConfig
+ * @typedef {import('./components/password-input/password-input.mjs').PasswordInputConfig} PasswordInputConfig
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/components/_all.scss
+++ b/packages/govuk-frontend/src/govuk/components/_all.scss
@@ -23,6 +23,7 @@
 @import "notification-banner/index";
 @import "pagination/index";
 @import "panel/index";
+@import "password-input/index";
 @import "phase-banner/index";
 @import "radios/index";
 @import "select/index";

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -43,6 +43,7 @@ describe('GOV.UK Frontend', () => {
         'ExitThisPage',
         'Header',
         'NotificationBanner',
+        'PasswordInput',
         'Radios',
         'SkipLink',
         'Tabs'

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -54,6 +54,7 @@
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
   {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
+  {%- if params.autocapitalize %} autocapitalize="{{ params.autocapitalize }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
 
   {%- if params.suffix.text or params.suffix.html -%}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -1,0 +1,26 @@
+@import "../button/index";
+@import "../error-message/index";
+@import "../hint/index";
+@import "../input/index";
+@import "../label/index";
+
+@include govuk-exports("govuk/component/password-input") {
+  .govuk-password-input {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+
+    @include govuk-media-query($from: mobile) {
+      flex-direction: row;
+    }
+  }
+
+  .govuk-password-input__toggle {
+    margin-bottom: 0;
+
+    // Buttons are normally 100% width on this breakpoint, but we don't want that in this case
+    @include govuk-media-query($from: mobile) {
+      width: auto;
+    }
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -5,7 +5,7 @@
 @import "../label/index";
 
 @include govuk-exports("govuk/component/password-input") {
-  .govuk-password-input {
+  .govuk-password-input__container {
     display: flex;
     width: 100%;
     flex-direction: column;

--- a/packages/govuk-frontend/src/govuk/components/password-input/_password-input.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_password-input.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/packages/govuk-frontend/src/govuk/components/password-input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/accessibility.puppeteer.test.mjs
@@ -1,0 +1,15 @@
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
+import { getExamples } from '@govuk-frontend/lib/components'
+
+describe('/components/password-input', () => {
+  describe('component examples', () => {
+    it('passes accessibility tests', async () => {
+      const examples = await getExamples('password-input')
+
+      for (const exampleName in examples) {
+        await render(page, 'password-input', examples[exampleName])
+        await expect(axe(page)).resolves.toHaveNoViolations()
+      }
+    }, 120000)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/password-input/macro.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukPasswordInput(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -91,7 +91,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     $showHideButton.setAttribute('type', 'button')
     $showHideButton.setAttribute(
       'aria-label',
-      this.i18n.t('showPasswordFullText')
+      this.i18n.t('showPasswordAriaLabel')
     )
     $showHideButton.innerHTML = this.i18n.t('showPassword')
     this.$showHideButton = $showHideButton
@@ -100,7 +100,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     // Create and append the status text for screen readers
     const $statusText = document.createElement('span')
     $statusText.className = 'govuk-visually-hidden'
-    $statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    $statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
     $statusText.setAttribute('aria-live', 'polite')
     this.$statusText = $statusText
     this.$wrapper.insertBefore($statusText, this.$input.nextSibling)
@@ -135,12 +135,12 @@ export class PasswordInput extends GOVUKFrontendComponent {
     this.$showHideButton.setAttribute(
       'aria-label',
       passwordIsHidden
-        ? this.i18n.t('showPasswordFullText')
-        : this.i18n.t('hidePasswordFullText')
+        ? this.i18n.t('showPasswordAriaLabel')
+        : this.i18n.t('hidePasswordAriaLabel')
     )
     this.$statusText.innerText = passwordIsHidden
-      ? this.i18n.t('hiddenPasswordAnnouncement')
-      : this.i18n.t('shownPasswordAnnouncement')
+      ? this.i18n.t('passwordHiddenAnnouncement')
+      : this.i18n.t('passwordShownAnnouncement')
   }
 
   /**
@@ -150,10 +150,10 @@ export class PasswordInput extends GOVUKFrontendComponent {
   revertToPasswordOnFormSubmit() {
     this.$showHideButton.setAttribute(
       'aria-label',
-      this.i18n.t('showPasswordFullText')
+      this.i18n.t('showPasswordAriaLabel')
     )
     this.$showHideButton.innerHTML = this.i18n.t('showPassword')
-    this.$statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    this.$statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
     this.$input.setAttribute('type', 'password')
   }
 
@@ -175,10 +175,10 @@ export class PasswordInput extends GOVUKFrontendComponent {
     i18n: {
       showPassword: 'Show',
       hidePassword: 'Hide',
-      showPasswordFullText: 'Show password',
-      hidePasswordFullText: 'Hide password',
-      shownPasswordAnnouncement: 'Your password is visible',
-      hiddenPasswordAnnouncement: 'Your password is hidden'
+      showPasswordAriaLabel: 'Show password',
+      hidePasswordAriaLabel: 'Hide password',
+      passwordShownAnnouncement: 'Your password is visible',
+      passwordHiddenAnnouncement: 'Your password is hidden'
     }
   })
 
@@ -212,14 +212,14 @@ export class PasswordInput extends GOVUKFrontendComponent {
  *   password is currently hidden. HTML is acceptable.
  * @property {string} [hidePassword] - Visible text of the button when the
  *   password is currently visible. HTML is acceptable.
- * @property {string} [showPasswordFullText] - aria-label of the button when
+ * @property {string} [showPasswordAriaLabel] - aria-label of the button when
  *   the password is currently hidden. Plain text only.
- * @property {string} [hidePasswordFullText] - aria-label of the button when
+ * @property {string} [hidePasswordAriaLabel] - aria-label of the button when
  *   the password is currently visible. Plain text only.
- * @property {string} [shownPasswordAnnouncement] - Screen reader
+ * @property {string} [passwordShownAnnouncement] - Screen reader
  *   announcement to make when the password has just become visible.
  *   Plain text only.
- * @property {string} [hiddenPasswordAnnouncement] - Screen reader
+ * @property {string} [passwordHiddenAnnouncement] - Screen reader
  *   announcement to make when the password has just been hidden.
  *   Plain text only.
  */

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -51,7 +51,6 @@ export class PasswordInput extends GOVUKFrontendComponent {
       })
     }
 
-    this.$wrapper = $module
     this.$input = $module.querySelector('input')
 
     if (!(this.$input instanceof HTMLInputElement)) {
@@ -79,6 +78,13 @@ export class PasswordInput extends GOVUKFrontendComponent {
       // Read the fallback if necessary rather than have it set in the defaults
       locale: closestAttributeValue($module, 'lang')
     })
+
+    // Create an element to wrap around the input as it doesn't exist in HTML
+    const $wrapper = document.createElement('div')
+    $wrapper.className = 'govuk-password-input__container'
+    this.$input.parentNode.insertBefore($wrapper, this.$input)
+    $wrapper.appendChild(this.$input)
+    this.$wrapper = $wrapper
 
     // Create and append the button element
     const $showHideButton = document.createElement('button')

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -1,0 +1,229 @@
+import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
+import {
+  extractConfigByNamespace,
+  mergeConfigs,
+  validateConfig
+} from '../../common/index.mjs'
+import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+import { I18n } from '../../i18n.mjs'
+
+/**
+ * Password input component
+ *
+ * @preserve
+ */
+export class PasswordInput extends GOVUKFrontendComponent {
+  /** @private */
+  $module
+
+  /**
+   * @private
+   * @type {PasswordInputConfig}
+   */
+  config
+
+  /**
+   * @private
+   * @type {HTMLElement | null}
+   */
+  $showHideButton = null
+
+  /**
+   * @private
+   * @type {HTMLElement | null}
+   */
+  $statusText = null
+
+  /**
+   * @param {Element} $module - HTML element to use for password input
+   * @param {PasswordInputConfig} [config] - Password input config
+   */
+  constructor($module, config = {}) {
+    super()
+
+    if (!($module instanceof HTMLElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: $module,
+        identifier: 'Root element (`$module`)'
+      })
+    }
+
+    this.$wrapper = $module
+    this.$input = $module.querySelector('input')
+
+    if (!(this.$input instanceof HTMLInputElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: this.$input,
+        expectedType: 'HTMLInputElement',
+        identifier: 'Form field (`.govuk-password-input`)'
+      })
+    }
+
+    this.config = mergeConfigs(
+      PasswordInput.defaults,
+      config || {},
+      normaliseDataset($module.dataset)
+    )
+
+    // Check for valid config
+    const errors = validateConfig(PasswordInput.schema, this.config)
+    if (errors[0]) {
+      throw new ConfigError(`Password input: ${errors[0]}`)
+    }
+
+    this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'), {
+      // Read the fallback if necessary rather than have it set in the defaults
+      locale: closestAttributeValue($module, 'lang')
+    })
+
+    // Create and append the button element
+    const $showHideButton = document.createElement('button')
+    $showHideButton.className =
+      'govuk-button govuk-button--secondary govuk-password-input__toggle'
+    $showHideButton.setAttribute(
+      'aria-controls',
+      this.$input.getAttribute('id')
+    )
+    $showHideButton.setAttribute('type', 'button')
+    $showHideButton.setAttribute(
+      'aria-label',
+      this.i18n.t('showPasswordFullText')
+    )
+    $showHideButton.innerHTML = this.i18n.t('showPassword')
+    this.$showHideButton = $showHideButton
+    this.$wrapper.insertBefore($showHideButton, this.$input.nextSibling)
+
+    // Create and append the status text for screen readers
+    const $statusText = document.createElement('span')
+    $statusText.className = 'govuk-visually-hidden'
+    $statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    $statusText.setAttribute('aria-live', 'polite')
+    this.$statusText = $statusText
+    this.$wrapper.insertBefore($statusText, this.$input.nextSibling)
+
+    // Bind toggle button
+    this.$showHideButton.addEventListener(
+      'click',
+      this.togglePassword.bind(this)
+    )
+
+    // Bind form submit check, unless it's been disabled
+    if (this.$input.form && !this.config.disableFormSubmitCheck) {
+      this.$input.form.addEventListener('submit', () =>
+        this.revertToPasswordOnFormSubmit()
+      )
+    }
+  }
+
+  /**
+   * @param {MouseEvent} event -
+   */
+  togglePassword(event) {
+    event.preventDefault()
+    this.$input.setAttribute(
+      'type',
+      this.$input.type === 'password' ? 'text' : 'password'
+    )
+    const passwordIsHidden = this.$input.type === 'password'
+    this.$showHideButton.innerHTML = passwordIsHidden
+      ? this.i18n.t('showPassword')
+      : this.i18n.t('hidePassword')
+    this.$showHideButton.setAttribute(
+      'aria-label',
+      passwordIsHidden
+        ? this.i18n.t('showPasswordFullText')
+        : this.i18n.t('hidePasswordFullText')
+    )
+    this.$statusText.innerText = passwordIsHidden
+      ? this.i18n.t('hiddenPasswordAnnouncement')
+      : this.i18n.t('shownPasswordAnnouncement')
+  }
+
+  /**
+   * Revert the input to type=password when the form is submitted. This prevents
+   * user agents potentially saving or caching the plain text password.
+   */
+  revertToPasswordOnFormSubmit() {
+    this.$showHideButton.setAttribute(
+      'aria-label',
+      this.i18n.t('showPasswordFullText')
+    )
+    this.$showHideButton.innerHTML = this.i18n.t('showPassword')
+    this.$statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    this.$input.setAttribute('type', 'password')
+  }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-password-input'
+
+  /**
+   * Password input default config
+   *
+   * @see {@link PasswordInputConfig}
+   * @constant
+   * @default
+   * @type {PasswordInputConfig}
+   */
+  static defaults = Object.freeze({
+    disableFormSubmitCheck: false,
+    i18n: {
+      showPassword: 'Show',
+      hidePassword: 'Hide',
+      showPasswordFullText: 'Show password',
+      hidePasswordFullText: 'Hide password',
+      shownPasswordAnnouncement: 'Your password is visible',
+      hiddenPasswordAnnouncement: 'Your password is hidden'
+    }
+  })
+
+  /**
+   * Character count config schema
+   *
+   * @constant
+   * @satisfies {Schema}
+   */
+  static schema = Object.freeze({})
+}
+
+/**
+ * Password input config
+ *
+ * @typedef {object} PasswordInputConfig
+ * @property {boolean} [disableFormSubmitCheck=false] - If set to `true` the
+ *   password input will not automatically change back to the `password` type
+ *   upon submission of the parent form.
+ * @property {PasswordInputTranslations} [i18n=PasswordInput.defaults.i18n] - Password input translations
+ */
+
+/**
+ * Password input translations
+ *
+ * @see {@link PasswordInput.defaults.i18n}
+ * @typedef {object} PasswordInputTranslations
+ *
+ * Messages displayed to the user indicating the state of the show/hide toggle.
+ * @property {string} [showPassword] - Visible text of the button when the
+ *   password is currently hidden. HTML is acceptable.
+ * @property {string} [hidePassword] - Visible text of the button when the
+ *   password is currently visible. HTML is acceptable.
+ * @property {string} [showPasswordFullText] - aria-label of the button when
+ *   the password is currently hidden. Plain text only.
+ * @property {string} [hidePasswordFullText] - aria-label of the button when
+ *   the password is currently visible. Plain text only.
+ * @property {string} [shownPasswordAnnouncement] - Screen reader
+ *   announcement to make when the password has just become visible.
+ *   Plain text only.
+ * @property {string} [hiddenPasswordAnnouncement] - Screen reader
+ *   announcement to make when the password has just been hidden.
+ *   Plain text only.
+ */
+
+/**
+ * @typedef {import('../../common/index.mjs').Schema} Schema
+ */

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -45,3 +45,15 @@ examples:
       newPassword: true
       id: password-input-new-password
       name: password
+  - name: with translations
+    options:
+      label:
+        text: Cyfrinair
+      id: password-translated
+      name: password-translated
+      showPasswordText: Datguddia
+      hidePasswordText: Cuddio
+      showPasswordAriaLabelText: Datgelu cyfrinair
+      hidePasswordAriaLabelText: Cuddio cyfrinair
+      passwordShownAnnouncementText: Mae eich cyfrinair yn weladwy.
+      passwordHiddenAnnouncementText: Mae eich cyfrinair wedi'i guddio.

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -1,0 +1,47 @@
+params:
+  - name: id
+    type: string
+    required: true
+    description: The ID of the input.
+
+examples:
+  - name: default
+    options:
+      label:
+        text: Password
+      id: password-input
+      name: password
+  - name: with hint text
+    options:
+      label:
+        text: Password
+      hint:
+        text: It probably has some letters, numbers and maybe even some symbols in it.
+      id: password-input-with-hint-text
+      name: test-name-2
+  - name: with error message
+    options:
+      label:
+        text: Password
+      hint:
+        text: It probably has some letters, numbers and maybe even some symbols in it.
+      id: password-input-with-error-message
+      name: test-name-3
+      errorMessage:
+        text: Error message goes here
+  - name: with label as page heading
+    options:
+      label:
+        text: Password
+        classes: govuk-label--l
+        isPageHeading: true
+      id: password-input-with-page-heading
+      name: test-name
+  - name: with new-password autocomplete
+    description: Browsers and password managers should prompt to generate a password.
+    options:
+      label:
+        text: Password
+      newPassword: true
+      id: password-input-new-password
+      name: password

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,0 +1,59 @@
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
+
+{#- a record of other elements that we need to associate with the input using
+  aria-describedby – for example hints or error messages -#}
+{% set describedBy = params.describedBy if params.describedBy else "" %}
+
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+  {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+
+  <div class="govuk-password-input" data-module="govuk-password-input">
+
+    <input
+      class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"
+      id="{{ params.id }}"
+      name="{{ params.name }}"
+      type="password"
+      spellcheck="false"
+      autocapitalize="off"
+      autocomplete="{{ 'new-password' if params.newPassword else 'current-password' }}"
+      {%- if params.value %} value="{{ params.value}}"{% endif %}
+      {%- if params.disabled %} disabled{% endif %}
+      {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+      {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+
+  </div>
+
+</div>

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,3 +1,5 @@
+{% from "../../macros/i18n.njk" import govukI18nAttributes %}
+
 {% from "../error-message/macro.njk" import govukErrorMessage -%}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -39,7 +41,14 @@
   }) | indent(2) | trim }}
 {% endif %}
 
-  <div class="govuk-password-input" data-module="govuk-password-input">
+  <div class="govuk-password-input" data-module="govuk-password-input"
+    {%- if params.disableFormSubmitCheck %} data-disable-form-submit-check="true"{% endif %}
+    {{- govukI18nAttributes({ key: 'show-password', message: params.showPasswordText }) -}}
+    {{- govukI18nAttributes({ key: 'hide-password', message: params.hidePasswordText }) -}}
+    {{- govukI18nAttributes({ key: 'show-password-aria-label', message: params.showPasswordAriaLabelText }) -}}
+    {{- govukI18nAttributes({ key: 'hide-password-aria-label', message: params.hidePasswordAriaLabelText }) -}}
+    {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
+    {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}>
 
     <input
       class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,68 +1,36 @@
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
+{% from "../input/macro.njk" import govukInput -%}
 
-{#- a record of other elements that we need to associate with the input using
-  aria-describedby – for example hints or error messages -#}
-{% set describedBy = params.describedBy if params.describedBy else "" %}
+<div class="govuk-password-input" data-module="govuk-password-input"
+  {%- if params.disableFormSubmitCheck %} data-disable-form-submit-check="true"{% endif %}
+  {{- govukI18nAttributes({ key: 'show-password', message: params.showPasswordText }) -}}
+  {{- govukI18nAttributes({ key: 'hide-password', message: params.hidePasswordText }) -}}
+  {{- govukI18nAttributes({ key: 'show-password-aria-label', message: params.showPasswordAriaLabelText }) -}}
+  {{- govukI18nAttributes({ key: 'hide-password-aria-label', message: params.hidePasswordAriaLabelText }) -}}
+  {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
+  {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}
+>
+  {{ govukInput({
+    label: params.label,
+    hint: params.hint,
+    errorMessage: params.errorMessage,
+    formGroup: params.formGroup,
+    describedBy: params.describedBy,
+    prefix: params.prefix,
+    suffix: params.suffix,
+    classes: params.classes,
+    id: params.id,
+    name: params.name,
+    value: params.value,
+    disabled: params.disabled,
+    pattern: params.pattern,
+    inputmode: params.inputmode,
+    attributes: params.attributes,
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-  {{ govukLabel({
-    html: params.label.html,
-    text: params.label.text,
-    classes: params.label.classes,
-    isPageHeading: params.label.isPageHeading,
-    attributes: params.label.attributes,
-    for: params.id
-  }) | indent(2) | trim }}
-{% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
-
-  <div class="govuk-password-input" data-module="govuk-password-input"
-    {%- if params.disableFormSubmitCheck %} data-disable-form-submit-check="true"{% endif %}
-    {{- govukI18nAttributes({ key: 'show-password', message: params.showPasswordText }) -}}
-    {{- govukI18nAttributes({ key: 'hide-password', message: params.hidePasswordText }) -}}
-    {{- govukI18nAttributes({ key: 'show-password-aria-label', message: params.showPasswordAriaLabelText }) -}}
-    {{- govukI18nAttributes({ key: 'hide-password-aria-label', message: params.hidePasswordAriaLabelText }) -}}
-    {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
-    {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}>
-
-    <input
-      class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"
-      id="{{ params.id }}"
-      name="{{ params.name }}"
-      type="password"
-      spellcheck="false"
-      autocapitalize="off"
-      autocomplete="{{ 'new-password' if params.newPassword else 'current-password' }}"
-      {%- if params.value %} value="{{ params.value}}"{% endif %}
-      {%- if params.disabled %} disabled{% endif %}
-      {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-      {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
-
-  </div>
-
+    type: 'password',
+    autocomplete: 'new-password' if params.newPassword else 'current-password',
+    spellcheck: false,
+    autocapitalize: 'off'
+  }) }}
 </div>

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -184,6 +184,7 @@ describe('packages/govuk-frontend/dist/', () => {
           import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs';
           import { Header } from './components/header/header.mjs';
           import { NotificationBanner } from './components/notification-banner/notification-banner.mjs';
+          import { PasswordInput } from './components/password-input/password-input.mjs';
           import { Radios } from './components/radios/radios.mjs';
           import { SkipLink } from './components/skip-link/skip-link.mjs';
           import { Tabs } from './components/tabs/tabs.mjs';
@@ -191,7 +192,7 @@ describe('packages/govuk-frontend/dist/', () => {
 
         // Look for ES modules named exports
         expect(contents).toContain(
-          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };'
+          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, PasswordInput, Radios, SkipLink, Tabs, initAll };'
         )
       })
     })


### PR DESCRIPTION
Alternative approach to a password input component using the 'hybrid' approach documented in #4512. Like the 'standalone' spike (#4442), there are no tests or documentation included. 

As noted in #4512, this demonstrates a few things:
- There is less code duplication compared to entirely standalone.
- There is slightly less flexibility in how HTML can be used. In this instance, the `govuk-password-input` div has had to move to be outside of `govuk-form-group` and new JavaScript added to create the necessary 'wrapper' around the input/button. 
- A lot of parameters need to be manually forwarded down to the child macro, similar to the character count.
  - This is actually neater than the character count's case, as that has to override some nested parameters. 
  - It could be neatened up still if we decide that some features of text input are just not useful in this context. i.e. Do we realistically want the `pattern`, `inputmode`, `prefix` or `suffix` options to be available for password inputs?
  - I think the DOM changes needed for `prefix` and `suffix` are incompatible with the DOM changes needed for password input anyway.
- The input component has had to be updated to add new parameters that the password input needs, as they cannot be applied directly in the password input component. 
  - Or rather, they could, if we hijacked the `attributes` parameter, but then end users couldn't use it and we probably don't want that. 