### PR TITLE
Fix Nunjucks HTML indentation: Pagination

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -16,32 +16,32 @@
 
 <nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}"
   {{- govukAttributes(params.attributes) }}>
-  {%- if params.previous and params.previous.href -%}
+  {% if params.previous and params.previous.href %}
     <div class="govuk-pagination__prev">
       <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev"
         {{- govukAttributes(params.previous.attributes) }}>
-        {{- arrowPrevious | safe -}}
+        {{ arrowPrevious | safe }}
         <span class="govuk-pagination__link-title {%- if blockLevel and not params.previous.labelText %} govuk-pagination__link-title--decorated{% endif %}">
-          {%- if params.previous.html or params.previous.text -%}
+          {% if params.previous.html or params.previous.text %}
             {{ params.previous.html | safe if params.previous.html else params.previous.text }}
-          {%- else -%}
+          {% else %}
             Previous<span class="govuk-visually-hidden"> page</span>
-          {%- endif -%}
+          {% endif %}
         </span>
-        {%- if params.previous.labelText and blockLevel -%}
+        {% if params.previous.labelText and blockLevel %}
           <span class="govuk-visually-hidden">:</span>
           <span class="govuk-pagination__link-label">{{ params.previous.labelText }}</span>
-        {%- endif -%}
+        {% endif %}
       </a>
     </div>
   {% endif %}
 
-  {%- if params.items -%}
+  {%- if params.items %}
     <ul class="govuk-pagination__list">
-      {%- for item in params.items -%}
-        {%- if item.ellipsis -%}
+      {% for item in params.items %}
+        {% if item.ellipsis %}
           <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
-        {%- elseif item.number -%}
+        {% elseif item.number %}
           <li class="govuk-pagination__item {%- if item.current %} govuk-pagination__item--current{% endif %}">
             <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}"
               {%- if item.current %} aria-current="page"{% endif %}
@@ -49,33 +49,33 @@
               {{ item.number }}
             </a>
           </li>
-        {%- endif -%}
-      {%- endfor -%}
+        {% endif %}
+      {% endfor %}
     </ul>
-  {%- endif -%}
+  {% endif %}
 
-  {%- if params.next and params.next.href -%}
+  {%- if params.next and params.next.href %}
     <div class="govuk-pagination__next">
       <a class="govuk-link govuk-pagination__link" href="{{ params.next.href }}" rel="next"
         {{- govukAttributes(params.next.attributes) }}>
-        {%- if blockLevel -%}
-          {{- arrowNext | safe -}}
-        {%- endif %}
+        {% if blockLevel %}
+          {{- arrowNext | safe }}
+        {% endif %}
         <span class="govuk-pagination__link-title {%- if blockLevel and not params.next.labelText %} govuk-pagination__link-title--decorated{% endif %}">
-          {%- if params.next.html or params.next.text -%}
+          {% if params.next.html or params.next.text %}
             {{ params.next.html | safe if params.next.html else params.next.text }}
-          {%- else -%}
+          {% else %}
             Next<span class="govuk-visually-hidden"> page</span>
-          {%- endif -%}
+          {% endif %}
         </span>
-        {%- if params.next.labelText and blockLevel -%}
+        {% if params.next.labelText and blockLevel %}
           <span class="govuk-visually-hidden">:</span>
           <span class="govuk-pagination__link-label">{{ params.next.labelText }}</span>
-        {%- endif -%}
-        {%- if not blockLevel -%}
-          {{- arrowNext | safe -}}
-        {%- endif -%}
+        {% endif %}
+        {% if not blockLevel %}
+          {{- arrowNext | safe }}
+        {% endif %}
       </a>
     </div>
-  {%- endif -%}
+  {% endif %}
 </nav>

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -36,6 +36,20 @@
   </div>
 {% endmacro -%}
 
+{%- macro _pageItem(item) -%}
+  <li class="govuk-pagination__item {%- if item.current %} govuk-pagination__item--current{% endif %} {%- if item.ellipsis %} govuk-pagination__item--ellipses{% endif %}">
+  {% if item.ellipsis %}
+    &ctdot;
+  {% else %}
+    <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}"
+      {%- if item.current %} aria-current="page"{% endif %}
+      {{- govukAttributes(item.attributes) }}>
+      {{ item.number }}
+    </a>
+  {% endif %}
+  </li>
+{%- endmacro -%}
+
 <nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}"
   {{- govukAttributes(params.attributes) }}>
   {% set previous = params.previous %}
@@ -54,17 +68,7 @@
   {%- if params.items %}
     <ul class="govuk-pagination__list">
       {% for item in params.items %}
-        {% if item.ellipsis %}
-          <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
-        {% elseif item.number %}
-          <li class="govuk-pagination__item {%- if item.current %} govuk-pagination__item--current{% endif %}">
-            <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}"
-              {%- if item.current %} aria-current="page"{% endif %}
-              {{- govukAttributes(item.attributes) }}>
-              {{ item.number }}
-            </a>
-          </li>
-        {% endif %}
+        {{ _pageItem(item) | indent(2) }}
       {% endfor %}
     </ul>
   {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -2,15 +2,25 @@
 
 {% set blockLevel = not params.items and (params.next or params.previous) -%}
 
+{%- set arrowPrevious -%}
+  <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+    <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+  </svg>
+{%- endset -%}
+
+{%- set arrowNext -%}
+  <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+    <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+  </svg>
+{%- endset -%}
+
 <nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}"
   {{- govukAttributes(params.attributes) }}>
   {%- if params.previous and params.previous.href -%}
     <div class="govuk-pagination__prev">
       <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev"
         {{- govukAttributes(params.previous.attributes) }}>
-        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-        </svg>
+        {{- arrowPrevious | safe -}}
         <span class="govuk-pagination__link-title {%- if blockLevel and not params.previous.labelText %} govuk-pagination__link-title--decorated{% endif %}">
           {%- if params.previous.html or params.previous.text -%}
             {{ params.previous.html | safe if params.previous.html else params.previous.text }}
@@ -45,17 +55,11 @@
   {%- endif -%}
 
   {%- if params.next and params.next.href -%}
-    {%- set nextArrow -%}
-      <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-      </svg>
-    {%- endset -%}
-
     <div class="govuk-pagination__next">
       <a class="govuk-link govuk-pagination__link" href="{{ params.next.href }}" rel="next"
         {{- govukAttributes(params.next.attributes) }}>
         {%- if blockLevel -%}
-          {{- nextArrow | safe -}}
+          {{- arrowNext | safe -}}
         {%- endif %}
         <span class="govuk-pagination__link-title {%- if blockLevel and not params.next.labelText %} govuk-pagination__link-title--decorated{% endif %}">
           {%- if params.next.html or params.next.text -%}
@@ -69,7 +73,7 @@
           <span class="govuk-pagination__link-label">{{ params.next.labelText }}</span>
         {%- endif -%}
         {%- if not blockLevel -%}
-          {{- nextArrow | safe -}}
+          {{- arrowNext | safe -}}
         {%- endif -%}
       </a>
     </div>

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -26,8 +26,8 @@
         {{ caller() | safe | trim }}
       </span>
       {% if link.labelText and blockLevel %}
-        <span class="govuk-visually-hidden">:</span>
-        <span class="govuk-pagination__link-label">{{ link.labelText }}</span>
+      <span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">{{ link.labelText }}</span>
       {% endif %}
       {% if not blockLevel and type == "next" %}
         {{- arrowType | safe | indent(4, true) }}
@@ -66,11 +66,11 @@
   {%- endif %}
 
   {%- if params.items %}
-    <ul class="govuk-pagination__list">
-      {% for item in params.items %}
-        {{ _pageItem(item) | indent(2) }}
-      {% endfor %}
-    </ul>
+  <ul class="govuk-pagination__list">
+  {% for item in params.items %}
+    {{ _pageItem(item) | indent(2) }}
+  {% endfor %}
+  </ul>
   {% endif %}
 
   {%- if next and next.href %}

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -14,27 +14,42 @@
   </svg>
 {%- endset -%}
 
+{%- macro _arrowLink(link, type = "next") %}
+  {% set arrowType = arrowPrevious if type == "prev" else arrowNext %}
+  <div class="govuk-pagination__{{ type }}">
+    <a class="govuk-link govuk-pagination__link" href="{{ link.href }}" rel="{{ type }}"
+      {{- govukAttributes(link.attributes) }}>
+      {% if blockLevel or type == "prev" %}
+        {{- arrowType | safe | indent(4, true) }}
+      {% endif %}
+      <span class="govuk-pagination__link-title {%- if blockLevel and not link.labelText %} govuk-pagination__link-title--decorated{% endif %}">
+        {{ caller() | safe | trim }}
+      </span>
+      {% if link.labelText and blockLevel %}
+        <span class="govuk-visually-hidden">:</span>
+        <span class="govuk-pagination__link-label">{{ link.labelText }}</span>
+      {% endif %}
+      {% if not blockLevel and type == "next" %}
+        {{- arrowType | safe | indent(4, true) }}
+      {% endif %}
+    </a>
+  </div>
+{% endmacro -%}
+
 <nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}"
   {{- govukAttributes(params.attributes) }}>
-  {% if params.previous and params.previous.href %}
-    <div class="govuk-pagination__prev">
-      <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev"
-        {{- govukAttributes(params.previous.attributes) }}>
-        {{ arrowPrevious | safe }}
-        <span class="govuk-pagination__link-title {%- if blockLevel and not params.previous.labelText %} govuk-pagination__link-title--decorated{% endif %}">
-          {% if params.previous.html or params.previous.text %}
-            {{ params.previous.html | safe if params.previous.html else params.previous.text }}
-          {% else %}
-            Previous<span class="govuk-visually-hidden"> page</span>
-          {% endif %}
-        </span>
-        {% if params.previous.labelText and blockLevel %}
-          <span class="govuk-visually-hidden">:</span>
-          <span class="govuk-pagination__link-label">{{ params.previous.labelText }}</span>
-        {% endif %}
-      </a>
-    </div>
-  {% endif %}
+  {% set previous = params.previous %}
+  {% set next = params.next %}
+
+  {%- if previous and previous.href %}
+    {% call _arrowLink(previous, "prev") %}
+      {% if previous.html or previous.text %}
+        {{ previous.html | safe | trim | indent(8) if previous.html else previous.text }}
+      {% else %}
+        Previous<span class="govuk-visually-hidden"> page</span>
+      {% endif %}
+    {% endcall %}
+  {%- endif %}
 
   {%- if params.items %}
     <ul class="govuk-pagination__list">
@@ -54,28 +69,13 @@
     </ul>
   {% endif %}
 
-  {%- if params.next and params.next.href %}
-    <div class="govuk-pagination__next">
-      <a class="govuk-link govuk-pagination__link" href="{{ params.next.href }}" rel="next"
-        {{- govukAttributes(params.next.attributes) }}>
-        {% if blockLevel %}
-          {{- arrowNext | safe }}
-        {% endif %}
-        <span class="govuk-pagination__link-title {%- if blockLevel and not params.next.labelText %} govuk-pagination__link-title--decorated{% endif %}">
-          {% if params.next.html or params.next.text %}
-            {{ params.next.html | safe if params.next.html else params.next.text }}
-          {% else %}
-            Next<span class="govuk-visually-hidden"> page</span>
-          {% endif %}
-        </span>
-        {% if params.next.labelText and blockLevel %}
-          <span class="govuk-visually-hidden">:</span>
-          <span class="govuk-pagination__link-label">{{ params.next.labelText }}</span>
-        {% endif %}
-        {% if not blockLevel %}
-          {{- arrowNext | safe }}
-        {% endif %}
-      </a>
-    </div>
+  {%- if next and next.href %}
+    {% call _arrowLink(next, "next") %}
+      {% if next.html or next.text %}
+        {{ next.html | safe | trim | indent(8) if next.html else next.text }}
+      {% else %}
+        Next<span class="govuk-visually-hidden"> page</span>
+      {% endif %}
+    {% endcall %}
   {% endif %}
 </nav>

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
@@ -60,7 +60,7 @@ describe('Pagination', () => {
 
       expect($firstEllipsis).toBeTruthy()
       // Test for the unicode character of &ctdot;
-      expect($firstEllipsis.text()).toEqual('\u22ef')
+      expect($firstEllipsis.text().trim()).toEqual('\u22ef')
     })
   })
 


### PR DESCRIPTION
Pagination changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

Similar to the `_actionLink()` and `_summaryCard()` macros in **Summary list**, I've added `_arrowLink()` and `_pageItem()` macros to flatten the HTML indent level back to 2 spaces