### PR TITLE
Use Character count `formGroup` as module wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+#### Update the HTML for the character count
+
+We've updated the HTML for the character count.
+
+The component wrapper `data-module="govuk-character-count"` and its form group `class="govuk-form-group"` are now combined as the same `<div>`. The hint text used as the count message is now placed directly after the `<textarea>`.
+
+If you're not using Nunjucks macros, then you should:
+
+- move all classes and attributes from the form group `<div>` to the component wrapper `<div>`
+- remove the opening `<div>` and closing `</div>` tags used by the form group
+- check the count message is now directly after the `<textarea>`
+
+The following example shows some HTML and the difference once it is updated.
+
+HTML before:
+
+```html
+<div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="100">
+  <div class="govuk-form-group">
+    <!-- // Label, hint, error and textarea -->
+  </div>
+  <!-- // Count message -->
+</div>
+```
+
+HTML after:
+
+```html
+<div class="govuk-form-group govuk-character-count" data-module="govuk-character-count" data-maxlength="100">
+  <!-- // Label, hint, error, textarea and count message -->
+</div>
+```
+
+Check your changes against [the character count example in the Design System](https://design-system.service.gov.uk/components/character-count/#character-count-example) to make sure you have correctly implemented them.
+
+This change was introduced in [pull request #4566: Use Character count `formGroup` as module wrapper](https://github.com/alphagov/govuk-frontend/pull/4566).
+
 ### Fixes
 
 - [#4811: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Tabs component](https://github.com/alphagov/govuk-frontend/pull/4811)

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -85,7 +85,12 @@
   }) -}}
 {% endset -%}
 
-<div class="govuk-character-count" {{- attributesHtml | safe }}>
+{#- Append form group attributes onto attributes set above #}
+{%- for name, value in params.formGroup.attributes %}
+  {% set attributesHtml = attributesHtml + " " + name | escape + '="' + value | escape + '"' %}
+{% endfor -%}
+
+<div class="govuk-character-count">
   {{ govukTextarea({
     id: params.id,
     name: params.name,
@@ -95,7 +100,7 @@
     value: params.value,
     formGroup: {
       classes: params.formGroup.classes,
-      attributes: params.formGroup.attributes,
+      attributes: attributesHtml,
       beforeInput: params.formGroup.beforeInput,
       afterInput: {
         html: countMessageHtml

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 {% from "../textarea/macro.njk" import govukTextarea %}
 {% from "../hint/macro.njk" import govukHint %}
@@ -23,10 +24,23 @@
 {% endif -%}
 {% endset -%}
 
-<div class="govuk-character-count" data-module="govuk-character-count"
-  {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
-  {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
-  {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
+{%- set attributesHtml %}
+  {{- govukAttributes({
+    "data-module": "govuk-character-count",
+    "data-maxlength": {
+      value: params.maxlength,
+      optional: true
+    },
+    "data-threshold": {
+      value: params.threshold,
+      optional: true
+    },
+    "data-maxwords": {
+      value: params.maxwords,
+      optional: true
+    }
+  }) -}}
+
   {#-
     Without maxlength or maxwords, we can't guess if the component will count words or characters.
     We can't guess a default textarea description to be interpolated in JavaScript
@@ -68,7 +82,10 @@
   {{- govukI18nAttributes({
     key: 'words-over-limit',
     messages: params.wordsOverLimitText
-  }) -}}>
+  }) -}}
+{% endset -%}
+
+<div class="govuk-character-count" {{- attributesHtml | safe }}>
   {{ govukTextarea({
     id: params.id,
     name: params.name,

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -90,33 +90,31 @@
   {% set attributesHtml = attributesHtml + " " + name | escape + '="' + value | escape + '"' %}
 {% endfor -%}
 
-<div class="govuk-character-count">
-  {{ govukTextarea({
-    id: params.id,
-    name: params.name,
-    describedBy: params.id + '-info',
-    rows: params.rows,
-    spellcheck: params.spellcheck,
-    value: params.value,
-    formGroup: {
-      classes: params.formGroup.classes,
-      attributes: attributesHtml,
-      beforeInput: params.formGroup.beforeInput,
-      afterInput: {
-        html: countMessageHtml
-      }
-    },
-    classes: 'govuk-js-character-count' + (' ' + params.classes if params.classes),
-    label: {
-      html: params.label.html,
-      text: params.label.text,
-      classes: params.label.classes,
-      isPageHeading: params.label.isPageHeading,
-      attributes: params.label.attributes,
-      for: params.id
-    },
-    hint: params.hint,
-    errorMessage: params.errorMessage,
-    attributes: params.attributes
-  }) | trim }}
-</div>
+{{ govukTextarea({
+  id: params.id,
+  name: params.name,
+  describedBy: params.id + '-info',
+  rows: params.rows,
+  spellcheck: params.spellcheck,
+  value: params.value,
+  formGroup: {
+    classes: 'govuk-character-count' + (' ' + params.formGroup.classes if params.formGroup.classes),
+    attributes: attributesHtml,
+    beforeInput: params.formGroup.beforeInput,
+    afterInput: {
+      html: countMessageHtml
+    }
+  },
+  classes: 'govuk-js-character-count' + (' ' + params.classes if params.classes),
+  label: {
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  },
+  hint: params.hint,
+  errorMessage: params.errorMessage,
+  attributes: params.attributes
+}) | trim }}

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -2,7 +2,26 @@
 {% from "../textarea/macro.njk" import govukTextarea %}
 {% from "../hint/macro.njk" import govukHint %}
 
+{#-
+  If the limit is set in JavaScript, we won't be able to interpolate the message
+  until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
+  were provided to the macro.
+#}
 {%- set hasNoLimit = (not params.maxwords and not params.maxlength) -%}
+{%- set textareaDescriptionLength = params.maxwords or params.maxlength -%}
+{%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') -%}
+{%- set textareaDescriptionTextNoLimit = textareaDescriptionText | replace('%{count}', textareaDescriptionLength) if not hasNoLimit -%}
+
+{%- set countMessageHtml %}
+{{ govukHint({
+  text: textareaDescriptionTextNoLimit,
+  id: params.id + '-info',
+  classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
+}) | trim }}
+{% if params.formGroup.afterInput %}
+  {{- params.formGroup.afterInput.html | safe | trim if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+{% endif -%}
+{% endset -%}
 
 <div class="govuk-character-count" data-module="govuk-character-count"
   {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
@@ -57,7 +76,14 @@
     rows: params.rows,
     spellcheck: params.spellcheck,
     value: params.value,
-    formGroup: params.formGroup,
+    formGroup: {
+      classes: params.formGroup.classes,
+      attributes: params.formGroup.attributes,
+      beforeInput: params.formGroup.beforeInput,
+      afterInput: {
+        html: countMessageHtml
+      }
+    },
     classes: 'govuk-js-character-count' + (' ' + params.classes if params.classes),
     label: {
       html: params.label.html,
@@ -70,18 +96,5 @@
     hint: params.hint,
     errorMessage: params.errorMessage,
     attributes: params.attributes
-  }) }}
-
-  {%- set textareaDescriptionLength = params.maxwords or params.maxlength %}
-  {%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
-  {#-
-    If the limit is set in JavaScript, we won't be able to interpolate the message
-    until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
-    were provided to the macro.
-  #}
-  {{ govukHint({
-    text: ((textareaDescriptionText) | replace('%{count}', textareaDescriptionLength) if not hasNoLimit),
-    id: params.id + '-info',
-    classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
-  }) | trim | indent(2) }}
+  }) | trim }}
 </div>


### PR DESCRIPTION
This is a non-breaking change to remove an unnecessary **Character count** wrapper

It uses the same `afterInput` approach adopted by **Password input** in https://github.com/alphagov/govuk-frontend/pull/4442

Closes https://github.com/alphagov/govuk-frontend/issues/1602, closes https://github.com/alphagov/govuk-frontend/issues/1649 and closes https://github.com/alphagov/govuk-frontend/issues/2893

## Before

The **Character count** component includes both a `data-module` wrapper and **Textarea** form group

```html
<div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="100">
  <div class="govuk-form-group govuk-form-group--error">
    <!-- // Label, hint, error and textarea -->
  </div>
  <!-- // Count message -->
</div>
```

## After

The **Character count** component adds `data-module` directly onto the **Textarea** form group

```html
<div class="govuk-form-group govuk-form-group--error govuk-character-count" data-module="govuk-character-count" data-maxlength="100">
  <!-- // Label, hint, error, textarea and count message -->
</div>
```