### PR TITLE
Document nested components with subset of options

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -63,8 +63,17 @@ params:
       - name: label
         type: object
         required: false
-        description: Additional options for the label used by each checkbox item within the checkboxes component.
+        description: Subset of options for the label used by each checkbox item within the checkboxes component.
         isComponent: true
+        params:
+          - name: classes
+            type: string
+            required: false
+            description: Classes to add to the label tag.
+          - name: attributes
+            type: object
+            required: false
+            description: HTML attributes (for example data attributes) to add to the label tag.
       - name: hint
         type: object
         required: false

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -55,8 +55,17 @@ params:
       - name: label
         type: object
         required: false
-        description: Additional options for the label used by each radio item within the radios component.
+        description: Subset of options for the label used by each radio item within the radios component.
         isComponent: true
+        params:
+          - name: classes
+            type: string
+            required: false
+            description: Classes to add to the label tag.
+          - name: attributes
+            type: object
+            required: false
+            description: HTML attributes (for example data attributes) to add to the label tag.
       - name: hint
         type: object
         required: false


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/1779 and correctly documents:

1. **Radios** component nested `label` supports only `classes` and `attributes`
1. **Checkboxes** component nested `label` supports only `classes` and `attributes`

Adding component `option.params` creates a Nunjucks macro options table on the Design System website

But see the supporting change https://github.com/alphagov/govuk-design-system/pull/3372 to maintain a link to the component guidance

<img width="636" alt="Nunjucks macro options table" src="https://github.com/alphagov/govuk-frontend/assets/415517/c9d1885e-75ff-4a5d-a04a-526a0419118f">
