### PR TITLE
Minor changelog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
-## GOV.UK Frontend v5.1.0 (Feature release)
-
-### New features
+## 5.1.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@5.1.0`. You can also find more information about [how to stay up to date in our documentation](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version).
+
+### New features
 
 #### Update to the new GOV.UK logo
 


### PR DESCRIPTION
Small fixes to the changelog following yesterday's release.

- Remove "GOV.UK Frontend v" from before version number to match other sections
- Move introductory paragraph out of "New features" section