### PR TITLE
Fix Nunjucks HTML indentation: Details

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/details/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/details/template.njk
@@ -1,7 +1,7 @@
 <details {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-details {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} {{- " open" if params.open }}>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      {{ params.summaryHtml | safe if params.summaryHtml else params.summaryText }}
+      {{ params.summaryHtml | safe | trim | indent(6) if params.summaryHtml else params.summaryText }}
     </span>
   </summary>
   <div class="govuk-details__text">


### PR DESCRIPTION
Details changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

This PR adds `| trim | indent(6)` to `params.summaryHtml` ensuring subsequent HTML lines are indented