### PR TITLE
Adjust the spacing of the new Tudor crown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes were made in the following pull requests:
 
 - [#4376: Implement the Tudor crown favicons (v4.x)](https://github.com/alphagov/govuk-frontend/pull/4376)
 - [#4278: Implement the Tudor crown in the Header component (v4.x)](https://github.com/alphagov/govuk-frontend/pull/4278)
+- [#4677: Adjust the spacing of the new Tudor crown (v4.x)](https://github.com/alphagov/govuk-frontend/pull/4677) - thanks to [Martin Jones](https://github.com/MartinJJones) and [Mónica Crusellas](https://github.com/monicacrusellasfanlo) for contributing this change
 
 ##### Include the new logo assets
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -66,7 +66,8 @@
   // existing crown. In Frontend v5, this rule should replace the equivalent in
   // the block above.
   .govuk-header__logotype-crown[width="32"] {
-    margin-right: 4px;
+    top: -3px;
+    margin-right: 2px;
   }
 
   .govuk-header__logotype-crown-fallback-image {


### PR DESCRIPTION
Adjust the spacing of the new Tudor crown to closely match the new SVG Tudor crown to be released in 5.1.

## Visual Changes

### 4.8 - Before

Screenshot
![localhost_3000_components_header_with-Tudor-crown_preview-before](https://github.com/alphagov/govuk-frontend/assets/28779939/0d8bca0b-acda-4848-8870-bff92c5a9372)

Video comparison, switching from 4.8 to 5.1

https://github.com/alphagov/govuk-frontend/assets/28779939/086385b6-9984-4bfa-a834-0dbe493e8ead

### 4.8 - After

Screenshot
![localhost_3000_components_header_with-Tudor-crown_preview-after](https://github.com/alphagov/govuk-frontend/assets/28779939/50854f0c-22f8-4b37-90b4-689b2e6dff7e)

Video comparison, switching from 4.8 to 5.1

https://github.com/alphagov/govuk-frontend/assets/28779939/a73eaf53-49e6-47b2-9b6d-8581e625443d
