### PR TITLE
Fix Nunjucks HTML indentation: Radios and Checkboxes

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -26,7 +26,7 @@
   {% set conditionalId = "conditional-" + itemId %}
   {%- if item.divider %}
     <div class="govuk-checkboxes__divider">{{ item.divider }}</div>
-  {%- else %}
+  {% else %}
     {% set isChecked = item.checked | default((item.value in params.values and item.checked != false) if params.values else false, true) %}
     {% set hasHint = true if item.hint.text or item.hint.html %}
     {% set itemHintId = itemId + "-item-hint" if hasHint else "" %}
@@ -34,12 +34,12 @@
     {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
     <div class="govuk-checkboxes__item">
       <input class="govuk-checkboxes__input" id="{{ itemId }}" name="{{ itemName }}" type="checkbox" value="{{ item.value }}"
-      {{-" checked" if isChecked }}
-      {{-" disabled" if item.disabled }}
-      {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-      {%- if item.behaviour %} data-behaviour="{{ item.behaviour }}"{% endif -%}
-      {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
-      {{- govukAttributes(item.attributes) }}>
+        {{-" checked" if isChecked }}
+        {{-" disabled" if item.disabled }}
+        {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+        {%- if item.behaviour %} data-behaviour="{{ item.behaviour }}"{% endif -%}
+        {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
+        {{- govukAttributes(item.attributes) }}>
       {{ govukLabel({
         html: item.html,
         text: item.text,
@@ -58,9 +58,9 @@
       {% endif %}
     </div>
     {% if item.conditional.html %}
-      <div class="govuk-checkboxes__conditional {%- if not isChecked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
-        {{ item.conditional.html | safe }}
-      </div>
+    <div class="govuk-checkboxes__conditional {%- if not isChecked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+      {{ item.conditional.html | safe | trim | indent(6) }}
+    </div>
     {% endif %}
   {% endif %}
 {% endmacro -%}
@@ -106,7 +106,8 @@
   </div>
 {% endset -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {{- govukAttributes(params.formGroup.attributes) }}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- govukAttributes(params.formGroup.attributes) }}>
 {% if hasFieldset %}
   {{ govukFieldset({
     describedBy: describedBy,

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -18,6 +18,61 @@
 {#- fieldset is false by default -#}
 {% set hasFieldset = true if params.fieldset else false %}
 
+{%- macro _checkboxItem(params, item, index) %}
+  {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
+  {%- if item.id -%}
+    {%- set itemId = item.id -%}
+  {%- else -%}
+    {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+    {%- if not index > 1 -%}
+      {%- set itemId = idPrefix %}
+    {% else %}
+      {%- set itemId = idPrefix + "-" + index -%}
+    {%- endif -%}
+  {%- endif -%}
+  {% set itemName = item.name if item.name else params.name %}
+  {% set conditionalId = "conditional-" + itemId %}
+  {%- if item.divider %}
+    <div class="govuk-checkboxes__divider">{{ item.divider }}</div>
+  {%- else %}
+    {% set isChecked = item.checked | default((item.value in params.values and item.checked != false) if params.values else false, true) %}
+    {% set hasHint = true if item.hint.text or item.hint.html %}
+    {% set itemHintId = itemId + "-item-hint" if hasHint else "" %}
+    {% set itemDescribedBy = describedBy if not hasFieldset else "" %}
+    {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="{{ itemId }}" name="{{ itemName }}" type="checkbox" value="{{ item.value }}"
+      {{-" checked" if isChecked }}
+      {{-" disabled" if item.disabled }}
+      {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+      {%- if item.behaviour %} data-behaviour="{{ item.behaviour }}"{% endif -%}
+      {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
+      {{- govukAttributes(item.attributes) }}>
+      {{ govukLabel({
+        html: item.html,
+        text: item.text,
+        classes: 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label.classes),
+        attributes: item.label.attributes,
+        for: itemId
+      }) | trim | indent(6) }}
+      {% if hasHint %}
+      {{ govukHint({
+        id: itemHintId,
+        classes: 'govuk-checkboxes__hint' + (' ' + item.hint.classes if item.hint.classes),
+        attributes: item.hint.attributes,
+        html: item.hint.html,
+        text: item.hint.text
+      }) | trim | indent(6) }}
+      {% endif %}
+    </div>
+    {% if item.conditional.html %}
+      <div class="govuk-checkboxes__conditional {%- if not isChecked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+        {{ item.conditional.html | safe }}
+      </div>
+    {% endif %}
+  {% endif %}
+{% endmacro -%}
+
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
@@ -50,58 +105,7 @@
     {% endif %}
     {% for item in params.items %}
       {% if item %}
-        {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
-        {%- if item.id -%}
-          {%- set id = item.id -%}
-        {%- else -%}
-          {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
-          {%- if loop.first -%}
-            {%- set id = idPrefix %}
-          {% else %}
-            {%- set id = idPrefix + "-" + loop.index -%}
-          {%- endif -%}
-        {%- endif -%}
-        {% set name = item.name if item.name else params.name %}
-        {% set conditionalId = "conditional-" + id %}
-        {%- if item.divider %}
-          <div class="govuk-checkboxes__divider">{{ item.divider }}</div>
-        {%- else %}
-          {% set isChecked = item.checked | default((item.value in params.values and item.checked != false) if params.values else false, true) %}
-          {% set hasHint = true if item.hint.text or item.hint.html %}
-          {% set itemHintId = id + "-item-hint" if hasHint else "" %}
-          {% set itemDescribedBy = describedBy if not hasFieldset else "" %}
-          {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
-            {{-" checked" if isChecked }}
-            {{-" disabled" if item.disabled }}
-            {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-            {%- if item.behaviour %} data-behaviour="{{ item.behaviour }}"{% endif -%}
-            {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
-            {{- govukAttributes(item.attributes) }}>
-            {{ govukLabel({
-              html: item.html,
-              text: item.text,
-              classes: 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label.classes),
-              attributes: item.label.attributes,
-              for: id
-            }) | trim | indent(6) }}
-            {% if hasHint %}
-            {{ govukHint({
-              id: itemHintId,
-              classes: 'govuk-checkboxes__hint' + (' ' + item.hint.classes if item.hint.classes),
-              attributes: item.hint.attributes,
-              html: item.hint.html,
-              text: item.hint.text
-            }) | trim | indent(6) }}
-            {% endif %}
-          </div>
-          {% if item.conditional.html %}
-            <div class="govuk-checkboxes__conditional {%- if not isChecked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
-              {{ item.conditional.html | safe }}
-            </div>
-          {% endif %}
-        {% endif %}
+        {{- _checkboxItem(params, item, loop.index) -}}
       {% endif %}
     {% endfor %}
     {% if params.formGroup.afterInputs %}

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -20,16 +20,8 @@
 
 {%- macro _checkboxItem(params, item, index) %}
   {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
-  {%- if item.id -%}
-    {%- set itemId = item.id -%}
-  {%- else -%}
-    {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
-    {%- if not index > 1 -%}
-      {%- set itemId = idPrefix %}
-    {% else %}
-      {%- set itemId = idPrefix + "-" + index -%}
-    {%- endif -%}
-  {%- endif -%}
+  {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+  {% set itemId = item.id if item.id else idPrefix + ("-" + index if index > 1 else "") %}
   {% set itemName = item.name if item.name else params.name %}
   {% set conditionalId = "conditional-" + itemId %}
   {%- if item.divider %}

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -15,6 +15,57 @@
 {#- fieldset is false by default -#}
 {% set hasFieldset = true if params.fieldset else false %}
 
+{%- macro _radioItem(params, item, index) %}
+  {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
+  {%- if item.id -%}
+    {%- set itemId = item.id -%}
+  {%- else -%}
+    {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+    {%- if not index > 1 -%}
+      {%- set itemId = idPrefix %}
+    {% else %}
+      {%- set itemId = idPrefix + "-" + index -%}
+    {%- endif -%}
+  {%- endif -%}
+  {% set conditionalId = "conditional-" + itemId %}
+  {%- if item.divider %}
+  <div class="govuk-radios__divider">{{ item.divider }}</div>
+  {%- else %}
+  {% set isChecked = item.checked | default((item.value == params.value and item.checked != false) if params.value else false, true) %}
+  {% set hasHint = true if item.hint.text or item.hint.html %}
+  {% set itemHintId = itemId + '-item-hint' %}
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="{{ itemId }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
+    {{-" checked" if isChecked }}
+    {{-" disabled" if item.disabled }}
+    {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+    {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
+    {{- govukAttributes(item.attributes) }}>
+    {{ govukLabel({
+      html: item.html,
+      text: item.text,
+      classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
+      attributes: item.label.attributes,
+      for: itemId
+    }) | trim | indent(6) }}
+    {% if hasHint %}
+    {{ govukHint({
+      id: itemHintId,
+      classes: 'govuk-radios__hint' + (' ' + item.hint.classes if item.hint.classes),
+      attributes: item.hint.attributes,
+      html: item.hint.html,
+      text: item.hint.text
+    }) | trim | indent(6) }}
+    {% endif %}
+  </div>
+  {% if item.conditional.html %}
+    <div class="govuk-radios__conditional {%- if not isChecked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+      {{ item.conditional.html | safe }}
+    </div>
+  {% endif %}
+  {% endif %}
+{%- endmacro %}
+
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
@@ -47,54 +98,7 @@
     {% endif %}
     {% for item in params.items %}
       {% if item %}
-        {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
-        {%- if item.id -%}
-          {%- set id = item.id -%}
-        {%- else -%}
-          {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
-          {%- if loop.first -%}
-            {%- set id = idPrefix %}
-          {% else %}
-            {%- set id = idPrefix + "-" + loop.index -%}
-          {%- endif -%}
-        {%- endif -%}
-        {% set conditionalId = "conditional-" + id %}
-        {%- if item.divider %}
-        <div class="govuk-radios__divider">{{ item.divider }}</div>
-        {%- else %}
-        {% set isChecked = item.checked | default((item.value == params.value and item.checked != false) if params.value else false, true) %}
-        {% set hasHint = true if item.hint.text or item.hint.html %}
-        {% set itemHintId = id + '-item-hint' %}
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
-          {{-" checked" if isChecked }}
-          {{-" disabled" if item.disabled }}
-          {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-          {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
-          {{- govukAttributes(item.attributes) }}>
-          {{ govukLabel({
-            html: item.html,
-            text: item.text,
-            classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
-            attributes: item.label.attributes,
-            for: id
-          }) | trim | indent(6) }}
-          {% if hasHint %}
-          {{ govukHint({
-            id: itemHintId,
-            classes: 'govuk-radios__hint' + (' ' + item.hint.classes if item.hint.classes),
-            attributes: item.hint.attributes,
-            html: item.hint.html,
-            text: item.hint.text
-          }) | trim | indent(6) }}
-          {% endif %}
-        </div>
-        {% if item.conditional.html %}
-          <div class="govuk-radios__conditional {%- if not isChecked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
-            {{ item.conditional.html | safe }}
-          </div>
-        {% endif %}
-        {% endif %}
+        {{- _radioItem(params, item, loop.index) -}}
       {% endif %}
     {% endfor %}
     {% if params.formGroup.afterInputs %}

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -17,16 +17,8 @@
 
 {%- macro _radioItem(params, item, index) %}
   {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
-  {%- if item.id -%}
-    {%- set itemId = item.id -%}
-  {%- else -%}
-    {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
-    {%- if not index > 1 -%}
-      {%- set itemId = idPrefix %}
-    {% else %}
-      {%- set itemId = idPrefix + "-" + index -%}
-    {%- endif -%}
-  {%- endif -%}
+  {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+  {% set itemId = item.id if item.id else idPrefix + ("-" + index if index > 1 else "") %}
   {% set conditionalId = "conditional-" + itemId %}
   {%- if item.divider %}
   <div class="govuk-radios__divider">{{ item.divider }}</div>

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -21,40 +21,40 @@
   {% set itemId = item.id if item.id else idPrefix + ("-" + index if index > 1 else "") %}
   {% set conditionalId = "conditional-" + itemId %}
   {%- if item.divider %}
-  <div class="govuk-radios__divider">{{ item.divider }}</div>
-  {%- else %}
-  {% set isChecked = item.checked | default((item.value == params.value and item.checked != false) if params.value else false, true) %}
-  {% set hasHint = true if item.hint.text or item.hint.html %}
-  {% set itemHintId = itemId + '-item-hint' %}
-  <div class="govuk-radios__item">
-    <input class="govuk-radios__input" id="{{ itemId }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
-    {{-" checked" if isChecked }}
-    {{-" disabled" if item.disabled }}
-    {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-    {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
-    {{- govukAttributes(item.attributes) }}>
-    {{ govukLabel({
-      html: item.html,
-      text: item.text,
-      classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
-      attributes: item.label.attributes,
-      for: itemId
-    }) | trim | indent(6) }}
-    {% if hasHint %}
-    {{ govukHint({
-      id: itemHintId,
-      classes: 'govuk-radios__hint' + (' ' + item.hint.classes if item.hint.classes),
-      attributes: item.hint.attributes,
-      html: item.hint.html,
-      text: item.hint.text
-    }) | trim | indent(6) }}
-    {% endif %}
-  </div>
-  {% if item.conditional.html %}
-    <div class="govuk-radios__conditional {%- if not isChecked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
-      {{ item.conditional.html | safe }}
+    <div class="govuk-radios__divider">{{ item.divider }}</div>
+  {% else %}
+    {% set isChecked = item.checked | default((item.value == params.value and item.checked != false) if params.value else false, true) %}
+    {% set hasHint = true if item.hint.text or item.hint.html %}
+    {% set itemHintId = itemId + '-item-hint' %}
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="{{ itemId }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
+        {{-" checked" if isChecked }}
+        {{-" disabled" if item.disabled }}
+        {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+        {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
+        {{- govukAttributes(item.attributes) }}>
+      {{ govukLabel({
+        html: item.html,
+        text: item.text,
+        classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
+        attributes: item.label.attributes,
+        for: itemId
+      }) | trim | indent(6) }}
+      {% if hasHint %}
+      {{ govukHint({
+        id: itemHintId,
+        classes: 'govuk-radios__hint' + (' ' + item.hint.classes if item.hint.classes),
+        attributes: item.hint.attributes,
+        html: item.hint.html,
+        text: item.hint.text
+      }) | trim | indent(6) }}
+      {% endif %}
     </div>
-  {% endif %}
+    {% if item.conditional.html %}
+    <div class="govuk-radios__conditional {%- if not isChecked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+      {{ item.conditional.html | safe | trim | indent(6) }}
+    </div>
+    {% endif %}
   {% endif %}
 {%- endmacro %}
 


### PR DESCRIPTION
Radios and Checkboxes changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

Similar to the `_actionLink()` and `_summaryCard()` macros in **Summary list**, I've added `_radioItem()` and `_checkboxItem()` macros to flatten the HTML indent level back to 2 spaces