### PR TITLE
Omit nav element and menu button when header `navigation` is an empty array

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -331,3 +331,8 @@ examples:
           text: Navigation item 3
         - href: '#4'
           text: Navigation item 4
+
+  - name: empty navigation array
+    hidden: true
+    options:
+      navigation: []

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -51,7 +51,7 @@
         {% endif %}
       </a>
     </div>
-    {% if params.serviceName or params.navigation  %}
+    {% if params.serviceName or params.navigation | length %}
     <div class="govuk-header__content">
     {% if params.serviceName %}
     {% if params.serviceUrl %}
@@ -64,7 +64,7 @@
       </span>
     {% endif %}
     {% endif %}
-    {% if params.navigation %}
+    {% if params.navigation | length %}
     <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>{{ menuButtonText }}</button>
 

--- a/packages/govuk-frontend/src/govuk/components/header/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/template.test.js
@@ -249,6 +249,29 @@ describe('header', () => {
     })
   })
 
+  describe.each([
+    { message: 'without navigation', exampleName: 'default' },
+    { message: 'with empty navigation', exampleName: 'empty navigation array' }
+  ])('$message', ({ exampleName }) => {
+    let $
+
+    beforeAll(() => {
+      $ = render('summary-list', examples[exampleName])
+    })
+
+    it('does not include a menu button', async () => {
+      expect($('.govuk-header__menu-button')).toHaveLength(0)
+    })
+
+    it('does not include a <nav> element', async () => {
+      expect($('nav')).toHaveLength(0)
+    })
+
+    it('does not include a govuk-header__content wrapper', async () => {
+      expect($('.govuk-header__content')).toHaveLength(0)
+    })
+  })
+
   describe('SVG logo', () => {
     let $
     let $svg


### PR DESCRIPTION
Ensure that the `navigation` param of the header is non-empty rather than truthy. This avoids a scenario where the wrapper, nav and menu button are outputted with an empty navigation `<ul>` when the `navigation` param is an empty array (`[]`):

```html
<div class="govuk-header__content">
  <nav aria-label="Menu" class="govuk-header__navigation">
    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" hidden>Menu</button>
    <ul id="navigation" class="govuk-header__navigation-list"></ul>
  </nav>
</div>
```

This issue is hard to spot as there is no visual change on tablet breakpoints and above – only on the mobile breakpoint where the menu button is visible (but clicking it only changes the arrow direction).