### PR TITLE
Deprecate `element` parameter on button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ This is an experimental change, based on our hypothesis that `govuk-font-size` a
 
 This change was introduced in [pull request #4291: Rename `govuk-typography-responsive` to `govuk-font-size`](https://github.com/alphagov/govuk-frontend/pull/4291)
 
+### Deprecated features
+
+#### Stop using the `element` parameter on buttons
+
+We have deprecated the `element` Nunjucks parameter and will remove it in the next major release.
+
+In the future, the component will automatically use the use the `<a>` element if the `href` parameter is set, or the `<button>` element otherwise, without the ability to override it.
+
+This change was introduced in [pull request #4646: Deprecate `element` parameter on button component](https://github.com/alphagov/govuk-frontend/pull/4646)
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -2,7 +2,7 @@ params:
   - name: element
     type: string
     required: false
-    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if `href` is provided.
+    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if `href` is provided. This parameter will be removed in the next major version.
   - name: text
     type: string
     required: true


### PR DESCRIPTION
As per #4168, mark the `element` parameter as deprecated in the Nunjucks parameter docs and in the changelog. 