### PR TITLE
Revert "Bump @prettier/sync from 0.3.0 to 0.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3991,17 +3991,14 @@
       }
     },
     "node_modules/@prettier/sync": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.5.0.tgz",
-      "integrity": "sha512-1a6veNypZYkSbU33anha4Pdna9Jz3HXUc0aru7sgN7HuyJHPIVNdCTfjhm1S+mG9yXmWuAO+a6I+Cznp9Ogt3A==",
-      "dependencies": {
-        "make-synchronized": "^0.2.5"
-      },
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.3.0.tgz",
+      "integrity": "sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==",
       "funding": {
         "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
       },
       "peerDependencies": {
-        "prettier": "*"
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -20393,14 +20390,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/make-synchronized": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.2.7.tgz",
-      "integrity": "sha512-tbTJaNgmKV3E6yYxEN5djObcMt0j1WB2ltn8JteZYczrdFkGMor3KAraPGUf4NJsf5u+FvJbgbGGL35N3J6VVw==",
-      "funding": {
-        "url": "https://github.com/fisker/make-synchronized?sponsor=1"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -31150,7 +31139,7 @@
         "@govuk-frontend/config": "*",
         "@govuk-frontend/lib": "*",
         "@govuk-frontend/stats": "*",
-        "@prettier/sync": "^0.5.0",
+        "@prettier/sync": "^0.3.0",
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -26,7 +26,7 @@
     "@govuk-frontend/config": "*",
     "@govuk-frontend/lib": "*",
     "@govuk-frontend/stats": "*",
-    "@prettier/sync": "^0.5.0",
+    "@prettier/sync": "^0.3.0",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",


### PR DESCRIPTION
Reverts alphagov/govuk-frontend#4687

We've seen too many [`make-synchronized`](https://github.com/fisker/make-synchronized/) errors on Windows since merging:

* https://github.com/alphagov/govuk-frontend/actions/runs/7698179202/job/20977038657
* https://github.com/alphagov/govuk-frontend/actions/runs/7697352994/job/20974366348
* https://github.com/alphagov/govuk-frontend/actions/runs/7696099803/job/20970540369
* https://github.com/alphagov/govuk-frontend/actions/runs/7695785158/job/20969630574
* https://github.com/alphagov/govuk-frontend/actions/runs/7707963406/job/21006202743