### PR TITLE
[SPIKE] Investigate the utility of an input macro separate from `govukInput` 

### DIFF
--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -137,6 +137,10 @@ describe('GOV.UK Prototype Kit config', () => {
           macroName: 'govukPanel'
         },
         {
+          importFrom: 'govuk/components/password-input/macro.njk',
+          macroName: 'govukPasswordInput'
+        },
+        {
           importFrom: 'govuk/components/phase-banner/macro.njk',
           macroName: 'govukPhaseBanner'
         },

--- a/packages/govuk-frontend/src/govuk/all.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.jsdom.test.mjs
@@ -14,6 +14,7 @@ jest.mock(`./components/error-summary/error-summary.mjs`)
 jest.mock(`./components/exit-this-page/exit-this-page.mjs`)
 jest.mock(`./components/header/header.mjs`)
 jest.mock(`./components/notification-banner/notification-banner.mjs`)
+jest.mock(`./components/password-input/password-input.mjs`)
 jest.mock(`./components/radios/radios.mjs`)
 jest.mock(`./components/skip-link/skip-link.mjs`)
 jest.mock(`./components/tabs/tabs.mjs`)
@@ -27,7 +28,8 @@ describe('initAll', () => {
     'character-count',
     'error-summary',
     'exit-this-page',
-    'notification-banner'
+    'notification-banner',
+    'password-input'
   ]
 
   afterEach(() => {

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -10,6 +10,7 @@ import { ErrorSummary } from './components/error-summary/error-summary.mjs'
 import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs'
 import { Header } from './components/header/header.mjs'
 import { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
+import { PasswordInput } from './components/password-input/password-input.mjs'
 import { Radios } from './components/radios/radios.mjs'
 import { SkipLink } from './components/skip-link/skip-link.mjs'
 import { Tabs } from './components/tabs/tabs.mjs'
@@ -41,6 +42,7 @@ function initAll(config) {
     [ExitThisPage, config.exitThisPage],
     [Header],
     [NotificationBanner, config.notificationBanner],
+    [PasswordInput, config.passwordInput],
     [Radios],
     [SkipLink],
     [Tabs]
@@ -81,6 +83,7 @@ export {
   ExitThisPage,
   Header,
   NotificationBanner,
+  PasswordInput,
   Radios,
   SkipLink,
   Tabs
@@ -96,6 +99,7 @@ export {
  * @property {ErrorSummaryConfig} [errorSummary] - Error Summary config
  * @property {ExitThisPageConfig} [exitThisPage] - Exit This Page config
  * @property {NotificationBannerConfig} [notificationBanner] - Notification Banner config
+ * @property {PasswordInputConfig} [passwordInput] - Password input config
  */
 
 /**
@@ -110,6 +114,7 @@ export {
  * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageConfig} ExitThisPageConfig
  * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageTranslations} ExitThisPageTranslations
  * @typedef {import('./components/notification-banner/notification-banner.mjs').NotificationBannerConfig} NotificationBannerConfig
+ * @typedef {import('./components/password-input/password-input.mjs').PasswordInputConfig} PasswordInputConfig
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/components/_all.scss
+++ b/packages/govuk-frontend/src/govuk/components/_all.scss
@@ -23,6 +23,7 @@
 @import "notification-banner/index";
 @import "pagination/index";
 @import "panel/index";
+@import "password-input/index";
 @import "phase-banner/index";
 @import "radios/index";
 @import "select/index";

--- a/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
@@ -4,15 +4,6 @@
 @import "../textarea/index";
 
 @include govuk-exports("govuk/component/character-count") {
-  .govuk-character-count {
-    @include govuk-responsive-margin(6, "bottom");
-
-    .govuk-form-group,
-    .govuk-textarea {
-      margin-bottom: govuk-spacing(1);
-    }
-  }
-
   .govuk-character-count__message {
     @include govuk-font-tabular-numbers;
     margin-top: 0;

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -152,10 +152,6 @@ export class CharacterCount extends GOVUKFrontendComponent {
       })
     }
 
-    // Move the textarea description to be immediately after the textarea
-    // Kept for backwards compatibility
-    this.$textarea.insertAdjacentElement('afterend', $textareaDescription)
-
     // Create the *screen reader* specific live-updating counter
     // This doesn't need any styling classes, as it is never visible
     const $screenReaderCountMessage = document.createElement('div')

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -1,86 +1,118 @@
+{% from "../../macros/text-input.njk" import govukTextareaElement %}
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
-{% from "../textarea/macro.njk" import govukTextarea %}
+{% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {%- set hasNoLimit = (not params.maxwords and not params.maxlength) -%}
+{#- a record of other elements that we need to associate with the input using
+  aria-describedby – for example hints or error messages -#}
+{% set describedBy = params.describedBy if params.describedBy else "" %}
 
-<div class="govuk-character-count" data-module="govuk-character-count"
-  {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
-  {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
-  {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
-  {#-
-    Without maxlength or maxwords, we can't guess if the component will count words or characters.
-    We can't guess a default textarea description to be interpolated in JavaScript
-    once the maximum gets configured there.
-    So we only add the attribute if a textarea description was explicitely provided.
-  #}
-  {%- if hasNoLimit and params.textareaDescriptionText %}
-    {{- govukI18nAttributes({
-      key: 'textarea-description',
-      messages: { other: params.textareaDescriptionText }
-    }) -}}
-  {% endif -%}
-
-  {{- govukI18nAttributes({
-    key: 'characters-under-limit',
-    messages: params.charactersUnderLimitText
-  }) -}}
-
-  {{- govukI18nAttributes({
-    key: 'characters-at-limit',
-    message: params.charactersAtLimitText
-  }) -}}
-
-  {{- govukI18nAttributes({
-    key: 'characters-over-limit',
-    messages: params.charactersOverLimitText
-  }) -}}
-
-  {{- govukI18nAttributes({
-    key: 'words-under-limit',
-    messages: params.wordsUnderLimitText
-  }) -}}
-
-  {{- govukI18nAttributes({
-    key: 'words-at-limit',
-    message: params.wordsAtLimitText
-  }) -}}
-
-  {{- govukI18nAttributes({
-    key: 'words-over-limit',
-    messages: params.wordsOverLimitText
-  }) -}}>
-  {{ govukTextarea({
-    id: params.id,
-    name: params.name,
-    describedBy: params.id + '-info',
-    rows: params.rows,
-    spellcheck: params.spellcheck,
-    value: params.value,
-    formGroup: params.formGroup,
-    classes: 'govuk-js-character-count' + (' ' + params.classes if params.classes),
-    label: {
-      html: params.label.html,
-      text: params.label.text,
-      classes: params.label.classes,
-      isPageHeading: params.label.isPageHeading,
-      attributes: params.label.attributes,
-      for: params.id
-    },
-    hint: params.hint,
-    errorMessage: params.errorMessage,
-    attributes: params.attributes
-  }) }}
-  {%- set textareaDescriptionLength = params.maxwords or params.maxlength %}
-  {%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
-  {#-
-    If the limit is set in JavaScript, we won't be able to interpolate the message
-    until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
-    were provided to the macro.
-  #}
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | trim | indent(2) }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
-    text: ((textareaDescriptionText) | replace('%{count}', textareaDescriptionLength) if not hasNoLimit),
-    id: params.id + '-info',
-    classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
-  }) }}
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | trim | indent(2) }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | trim | indent(2) }}
+{% endif %}
+
+  <div class="govuk-character-count" data-module="govuk-character-count"
+    {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
+    {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
+    {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
+    {#-
+      Without maxlength or maxwords, we can't guess if the component will count words or characters.
+      We can't guess a default textarea description to be interpolated in JavaScript
+      once the maximum gets configured there.
+      So we only add the attribute if a textarea description was explicitely provided.
+    #}
+    {%- if hasNoLimit and params.textareaDescriptionText %}
+      {{- govukI18nAttributes({
+        key: 'textarea-description',
+        messages: { other: params.textareaDescriptionText }
+      }) -}}
+    {% endif -%}
+
+    {{- govukI18nAttributes({
+      key: 'characters-under-limit',
+      messages: params.charactersUnderLimitText
+    }) -}}
+
+    {{- govukI18nAttributes({
+      key: 'characters-at-limit',
+      message: params.charactersAtLimitText
+    }) -}}
+
+    {{- govukI18nAttributes({
+      key: 'characters-over-limit',
+      messages: params.charactersOverLimitText
+    }) -}}
+
+    {{- govukI18nAttributes({
+      key: 'words-under-limit',
+      messages: params.wordsUnderLimitText
+    }) -}}
+
+    {{- govukI18nAttributes({
+      key: 'words-at-limit',
+      message: params.wordsAtLimitText
+    }) -}}
+
+    {{- govukI18nAttributes({
+      key: 'words-over-limit',
+      messages: params.wordsOverLimitText
+    }) -}}>
+
+    {{ govukTextareaElement({
+      id: params.id,
+      name: params.name,
+      errorClass: params.errorMessage,
+      describedBy: params.id + '-info' + (' ' + describedBy if describedBy),
+      rows: params.rows,
+      spellcheck: params.spellcheck,
+      value: params.value,
+      classes: 'govuk-js-character-count' + (' ' + params.classes if params.classes),
+      attributes: params.attributes
+    }) }}
+
+    {%- set textareaDescriptionLength = params.maxwords or params.maxlength %}
+    {%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
+    {#-
+      If the limit is set in JavaScript, we won't be able to interpolate the message
+      until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
+      were provided to the macro.
+    #}
+    {{ govukHint({
+      text: ((textareaDescriptionText) | replace('%{count}', textareaDescriptionLength) if not hasNoLimit),
+      id: params.id + '-info',
+      classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
+    }) }}
+  </div>
+
 </div>

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
@@ -216,7 +216,7 @@ describe('Character count', () => {
         examples['with default value exceeding limit']
       )
 
-      const $component = $('.govuk-form-group > .govuk-js-character-count')
+      const $component = $('.govuk-form-group .govuk-js-character-count')
       expect($component.length).toBeTruthy()
     })
 

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -1,7 +1,8 @@
+{% from "../../macros/text-input.njk" import govukInputElement %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../fieldset/macro.njk" import govukFieldset %}
 {% from "../hint/macro.njk" import govukHint %}
-{% from "../input/macro.njk" import govukInput %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
@@ -55,13 +56,15 @@
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% for item in dateInputItems %}
+    {% set inputId = item.id if item.id else (params.id + "-" + item.name) %}
     <div class="govuk-date-input__item">
-      {{ govukInput({
-        label: {
-          text: item.label if item.label else item.name | capitalize,
-          classes: "govuk-date-input__label"
-        },
-        id: item.id if item.id else (params.id + "-" + item.name),
+      {{ govukLabel({
+        for: inputId,
+        classes: "govuk-date-input__label",
+        text: item.label if item.label else item.name | capitalize
+      }) }}
+      {{ govukInputElement({
+        id: inputId,
         classes: "govuk-date-input__input " + (item.classes if item.classes),
         name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,
@@ -70,7 +73,7 @@
         autocomplete: item.autocomplete,
         pattern: item.pattern,
         attributes: item.attributes
-      }) | trim | indent(6) }}
+      }) }}
     </div>
   {% endfor %}
   </div>

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -43,6 +43,7 @@ describe('GOV.UK Frontend', () => {
         'ExitThisPage',
         'Header',
         'NotificationBanner',
+        'PasswordInput',
         'Radios',
         'SkipLink',
         'Tabs'

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -1,6 +1,8 @@
+{% from "../../macros/text-input.njk" import govukInputElement %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
+
 
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
@@ -47,15 +49,21 @@
     </div>
   {% endif -%}
 
-  <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default("text", true) }}"
-  {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
-  {%- if params.value %} value="{{ params.value }}"{% endif %}
-  {%- if params.disabled %} disabled{% endif %}
-  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
-  {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
-  {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{ govukInputElement({
+    classes: params.classes,
+    attributes: params.attributes,
+    errorClass: params.errorMessage,
+    id: params.id,
+    name: params.name,
+    type: params.type,
+    autocomplete: params.autocomplete,
+    describedBy: describedBy,
+    disabled: params.disabled,
+    inputmode: params.inputmode,
+    pattern: params.pattern,
+    spellcheck: params.spellcheck,
+    value: params.value
+  }) }}
 
   {%- if params.suffix.text or params.suffix.html -%}
     <div class="govuk-input__suffix {%- if params.suffix.classes %} {{ params.suffix.classes }}{% endif %}" aria-hidden="true" {%- for attribute, value in params.suffix.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -7,20 +7,34 @@
 @include govuk-exports("govuk/component/password-input") {
   .govuk-password-input {
     display: flex;
-    width: 100%;
     flex-direction: column;
 
     @include govuk-media-query($from: mobile) {
       flex-direction: row;
+
+      // The default of `stretch` makes the toggle button appear taller than the input, due to using
+      // box-shadow, which we don't particularly want in this situation
+      align-items: flex-start;
     }
   }
 
   .govuk-password-input__toggle {
+    // Add margin to the top so that the button doesn't obscure the input's focus style
+    margin-top: govuk-spacing(1);
+
+    // Remove default margin-bottom from button
     margin-bottom: 0;
 
-    // Buttons are normally 100% width on this breakpoint, but we don't want that in this case
     @include govuk-media-query($from: mobile) {
+      // Buttons are normally 100% width on this breakpoint, but we don't want that in this case
       width: auto;
+      flex-grow: 1;
+      flex-shrink: 0;
+      flex-basis: 5em;
+
+      // Move the spacing from top to the left
+      margin-top: 0;
+      margin-left: govuk-spacing(1);
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -1,0 +1,26 @@
+@import "../button/index";
+@import "../error-message/index";
+@import "../hint/index";
+@import "../input/index";
+@import "../label/index";
+
+@include govuk-exports("govuk/component/password-input") {
+  .govuk-password-input {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+
+    @include govuk-media-query($from: mobile) {
+      flex-direction: row;
+    }
+  }
+
+  .govuk-password-input__toggle {
+    margin-bottom: 0;
+
+    // Buttons are normally 100% width on this breakpoint, but we don't want that in this case
+    @include govuk-media-query($from: mobile) {
+      width: auto;
+    }
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_password-input.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_password-input.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/packages/govuk-frontend/src/govuk/components/password-input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/accessibility.puppeteer.test.mjs
@@ -1,0 +1,15 @@
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
+import { getExamples } from '@govuk-frontend/lib/components'
+
+describe('/components/password-input', () => {
+  describe('component examples', () => {
+    it('passes accessibility tests', async () => {
+      const examples = await getExamples('password-input')
+
+      for (const exampleName in examples) {
+        await render(page, 'password-input', examples[exampleName])
+        await expect(axe(page)).resolves.toHaveNoViolations()
+      }
+    }, 120000)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/password-input/macro.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukPasswordInput(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -15,9 +15,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class PasswordInput extends GOVUKFrontendComponent {
-  /** @private */
-  $module
-
   /**
    * @private
    * @type {PasswordInputConfig}
@@ -26,7 +23,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
 
   /**
    * @private
-   * @type {HTMLElement | null}
+   * @type {HTMLButtonElement | null}
    */
   $showHideButton = null
 
@@ -81,29 +78,24 @@ export class PasswordInput extends GOVUKFrontendComponent {
     })
 
     // Create and append the button element
-    const $showHideButton = document.createElement('button')
-    $showHideButton.className =
+    this.$showHideButton = document.createElement('button')
+    this.$showHideButton.className =
       'govuk-button govuk-button--secondary govuk-password-input__toggle'
-    $showHideButton.setAttribute(
-      'aria-controls',
-      this.$input.getAttribute('id')
-    )
-    $showHideButton.setAttribute('type', 'button')
-    $showHideButton.setAttribute(
+    this.$showHideButton.setAttribute('aria-controls', this.$input.id)
+    this.$showHideButton.setAttribute('type', 'button')
+    this.$showHideButton.setAttribute(
       'aria-label',
       this.i18n.t('showPasswordAriaLabel')
     )
-    $showHideButton.innerHTML = this.i18n.t('showPassword')
-    this.$showHideButton = $showHideButton
-    this.$wrapper.insertBefore($showHideButton, this.$input.nextSibling)
+    this.$showHideButton.innerHTML = this.i18n.t('showPassword')
+    this.$wrapper.insertBefore(this.$showHideButton, this.$input.nextSibling)
 
     // Create and append the status text for screen readers
-    const $statusText = document.createElement('span')
-    $statusText.className = 'govuk-visually-hidden'
-    $statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
-    $statusText.setAttribute('aria-live', 'polite')
-    this.$statusText = $statusText
-    this.$wrapper.insertBefore($statusText, this.$input.nextSibling)
+    this.$statusText = document.createElement('span')
+    this.$statusText.className = 'govuk-visually-hidden'
+    this.$statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
+    this.$statusText.setAttribute('aria-live', 'polite')
+    this.$wrapper.insertBefore(this.$statusText, this.$input.nextSibling)
 
     // Bind toggle button
     this.$showHideButton.addEventListener(
@@ -124,6 +116,11 @@ export class PasswordInput extends GOVUKFrontendComponent {
    */
   togglePassword(event) {
     event.preventDefault()
+
+    if (!this.$showHideButton || !this.$statusText) {
+      return
+    }
+
     this.$input.setAttribute(
       'type',
       this.$input.type === 'password' ? 'text' : 'password'
@@ -148,6 +145,10 @@ export class PasswordInput extends GOVUKFrontendComponent {
    * user agents potentially saving or caching the plain text password.
    */
   revertToPasswordOnFormSubmit() {
+    if (!this.$showHideButton || !this.$statusText) {
+      return
+    }
+
     this.$showHideButton.setAttribute(
       'aria-label',
       this.i18n.t('showPasswordAriaLabel')

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -65,7 +65,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       PasswordInput.defaults,
-      config || {},
+      config,
       normaliseDataset($module.dataset)
     )
 
@@ -91,7 +91,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     $showHideButton.setAttribute('type', 'button')
     $showHideButton.setAttribute(
       'aria-label',
-      this.i18n.t('showPasswordFullText')
+      this.i18n.t('showPasswordAriaLabel')
     )
     $showHideButton.innerHTML = this.i18n.t('showPassword')
     this.$showHideButton = $showHideButton
@@ -100,7 +100,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     // Create and append the status text for screen readers
     const $statusText = document.createElement('span')
     $statusText.className = 'govuk-visually-hidden'
-    $statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    $statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
     $statusText.setAttribute('aria-live', 'polite')
     this.$statusText = $statusText
     this.$wrapper.insertBefore($statusText, this.$input.nextSibling)
@@ -135,12 +135,12 @@ export class PasswordInput extends GOVUKFrontendComponent {
     this.$showHideButton.setAttribute(
       'aria-label',
       passwordIsHidden
-        ? this.i18n.t('showPasswordFullText')
-        : this.i18n.t('hidePasswordFullText')
+        ? this.i18n.t('showPasswordAriaLabel')
+        : this.i18n.t('hidePasswordAriaLabel')
     )
     this.$statusText.innerText = passwordIsHidden
-      ? this.i18n.t('hiddenPasswordAnnouncement')
-      : this.i18n.t('shownPasswordAnnouncement')
+      ? this.i18n.t('passwordHiddenAnnouncement')
+      : this.i18n.t('passwordShownAnnouncement')
   }
 
   /**
@@ -150,10 +150,10 @@ export class PasswordInput extends GOVUKFrontendComponent {
   revertToPasswordOnFormSubmit() {
     this.$showHideButton.setAttribute(
       'aria-label',
-      this.i18n.t('showPasswordFullText')
+      this.i18n.t('showPasswordAriaLabel')
     )
     this.$showHideButton.innerHTML = this.i18n.t('showPassword')
-    this.$statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    this.$statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
     this.$input.setAttribute('type', 'password')
   }
 
@@ -175,10 +175,10 @@ export class PasswordInput extends GOVUKFrontendComponent {
     i18n: {
       showPassword: 'Show',
       hidePassword: 'Hide',
-      showPasswordFullText: 'Show password',
-      hidePasswordFullText: 'Hide password',
-      shownPasswordAnnouncement: 'Your password is visible',
-      hiddenPasswordAnnouncement: 'Your password is hidden'
+      showPasswordAriaLabel: 'Show password',
+      hidePasswordAriaLabel: 'Hide password',
+      passwordShownAnnouncement: 'Your password is visible',
+      passwordHiddenAnnouncement: 'Your password is hidden'
     }
   })
 
@@ -212,14 +212,14 @@ export class PasswordInput extends GOVUKFrontendComponent {
  *   password is currently hidden. HTML is acceptable.
  * @property {string} [hidePassword] - Visible text of the button when the
  *   password is currently visible. HTML is acceptable.
- * @property {string} [showPasswordFullText] - aria-label of the button when
+ * @property {string} [showPasswordAriaLabel] - aria-label of the button when
  *   the password is currently hidden. Plain text only.
- * @property {string} [hidePasswordFullText] - aria-label of the button when
+ * @property {string} [hidePasswordAriaLabel] - aria-label of the button when
  *   the password is currently visible. Plain text only.
- * @property {string} [shownPasswordAnnouncement] - Screen reader
+ * @property {string} [passwordShownAnnouncement] - Screen reader
  *   announcement to make when the password has just become visible.
  *   Plain text only.
- * @property {string} [hiddenPasswordAnnouncement] - Screen reader
+ * @property {string} [passwordHiddenAnnouncement] - Screen reader
  *   announcement to make when the password has just been hidden.
  *   Plain text only.
  */

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -1,0 +1,229 @@
+import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
+import {
+  extractConfigByNamespace,
+  mergeConfigs,
+  validateConfig
+} from '../../common/index.mjs'
+import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+import { I18n } from '../../i18n.mjs'
+
+/**
+ * Password input component
+ *
+ * @preserve
+ */
+export class PasswordInput extends GOVUKFrontendComponent {
+  /** @private */
+  $module
+
+  /**
+   * @private
+   * @type {PasswordInputConfig}
+   */
+  config
+
+  /**
+   * @private
+   * @type {HTMLElement | null}
+   */
+  $showHideButton = null
+
+  /**
+   * @private
+   * @type {HTMLElement | null}
+   */
+  $statusText = null
+
+  /**
+   * @param {Element} $module - HTML element to use for password input
+   * @param {PasswordInputConfig} [config] - Password input config
+   */
+  constructor($module, config = {}) {
+    super()
+
+    if (!($module instanceof HTMLElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: $module,
+        identifier: 'Root element (`$module`)'
+      })
+    }
+
+    this.$wrapper = $module
+    this.$input = $module.querySelector('input')
+
+    if (!(this.$input instanceof HTMLInputElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: this.$input,
+        expectedType: 'HTMLInputElement',
+        identifier: 'Form field (`.govuk-password-input`)'
+      })
+    }
+
+    this.config = mergeConfigs(
+      PasswordInput.defaults,
+      config || {},
+      normaliseDataset($module.dataset)
+    )
+
+    // Check for valid config
+    const errors = validateConfig(PasswordInput.schema, this.config)
+    if (errors[0]) {
+      throw new ConfigError(`Password input: ${errors[0]}`)
+    }
+
+    this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'), {
+      // Read the fallback if necessary rather than have it set in the defaults
+      locale: closestAttributeValue($module, 'lang')
+    })
+
+    // Create and append the button element
+    const $showHideButton = document.createElement('button')
+    $showHideButton.className =
+      'govuk-button govuk-button--secondary govuk-password-input__toggle'
+    $showHideButton.setAttribute(
+      'aria-controls',
+      this.$input.getAttribute('id')
+    )
+    $showHideButton.setAttribute('type', 'button')
+    $showHideButton.setAttribute(
+      'aria-label',
+      this.i18n.t('showPasswordFullText')
+    )
+    $showHideButton.innerHTML = this.i18n.t('showPassword')
+    this.$showHideButton = $showHideButton
+    this.$wrapper.insertBefore($showHideButton, this.$input.nextSibling)
+
+    // Create and append the status text for screen readers
+    const $statusText = document.createElement('span')
+    $statusText.className = 'govuk-visually-hidden'
+    $statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    $statusText.setAttribute('aria-live', 'polite')
+    this.$statusText = $statusText
+    this.$wrapper.insertBefore($statusText, this.$input.nextSibling)
+
+    // Bind toggle button
+    this.$showHideButton.addEventListener(
+      'click',
+      this.togglePassword.bind(this)
+    )
+
+    // Bind form submit check, unless it's been disabled
+    if (this.$input.form && !this.config.disableFormSubmitCheck) {
+      this.$input.form.addEventListener('submit', () =>
+        this.revertToPasswordOnFormSubmit()
+      )
+    }
+  }
+
+  /**
+   * @param {MouseEvent} event -
+   */
+  togglePassword(event) {
+    event.preventDefault()
+    this.$input.setAttribute(
+      'type',
+      this.$input.type === 'password' ? 'text' : 'password'
+    )
+    const passwordIsHidden = this.$input.type === 'password'
+    this.$showHideButton.innerHTML = passwordIsHidden
+      ? this.i18n.t('showPassword')
+      : this.i18n.t('hidePassword')
+    this.$showHideButton.setAttribute(
+      'aria-label',
+      passwordIsHidden
+        ? this.i18n.t('showPasswordFullText')
+        : this.i18n.t('hidePasswordFullText')
+    )
+    this.$statusText.innerText = passwordIsHidden
+      ? this.i18n.t('hiddenPasswordAnnouncement')
+      : this.i18n.t('shownPasswordAnnouncement')
+  }
+
+  /**
+   * Revert the input to type=password when the form is submitted. This prevents
+   * user agents potentially saving or caching the plain text password.
+   */
+  revertToPasswordOnFormSubmit() {
+    this.$showHideButton.setAttribute(
+      'aria-label',
+      this.i18n.t('showPasswordFullText')
+    )
+    this.$showHideButton.innerHTML = this.i18n.t('showPassword')
+    this.$statusText.innerText = this.i18n.t('hiddenPasswordAnnouncement')
+    this.$input.setAttribute('type', 'password')
+  }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-password-input'
+
+  /**
+   * Password input default config
+   *
+   * @see {@link PasswordInputConfig}
+   * @constant
+   * @default
+   * @type {PasswordInputConfig}
+   */
+  static defaults = Object.freeze({
+    disableFormSubmitCheck: false,
+    i18n: {
+      showPassword: 'Show',
+      hidePassword: 'Hide',
+      showPasswordFullText: 'Show password',
+      hidePasswordFullText: 'Hide password',
+      shownPasswordAnnouncement: 'Your password is visible',
+      hiddenPasswordAnnouncement: 'Your password is hidden'
+    }
+  })
+
+  /**
+   * Character count config schema
+   *
+   * @constant
+   * @satisfies {Schema}
+   */
+  static schema = Object.freeze({})
+}
+
+/**
+ * Password input config
+ *
+ * @typedef {object} PasswordInputConfig
+ * @property {boolean} [disableFormSubmitCheck=false] - If set to `true` the
+ *   password input will not automatically change back to the `password` type
+ *   upon submission of the parent form.
+ * @property {PasswordInputTranslations} [i18n=PasswordInput.defaults.i18n] - Password input translations
+ */
+
+/**
+ * Password input translations
+ *
+ * @see {@link PasswordInput.defaults.i18n}
+ * @typedef {object} PasswordInputTranslations
+ *
+ * Messages displayed to the user indicating the state of the show/hide toggle.
+ * @property {string} [showPassword] - Visible text of the button when the
+ *   password is currently hidden. HTML is acceptable.
+ * @property {string} [hidePassword] - Visible text of the button when the
+ *   password is currently visible. HTML is acceptable.
+ * @property {string} [showPasswordFullText] - aria-label of the button when
+ *   the password is currently hidden. Plain text only.
+ * @property {string} [hidePasswordFullText] - aria-label of the button when
+ *   the password is currently visible. Plain text only.
+ * @property {string} [shownPasswordAnnouncement] - Screen reader
+ *   announcement to make when the password has just become visible.
+ *   Plain text only.
+ * @property {string} [hiddenPasswordAnnouncement] - Screen reader
+ *   announcement to make when the password has just been hidden.
+ *   Plain text only.
+ */
+
+/**
+ * @typedef {import('../../common/index.mjs').Schema} Schema
+ */

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -45,3 +45,15 @@ examples:
       newPassword: true
       id: password-input-new-password
       name: password
+  - name: with translations
+    options:
+      label:
+        text: Cyfrinair
+      id: password-translated
+      name: password-translated
+      showPasswordText: Datguddia
+      hidePasswordText: Cuddio
+      showPasswordAriaLabelText: Datgelu cyfrinair
+      hidePasswordAriaLabelText: Cuddio cyfrinair
+      passwordShownAnnouncementText: Mae eich cyfrinair yn weladwy.
+      passwordHiddenAnnouncementText: Mae eich cyfrinair wedi'i guddio.

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -1,0 +1,47 @@
+params:
+  - name: id
+    type: string
+    required: true
+    description: The ID of the input.
+
+examples:
+  - name: default
+    options:
+      label:
+        text: Password
+      id: password-input
+      name: password
+  - name: with hint text
+    options:
+      label:
+        text: Password
+      hint:
+        text: It probably has some letters, numbers and maybe even some symbols in it.
+      id: password-input-with-hint-text
+      name: test-name-2
+  - name: with error message
+    options:
+      label:
+        text: Password
+      hint:
+        text: It probably has some letters, numbers and maybe even some symbols in it.
+      id: password-input-with-error-message
+      name: test-name-3
+      errorMessage:
+        text: Error message goes here
+  - name: with label as page heading
+    options:
+      label:
+        text: Password
+        classes: govuk-label--l
+        isPageHeading: true
+      id: password-input-with-page-heading
+      name: test-name
+  - name: with new-password autocomplete
+    description: Browsers and password managers should prompt to generate a password.
+    options:
+      label:
+        text: Password
+      newPassword: true
+      id: password-input-new-password
+      name: password

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,0 +1,59 @@
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
+
+{#- a record of other elements that we need to associate with the input using
+  aria-describedby – for example hints or error messages -#}
+{% set describedBy = params.describedBy if params.describedBy else "" %}
+
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+  {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+
+  <div class="govuk-password-input" data-module="govuk-password-input">
+
+    <input
+      class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"
+      id="{{ params.id }}"
+      name="{{ params.name }}"
+      type="password"
+      spellcheck="false"
+      autocapitalize="off"
+      autocomplete="{{ 'new-password' if params.newPassword else 'current-password' }}"
+      {%- if params.value %} value="{{ params.value}}"{% endif %}
+      {%- if params.disabled %} disabled{% endif %}
+      {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+      {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+
+  </div>
+
+</div>

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/text-input.njk" import govukInputElement %}
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
 {% from "../error-message/macro.njk" import govukErrorMessage -%}
@@ -50,18 +51,20 @@
     {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
     {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}>
 
-    <input
-      class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"
-      id="{{ params.id }}"
-      name="{{ params.name }}"
-      type="password"
-      spellcheck="false"
-      autocapitalize="off"
-      autocomplete="{{ 'new-password' if params.newPassword else 'current-password' }}"
-      {%- if params.value %} value="{{ params.value}}"{% endif %}
-      {%- if params.disabled %} disabled{% endif %}
-      {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-      {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+    {{ govukInputElement({
+      classes: "govuk-password-input__input" + (" " + params.classes if params.classes),
+      errorClass: params.errorMessage,
+      id: params.id,
+      name: params.name,
+      type: "password",
+      spellcheck: "false",
+      autocapitalize: "off",
+      autocomplete: 'new-password' if params.newPassword else 'current-password',
+      disabled: params.disabled,
+      describedBy: describedBy,
+      value: params.value,
+      attributes: params.attributes
+    }) }}
 
   </div>
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,3 +1,5 @@
+{% from "../../macros/i18n.njk" import govukI18nAttributes %}
+
 {% from "../error-message/macro.njk" import govukErrorMessage -%}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -39,7 +41,14 @@
   }) | indent(2) | trim }}
 {% endif %}
 
-  <div class="govuk-password-input" data-module="govuk-password-input">
+  <div class="govuk-password-input" data-module="govuk-password-input"
+    {%- if params.disableFormSubmitCheck %} data-disable-form-submit-check="true"{% endif %}
+    {{- govukI18nAttributes({ key: 'show-password', message: params.showPasswordText }) -}}
+    {{- govukI18nAttributes({ key: 'hide-password', message: params.hidePasswordText }) -}}
+    {{- govukI18nAttributes({ key: 'show-password-aria-label', message: params.showPasswordAriaLabelText }) -}}
+    {{- govukI18nAttributes({ key: 'hide-password-aria-label', message: params.hidePasswordAriaLabelText }) -}}
+    {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
+    {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}>
 
     <input
       class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/text-input.njk" import govukTextareaElement %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -37,10 +38,17 @@
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | trim | indent(2) }}
 {% endif %}
-  <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
-  {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
-  {%- if params.disabled %} disabled{% endif %}
-  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ params.value }}</textarea>
+  {{ govukTextareaElement({
+    classes: params.classes,
+    errorClass: params.errorMessage,
+    id: params.id,
+    name: params.name,
+    rows: params.rows,
+    autocomplete: params.autocomplete,
+    describedBy: describedBy,
+    disabled: params.disabled,
+    spellcheck: params.spellcheck,
+    value: params.value,
+    attributes: params.attributes
+  }) }}
 </div>

--- a/packages/govuk-frontend/src/govuk/macros/text-input.njk
+++ b/packages/govuk-frontend/src/govuk/macros/text-input.njk
@@ -1,0 +1,34 @@
+{#
+  Internal-only macros to render out text-like inputs, which are used across
+  multiple components but where different components may want to only allow a
+  subset of configuration parameters.
+#}
+{% macro govukInputElement(params) %}
+<input
+  class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorClass %} govuk-input--error{% endif %}"
+  type="{{ params.type | default("text", true) }}"
+  {%- if params.value %} value="{{ params.value }}"{% endif %}
+  {{ _govukTextCommonAttributes(params) | indent(2) | trim }}>
+{% endmacro %}
+
+{% macro govukTextareaElement(params) %}
+<textarea
+  class="govuk-textarea {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorClass %} govuk-textarea--error{% endif %}"
+  rows="{{ params.rows | default(5, true) }}"
+  {{ _govukTextCommonAttributes(params) | indent(2) | trim }}>
+  {{- params.value -}}
+</textarea>
+{% endmacro %}
+
+{% macro _govukTextCommonAttributes(params) %}
+id="{{ params.id }}"
+name="{{ params.name }}"
+{%- if params.autocapitalize %} autocapitalize="{{ params.autocapitalize }}"{% endif %}
+{%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
+{%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
+{%- if params.disabled %} disabled{% endif %}
+{%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
+{%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
+{%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
+{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+{% endmacro %}

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -188,6 +188,7 @@ describe('packages/govuk-frontend/dist/', () => {
           import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs';
           import { Header } from './components/header/header.mjs';
           import { NotificationBanner } from './components/notification-banner/notification-banner.mjs';
+          import { PasswordInput } from './components/password-input/password-input.mjs';
           import { Radios } from './components/radios/radios.mjs';
           import { SkipLink } from './components/skip-link/skip-link.mjs';
           import { Tabs } from './components/tabs/tabs.mjs';
@@ -195,7 +196,7 @@ describe('packages/govuk-frontend/dist/', () => {
 
         // Look for ES modules named exports
         expect(contents).toContain(
-          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };'
+          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, PasswordInput, Radios, SkipLink, Tabs, initAll };'
         )
       })
     })


### PR DESCRIPTION
## Background

Currently, the Date input component directly imports and uses the `govukInput` macro to provide the date fields; and the Character count component directly imports and uses the `govukTextarea` macro for the textarea. 

In both cases, importing the macro carries with it the entire HTML of that component, including the `govuk-form-group` wrapper, label, hint, error message, and the input/textarea itself. This HTML is non-permeable to the parent component and cannot be altered, unless we specifically extend those macros with new parameters to do so.

### The Character count component

In the case of the Character count, this limitation has led to a few 'hacky' workarounds:

- The inability to alter what's inside `govukTextarea` means that the 'info' hint below the textarea has to live outside of `govuk-form-group`, which has a large bottom margin that pushes the 'info' hint away from the textarea. 
- Custom CSS is then used to remove the bottom margin from `govuk-form-group` and instead apply an identical margin to `govuk-character-count`, a new element that wraps around the entire form group.
- JavaScript is used to move the 'info' hint up to within the `govuk-form-group` where it's available to do so. 

None of these are ideal, and all of them constitutes extra code loaded by browsers that doesn't need to exist.

### The Password input component

In developing the Password input component, we also saw us having to deal with similar frustrations when it came to applying a wrapping element around only the input of `govukInput` and placing a button within that new wrapper. 

There was also some trepidation about how `govukInput` could conflict with or compromise the effectiveness of the Password input; such as how input's prefix/suffix HTML may interfere with the Password input's own wrapper and button, or that some of the accessibility and security features of the password input could be overridden through modification of the inherited input.

These issues led us to initially decide to not use the macro — #4512.

## Exploring solutions

Reckoning that this may be a recurring problem in future, we are considering a few ways to modify how these components are composed to avoid these problems.

One option being explored is to add 'injection' points within the components where arbitrary HTML can be added, similar to how we use Nunjucks `block`s in templating — #4567.

### The idea behind this spike

This spike seeks to minimise the use of directly importing and extending `govukInput` and `govukTextarea` in favour of two 'internal' macros. 

These macros only include the base `input` and `textarea` elements, and do not include the other parts (group wrapper, label, etc.) with the expectation that:

- Components become more 'standalone', implementing their own label/hint/error code rather than reusing them from the Text input and Textarea components.
- In doing so, we can 'liberalise' the component HTML and allow it to more readily diverge where it needs to, such as for Character count and Password input.
- These macros define the system-wide defaults and are extended with whatever parameter options become necessary, instead of having those options unnecessarily bloat the `govukInput` and `govukTextarea` components. 
- Components can choose to only expose the relevant parameters of the underlying macros. 

## Changes

- Creates `govukInputElement` and `govukTextareaElement` Nunjucks macros, each containing the base `input` and `textarea` elements. 
- Additionally creates a `_govukTextCommonAttributes` macro for attributes that are common to both `input` and `textarea`.
- Reworks Character Count, Date input, (Text) Input, Password input and Textarea to use the new macros.
- Additionally reworks Character count to:
  - move the wrapping element to within the form group
  - move the 'info' hint to within the form group
  - remove the CSS styles to adjust the bottom margins
  - remove the JavaScript to programatically move the 'info' hint 

## Thoughts

- I am not at all tied to the current names for the internal macros. They can probably be a lot clearer.
- Not much care put to how the HTML is output either. This can definitely be improved too.
- No tests as it's a spike.