### PR TITLE
Update CHANGELOG with a working workaroud for removal of govuk-if-ie8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,11 @@ If a library you depend on is not yet updated and relies on these mixins and var
 ```scss
 $govuk-is-ie8: false;
 $govuk-ie8-breakpoint: ('desktop');
-@mixin govuk-if-ie8 {}
+@mixin govuk-if-ie8 {
+  @if false {
+    @content;
+  }
+}
 @mixin govuk-not-ie8 {@content}
 ```
 


### PR DESCRIPTION
Mixins that accept content require `@content`, otherwise Sass fails to compile so the example need updating. 

[Release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0) and [PR content](https://github.com/alphagov/govuk-frontend/pull/4540) have already been updated.

Closes #4556