### PR TITLE
Bug fixes for Sass `gulp watch` tasks

### DIFF
--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -43,7 +43,13 @@ export const watch = (options) =>
     task.name('compile:scss watch', () =>
       gulp.watch(
         ['**/*.scss', join(paths.package, 'dist/govuk/all.scss')],
-        { cwd: options.srcPath },
+        {
+          cwd: options.srcPath,
+
+          // Prevent early Sass compile by ignoring delete (unlink) event
+          // when GOV.UK Frontend runs the `clean` script before build
+          events: ['add', 'change']
+        },
 
         // Run Sass compile
         styles(options)

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -44,6 +44,7 @@ export const watch = (options) =>
       gulp.watch(
         ['**/*.scss', join(paths.package, 'dist/govuk/all.scss')],
         {
+          awaitWriteFinish: true,
           cwd: options.srcPath,
 
           // Prevent early Sass compile by ignoring delete (unlink) event

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -9,9 +9,14 @@ import { scripts, styles } from './index.mjs'
 
 /**
  * Watch task
+ *
  * During development, this task will:
+ *
  * - lint and run `gulp styles` when `.scss` files change
- * - lint and run `gulp scripts` when `.mjs` files change
+ * - lint and run `gulp scripts` when `.{cjs,js,mjs}` files change
+ *
+ * These tasks respond to `gulp watch` output from GOV.UK Frontend:
+ * {@link file://./../../govuk-frontend/tasks/watch.mjs}
  *
  * @type {import('@govuk-frontend/tasks').TaskFunction}
  */

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -8,12 +8,17 @@ import { assets, fixtures, scripts, styles, templates } from './index.mjs'
 
 /**
  * Watch task
+ *
  * During development, this task will:
+ *
  * - lint and run `gulp styles` when `.scss` files change
  * - lint and run `gulp scripts` when `.{cjs,js,mjs}` files change
  * - lint and run `gulp fixtures` when `.yaml` files change
  * - lint and run `gulp templates` when `.{md,njk}` files change
  * - lint and run `gulp assets` when assets change
+ *
+ * These tasks build output for `gulp watch` in Review app:
+ * {@link file://./../../govuk-frontend-review/tasks/watch.mjs}
  *
  * @type {import('@govuk-frontend/tasks').TaskFunction}
  */
@@ -38,7 +43,13 @@ export const watch = (options) =>
      * Stylesheets build watcher
      */
     task.name('compile:scss watch', () =>
-      gulp.watch('**/*.scss', { cwd: options.srcPath }, styles(options))
+      gulp.watch(
+        '**/*.scss',
+        { cwd: options.srcPath },
+
+        // Run Sass compile
+        styles(options)
+      )
     ),
 
     /**
@@ -67,6 +78,8 @@ export const watch = (options) =>
       gulp.watch(
         '**/*.{cjs,js,mjs}',
         { cwd: options.srcPath, ignored: ['**/*.test.*'] },
+
+        // Run JavaScripts compile
         scripts(options)
       )
     ),
@@ -78,6 +91,8 @@ export const watch = (options) =>
       gulp.watch(
         'govuk/components/*/*.yaml',
         { cwd: options.srcPath },
+
+        // Run fixtures compile
         fixtures(options)
       )
     ),
@@ -89,12 +104,20 @@ export const watch = (options) =>
       gulp.watch(
         'govuk/**/*.{md,njk}',
         { cwd: options.srcPath },
+
+        // Run templates copy
         templates(options)
       )
     ),
 
     // Copy GOV.UK Frontend static assets
     task.name('copy:assets watch', () =>
-      gulp.watch('govuk/assets/**', { cwd: options.srcPath }, assets(options))
+      gulp.watch(
+        'govuk/assets/**',
+        { cwd: options.srcPath },
+
+        // Run assets copy
+        assets(options)
+      )
     )
   )


### PR DESCRIPTION
Couple of bug fixes with more info in the commit messages

* Prevent `gulp watch` early Sass compile after `clean` script runs
* Ensure `gulp watch` task waits for PostCSS to complete task

See https://github.com/alphagov/govuk-frontend/pull/3910#discussion_r1254347310 for previous discussion