### PR TITLE
Add test for incorrectly hoisted Dependabot updates

### DIFF
--- a/package-lock.json.unit.test.mjs
+++ b/package-lock.json.unit.test.mjs
@@ -1,0 +1,31 @@
+describe('package-lock.json', () => {
+  /** @type {import('./package-lock.json')} */
+  let packageLockJson
+
+  beforeAll(async () => {
+    packageLockJson = await import('./package-lock.json')
+  })
+
+  describe('Dependabot updates', () => {
+    /**
+     * When this check fails, the incorrect `package-lock.json` can be repaired
+     * by checking out the Dependabot branch and running `npm install` to remove
+     * the hoisted dependency
+     *
+     * {@link https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/pull-requests#reviewing-a-pr-from-dependabot}
+     */
+    it("should not hoist 'optionalDependencies' to 'dependencies'", () => {
+      const { dependencies, optionalDependencies } =
+        packageLockJson.packages['']
+
+      // List package names for comparison
+      const packageNames = Object.keys(dependencies ?? {})
+      const packageNamesOptional = Object.keys(optionalDependencies ?? {})
+
+      // Check no optional dependencies are hoisted
+      for (const name of packageNamesOptional) {
+        expect(packageNames).not.toContain(name)
+      }
+    })
+  })
+})


### PR DESCRIPTION
We know some Dependabot `"optionalDependencies"` updates get incorrectly hoisted to `"dependencies"`

See our [Team Docs **Reviewing a PR from Dependabot**](https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/pull-requests#reviewing-a-pr-from-dependabot) for the manual checks we do

## Hoisted optional dependencies

For safety, this PR adds a test for project-level `"dependencies"` to ensure we don't miss stray ones:

```patch
        "docs/examples/*"
      ],
+     "dependencies": {
+       "@types/node": "^20.10.5"
+     },
      "devDependencies": {
```

We have no **package.json** `"dependencies"` currently but might do one day

For example, this test on [Design System PR #3381](https://github.com/alphagov/govuk-design-system/pull/3381) looks like:

<img width="1132" alt="Failing test when optional dependencies have been hoisted" src="https://github.com/alphagov/govuk-frontend/assets/415517/8278debf-11ab-442b-a7a5-e531797f08e7">
