### PR TITLE
Deprecate 14 on the type scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,17 @@ In the future, the component will automatically use the use the `<a>` element if
 
 This change was introduced in [pull request #4646: Deprecate `element` parameter on button component](https://github.com/alphagov/govuk-frontend/pull/4646)
 
+#### Stop using `govuk-body-xs`, `govuk-!-font-size-14` and '14' on the type scale
+
+We have deprecated point 14 (14px large screens, 12px small screens) on the GOV.UK Frontend responsive type scale, including font override classes that use point 14:
+
+- `govuk-body-xs`
+- `govuk-!-font-size-14`
+
+We will be removing these classes and point 14 on the type scale in GOV.UK Frontend release v6.0.0. From the next major release, you will no longer be able to call the Sass mixins `govuk-font` or `govuk-font-size` with `$size` set to '14'.
+
+This change was introduced in [#4649: Deprecate 14 on the type scale](https://github.com/alphagov/govuk-frontend/pull/4649)
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/core/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/core/_typography.scss
@@ -128,6 +128,7 @@
     @extend %govuk-body-s;
   }
 
+  // @deprecated
   %govuk-body-xs {
     @include govuk-text-colour;
     @include govuk-font($size: 14);
@@ -136,6 +137,7 @@
     @include govuk-responsive-margin(4, "bottom");
   }
 
+  // @deprecated
   .govuk-body-xs {
     @extend %govuk-body-xs;
   }

--- a/packages/govuk-frontend/src/govuk/core/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/core/_typography.scss
@@ -131,7 +131,7 @@
   // @deprecated
   %govuk-body-xs {
     @include govuk-text-colour;
-    @include govuk-font($size: 14);
+    @include govuk-font($size: _14);
 
     margin-top: 0;
     @include govuk-responsive-margin(4, "bottom");

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -157,10 +157,19 @@
 
 @mixin govuk-font-size($size, $line-height: false, $important: false) {
   @if not map-has-key($govuk-typography-scale, $size) {
-    @error "Unknown font size `#{$size}` - expected a point from the typography scale.";
+    @error "Unknown font size `#{$size}` - expected a point from the type scale.";
   }
 
   $font-map: map-get($govuk-typography-scale, $size);
+
+  // Check for a deprecation within the type scale
+  $deprecation: map-get($font-map, "deprecation");
+
+  @if $deprecation {
+    @include _warning(map-get($deprecation, "key"), map-get($deprecation, "message"));
+    // remove the deprecation map keys so they do not break the breakpoint loop
+    $font-map: map-remove($font-map, "deprecation");
+  }
 
   @each $breakpoint, $breakpoint-map in $font-map {
     $font-size: map-get($breakpoint-map, "font-size");

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -99,14 +99,14 @@
 
 /// Font size and line height helper
 ///
-/// @param {Number} $size - Point from the spacing scale (the size as it would
+/// @param {Number} $size - Point from the type scale (the size as it would
 ///   appear on tablet and above)
 /// @param {Number} $override-line-height [false] - Non responsive custom line
 ///   height. Omit to use the line height from the font map.
 /// @param {Boolean} $important [false] - Whether to mark declarations as
 ///   `!important`.
 ///
-/// @throw if `$size` is not a valid point from the spacing scale
+/// @throw if `$size` is not a valid point from the type scale
 ///
 /// @access public
 ///
@@ -144,14 +144,14 @@
 ///   )
 /// );
 ///
-/// @param {Number} $size - Point from the spacing scale (the size as it would
-///   appear on tablet and above)
+/// @param {Number | String} $size - Point from the type scale (the size as
+///   it would appear on tablet and above)
 /// @param {Number} $line-height [false] - Non responsive custom line
 ///   height. Omit to use the line height from the font map.
 /// @param {Boolean} $important [false] - Whether to mark declarations as
 ///   `!important`.
 ///
-/// @throw if `$size` is not a valid point from the spacing scale
+/// @throw if `$size` is not a valid point from the type scale
 ///
 /// @access public
 
@@ -212,14 +212,15 @@
 
 /// Font helper
 ///
-/// @param {Number | Boolean} $size Point from the spacing scale (the size as it
-///   would appear on tablet and above). Use `false` to avoid setting a size.
+/// @param {Number | Boolean | String} $size Point from the type scale (the
+///   size as it would appear on tablet and above). Use `false` to avoid setting
+///   a size.
 /// @param {String} $weight [regular] - Weight: `bold` or `regular`
 /// @param {Boolean} $tabular [false] - Whether to use tabular numbers or not
 /// @param {Number} $line-height [false] - Line-height, if overriding the
 ///   default
 ///
-/// @throw if `$size` is not a valid point from the spacing scale (or false)
+/// @throw if `$size` is not a valid point from the type scale (or false)
 ///
 /// @access public
 

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -37,6 +37,20 @@ const sassBootstrap = `
         font-size: 14px,
         line-height: 20px
       )
+    ),
+    16: (
+      null: (
+        font-size: 14px,
+        line-height: 15px
+      ),
+      desktop: (
+        font-size: 16px,
+        line-height: 20px
+      ),
+      deprecation: (
+        key: "test-key",
+        message: "This point on the scale is deprecated."
+      )
     )
   );
 
@@ -273,7 +287,27 @@ describe('@mixin govuk-font-size', () => {
     `
 
     await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
-      'Unknown font size `3.1415926536` - expected a point from the typography scale.'
+      'Unknown font size `3.1415926536` - expected a point from the type scale.'
+    )
+  })
+
+  it('throws a deprecation warning if a point on the scale is deprecated', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        @include govuk-font-size($size: 16)
+      }
+    `
+
+    await compileSassString(sass, sassConfig)
+
+    // Expect our mocked @warn function to have been called once with a single
+    // argument, which should be the deprecation notice
+    expect(mockWarnFunction.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        'This point on the scale is deprecated. To silence this warning, update $govuk-suppressed-warnings with key: "test-key"'
+      ])
     )
   })
 

--- a/packages/govuk-frontend/src/govuk/overrides/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_typography.scss
@@ -5,9 +5,20 @@
   // typography scale eg .govuk-\!-font-size-80
   //
   // govuk-!-font-size-14 is deprecated
-  @each $size in map-keys($govuk-typography-scale) {
-    .govuk-\!-font-size-#{$size} {
-      @include govuk-font-size($size, $important: true);
+  @each $size, $font-map in $govuk-typography-scale {
+    // Suppress class if the map key is a string with an underscore eg: _14 to
+    // avoid classes like govuk-!-font-size-_14 getting generated
+    @if type-of($size) == "number" or str-slice(#{$size}, 1, 1) != "_" {
+      .govuk-\!-font-size-#{$size} {
+        $font-map: map-get($govuk-typography-scale, $size);
+
+        // Add underscore to deprecated typography scale keys
+        @if map-has-key($font-map, "deprecation") {
+          $size: _#{$size};
+        }
+
+        @include govuk-font-size($size, $important: true);
+      }
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/overrides/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_typography.scss
@@ -3,6 +3,8 @@
 
   // Generate typography override classes for each responsive font map in the
   // typography scale eg .govuk-\!-font-size-80
+  //
+  // govuk-!-font-size-14 is deprecated
   @each $size in map-keys($govuk-typography-scale) {
     .govuk-\!-font-size-#{$size} {
       @include govuk-font-size($size, $important: true);

--- a/packages/govuk-frontend/src/govuk/settings/_typography-responsive.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_typography-responsive.scss
@@ -151,6 +151,11 @@ $govuk-typography-scale: (
     print: (
       font-size: 12pt,
       line-height: 1.2
+    ),
+    deprecation: (
+      key: "govuk-typography-scale-14",
+      message: "14 on the type scale is deprecated and will be removed as " +
+        "a possible option in the next major version."
     )
   )
 ) !default;

--- a/packages/govuk-frontend/src/govuk/settings/_typography-responsive.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_typography-responsive.scss
@@ -157,5 +157,19 @@ $govuk-typography-scale: (
       message: "14 on the type scale is deprecated and will be removed as " +
         "a possible option in the next major version."
     )
+  ),
+  _14: (
+    null: (
+      font-size: 12px,
+      line-height: 15px
+    ),
+    tablet: (
+      font-size: 14px,
+      line-height: 20px
+    ),
+    print: (
+      font-size: 12pt,
+      line-height: 1.2
+    )
   )
 ) !default;


### PR DESCRIPTION
## What/Why
Deprecates 14 on the responsive typography scale along with the classes `govuk-body-xs` and `govuk-!-font-size-14` as we're removing this option from the typography scale in 6.0.

Fixes https://github.com/alphagov/govuk-frontend/issues/2786.

## Thoughts
Deprecating a key in a map is tricky. The solution I've gone for here is that `govuk-font-size` looks for a deprecation key and a deprecation message in the responsive scale. If they're there, it outputs a warning and removes those keys from the font map in the mixin so that the deprecation keys don't break the loop. To get around this internally, I've added a `_14` type scale point which replicates 14.

I've done this so that the deprecation is intrinsically tied to the scale value that we're removing. The downside is that users can override `$govuk-typography-scale` to get around the warning, however they could do that anyway with warning suppression.

The other options I explored are:

- Throw a warning if `$size == 14`. This feels a bit fragile to me as it's just looking at the map name. There's a theoretical, very unlikely case where a user has a custom type scale map where one of the keys is 14 but the actual returned font sizes are higher than 14.
- Throw a warning if the returned size from a given font-map is below 16px (and rem equivalent). This solution also infers that at 6.0 we'd throw an error if the same thing happened to block any user using font sizes below 16px regardless of custom type scales. Like the last option, this feels like it's disrupting the customisation of govuk-frontend and doesn't tie the actual scale value we're removing to the deprecation. I don't know how I feel about the error idea when we reach 6.0. I'm interested in views on this.