### PR TITLE
[SPIKE] Password input component - `afterInput` content approach

### DIFF
--- a/packages/govuk-frontend/.htmlvalidate.js
+++ b/packages/govuk-frontend/.htmlvalidate.js
@@ -8,6 +8,10 @@ const { defineConfig } = require('html-validate')
 module.exports = defineConfig({
   extends: ['html-validate:recommended'],
   rules: {
+    // Allow for `attributes: { "hidden": "" }` on password input button
+    // Related: https://github.com/alphagov/govuk-frontend/pull/1665
+    'attribute-boolean-style': 'off',
+
     // Allow for multiple buttons in the same form to have the same name
     // (as in the cookie banner examples)
     'form-dup-name': ['error', { shared: ['radio', 'checkbox', 'submit'] }],

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -137,6 +137,10 @@ describe('GOV.UK Prototype Kit config', () => {
           macroName: 'govukPanel'
         },
         {
+          importFrom: 'govuk/components/password-input/macro.njk',
+          macroName: 'govukPasswordInput'
+        },
+        {
           importFrom: 'govuk/components/phase-banner/macro.njk',
           macroName: 'govukPhaseBanner'
         },

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -10,6 +10,7 @@ import { ErrorSummary } from './components/error-summary/error-summary.mjs'
 import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs'
 import { Header } from './components/header/header.mjs'
 import { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
+import { PasswordInput } from './components/password-input/password-input.mjs'
 import { Radios } from './components/radios/radios.mjs'
 import { SkipLink } from './components/skip-link/skip-link.mjs'
 import { Tabs } from './components/tabs/tabs.mjs'
@@ -41,6 +42,7 @@ function initAll(config) {
     [ExitThisPage, config.exitThisPage],
     [Header],
     [NotificationBanner, config.notificationBanner],
+    [PasswordInput],
     [Radios],
     [SkipLink],
     [Tabs]
@@ -81,6 +83,7 @@ export {
   ExitThisPage,
   Header,
   NotificationBanner,
+  PasswordInput,
   Radios,
   SkipLink,
   Tabs

--- a/packages/govuk-frontend/src/govuk/components/_all.scss
+++ b/packages/govuk-frontend/src/govuk/components/_all.scss
@@ -23,6 +23,7 @@
 @import "notification-banner/index";
 @import "pagination/index";
 @import "panel/index";
+@import "password-input/index";
 @import "phase-banner/index";
 @import "radios/index";
 @import "select/index";

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -43,6 +43,7 @@ describe('GOV.UK Frontend', () => {
         'ExitThisPage',
         'Header',
         'NotificationBanner',
+        'PasswordInput',
         'Radios',
         'SkipLink',
         'Tabs'

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -17,6 +17,7 @@
     {%- if params.value %} value="{{ params.value }}"{% endif %}
     {%- if params.disabled %} disabled{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+    {%- if params.autocapitalize %} autocapitalize="{{ params.autocapitalize }}"{% endif %}
     {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
     {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
     {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -1,0 +1,55 @@
+@import "../button/index";
+@import "../error-message/index";
+@import "../hint/index";
+@import "../input/index";
+@import "../label/index";
+
+@include govuk-exports("govuk/component/password-input") {
+  .govuk-password-input .govuk-input__wrapper {
+    display: flex;
+    flex-direction: column;
+
+    @include govuk-media-query($from: mobile) {
+      flex-direction: row;
+
+      // The default of `stretch` makes the toggle button appear taller than the input, due to using
+      // box-shadow, which we don't particularly want in this situation
+      align-items: flex-start;
+    }
+  }
+
+  .govuk-password-input .govuk-input {
+    // IE 11 and Microsoft Edge comes with its own password reveal function. We want to hide it, so
+    // that there aren't two controls presented to the user that do the same thing but aren't in
+    // sync with one another. This doesn't affect the function that allows Edge user's to toggle\
+    // password visibility by pressing Alt+F8.
+    &::-ms-reveal {
+      display: none;
+    }
+  }
+
+  .govuk-password-input .govuk-button {
+    // Add margin to the top so that the button doesn't obscure the input's focus style
+    margin-top: govuk-spacing(1);
+
+    // Remove default margin-bottom from button
+    margin-bottom: 0;
+
+    // Hide buttons by default until revealed by JavaScript
+    &[hidden] {
+      display: none;
+    }
+
+    @include govuk-media-query($from: mobile) {
+      // Buttons are normally 100% width on this breakpoint, but we don't want that in this case
+      width: auto;
+      flex-grow: 1;
+      flex-shrink: 0;
+      flex-basis: 5em;
+
+      // Move the spacing from top to the left
+      margin-top: 0;
+      margin-left: govuk-spacing(1);
+    }
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_password-input.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_password-input.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/packages/govuk-frontend/src/govuk/components/password-input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/accessibility.puppeteer.test.mjs
@@ -1,0 +1,15 @@
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
+import { getExamples } from '@govuk-frontend/lib/components'
+
+describe('/components/password-input', () => {
+  describe('component examples', () => {
+    it('passes accessibility tests', async () => {
+      const examples = await getExamples('password-input')
+
+      for (const exampleName in examples) {
+        await render(page, 'password-input', examples[exampleName])
+        await expect(axe(page)).resolves.toHaveNoViolations()
+      }
+    }, 120000)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/password-input/macro.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukPasswordInput(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -1,0 +1,118 @@
+import { ElementError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+
+/**
+ * Password input component
+ *
+ * @preserve
+ */
+export class PasswordInput extends GOVUKFrontendComponent {
+  /** @private */
+  $module
+
+  /** @private */
+  $input
+
+  /** @private */
+  $buttonShow
+
+  /** @private */
+  $buttonHide
+
+  /**
+   * @param {Element} $module - HTML element to use for password input
+   */
+  constructor($module) {
+    super()
+
+    if (!($module instanceof HTMLElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: $module,
+        identifier: 'Root element (`$module`)'
+      })
+    }
+
+    const $input = $module.querySelector('.govuk-js-password-input')
+    if (!($input instanceof HTMLInputElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: $input,
+        expectedType: 'HTMLInputElement',
+        identifier: 'Form field (`.govuk-js-password-input`)'
+      })
+    }
+
+    const $buttonShow = $module.querySelector('.govuk-js-password-input-show')
+    if (!($buttonShow instanceof HTMLButtonElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: $buttonShow,
+        expectedType: 'HTMLButtonElement',
+        identifier: 'Button (`.govuk-js-password-input-show`)'
+      })
+    }
+
+    const $buttonHide = $module.querySelector('.govuk-js-password-input-hide')
+    if (!($buttonHide instanceof HTMLButtonElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: $buttonHide,
+        expectedType: 'HTMLButtonElement',
+        identifier: 'Button (`.govuk-js-password-input-hide`)'
+      })
+    }
+
+    this.$module = $module
+    this.$input = $input
+    this.$buttonShow = $buttonShow
+    this.$buttonHide = $buttonHide
+
+    // Toggle between buttons on click
+    this.$buttonShow.addEventListener('click', (event) => this.show(event))
+    this.$buttonHide.addEventListener('click', (event) => this.hide(event))
+
+    // Hide password on form submit
+    this.$input.form?.addEventListener('submit', () => this.hide())
+
+    // Default to hide password
+    this.hide()
+  }
+
+  /**
+   * Show password
+   *
+   * @param {MouseEvent} [event] - Click event (optional)
+   */
+  show(event) {
+    event?.preventDefault()
+
+    // Show password
+    this.$input.setAttribute('type', 'text')
+
+    // Switch to the hide button
+    this.$buttonShow.setAttribute('hidden', '')
+    this.$buttonHide.removeAttribute('hidden')
+  }
+
+  /**
+   * Hide password
+   *
+   * @param {MouseEvent} [event] - Click event (optional)
+   */
+  hide(event) {
+    event?.preventDefault()
+
+    // Hide password
+    this.$input.setAttribute('type', 'password')
+
+    // Switch to the show button
+    this.$buttonHide.setAttribute('hidden', '')
+    this.$buttonShow.removeAttribute('hidden')
+  }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-password-input'
+}

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -1,0 +1,216 @@
+params:
+  - name: id
+    type: string
+    required: true
+    description: The ID of the password input.
+  - name: name
+    type: string
+    required: true
+    description: The name of the password input, which is submitted with the form data.
+  - name: value
+    type: string
+    required: false
+    description: Optional initial value of the password input.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If `true`, password input will be disabled.
+  - name: describedBy
+    type: string
+    required: false
+    description: One or more element IDs to add to the `aria-describedby` attribute, used to provide additional descriptive information for screenreader users.
+  - name: label
+    type: object
+    required: true
+    description: The label used by the password input component.
+    isComponent: true
+  - name: hint
+    type: object
+    required: false
+    description: Can be used to add a hint to a password input component.
+    isComponent: true
+  - name: errorMessage
+    type: object
+    required: false
+    description: Can be used to add an error message to the password input component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
+    isComponent: true
+  - name: formGroup
+    type: object
+    required: false
+    description: Additional options for the form group containing the password input component.
+    params:
+      - name: classes
+        type: string
+        required: false
+        description: Classes to add to the form group (for example to show error state for the whole group).
+      - name: attributes
+        type: object
+        required: false
+        description: HTML attributes (for example data attributes) to add to the form group.
+      - name: beforeInput
+        type: object
+        required: false
+        description: Content to add before the password input used by the password input component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add before the password input. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add before the password input. If `html` is provided, the `text` option will be ignored.
+      - name: afterInput
+        type: object
+        required: false
+        description: Content to add after the password input used by the password input component.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: Text to add after the password input. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: HTML to add after the password input. If `html` is provided, the `text` option will be ignored.
+  - name: buttonShow
+    type: object
+    required: false
+    description: Subset of options for the button used to show the password input text.
+    isComponent: true
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text for the "Show" button used by the password input component. If `html` is provided, the `text` option will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML for the "Show" button used by the password input component. If `html` is provided, the `text` option will be ignored.
+      - name: name
+        type: string
+        required: false
+        description: Name for the `input` or `button`. This has no effect on `a` elements.
+      - name: disabled
+        type: boolean
+        required: false
+        description: Whether the "Show" button used by the password input component should be disabled.
+      - name: classes
+        type: string
+        required: false
+        description: Classes to add to the "Show" button used by the password input component.
+      - name: attributes
+        type: object
+        required: false
+        description: HTML attributes (for example data attributes) to add to the "Show" button used by the password input component.
+      - name: id
+        type: string
+        required: false
+        description: The ID of the "Show" button used by the password input component.
+  - name: buttonHide
+    type: object
+    required: false
+    description: Subset of options for the button used to show the password input text.
+    isComponent: true
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text for the "Show" button used by the password input component. If `html` is provided, the `text` option will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML for the "Show" button used by the password input component. If `html` is provided, the `text` option will be ignored.
+      - name: name
+        type: string
+        required: false
+        description: Name for the `input` or `button`. This has no effect on `a` elements.
+      - name: disabled
+        type: boolean
+        required: false
+        description: Whether the "Show" button used by the password input component should be disabled.
+      - name: classes
+        type: string
+        required: false
+        description: Classes to add to the "Show" button used by the password input component.
+      - name: attributes
+        type: object
+        required: false
+        description: HTML attributes (for example data attributes) to add to the "Show" button used by the password input component.
+      - name: id
+        type: string
+        required: false
+        description: The ID of the "Show" button used by the password input component.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the password input.
+  - name: autocomplete
+    type: string
+    required: false
+    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "new-password" or "current-password". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the password input.
+
+examples:
+  - name: default
+    options:
+      label:
+        text: Password
+      id: password-input
+      name: password
+
+  - name: with hint text
+    options:
+      label:
+        text: Password
+      hint:
+        text: It probably has some letters, numbers and maybe even some symbols in it.
+      id: password-input-with-hint-text
+      name: test-name-2
+
+  - name: with error message
+    options:
+      label:
+        text: Password
+      hint:
+        text: It probably has some letters, numbers and maybe even some symbols in it.
+      id: password-input-with-error-message
+      name: test-name-3
+      errorMessage:
+        text: Error message goes here
+
+  - name: with label as page heading
+    options:
+      label:
+        text: Password
+        classes: govuk-label--l
+        isPageHeading: true
+      id: password-input-with-page-heading
+      name: test-name
+
+  - name: with autocomplete attribute
+    description: Browsers and password managers should prompt to generate a password.
+    options:
+      label:
+        text: Password
+      id: password-input-new-password
+      name: password
+      autocomplete: new-password
+
+  - name: with translations
+    options:
+      label:
+        text: Cyfrinair
+      id: password-translated
+      name: password-translated
+      button:
+
+      showPasswordText: Datguddia
+      hidePasswordText: Cuddio
+      showPasswordAriaLabelText: Datgelu cyfrinair
+      hidePasswordAriaLabelText: Cuddio cyfrinair
+      passwordShownAnnouncementText: Mae eich cyfrinair yn weladwy.
+      passwordHiddenAnnouncementText: Mae eich cyfrinair wedi'i guddio.

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,0 +1,60 @@
+{% from "../button/macro.njk" import govukButton %}
+{% from "../input/macro.njk" import govukInput %}
+
+{%- macro _showHideButton(params, button) -%}
+  {{ govukButton({
+    text: button.text,
+    html: button.html,
+    type: "button",
+    disabled: button.disabled,
+    classes: "govuk-button--secondary" + (" " + button.classes if button.classes),
+    attributes: {
+      "aria-controls": params.id,
+      "hidden": ""
+    },
+    id: button.id
+  }) | trim }}
+{%- endmacro -%}
+
+{%- set buttonHtml %}
+{{ _showHideButton(params, {
+  text: params.buttonShow.html if (params.buttonShow.html or params.buttonShow.text) else "Show",
+  html: params.buttonShow.html,
+  classes: "govuk-js-password-input-show"
+}) }}
+{{ _showHideButton(params, {
+  text: params.buttonHide.html if (params.buttonHide.html or params.buttonHide.text) else "Hide",
+  html: params.buttonHide.html,
+  classes: "govuk-js-password-input-hide"
+}) }}
+{% if params.formGroup.afterInput %}
+  {{- params.formGroup.afterInput.html | safe | trim if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+{% endif -%}
+{% endset -%}
+
+{{ govukInput({
+  id: params.id,
+  name: params.name,
+  type: "password",
+  value: params.value,
+  disabled: params.disabled,
+  describedBy: params.describedBy,
+  label: params.label,
+  hint: params.hint,
+  errorMessage: params.errorMessage,
+  formGroup: {
+    classes: "govuk-password-input" + (" " + params.formGroup.classes if params.formGroup.classes),
+    attributes: {
+      "data-module": "govuk-password-input"
+    },
+    beforeInput: params.formGroup.beforeInput,
+    afterInput: {
+      html: buttonHtml
+    }
+  },
+  classes: "govuk-js-password-input" + (" " + params.classes if params.classes),
+  autocapitalize: "off",
+  autocomplete: params.autocomplete,
+  spellcheck: "off",
+  attributes: params.attributes
+}) | trim }}

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -188,6 +188,7 @@ describe('packages/govuk-frontend/dist/', () => {
           import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs';
           import { Header } from './components/header/header.mjs';
           import { NotificationBanner } from './components/notification-banner/notification-banner.mjs';
+          import { PasswordInput } from './components/password-input/password-input.mjs';
           import { Radios } from './components/radios/radios.mjs';
           import { SkipLink } from './components/skip-link/skip-link.mjs';
           import { Tabs } from './components/tabs/tabs.mjs';
@@ -195,7 +196,7 @@ describe('packages/govuk-frontend/dist/', () => {
 
         // Look for ES modules named exports
         expect(contents).toContain(
-          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };'
+          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, PasswordInput, Radios, SkipLink, Tabs, initAll };'
         )
       })
     })


### PR DESCRIPTION
Super quick and basic spike to keep password input JavaScript as minimal as possible

All HTML is rendered by Nunjucks ready for progressive enhancement:

1. Macro `govukPasswordInput()` wraps `govukInput()`
2. Password "Show" button via `govukButton()` with `isComponent: true` options
3. Password "Hide" button via `govukButton()` with `isComponent: true` options
3. Both buttons added via `govukInput({ formGroup: { afterInput } })` content in [#4567](https://github.com/alphagov/govuk-frontend/pull/4567)

Credit to @querkmachine for most of the code lifted from https://github.com/alphagov/govuk-frontend/pull/4442

**TODO:** Lots of I18n and ARIA functionality