### PR TITLE
Add `beforeInput(s)` and `afterInput(s)` options to form groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### New features
+
+#### Insert custom HTML into component form group wrappers
+
+You can now insert custom HTML into form group wrappers for all components with form fields.
+
+```njk
+govukInput({
+  formGroup: {
+    beforeInput: {
+      html: "example"
+    },
+    afterInput: {
+      html: "example"
+    },
+  }
+})
+```
+
+This change was introduced in [pull request #4567: Add `beforeInput(s)` and `beforeInput(s)` options to form groups](https://github.com/alphagov/govuk-frontend/pull/4567).
+
 ## 5.1.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@5.1.0`. You can also find more information about [how to stay up to date in our documentation](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version).

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -55,6 +55,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInput
+        type: object
+        required: false
+        description: Content to add before the textarea used by the character count component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the textarea. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the textarea. If `html` is provided, the `text` option will be ignored.
+      - name: afterInput
+        type: object
+        required: false
+        description: Content to add after the textarea used by the character count component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the textarea. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the textarea. If `html` is provided, the `text` option will be ignored.
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -31,6 +31,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInputs
+        type: object
+        required: false
+        description: Content to add before all checkbox items within the checkboxes component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before all checkbox items. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before all checkbox items. If `html` is provided, the `text` option will be ignored.
+      - name: afterInputs
+        type: object
+        required: false
+        description: Content to add after all checkbox items within the checkboxes component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after all checkbox items. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after all checkbox items. If `html` is provided, the `text` option will be ignored.
   - name: idPrefix
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -44,6 +44,9 @@
 {% endif %}
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-checkboxes">
+    {% if params.formGroup.beforeInputs %}
+    {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
+    {% endif %}
     {% for item in params.items %}
       {% if item %}
         {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
@@ -100,6 +103,9 @@
         {% endif %}
       {% endif %}
     {% endfor %}
+    {% if params.formGroup.afterInputs %}
+    {{ params.formGroup.afterInputs.html | safe | trim | indent(4) if params.formGroup.afterInputs.html else params.formGroup.afterInputs.text }}
+    {% endif %}
   </div>
 {% endset -%}
 

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -67,6 +67,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInputs
+        type: object
+        required: false
+        description: Content to add before the inputs used by the date input component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the inputs. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the inputs. If `html` is provided, the `text` option will be ignored.
+      - name: afterInputs
+        type: object
+        required: false
+        description: Content to add after the inputs used by the date input component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the inputs. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the inputs. If `html` is provided, the `text` option will be ignored.
   - name: fieldset
     type: object
     required: false

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -57,6 +57,9 @@
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
+    {% if params.formGroup.beforeInputs %}
+    {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
+    {% endif %}
     {% for item in dateInputItems %}
     <div class="govuk-date-input__item">
       {{ govukInput({
@@ -75,7 +78,10 @@
         attributes: item.attributes
       }) | trim | indent(6) }}
     </div>
-  {% endfor %}
+    {% endfor %}
+    {% if params.formGroup.afterInputs %}
+    {{ params.formGroup.afterInputs.html | safe | trim | indent(4) if params.formGroup.afterInputs.html else params.formGroup.afterInputs.text }}
+    {% endif %}
   </div>
 {% endset -%}
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -47,6 +47,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInput
+        type: object
+        required: false
+        description: Content to add before the input used by the file upload component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the input. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the input. If `html` is provided, the `text` option will be ignored.
+      - name: afterInput
+        type: object
+        required: false
+        description: Content to add after the input used by the file upload component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the input. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the input. If `html` is provided, the `text` option will be ignored.
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -37,9 +37,15 @@
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | trim | indent(2) }}
 {% endif %}
+{% if params.formGroup.beforeInput %}
+  {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
+{% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+{% if params.formGroup.afterInput %}
+  {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+{% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -87,7 +87,7 @@ params:
   - name: formGroup
     type: object
     required: false
-    description: Additional options for the form group containing the text-input component.
+    description: Additional options for the form group containing the text input component.
     params:
       - name: classes
         type: string
@@ -97,6 +97,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInput
+        type: object
+        required: false
+        description: Content to add before the input used by the text input component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the input. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the input. If `html` is provided, the `text` option will be ignored.
+      - name: afterInput
+        type: object
+        required: false
+        description: Content to add after the input used by the text input component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the input. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the input. If `html` is provided, the `text` option will be ignored.
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -8,6 +8,8 @@
 
 {%- set hasPrefix = true if params.prefix and (params.prefix.text or params.prefix.html) else false %}
 {%- set hasSuffix = true if params.suffix and (params.suffix.text or params.suffix.html) else false %}
+{%- set hasBeforeInput = true if params.formGroup.beforeInput and (params.formGroup.beforeInput.text or params.formGroup.beforeInput.html) else false %}
+{%- set hasAfterInput = true if params.formGroup.afterInput and (params.formGroup.afterInput.text or params.formGroup.afterInput.html) else false %}
 
 {%- macro _inputElement(params) -%}
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default("text", true) }}"
@@ -60,11 +62,11 @@
   }) | trim | indent(2) }}
 {% endif %}
 
-{%- if params.formGroup.beforeInput %}
-  {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
-{% endif %}
-{%- if hasPrefix or hasSuffix %}
+{%- if hasPrefix or hasSuffix or hasBeforeInput or hasAfterInput %}
   <div class="govuk-input__wrapper">
+    {% if hasBeforeInput %}
+      {{- params.formGroup.beforeInput.html | safe | trim | indent(4, true) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
+    {% endif %}
     {% if hasPrefix %}
       {{- _affixItem(params.prefix, "prefix") | indent(2, true) }}
     {% endif %}
@@ -72,11 +74,11 @@
     {% if hasSuffix %}
       {{- _affixItem(params.suffix, "suffix") | indent(2, true) }}
     {% endif %}
+    {% if hasAfterInput %}
+      {{- params.formGroup.afterInput.html | safe | trim | indent(4, true) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+    {% endif %}
   </div>
 {% else %}
   {{ _inputElement(params) }}
 {% endif %}
-{%- if params.formGroup.afterInput %}
-  {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
-{% endif -%}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -60,6 +60,9 @@
   }) | trim | indent(2) }}
 {% endif %}
 
+{%- if params.formGroup.beforeInput %}
+  {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
+{% endif %}
 {%- if hasPrefix or hasSuffix %}
   <div class="govuk-input__wrapper">
     {% if hasPrefix %}
@@ -73,4 +76,7 @@
 {% else %}
   {{ _inputElement(params) }}
 {% endif %}
+{%- if params.formGroup.afterInput %}
+  {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+{% endif -%}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -27,6 +27,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInputs
+        type: object
+        required: false
+        description: Content to add before all radio items within the checkboxes component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before all radio items. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before all radio items. If `html` is provided, the `text` option will be ignored.
+      - name: afterInputs
+        type: object
+        required: false
+        description: Content to add after all radio items within the checkboxes component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after all radio items. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after all radio items. If `html` is provided, the `text` option will be ignored.
   - name: idPrefix
     type: string
     required: false
@@ -34,7 +60,7 @@ params:
   - name: name
     type: string
     required: true
-    description: Name attribute for all radio items.
+    description: Name attribute for the radio items.
   - name: items
     type: array
     required: true

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -41,6 +41,9 @@
 {% endif %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-radios">
+    {% if params.formGroup.beforeInputs %}
+    {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
+    {% endif %}
     {% for item in params.items %}
       {% if item %}
         {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
@@ -93,6 +96,9 @@
         {% endif %}
       {% endif %}
     {% endfor %}
+    {% if params.formGroup.afterInputs %}
+    {{ params.formGroup.afterInputs.html | safe | trim | indent(4) if params.formGroup.afterInputs.html else params.formGroup.afterInputs.text }}
+    {% endif %}
   </div>
 {% endset -%}
 

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -72,6 +72,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInput
+        type: object
+        required: false
+        description: Content to add before the select used by the select component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the select. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the select. If `html` is provided, the `text` option will be ignored.
+      - name: afterInput
+        type: object
+        required: false
+        description: Content to add after the select used by the select component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the select. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the select. If `html` is provided, the `text` option will be ignored.
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -37,6 +37,9 @@
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | trim | indent(2) }}
 {% endif %}
+{% if params.formGroup.beforeInput %}
+  {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
+{% endif %}
   <select class="govuk-select
     {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
     {%- if params.disabled %} disabled{% endif %}
@@ -53,4 +56,7 @@
     {% endif %}
   {% endfor %}
   </select>
+{% if params.formGroup.afterInput %}
+  {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+{% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.njk
@@ -37,10 +37,16 @@
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | trim | indent(2) }}
 {% endif %}
+{% if params.formGroup.beforeInput %}
+  {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
+{% endif %}
   <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ params.value }}</textarea>
+{% if params.formGroup.afterInput %}
+  {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+{% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -55,6 +55,32 @@ params:
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInput
+        type: object
+        required: false
+        description: Content to add before the textarea used by the textarea component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the textarea. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the textarea. If `html` is provided, the `text` option will be ignored.
+      - name: afterInput
+        type: object
+        required: false
+        description: Content to add after the textarea used by the textarea component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the textarea. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the textarea. If `html` is provided, the `text` option will be ignored.
   - name: classes
     type: string
     required: false


### PR DESCRIPTION
This PR adds support for component before/after content

This work is based on a fix suggested by @36degrees in https://github.com/alphagov/govuk-frontend/issues/1602#issuecomment-913740373 to solve these issues:

* https://github.com/alphagov/govuk-frontend/issues/924
* https://github.com/alphagov/govuk-frontend/issues/1602

>I don't think it'd have to be specific to hints though – we could allow e.g. an 'arbitrary' `formGroup.beforeHtml` / `formGroup.afterHtml` to be passed, which _might_ also be useful for scenarios like those described in #924

It is a supporting change to enable "components within components" as used by:

* https://github.com/alphagov/govuk-frontend/pull/4566
* https://github.com/alphagov/govuk-design-system/issues/3479

# Nunjucks options

I've picked "input" for all form controls (input, select, textarea) as we do with [**Error summary** `$input`](https://github.com/alphagov/govuk-frontend/blob/396996fba09f8ac6d08276f9b7c28c9739ce753d/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs#L104-L112)

All options considered might be:

1. `beforeInput`/`afterInput`
2. `beforeControl`/`afterControl`
3. `beforeField`/`afterField`

Nunjucks options have also been varied for components with single or multiple fields:

## Components with single form field

Use options `beforeInput` and `afterInput` for components with a single field

```js
govukInput({
  formGroup: {
    beforeInput: {
      html: "example HTML",
      text: "example text"
    },
    afterInput: {
      html: "example HTML",
      text: "example text"
    },
  }
})
```

## Components with single form field

Use options `beforeInputs` and `afterInputs` for components with multiple fields

```js
govukRadios({
  formGroup: {
    beforeInputs: {
      html: "example HTML",
      text: "example text"
    },
    afterInputs: {
      html: "example HTML",
      text: "example text"
    },
  }
})
```

☝️ Note that **Password input** will have an input + button combo, is the option name still suitable?