### PR TITLE
Fix Nunjucks HTML indentation: Button

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/button/template.njk
@@ -5,6 +5,10 @@
   {% set classNames = classNames + " " + params.classes %}
 {% endif %}
 
+{%- if params.isStartButton %}
+  {% set classNames = classNames + " govuk-button--start" %}
+{% endif %}
+
 {#- Determine type of element to use, if not explicitly set #}
 {%- if params.element %}
   {% set element = params.element | lower %}
@@ -16,17 +20,14 @@
   {% endif %}
 {% endif -%}
 
-{% if params.isStartButton %}
-  {% set iconHtml %}
-{#- The SVG needs `focusable="false"` so that Internet Explorer does not
-treat it as an interactive element - without this it will be
-'focusable' when using the keyboard to navigate. #}
-<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-  <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
-</svg>
-  {% endset %}
-  {% set classNames = classNames + " govuk-button--start" %}
-{% endif %}
+{%- macro _startIcon() %}
+  {#- The SVG needs `focusable="false"` so that Internet Explorer does not
+  treat it as an interactive element - without this it will be
+  'focusable' when using the keyboard to navigate. #}
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+  </svg>
+{%- endmacro -%}
 
 {#- Define common attributes that we can use across all element types #}
 
@@ -40,16 +41,14 @@ treat it as an interactive element - without this it will be
 
 {%- if element == 'a' %}
 <a href="{{ params.href if params.href else '#' }}" role="button" draggable="false" {{- commonAttributes | safe }}>
-  {{ params.html | safe if params.html else params.text }}
-{# Indentation is intentional to output HTML nicely #}
-{{- iconHtml | safe | trim | indent(2, true) if iconHtml -}}
+  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
+  {{- _startIcon() | safe if params.isStartButton }}
 </a>
 
 {%- elseif element == 'button' %}
 <button {%- if params.value %} value="{{ params.value }}"{% endif %} type="{{ params.type if params.type else 'submit' }}" {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
-  {{ params.html | safe if params.html else params.text }}
-{# Indentation is intentional to output HTML nicely #}
-{{- iconHtml | safe | trim | indent(2, true) if iconHtml -}}
+  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
+  {{- _startIcon() | safe if params.isStartButton }}
 </button>
 
 {%- elseif element == 'input' %}

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
@@ -1,8 +1,8 @@
 {% from "../button/macro.njk" import govukButton %}
 
-{%- set defaultHtml -%}
+{%- set defaultHtml %}
   <span class="govuk-visually-hidden">Emergency</span> Exit this page
-{%- endset -%}
+{% endset -%}
 
 <div
   {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-exit-this-page {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-exit-this-page" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
@@ -11,7 +11,7 @@
   {%- if params.pressTwoMoreTimesText %} data-i18n.press-two-more-times="{{ params.pressTwoMoreTimesText | escape }}"{% endif %}
   {%- if params.pressOneMoreTimeText %} data-i18n.press-one-more-time="{{ params.pressOneMoreTimeText | escape }}"{% endif %}
 >
-  {{- govukButton({
+  {{ govukButton({
     html: params.html if (params.html or params.text) else defaultHtml,
     text: params.text,
     classes: "govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button",
@@ -19,5 +19,5 @@
     attributes: {
       rel: "nofollow noreferrer"
     }
-  }) -}}
+  }) | trim | indent(2) }}
 </div>


### PR DESCRIPTION
Button HTML indentation changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve https://github.com/alphagov/govuk-frontend/issues/3211

These changes also include the nested `govukButton()` on Exit this page