### PR TITLE
Only use fixture HTML 'cache' when running on CI

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -48,8 +48,7 @@ export default async () => {
 
   // Feature flags
   const flags = /** @type {FeatureFlags} */ ({
-    isDeployedToHeroku: !!process.env.HEROKU_APP,
-    isDevelopment: !['test', 'production'].includes(process.env.NODE_ENV),
+    isDevelopment: !process.env.HEROKU_APP && !process.env.CI,
 
     // Check for JSDoc, SassDoc and Rollup stats
     hasDocsScripts: await hasPath(join(paths.app, 'dist/docs/jsdoc')),
@@ -221,7 +220,7 @@ export default async () => {
         env,
 
         // Skip Nunjucks render from cache in development
-        fixture: !flags.isDevelopment ? fixture : undefined
+        fixture: flags.isDevelopment ? undefined : fixture
       })
 
       let bodyClasses = 'app-template__body'
@@ -278,8 +277,7 @@ export default async () => {
 
 /**
  * @typedef {object} FeatureFlags
- * @property {boolean} isDeployedToHeroku - Review app using `HEROKU_APP`
- * @property {boolean} isDevelopment - Review app not using `NODE_ENV` production or test
+ * @property {boolean} isDevelopment - Review app not in CI or on Heroku
  * @property {boolean} hasDocsStyles - Stylesheets documentation (SassDoc) is available
  * @property {boolean} hasDocsScripts - JavaScripts documentation (JSDoc) is available
  * @property {boolean} hasStats - Rollup stats are available

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -218,9 +218,7 @@ export default async () => {
       const componentView = render(componentName, {
         context: fixture.options,
         env,
-
-        // Skip Nunjucks render from cache in development
-        fixture: flags.isDevelopment ? undefined : fixture
+        fixture
       })
 
       let bodyClasses = 'app-template__body'

--- a/packages/govuk-frontend-review/src/common/middleware/docs.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/docs.mjs
@@ -16,10 +16,10 @@ router.get('/', (req, res) => {
  * Sass docs latest release (when deployed)
  */
 router.use('/sass', ({ app }, res, next) => {
-  const { isDeployedToHeroku } =
+  const { isDevelopment } =
     /** @type {import('../../app.mjs').FeatureFlags} */ (app.get('flags'))
 
-  if (isDeployedToHeroku) {
+  if (!isDevelopment) {
     return res.redirect(
       'https://frontend.design-system.service.gov.uk/sass-api-reference/'
     )

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -22,7 +22,7 @@ export function renderer(app) {
     {
       dev: true, // log stack traces
       express: app, // the Express.js review app that nunjucks should install to
-      noCache: !flags.isDeployedToHeroku, // use cache when deployed only
+      noCache: flags.isDevelopment, // use cache in development only
       watch: flags.isDevelopment // reload templates in development only
     },
     {

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -155,8 +155,10 @@ function render(componentName, options) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  // Use built fixtures (if they exist) on CI to optimise for speed
-  if (process.env.CI === 'true' && options?.fixture?.html) {
+  // On Heroku / CI we know we're running against an up-to-date build so we can
+  // use the generated HTML from the component JSON (where it exists) to make
+  // things faster
+  if ((process.env.HEROKU_APP || process.env.CI) && options?.fixture?.html) {
     return options.fixture.html
   }
 

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -155,8 +155,12 @@ function render(componentName, options) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  // Return built fixture or render
-  return options?.fixture?.html ?? renderMacro(macroName, macroPath, options)
+  // Use built fixtures (if they exist) on CI to optimise for speed
+  if (process.env.CI === 'true' && options?.fixture?.html) {
+    return options.fixture.html
+  }
+
+  return renderMacro(macroName, macroPath, options)
 }
 
 /**


### PR DESCRIPTION
Using `options?.fixture?.html` provides a neat speed optimisation when running the tests on CI (where we already rendered all of the fixtures to HTML and they will not change).

However, for local development, we currently only update the fixtures based on watching the YAML files. This means they are not updated when the Nunjucks template changes, so tests can run on outdated versions of templates, which is confusing and potentially misleading.

We discussed additionally watching for changes to the Nunjucks templates as well, however there is still a race condition when running tests (especially as the fixture generation currently takes ~1.6-1.8s).

For now, only use this optimisation on CI where we can guarantee we’re testing against an up to date build.

Also update the review app to try and keep it in sync and avoid having multiple different ways of switching on and off the various optimisations.