### PR TITLE
Fix Nunjucks HTML indentation: Accordion

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.njk
@@ -1,9 +1,33 @@
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
-{%- set id = params.id %}
-{% set headingLevel = params.headingLevel if params.headingLevel else 2 -%}
+{%- macro _accordionItem(params, item, index) %}
+  {%- set headingLevel = params.headingLevel if params.headingLevel else 2 %}
+  <div class="govuk-accordion__section {%- if item.expanded %} govuk-accordion__section--expanded{% endif %}">
+    <div class="govuk-accordion__section-header">
+      <h{{ headingLevel }} class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="{{ params.id }}-heading-{{ index }}">
+          {{ item.heading.html | safe | trim | indent(8) if item.heading.html else item.heading.text }}
+        </span>
+      </h{{ headingLevel }}>
+      {% if item.summary.html or item.summary.text %}
+      <div class="govuk-accordion__section-summary govuk-body" id="{{ params.id }}-summary-{{ index }}">
+        {{ item.summary.html | safe | trim | indent(8) if item.summary.html else item.summary.text }}
+      </div>
+      {% endif %}
+    </div>
+    <div id="{{ params.id }}-content-{{ index }}" class="govuk-accordion__section-content">
+    {% if item.content.html %}
+      {{ item.content.html | safe | trim | indent(6) }}
+    {% elif item.content.text %}
+      <p class="govuk-body">
+        {{ item.content.text | trim | indent(8) }}
+      </p>
+    {% endif %}
+    </div>
+  </div>
+{% endmacro -%}
 
-<div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-accordion" id="{{ id }}"
+<div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-accordion" id="{{ params.id }}"
   {{- govukI18nAttributes({
     key: 'hide-all-sections',
     message: params.hideAllSectionsText
@@ -37,28 +61,6 @@
   {%- if params.rememberExpanded !== undefined %} data-remember-expanded="{{ params.rememberExpanded | escape }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
-    {% if item %}
-      <div class="govuk-accordion__section {%- if item.expanded %} govuk-accordion__section--expanded{% endif %}">
-        <div class="govuk-accordion__section-header">
-          <h{{ headingLevel }} class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="{{ id }}-heading-{{ loop.index }}">
-              {{ item.heading.html | safe if item.heading.html else item.heading.text }}
-            </span>
-          </h{{ headingLevel }}>
-          {% if item.summary.html or item.summary.text %}
-            <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
-              {{ item.summary.html | safe if item.summary.html else item.summary.text }}
-            </div>
-          {% endif %}
-        </div>
-        <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content">
-          {% if item.content.html %}
-            {{ item.content.html | safe }}
-          {% elif item.content.text %}
-            <p class="govuk-body">{{ item.content.text }}</p>
-          {% endif %}
-        </div>
-      </div>
-    {% endif %}
+    {% if item %}{{ _accordionItem(params, item, loop.index) }}{% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
Accordion HTML indentation changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

Similar to the `_actionLink()` and `_summaryCard()` macros in **Summary list**, I've added `_accordionItem()` to flatten the HTML indent level back to 2 spaces

For components with further nesting this approach lets us add `| indent(n)` to the macro output when needed