### PR TITLE
Fix Nunjucks HTML indentation: Panel, Phase banner

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -1,4 +1,5 @@
-{% set headingLevel = params.headingLevel if params.headingLevel else 1 %}
+{% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
+
 <div class="govuk-panel govuk-panel--confirmation
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
@@ -7,7 +8,7 @@
   </h{{ headingLevel }}>
   {% if caller or params.html or params.text %}
   <div class="govuk-panel__body">
-    {{ caller() if caller else (params.html | safe if params.html else params.text) }}
+    {{ caller() if caller else (params.html | safe | trim | indent(4) if params.html else params.text) }}
   </div>
   {% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/template.njk
@@ -9,7 +9,7 @@
       classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
     }) | trim | indent(4) }}
     <span class="govuk-phase-banner__text">
-      {{ params.html | safe if params.html else params.text }}
+      {{ params.html | safe | trim | indent(6) if params.html else params.text }}
     </span>
   </p>
 </div>


### PR DESCRIPTION
Panel and Phase banner changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

Nice easy one where `params.html` is now trimmed and indented correctly in both components

**Note:** No HTML diff since our examples lack multi-line `params.html` content