### PR TITLE
Consistent Nunjucks `safe` and `trim` filter order

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -111,9 +111,9 @@
     attributes: params.fieldset.attributes,
     legend: params.fieldset.legend
   }) %}
-  {{ innerHtml | trim | safe }}
+  {{ innerHtml | safe | trim }}
   {% endcall %}
 {% else %}
-  {{ innerHtml | trim | safe }}
+  {{ innerHtml | safe | trim }}
 {% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -28,7 +28,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = idPrefix + '-error' %}
@@ -40,7 +40,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-checkboxes">
@@ -81,7 +81,7 @@
               classes: 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label.classes),
               attributes: item.label.attributes,
               for: id
-            }) | indent(6) | trim }}
+            }) | trim | indent(6) }}
             {% if hasHint %}
             {{ govukHint({
               id: itemHintId,
@@ -89,7 +89,7 @@
               attributes: item.hint.attributes,
               html: item.hint.html,
               text: item.hint.text
-            }) | indent(6) | trim }}
+            }) | trim | indent(6) }}
             {% endif %}
           </div>
           {% if item.conditional.html %}

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/template.njk
@@ -42,7 +42,7 @@
                 "classes": action.classes,
                 "href": action.href,
                 "attributes": action.attributes
-              }) | indent(12) | trim }}
+              }) | trim | indent(12) }}
             {% else %}
               <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ action.text }}</a>
             {% endif %}
@@ -54,7 +54,7 @@
               "type": action.type,
               "classes": action.classes,
               "attributes": action.attributes
-            }) | indent(12) | trim }}
+            }) | trim | indent(12) }}
           {% endif %}
         {% endfor %}
       </div>

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -37,7 +37,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = params.id + "-error" %}
@@ -49,7 +49,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
@@ -70,7 +70,7 @@
         autocomplete: item.autocomplete,
         pattern: item.pattern,
         attributes: item.attributes
-      }) | indent(6) | trim }}
+      }) | trim | indent(6) }}
     </div>
   {% endfor %}
   </div>

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -89,9 +89,9 @@
     attributes: params.fieldset.attributes,
     legend: params.fieldset.legend
   }) %}
-  {{ innerHtml | trim | safe }}
+  {{ innerHtml | safe | trim }}
   {% endcall %}
 {% else %}
-  {{ innerHtml | trim | safe }}
+  {{ innerHtml | safe | trim }}
 {% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -13,7 +13,7 @@
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = params.id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
@@ -23,7 +23,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = params.id + '-error' %}
@@ -35,7 +35,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -14,7 +14,7 @@
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = params.id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
@@ -24,7 +24,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = params.id + '-error' %}
@@ -36,7 +36,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 
   {%- if params.prefix or params.suffix %}<div class="govuk-input__wrapper">{% endif -%}

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/template.njk
@@ -7,7 +7,7 @@
       text: params.tag.text,
       html: params.tag.html,
       classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
-    }) | indent(4) | trim }}
+    }) | trim | indent(4) }}
     <span class="govuk-phase-banner__text">
       {{ params.html | safe if params.html else params.text }}
     </span>

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -22,7 +22,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = idPrefix + '-error' %}
@@ -34,7 +34,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-radios">
@@ -71,7 +71,7 @@
             classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
             attributes: item.label.attributes,
             for: id
-          }) | indent(6) | trim }}
+          }) | trim | indent(6) }}
           {% if hasHint %}
           {{ govukHint({
             id: itemHintId,
@@ -79,7 +79,7 @@
             attributes: item.hint.attributes,
             html: item.hint.html,
             text: item.hint.text
-          }) | indent(6) | trim }}
+          }) | trim | indent(6) }}
           {% endif %}
         </div>
         {% if item.conditional.html %}

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -101,9 +101,9 @@
     attributes: params.fieldset.attributes,
     legend: params.fieldset.legend
   }) %}
-  {{ innerHtml | trim | safe }}
+  {{ innerHtml | safe | trim }}
   {% endcall %}
 {% else %}
-  {{ innerHtml | trim | safe }}
+  {{ innerHtml | safe | trim }}
 {% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -13,7 +13,7 @@
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = params.id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
@@ -23,7 +23,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = params.id + '-error' %}
@@ -35,7 +35,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
   <select class="govuk-select
     {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.njk
@@ -59,7 +59,7 @@
             {{ row.key.html | indent(4 if params.card else 0) | safe if row.key.html else row.key.text }}
           </dt>
           <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
-            {{ row.value.html | indent(12 if params.card else 8) | trim | safe if row.value.html else row.value.text }}
+            {{ row.value.html | indent(12 if params.card else 8) | safe | trim if row.value.html else row.value.text }}
           </dd>
           {% if row.actions.items.length %}
             <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -21,7 +21,7 @@
       </div>
       <div class="govuk-task-list__status {%- if item.status.classes %} {{ item.status.classes }}{% endif %}" id="{{ statusId }}">
         {% if item.status.tag %}
-          {{ govukTag(item.status.tag) | indent(4) | trim }}
+          {{ govukTag(item.status.tag) | trim | indent(4) }}
         {% else %}
           {{ item.status.html | safe if item.status.html else item.status.text }}
         {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.njk
@@ -13,7 +13,7 @@
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = params.id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
@@ -23,7 +23,7 @@
     attributes: params.hint.attributes,
     html: params.hint.html,
     text: params.hint.text
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = params.id + '-error' %}
@@ -35,7 +35,7 @@
     html: params.errorMessage.html,
     text: params.errorMessage.text,
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
+  }) | trim | indent(2) }}
 {% endif %}
   <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}


### PR DESCRIPTION
Split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

### Prefer filter `trim` before `indent()`

This change is in preparation for later Nunjucks indentation tweaks to prevent `trim` from removing the first line’s indentation. For example, when using `indent(2, true)` first we must not use `trim` second

### Prefer filter `safe` before `trim`

Ensure HTML output is trimmed first to prevent escaped whitespace characters remaining un-trimmed