### PR TITLE
Use Gulp to copy files instead of `cpy`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8779,22 +8779,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/copy-file": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/copy-file/-/copy-file-11.0.0.tgz",
-      "integrity": "sha512-mFsNh/DIANLqFt5VHZoGirdg7bK5+oTWlhnGu6tgRhzBlnEKWaPX2xrFaLltii/6rmhqFMJqffUgknuRdpYlHw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.11",
-        "p-event": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/copy-props": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.5.tgz",
@@ -8936,57 +8920,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cpy": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-11.0.0.tgz",
-      "integrity": "sha512-vA71mFQyIxCrqvP/9JBLCj05UJV/+WpvAxZK2/EiK5ndD090cjuChfJ3ExVVuZXHoTJ/3HLedOPYDWyxnNHjrg==",
-      "dev": true,
-      "dependencies": {
-        "copy-file": "^11.0.0",
-        "globby": "^13.2.2",
-        "junk": "^4.0.1",
-        "micromatch": "^4.0.5",
-        "p-filter": "^3.0.0",
-        "p-map": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cpy/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cpy/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/create-jest": {
@@ -18886,18 +18819,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/junk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
-      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/just-debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
@@ -22125,94 +22046,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-event": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
-      "integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
-      "dev": true,
-      "dependencies": {
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-filter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-3.0.0.tgz",
-      "integrity": "sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==",
-      "dev": true,
-      "dependencies": {
-        "p-map": "^5.1.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-filter/node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-filter/node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-filter/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-filter/node_modules/p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -22243,18 +22076,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
-      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -22275,18 +22096,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -30723,7 +30532,6 @@
         "@npmcli/run-script": "^7.0.2",
         "@percy/puppeteer": "^2.0.2",
         "chalk": "^5.3.0",
-        "cpy": "^11.0.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^2.3.0",
         "nunjucks": "^3.2.4",

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -22,7 +22,8 @@ export const watch = (options) =>
      */
     task.name('lint:scss watch', () =>
       gulp.watch(
-        [join(options.srcPath, '**/*.scss')],
+        '**/*.scss',
+        { cwd: options.srcPath },
 
         // Run Stylelint checks
         npm.script('lint:scss:cli', [
@@ -36,10 +37,8 @@ export const watch = (options) =>
      */
     task.name('compile:scss watch', () =>
       gulp.watch(
-        [
-          join(options.srcPath, '**/*.scss'),
-          join(paths.package, 'dist/govuk/all.scss')
-        ],
+        ['**/*.scss', join(paths.package, 'dist/govuk/all.scss')],
+        { cwd: options.srcPath },
 
         // Run Sass compile
         styles(options)
@@ -51,8 +50,8 @@ export const watch = (options) =>
      */
     task.name('lint:js watch', () =>
       gulp.watch(
-        join(options.srcPath, '**/*.{cjs,js,mjs}'),
-        { ignored: ['**/*.test.*'] },
+        '**/*.{cjs,js,mjs}',
+        { cwd: options.srcPath, ignored: ['**/*.test.*'] },
         gulp.parallel(
           // Run TypeScript compiler
           npm.script('build:types', ['--incremental', '--pretty'], options),
@@ -70,7 +69,8 @@ export const watch = (options) =>
      */
     task.name('compile:js watch', () =>
       gulp.watch(
-        [join(options.srcPath, 'javascripts/**/*.mjs')],
+        'javascripts/**/*.mjs',
+        { cwd: options.srcPath },
 
         // Run JavaScripts compile
         scripts(options)

--- a/packages/govuk-frontend/tasks/assets.mjs
+++ b/packages/govuk-frontend/tasks/assets.mjs
@@ -1,6 +1,6 @@
 import { join } from 'path'
 
-import { files, task } from '@govuk-frontend/tasks'
+import { task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
 /**
@@ -11,9 +11,8 @@ import gulp from 'gulp'
 export const assets = (options) =>
   gulp.series(
     task.name('copy:assets', () =>
-      files.copy('**/*', {
-        srcPath: join(options.srcPath, 'govuk/assets'),
-        destPath: join(options.destPath, 'govuk/assets')
-      })
+      gulp
+        .src(join(options.srcPath, 'govuk/assets/**/*'))
+        .pipe(gulp.dest(join(options.destPath, 'govuk/assets')))
     )
   )

--- a/packages/govuk-frontend/tasks/assets.mjs
+++ b/packages/govuk-frontend/tasks/assets.mjs
@@ -1,5 +1,3 @@
-import { join } from 'path'
-
 import { task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
@@ -12,7 +10,10 @@ export const assets = (options) =>
   gulp.series(
     task.name('copy:assets', () =>
       gulp
-        .src(join(options.srcPath, 'govuk/assets/**/*'))
-        .pipe(gulp.dest(join(options.destPath, 'govuk/assets')))
+        .src('govuk/assets/**/*', {
+          base: options.srcPath,
+          cwd: options.srcPath
+        })
+        .pipe(gulp.dest(options.destPath))
     )
   )

--- a/packages/govuk-frontend/tasks/build/package.mjs
+++ b/packages/govuk-frontend/tasks/build/package.mjs
@@ -1,5 +1,3 @@
-import { join } from 'path'
-
 import { paths } from '@govuk-frontend/config'
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
@@ -26,7 +24,10 @@ export default (options) =>
     // Copy GOV.UK Prototype Kit JavaScript
     task.name("copy:files 'govuk-prototype-kit'", () =>
       gulp
-        .src(join(options.srcPath, 'govuk-prototype-kit/**/*.js'))
-        .pipe(gulp.dest(join(options.destPath, 'govuk-prototype-kit')))
+        .src('govuk-prototype-kit/**/*.js', {
+          base: options.srcPath,
+          cwd: options.srcPath
+        })
+        .pipe(gulp.dest(options.destPath))
     )
   )

--- a/packages/govuk-frontend/tasks/build/package.mjs
+++ b/packages/govuk-frontend/tasks/build/package.mjs
@@ -1,7 +1,7 @@
 import { join } from 'path'
 
 import { paths } from '@govuk-frontend/config'
-import { files, npm, task } from '@govuk-frontend/tasks'
+import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
 import { assets, fixtures, scripts, styles, templates } from '../index.mjs'
@@ -25,9 +25,8 @@ export default (options) =>
 
     // Copy GOV.UK Prototype Kit JavaScript
     task.name("copy:files 'govuk-prototype-kit'", () =>
-      files.copy('**/*.js', {
-        srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-        destPath: join(options.destPath, 'govuk-prototype-kit')
-      })
+      gulp
+        .src(join(options.srcPath, 'govuk-prototype-kit/**/*.js'))
+        .pipe(gulp.dest(join(options.destPath, 'govuk-prototype-kit')))
     )
   )

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -17,8 +17,11 @@ export default (options) =>
     // Copy GOV.UK Frontend static assets
     task.name('copy:assets', () =>
       gulp
-        .src(join(options.srcPath, 'govuk/assets/**/*'))
-        .pipe(gulp.dest(join(options.destPath, 'assets')))
+        .src('govuk/assets/**/*', {
+          base: join(options.srcPath, 'govuk'),
+          cwd: options.srcPath
+        })
+        .pipe(gulp.dest(options.destPath))
     ),
 
     // Compile GOV.UK Frontend JavaScript

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -16,10 +16,9 @@ export default (options) =>
 
     // Copy GOV.UK Frontend static assets
     task.name('copy:assets', () =>
-      files.copy('**/*', {
-        srcPath: join(options.srcPath, 'govuk/assets'),
-        destPath: join(options.destPath, 'assets')
-      })
+      gulp
+        .src(join(options.srcPath, 'govuk/assets/**/*'))
+        .pipe(gulp.dest(join(options.destPath, 'assets')))
     ),
 
     // Compile GOV.UK Frontend JavaScript

--- a/packages/govuk-frontend/tasks/templates.mjs
+++ b/packages/govuk-frontend/tasks/templates.mjs
@@ -1,5 +1,3 @@
-import { join } from 'path'
-
 import { task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
@@ -12,7 +10,10 @@ export const templates = (options) =>
   gulp.series(
     task.name('copy:templates', () =>
       gulp
-        .src(join(options.srcPath, 'govuk/**/*.{md,njk}'))
+        .src('govuk/**/*.{md,njk}', {
+          base: options.srcPath,
+          cwd: options.srcPath
+        })
         .pipe(gulp.dest(options.destPath))
     )
   )

--- a/packages/govuk-frontend/tasks/templates.mjs
+++ b/packages/govuk-frontend/tasks/templates.mjs
@@ -1,6 +1,6 @@
 import { join } from 'path'
 
-import { files, task } from '@govuk-frontend/tasks'
+import { task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
 /**
@@ -11,9 +11,8 @@ import gulp from 'gulp'
 export const templates = (options) =>
   gulp.series(
     task.name('copy:templates', () =>
-      files.copy('**/*.{md,njk}', {
-        srcPath: join(options.srcPath, 'govuk'),
-        destPath: join(options.destPath, 'govuk')
-      })
+      gulp
+        .src(join(options.srcPath, 'govuk/**/*.{md,njk}'))
+        .pipe(gulp.dest(options.destPath))
     )
   )

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -24,7 +24,8 @@ export const watch = (options) =>
      */
     task.name('lint:scss watch', () =>
       gulp.watch(
-        [join(options.srcPath, '**/*.scss')],
+        '**/*.scss',
+        { cwd: options.srcPath },
 
         // Run Stylelint checks
         npm.script('lint:scss:cli', [
@@ -37,7 +38,7 @@ export const watch = (options) =>
      * Stylesheets build watcher
      */
     task.name('compile:scss watch', () =>
-      gulp.watch([join(options.srcPath, '**/*.scss')], styles(options))
+      gulp.watch('**/*.scss', { cwd: options.srcPath }, styles(options))
     ),
 
     /**
@@ -45,8 +46,8 @@ export const watch = (options) =>
      */
     task.name('lint:js watch', () =>
       gulp.watch(
-        join(options.srcPath, '**/*.{cjs,js,mjs}'),
-        { ignored: ['**/*.test.*'] },
+        '**/*.{cjs,js,mjs}',
+        { cwd: options.srcPath, ignored: ['**/*.test.*'] },
         gulp.parallel(
           // Run TypeScript compiler
           npm.script('build:types', ['--incremental', '--pretty'], options),
@@ -64,8 +65,8 @@ export const watch = (options) =>
      */
     task.name('compile:js watch', () =>
       gulp.watch(
-        join(options.srcPath, '**/*.{cjs,js,mjs}'),
-        { ignored: ['**/*.test.*'] },
+        '**/*.{cjs,js,mjs}',
+        { cwd: options.srcPath, ignored: ['**/*.test.*'] },
         scripts(options)
       )
     ),
@@ -75,7 +76,8 @@ export const watch = (options) =>
      */
     task.name('compile:fixtures watch', () =>
       gulp.watch(
-        [join(options.srcPath, 'govuk/components/*/*.yaml')],
+        'govuk/components/*/*.yaml',
+        { cwd: options.srcPath },
         fixtures(options)
       )
     ),
@@ -85,13 +87,14 @@ export const watch = (options) =>
      */
     task.name('copy:templates watch', () =>
       gulp.watch(
-        [join(options.srcPath, 'govuk/**/*.{md,njk}')],
+        'govuk/**/*.{md,njk}',
+        { cwd: options.srcPath },
         templates(options)
       )
     ),
 
     // Copy GOV.UK Frontend static assets
     task.name('copy:assets watch', () =>
-      gulp.watch([join(options.srcPath, 'govuk/assets/**')], assets(options))
+      gulp.watch('govuk/assets/**', { cwd: options.srcPath }, assets(options))
     )
   )

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -2,8 +2,6 @@ import { mkdir, writeFile } from 'fs/promises'
 import { dirname, join, parse } from 'path'
 
 import config from '@govuk-frontend/config'
-import cpy from 'cpy'
-import slash from 'slash'
 
 /**
  * Write `packages/govuk-frontend/package.json` version to file
@@ -40,17 +38,6 @@ export async function write(assetPath, { destPath, filePath, fileContents }) {
 
   await mkdir(dirname(assetDestPath), { recursive: true })
   await writeFile(assetDestPath, `${await fileContents()}\n`)
-}
-
-/**
- * Copy files task
- * Copies files to destination
- *
- * @param {string} pattern - Minimatch pattern
- * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
- */
-export async function copy(pattern, { srcPath, destPath }) {
-  await cpy([slash(join(srcPath, pattern))], destPath, { cwd: srcPath })
 }
 
 /**

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -15,7 +15,6 @@
     "@npmcli/run-script": "^7.0.2",
     "@percy/puppeteer": "^2.0.2",
     "chalk": "^5.3.0",
-    "cpy": "^11.0.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "nunjucks": "^3.2.4",


### PR DESCRIPTION
Adding a dash of Gulp back again 😶

Closes https://github.com/alphagov/govuk-frontend/issues/4439 by replacing our `files.copy()` task with `gulp.src()` + `gulp.dest()`

## Removing the `cpy` package

This lets us remove the [`cpy` package](https://www.npmjs.com/package/cpy) added in https://github.com/alphagov/govuk-frontend/pull/3382/commits/8edda314842332f4c11200b379f4de516ce9d45d due to the maintainer stating:

>**IMPORTANT:** This package has a lot of problems and I unfortunately don't have time to fix them. I would recommend against using this package until these problems are resolved. Help welcome (see the issue tracker) 🙏