### PR TITLE
Ensure tests run against the latest version of the Nunjucks template

### DIFF
--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -155,8 +155,7 @@ function render(componentName, options) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  // Return built fixture or render
-  return options?.fixture?.html ?? renderMacro(macroName, macroPath, options)
+  return renderMacro(macroName, macroPath, options)
 }
 
 /**


### PR DESCRIPTION
This reverts commit fca508c3f5e678c76b320e281caa86985a5bd5c4.

Using `options?.fixture?.html` provides a neat speed optimisation when running the tests on CI (where we already rendered all of the fixtures to HTML and they will not change).

However, for local development, we currently [only update the fixtures based on watching the YAML files][1]. This means they are not updated when the Nunjucks template changes, so tests can run on outdated versions of templates, which is confusing and potentially misleading.

We discussed additionally watching for changes to the Nunjucks templates as well, however there is still a race condition when running tests (especially as the fixture generation currently takes ~1.6-1.8s)

For now, prioritise correctness over speed for local development. We could potentially re-enable this optimisation in the future, but perhaps only when running on CI?

[1]: https://github.com/alphagov/govuk-frontend/blob/60b0a67bcd7cbb9c072c0fd573c30cdd5c2d31ba/packages/govuk-frontend/tasks/watch.mjs#L92