### PR TITLE
Fix Nunjucks HTML indentation: Inset text

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.njk
@@ -1,4 +1,4 @@
 <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-inset-text {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  {{ caller() if caller else (params.html | safe if params.html else params.text) }}
+  {{ caller() if caller else (params.html | safe | trim | indent(2) if params.html else params.text) }}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
@@ -1,5 +1,7 @@
 const { render } = require('@govuk-frontend/helpers/nunjucks')
 const { getExamples } = require('@govuk-frontend/lib/components')
+const { indent } = require('nunjucks/src/filters')
+const { outdent } = require('outdent')
 
 describe('Inset text', () => {
   let examples
@@ -48,14 +50,23 @@ describe('Inset text', () => {
       const mainContent = $('.govuk-inset-text .govuk-body:first-child')
         .text()
         .trim()
+
       const warningContent = $('.govuk-inset-text .govuk-warning-text__text')
         .text()
         .trim()
+
       expect(mainContent).toEqual(
         'It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.'
       )
+
       expect(warningContent).toEqual(
-        'Warning\n    You can be fined up to £5,000 if you don’t register.'
+        indent(
+          outdent`
+            Warning
+            You can be fined up to £5,000 if you don’t register.
+          `,
+          6
+        )
       )
     })
 


### PR DESCRIPTION
Inset text changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

This PR adds `| trim | indent(2)` to `params.html` to ensure subsequent HTML lines are indented