### PR TITLE
[SPIKE] Undo Tabs JS styling when initialisation fails

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/tabs/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_index.scss
@@ -45,7 +45,7 @@
   }
 
   // GOV.UK Frontend JavaScript enabled
-  .govuk-frontend-supported {
+  .govuk-frontend-supported .govuk-tabs:not(.govuk-tabs--error) {
     @include govuk-media-query($from: tablet) {
       .govuk-tabs__list {
         @include govuk-clearfix;

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -55,15 +55,18 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
+    this.$module = $module
+
     const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
+      this.$module.classList.add('govuk-tabs--error')
+
       throw new ElementError({
         componentName: 'Tabs',
         identifier: 'Links (`<a class="govuk-tabs__tab">`)'
       })
     }
 
-    this.$module = $module
     this.$tabs = $tabs
 
     // Save bound functions so we can remove event listeners during teardown
@@ -77,6 +80,8 @@ export class Tabs extends GOVUKFrontendComponent {
     )
 
     if (!$tabList) {
+      this.$module.classList.add('govuk-tabs--error')
+
       throw new ElementError({
         componentName: 'Tabs',
         identifier: 'List (`<ul class="govuk-tabs__list">`)'
@@ -84,6 +89,8 @@ export class Tabs extends GOVUKFrontendComponent {
     }
 
     if (!$tabListItems.length) {
+      this.$module.classList.add('govuk-tabs--error')
+
       throw new ElementError({
         componentName: 'Tabs',
         identifier: 'List items (`<li class="govuk-tabs__list-item">`)'


### PR DESCRIPTION
Another thing worth a quick spike

We've added extra reasons for the **Tabs** component to fail initialisation now `ElementError` is thrown

Since all of these are in control, could we add a class like `.govuk-tabs--error` to "undo" JS styling?

```patch
  // GOV.UK Frontend JavaScript enabled
- .govuk-frontend-supported {
+ .govuk-frontend-supported .govuk-tabs:not(.govuk-tabs--error) {
```

## Failing sensibly

Accidents happen. Errors can handled, and we can fall back to the non-JS experience:

<img width="899" alt="Tabs component without JS styling" src="https://github.com/alphagov/govuk-frontend/assets/415517/3988d7f8-6fff-40b6-806b-05aed2da9826">

Might close https://github.com/alphagov/govuk-frontend/issues/999