### PR TITLE
Workaround delays in `~/.npm` cache restore time

### DIFF
--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -16,5 +16,4 @@ runs:
 
       with:
         cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}
-        check-latest: true
         node-version-file: .nvmrc

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -11,7 +11,7 @@ runs:
 
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4.0.0
+      uses: actions/setup-node@v3.8.2
       id: setup-node
 
       with:

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v3.8.2
         with:
           cache: npm
           node-version: 8 # Node.js 8 supported by Dart Sass v1.0.0
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v3.8.2
         with:
           cache: npm
           check-latest: true
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v3.8.2
         with:
           cache: npm
           node-version: 4 # Node.js 4 supported by Node Sass v3.4.0
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v3.8.2
         with:
           cache: npm
           check-latest: true

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -50,7 +50,6 @@ jobs:
         uses: actions/setup-node@v3.8.2
         with:
           cache: npm
-          check-latest: true
           node-version-file: .nvmrc # Node.js project version must support Dart Sass v1
 
       - name: Install package
@@ -103,7 +102,6 @@ jobs:
         uses: actions/setup-node@v3.8.2
         with:
           cache: npm
-          check-latest: true
           node-version-file: .nvmrc # Node.js project version must support Node Sass v8.x
 
       - name: Install package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,7 +275,7 @@ jobs:
         uses: ./.github/workflows/actions/build
 
       - name: Change Node.js version
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v3.8.2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -61,12 +61,12 @@
     "version": "echo $npm_package_version"
   },
   "devDependencies": {
+    "@babel/core": "^7.23.6",
+    "@babel/preset-env": "^7.23.6",
     "@govuk-frontend/config": "*",
     "@govuk-frontend/helpers": "*",
     "@govuk-frontend/lib": "*",
     "@govuk-frontend/tasks": "*",
-    "@babel/core": "^7.23.6",
-    "@babel/preset-env": "^7.23.6",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",


### PR DESCRIPTION
We've seen 5+ minutes for Windows `~/.npm` cache restore since https://github.com/alphagov/govuk-frontend/pull/4494 was merged

This PR rolls back to ~[`actions/setup-node@v4.0.0`](https://github.com/actions/setup-node/releases/tag/v4.0.0)~ [`actions/setup-node@v3.8.2`](https://github.com/actions/setup-node/releases/tag/v3.8.2) to avoid it:

<img width="310" alt="Windows cache restore time" src="https://github.com/alphagov/govuk-frontend/assets/415517/0e7bc2f3-df67-4e70-be18-9df8802c1d8e">

<br>
<br>

### Node.js `keepAlive` default

The issue is [caused by Node.js](https://github.com/nodejs/node/issues/47228) and [fixed in `actions/cache`](https://github.com/actions/cache/issues/810) but needs an `actions/setup-node` bump

* https://github.com/actions/setup-node/issues/878

There was a similar fix for [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby/issues/543) for more information