### PR TITLE
Fix GitHub Actions updates in nested directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,3 +95,39 @@ updates:
       interval: weekly
       time: '10:30'
       timezone: 'Europe/London'
+
+  # Update GitHub Actions (Build)
+  - package-ecosystem: github-actions
+    directory: /.github/workflows/actions/build
+    reviewers:
+      - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+  # Update GitHub Actions (Install dependencies)
+  - package-ecosystem: github-actions
+    directory: /.github/workflows/actions/install-node
+    reviewers:
+      - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+  # Update GitHub Actions (Setup Node.js)
+  - package-ecosystem: github-actions
+    directory: /.github/workflows/actions/setup-node
+    reviewers:
+      - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'


### PR DESCRIPTION
Looks like our GitHub Actions composite workflow YAML files aren't being updated:

This PR adds extra Dependabot config entries for each `directory` following other suggestions in: 

* https://github.com/dependabot/dependabot-core/issues/6704

## Missed update to `actions/setup-node`

We're currently seeing warnings that `actions/setup-node@3.8.2` still uses Node.js 16

<img width="761" alt="Warning shows GitHub Actions using Node js 16 are deprecated" src="https://github.com/alphagov/govuk-frontend/assets/415517/c38766dd-7587-475f-986b-77c7e8980384">

<br>
<br>

This action (line 14 below) should have been updated in https://github.com/alphagov/govuk-frontend/pull/4585 but each directory needs a Dependabot config

https://github.com/alphagov/govuk-frontend/blob/9da6e947afdc5844bd0caaecbe9f61cde76ee9f4/.github/workflows/actions/setup-node/action.yml#L13-L15