### PR TITLE
Fix Nunjucks HTML indentation: Select

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -44,12 +44,12 @@
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
     {% if item %}
-      {# Allow selecting by text content (the value for an option when no value attribute is specified) #}
-      {% set effectiveValue = item.value | default(item.text) %}
-      <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
-        {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
-        {{-" disabled" if item.disabled }}
-        {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.text }}</option>
+    {#- Allow selecting by text content (the value for an option when no value attribute is specified) #}
+    {%- set effectiveValue = item.value | default(item.text) %}
+    <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
+      {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
+      {{-" disabled" if item.disabled }}
+      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.text }}</option>
     {% endif %}
   {% endfor %}
   </select>


### PR DESCRIPTION
Select changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

This PR removes empty new lines and leading spaces before `<option>` elements