### PR TITLE
Fix Nunjucks HTML indentation: Breadcrumbs

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
@@ -11,14 +11,18 @@
 
 <div class="{{ classNames }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <ol class="govuk-breadcrumbs__list">
-  {% for item in params.items %}
-    {% if item.href %}
+{% for item in params.items %}
+  {% if item.href %}
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.html | safe if item.html else item.text }}</a>
+      <a class="govuk-breadcrumbs__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+        {{- item.html | safe if item.html else item.text -}}
+      </a>
     </li>
-    {% else %}
-    <li class="govuk-breadcrumbs__list-item" aria-current="page">{{ item.html | safe if item.html else item.text }}</li>
-    {% endif %}
-  {% endfor %}
+  {% else %}
+    <li class="govuk-breadcrumbs__list-item" aria-current="page">
+      {{- item.html | safe if item.html else item.text -}}
+    </li>
+  {% endif %}
+{% endfor %}
   </ol>
 </div>


### PR DESCRIPTION
Breadcrumbs HTML indentation changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

This PR has no diff output and affects Nunjucks formatting only