### PR TITLE
Output HTML in code preview without formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3573,11 +3573,6 @@
         "@octokit/openapi-types": "^19.0.0"
       }
     },
-    "node_modules/@one-ini/wasm": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
-      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
-    },
     "node_modules/@percy/cli": {
       "version": "1.27.7",
       "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.27.7.tgz",
@@ -8627,15 +8622,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/config-chain": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dependencies": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -10322,23 +10308,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
-      "dependencies": {
-        "@one-ini/wasm": "0.1.1",
-        "commander": "^10.0.0",
-        "minimatch": "9.0.1",
-        "semver": "^7.5.3"
-      },
-      "bin": {
-        "editorconfig": "bin/editorconfig"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/editorconfig-checker": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-5.1.2.tgz",
@@ -10355,58 +10324,6 @@
         "type": "buymeacoffee",
         "url": "https://www.buymeacoffee.com/mstruebing"
       }
-    },
-    "node_modules/editorconfig/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/editorconfig/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/editorconfig/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/editorconfig/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/editorconfig/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -15632,7 +15549,8 @@
     "node_modules/ini": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+      "dev": true
     },
     "node_modules/inquirer": {
       "version": "8.2.6",
@@ -18838,25 +18756,6 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
-    "node_modules/js-beautify": {
-      "version": "1.14.11",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.11.tgz",
-      "integrity": "sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==",
-      "dependencies": {
-        "config-chain": "^1.1.13",
-        "editorconfig": "^1.0.3",
-        "glob": "^10.3.3",
-        "nopt": "^7.2.0"
-      },
-      "bin": {
-        "css-beautify": "js/bin/css-beautify.js",
-        "html-beautify": "js/bin/html-beautify.js",
-        "js-beautify": "js/bin/js-beautify.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -21526,6 +21425,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
       "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
+      "dev": true,
       "dependencies": {
         "abbrev": "^2.0.0"
       },
@@ -21540,6 +21440,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
       "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -23786,11 +23687,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "node_modules/proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -30888,7 +30784,6 @@
         "govuk-frontend": "*",
         "highlight.js": "^11.9.0",
         "iframe-resizer": "^4.3.9",
-        "js-beautify": "^1.14.11",
         "marked": "^11.1.1",
         "marked-linkify-it": "^3.1.8",
         "marked-smartypants": "^1.1.5",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -34,7 +34,6 @@
     "govuk-frontend": "*",
     "highlight.js": "^11.9.0",
     "iframe-resizer": "^4.3.9",
-    "js-beautify": "^1.14.11",
     "marked": "^11.1.1",
     "marked-linkify-it": "^3.1.8",
     "marked-smartypants": "^1.1.5",

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/highlight.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/highlight.mjs
@@ -8,6 +8,5 @@ import hljs from 'highlight.js'
  * @returns {string} Code with syntax highlighting
  */
 export function highlight(code, language) {
-  return hljs.highlight(code.trim(), { language: language || 'plaintext' })
-    .value
+  return hljs.highlight(code, { language: language || 'plaintext' }).value
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -1,5 +1,4 @@
 import { render } from '@govuk-frontend/lib/components'
-import beautify from 'js-beautify'
 
 /**
  * Component HTML code (formatted)
@@ -10,20 +9,7 @@ import beautify from 'js-beautify'
  * @returns {string} HTML rendered by the component
  */
 export function getHTMLCode(componentName, options) {
-  const html = render(componentName, { ...options, env: this.env })
-
-  // Default beautify options
-  const beautifyOptions = beautify.html.defaultOptions()
-
-  return beautify.html(html, {
-    indent_size: 2,
-    // Ensure nested labels in headings are indented properly
-    inline: beautifyOptions.inline.filter((tag) => !['label'].includes(tag)),
-    // Remove blank lines
-    max_preserve_newlines: 0,
-    // Ensure attribute wrapping in header SVG is preserved
-    wrap_attributes: 'preserve'
-  })
+  return render(componentName, { ...options, env: this.env })
 }
 
 /**

--- a/packages/govuk-frontend-review/src/views/macros/showExamples.njk
+++ b/packages/govuk-frontend-review/src/views/macros/showExamples.njk
@@ -41,7 +41,8 @@
         <h4 class="govuk-heading-s">Markup</h4>
         <pre class="app-code"><code tabindex="0" class="app-code__container hljs language-html">
           {{- getHTMLCode(componentName, {
-            context: example.options
+            context: example.options,
+            fixture: example
           }) | highlight("html") | safe -}}
         </code></pre>
 


### PR DESCRIPTION
Whilst https://github.com/alphagov/govuk-frontend/issues/3211 is blocked I've split out changes from https://github.com/alphagov/govuk-frontend/pull/4448 used to show ~formatted~ actual HTML code output

This PR does the following:

* Removes `js-beautify` formatter for HTML code previews
* Removes `.trim()` from code preview syntax highlighter

## Correct code previews
This ensures the [Review app](https://govuk-frontend-review.herokuapp.com) previews our code exactly as published to [`govuk-frontend` on npm](https://www.npmjs.com/package/govuk-frontend)

<img width="697" alt="Start button formatting issue now shown in code preview" src="https://github.com/alphagov/govuk-frontend/assets/415517/220e13aa-ba32-47d1-a6a4-77a46c7f4725">