### PR TITLE
[SPIKE] Enable Rollup ES2015 helper code

### DIFF
--- a/packages/govuk-frontend-review/rollup.config.mjs
+++ b/packages/govuk-frontend-review/rollup.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig(({ i: input }) => ({
   output: {
     compact: true,
     format: 'es',
+    generatedCode: 'es2015',
 
     /**
      * Output plugins

--- a/packages/govuk-frontend/rollup.publish.config.mjs
+++ b/packages/govuk-frontend/rollup.publish.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig(({ i: input }) => ({
     {
       entryFileNames: '[name].mjs',
       format: 'es',
+      generatedCode: 'es2015',
 
       // Separate modules, not bundled
       preserveModules: true
@@ -30,6 +31,7 @@ export default defineConfig(({ i: input }) => ({
      */
     {
       format: 'es',
+      generatedCode: 'es2015',
 
       // Bundled modules
       preserveModules: false
@@ -41,6 +43,7 @@ export default defineConfig(({ i: input }) => ({
      */
     {
       format: 'umd',
+      generatedCode: 'es2015',
 
       // Bundled modules
       preserveModules: false,

--- a/packages/govuk-frontend/rollup.release.config.mjs
+++ b/packages/govuk-frontend/rollup.release.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig(({ i: input }) => ({
   output: {
     compact: true,
     format: 'es',
+    generatedCode: 'es2015',
 
     // Bundled modules
     preserveModules: false,

--- a/packages/govuk-frontend/rollup.release.config.mjs
+++ b/packages/govuk-frontend/rollup.release.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig(({ i: input }) => ({
      */
     plugins: [
       terser({
+        ecma: 2015,
         format: { comments: false },
         mangle: {
           keep_classnames: true,
@@ -37,6 +38,7 @@ export default defineConfig(({ i: input }) => ({
           // non-function string constants like `export { version }`
           reserved: Object.keys(GOVUKFrontend)
         },
+        module: true,
 
         // Include sources content from source maps to inspect
         // GOV.UK Frontend and other dependencies' source code

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -28,7 +28,8 @@ export default defineConfig(
          */
         output: {
           file: join('dist', modulePath),
-          format: 'es'
+          format: 'es',
+          generatedCode: 'es2015'
         },
 
         /**


### PR DESCRIPTION
We forgot to enable Rollup `generatedCode: 'es2015'` now we use [ES modules for `govuk-frontend.min.js` ](https://github.com/alphagov/govuk-frontend/pull/3726)

Adding this config change to see what the diff looks like

Builds on top of https://github.com/alphagov/govuk-frontend/pull/4537