### PR TITLE
Fix Nunjucks HTML indentation: Fieldset, Label and Hint

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -71,6 +71,7 @@
     errorMessage: params.errorMessage,
     attributes: params.attributes
   }) }}
+
   {%- set textareaDescriptionLength = params.maxwords or params.maxlength %}
   {%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
   {#-
@@ -82,5 +83,5 @@
     text: ((textareaDescriptionText) | replace('%{count}', textareaDescriptionLength) if not hasNoLimit),
     id: params.id + '-info',
     classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
-  }) }}
+  }) | trim | indent(2) }}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -104,15 +104,14 @@
 {% endset -%}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-{% if params.fieldset %}
-  {% call govukFieldset({
+{% if hasFieldset %}
+  {{ govukFieldset({
     describedBy: describedBy,
     classes: params.fieldset.classes,
     attributes: params.fieldset.attributes,
-    legend: params.fieldset.legend
-  }) %}
-  {{ innerHtml | safe | trim }}
-  {% endcall %}
+    legend: params.fieldset.legend,
+    html: innerHtml | trim
+  }) | trim | indent(2) }}
 {% else %}
   {{ innerHtml | safe | trim }}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -7,6 +7,9 @@
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
 
+{#- fieldset is false by default -#}
+{% set hasFieldset = true if params.fieldset else false %}
+
 {%- if params.items | length %}
   {% set dateInputItems = params.items %}
 {% else %}
@@ -77,20 +80,19 @@
 {% endset -%}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-{% if params.fieldset %}
-{#- We override the fieldset's role to 'group' because otherwise JAWS does not
+{% if hasFieldset %}
+  {# We override the fieldset's role to 'group' because otherwise JAWS does not
     announce the description for a fieldset comprised of text inputs, but
     adding the role to the fieldset always makes the output overly verbose for
     radio buttons or checkboxes. -#}
-  {% call govukFieldset({
+  {{ govukFieldset({
     describedBy: describedBy,
     classes: params.fieldset.classes,
     role: 'group',
     attributes: params.fieldset.attributes,
-    legend: params.fieldset.legend
-  }) %}
-  {{ innerHtml | safe | trim }}
-  {% endcall %}
+    legend: params.fieldset.legend,
+    html: innerHtml | trim
+  }) | trim | indent(2) }}
 {% else %}
   {{ innerHtml | safe | trim }}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.njk
@@ -7,10 +7,10 @@
   <legend class="govuk-fieldset__legend {%- if params.legend.classes %} {{ params.legend.classes }}{% endif %}">
   {% if params.legend.isPageHeading %}
     <h1 class="govuk-fieldset__heading">
-      {{ params.legend.html | safe if params.legend.html else params.legend.text }}
+      {{ params.legend.html | safe | trim | indent(6) if params.legend.html else params.legend.text }}
     </h1>
   {% else %}
-    {{ params.legend.html | safe if params.legend.html else params.legend.text }}
+    {{ params.legend.html | safe | trim | indent(4) if params.legend.html else params.legend.text }}
   {% endif %}
   </legend>
   {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/hint/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/hint/template.njk
@@ -1,4 +1,4 @@
 <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-hint {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  {{ params.html | safe if params.html else params.text }}
+  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/hint/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/hint/template.test.js
@@ -1,5 +1,7 @@
 const { render } = require('@govuk-frontend/helpers/nunjucks')
 const { getExamples } = require('@govuk-frontend/lib/components')
+const { indent } = require('nunjucks/src/filters')
+const { outdent } = require('outdent')
 
 describe('Hint', () => {
   let examples
@@ -46,7 +48,13 @@ describe('Hint', () => {
 
       const content = $('.govuk-hint').html().trim()
       expect(content).toEqual(
-        'It\'s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.\nFor example, \'QQ 12 34 56 C\'.'
+        indent(
+          outdent`
+            It's on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.
+            For example, 'QQ 12 34 56 C'.
+          `,
+          2
+        )
       )
     })
 

--- a/packages/govuk-frontend/src/govuk/components/label/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/label/template.njk
@@ -3,13 +3,15 @@
 <label class="govuk-label {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
   {%- if params.for %} for="{{ params.for }}"{% endif %}>
-  {{ params.html | safe if params.html else params.text }}
+  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
 </label>
 {% endset -%}
 
 {% if params.isPageHeading %}
-<h1 class="govuk-label-wrapper">{{ labelHtml | safe | indent(2) }}</h1>
+<h1 class="govuk-label-wrapper">
+  {{ labelHtml | safe | trim | indent(2) }}
+</h1>
 {% else %}
-{{ labelHtml | safe }}
+{{ labelHtml | safe | trim }}
 {% endif %}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -11,6 +11,9 @@
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
 
+{#- fieldset is false by default -#}
+{% set hasFieldset = true if params.fieldset else false %}
+
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
@@ -94,15 +97,14 @@
 {% endset -%}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-{% if params.fieldset %}
-  {% call govukFieldset({
+{% if hasFieldset %}
+  {{ govukFieldset({
     describedBy: describedBy,
     classes: params.fieldset.classes,
     attributes: params.fieldset.attributes,
-    legend: params.fieldset.legend
-  }) %}
-  {{ innerHtml | safe | trim }}
-  {% endcall %}
+    legend: params.fieldset.legend,
+    html: innerHtml | trim
+  }) | trim | indent(2) }}
 {% else %}
   {{ innerHtml | safe | trim }}
 {% endif %}


### PR DESCRIPTION
Fieldset, Label and Hint HTML indentation changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

## Nested fieldsets

This PR adds `indent(2)` to the macro call to correctly indent the entire fieldset, including the legend

### Problem

By only indenting `innerHtml`, neither the wrapping `<fieldset>`  nor inner `<legend>` are indented:

```njk
{% call govukFieldset({
  legend: params.fieldset.legend
}) %}
{{ innerHtml | safe | trim | indent(2) }}
{% endcall %}
```

### Solution

By indenting all macro output, we see the entire component is corrected indented:

```njk
{{ govukFieldset({
  legend: params.fieldset.legend,
  html: innerHtml | trim
}) | trim | indent(2) }}
```