### PR TITLE
Add macro `govukAttributes()` with `params.attributes` string support

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
 {%- macro _accordionItem(params, item, index) %}
@@ -59,7 +60,7 @@
   }) -}}
 
   {%- if params.rememberExpanded !== undefined %} data-remember-expanded="{{ params.rememberExpanded | escape }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   {% for item in params.items %}
     {% if item %}{{ _accordionItem(params, item, loop.index) }}{% endif %}
   {% endfor %}

--- a/packages/govuk-frontend/src/govuk/components/back-link/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/back-link/template.njk
@@ -1,2 +1,6 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <a href="{% if params.href %}{{ params.href }}{% else %}#{% endif %}" class="govuk-back-link {%- if params.classes %} {{ params.classes }}{% endif %}"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ (params.html | safe if params.html else (params.text if params.text else 'Back')) }}</a>
+  {{- govukAttributes(params.attributes) }}>
+  {{- params.html | safe if params.html else (params.text if params.text else "Back") -}}
+</a>

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
@@ -1,4 +1,6 @@
-{# Set classes for this component #}
+{% from "../../macros/attributes.njk" import govukAttributes %}
+
+{#- Set classes for this component #}
 {%- set classNames = "govuk-breadcrumbs" -%}
 
 {% if params.classes %}
@@ -9,12 +11,12 @@
   {% set classNames = classNames + " govuk-breadcrumbs--collapse-on-mobile" %}
 {% endif -%}
 
-<div class="{{ classNames }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="{{ classNames }}" {{- govukAttributes(params.attributes) }}>
   <ol class="govuk-breadcrumbs__list">
 {% for item in params.items %}
   {% if item.href %}
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+      <a class="govuk-breadcrumbs__link" href="{{ item.href }}" {{- govukAttributes(item.attributes) }}>
         {{- item.html | safe if item.html else item.text -}}
       </a>
     </li>

--- a/packages/govuk-frontend/src/govuk/components/button/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/button/template.njk
@@ -1,4 +1,6 @@
-{# Set classes for this component #}
+{% from "../../macros/attributes.njk" import govukAttributes %}
+
+{#- Set classes for this component #}
 {%- set classNames = "govuk-button" -%}
 
 {%- if params.classes %}
@@ -31,7 +33,7 @@
 
 {#- Define common attributes that we can use across all element types #}
 
-{%- set commonAttributes %} class="{{ classNames }}" data-module="govuk-button" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}{% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
+{%- set commonAttributes %} class="{{ classNames }}" data-module="govuk-button" {{- govukAttributes(params.attributes) -}} {% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
 
 {#- Define common attributes we can use for both button and input types #}
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../fieldset/macro.njk" import govukFieldset %}
 {% from "../hint/macro.njk" import govukHint %}
@@ -43,7 +44,7 @@
   }) | trim | indent(2) }}
 {% endif %}
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-checkboxes">
+    {{- govukAttributes(params.attributes) }} data-module="govuk-checkboxes">
     {% if params.formGroup.beforeInputs %}
     {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
     {% endif %}
@@ -77,7 +78,7 @@
             {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
             {%- if item.behaviour %} data-behaviour="{{ item.behaviour }}"{% endif -%}
             {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
-            {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+            {{- govukAttributes(item.attributes) }}>
             {{ govukLabel({
               html: item.html,
               text: item.text,
@@ -109,7 +110,7 @@
   </div>
 {% endset -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {{- govukAttributes(params.formGroup.attributes) }}>
 {% if hasFieldset %}
   {{ govukFieldset({
     describedBy: describedBy,

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/template.njk
@@ -1,11 +1,12 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../button/macro.njk" import govukButton -%}
 
 <div class="govuk-cookie-banner {%- if params.classes %} {{ params.classes }}{% endif %}" data-nosnippet role="region" aria-label="{{ params.ariaLabel | default("Cookie banner", true) }}"
   {%- if params.hidden %} hidden{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   {% for message in params.messages %}
   <div class="govuk-cookie-banner__message {%- if message.classes %} {{ message.classes }}{% endif %} govuk-width-container" {%- if message.role %} role="{{ message.role }}"{% endif %}
-    {%- for attribute, value in message.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+    {{- govukAttributes(message.attributes) -}}
     {%- if message.hidden %} hidden{% endif %}>
 
     <div class="govuk-grid-row">
@@ -41,7 +42,9 @@
           }) }}
         {% else %}
           <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}"
-            {%- for attribute, value in action.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ action.text }}</a>
+            {{- govukAttributes(action.attributes) }}>
+            {{- action.text -}}
+          </a>
         {% endif %}
       {%- endset %}
       {{ buttonHtml | safe | trim | indent(6) }}

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../fieldset/macro.njk" import govukFieldset %}
 {% from "../hint/macro.njk" import govukHint %}
@@ -55,7 +56,7 @@
   }) | trim | indent(2) }}
 {% endif %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+    {{- govukAttributes(params.attributes) -}}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% if params.formGroup.beforeInputs %}
     {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
@@ -85,7 +86,7 @@
   </div>
 {% endset -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {{- govukAttributes(params.formGroup.attributes) }}>
 {% if hasFieldset %}
   {# We override the fieldset's role to 'group' because otherwise JAWS does not
     announce the description for a fieldset comprised of text inputs, but

--- a/packages/govuk-frontend/src/govuk/components/details/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/details/template.njk
@@ -1,4 +1,8 @@
-<details {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-details {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} {{- " open" if params.open }}>
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
+<details {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-details {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) -}}
+  {{- " open" if params.open }}>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       {{ params.summaryHtml | safe | trim | indent(6) if params.summaryHtml else params.summaryText }}

--- a/packages/govuk-frontend/src/govuk/components/error-message/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/error-message/template.njk
@@ -1,7 +1,10 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 {% set visuallyHiddenText = params.visuallyHiddenText | default("Error") -%}
 {% set errorMessageText = params.html | safe | trim | indent(2) if params.html else params.text -%}
 
-<p {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-error-message {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<p {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-error-message {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }}>
   {% if visuallyHiddenText %}
   <span class="govuk-visually-hidden">{{ visuallyHiddenText }}:</span> {{ errorMessageText }}
   {% else %}

--- a/packages/govuk-frontend/src/govuk/components/error-summary/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/template.njk
@@ -1,7 +1,9 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <div class="govuk-error-summary
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-error-summary">
+  {{- govukAttributes(params.attributes) }} data-module="govuk-error-summary">
   {#- Keep the role="alert" in a seperate child container to prevent a race condition between
   the focusing js at the alert, resulting in information getting missed in screen reader announcements #}
   <div role="alert">
@@ -18,7 +20,8 @@
       {% for item in params.errorList %}
         <li>
         {% if item.href %}
-          <a href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+          <a href="{{ item.href }}"
+            {{- govukAttributes(item.attributes) }}>
             {{- item.html | safe | trim | indent(12) if item.html else item.text -}}
           </a>
         {% else %}

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../button/macro.njk" import govukButton %}
 
 {%- set defaultHtml %}
@@ -5,7 +6,8 @@
 {% endset -%}
 
 <div
-  {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-exit-this-page {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-exit-this-page" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+  {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-exit-this-page {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-exit-this-page"
+  {{- govukAttributes(params.attributes) -}}
   {%- if params.activatedText %} data-i18n.activated="{{ params.activatedText | escape }}"{% endif %}
   {%- if params.timedOutText %} data-i18n.timed-out="{{ params.timedOutText | escape }}"{% endif %}
   {%- if params.pressTwoMoreTimesText %} data-i18n.press-two-more-times="{{ params.pressTwoMoreTimesText | escape }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.njk
@@ -1,8 +1,10 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <fieldset class="govuk-fieldset
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- if params.role %} role="{{ params.role }}"{% endif %}
   {%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   {% if params.legend.html or params.legend.text %}
   <legend class="govuk-fieldset__legend {%- if params.legend.classes %} {{ params.legend.classes }}{% endif %}">
   {% if params.legend.isPageHeading %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -5,7 +6,8 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
@@ -44,7 +46,7 @@
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -1,5 +1,7 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <footer class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}" role="contentinfo"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   <div class="govuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
     {% if params.navigation | length %}
       <div class="govuk-footer__navigation">
@@ -12,7 +14,8 @@
                 {% for item in nav.items %}
                   {% if item.href and item.text %}
                     <li class="govuk-footer__list-item">
-                      <a class="govuk-footer__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                      <a class="govuk-footer__link" href="{{ item.href }}"
+                        {{- govukAttributes(item.attributes) }}>
                         {{ item.text }}
                       </a>
                     </li>
@@ -33,7 +36,8 @@
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                  <a class="govuk-footer__link" href="{{ item.href }}"
+                    {{- govukAttributes(item.attributes) }}>
                     {{ item.text }}
                   </a>
                 </li>

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -1,3 +1,5 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 {% set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
 
 {% set _stEdwardsCrown %}
@@ -33,7 +35,7 @@
 {% endset %}
 
 <header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" role="banner" data-module="govuk-header"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
@@ -73,7 +75,8 @@
           {% if item.text or item.html %}
             <li class="govuk-header__navigation-item {%- if item.active %} govuk-header__navigation-item--active{% endif %}">
               {% if item.href %}
-                <a class="govuk-header__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                <a class="govuk-header__link" href="{{ item.href }}"
+                  {{- govukAttributes(item.attributes) -}}>
               {% endif %}
                 {{ item.html | safe if item.html else item.text }}
               {% if item.href %}

--- a/packages/govuk-frontend/src/govuk/components/hint/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/hint/template.njk
@@ -1,4 +1,6 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-hint {%- if params.classes %} {{ params.classes }}{% endif %}"
-{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   {{ params.html | safe | trim | indent(2) if params.html else params.text }}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -20,16 +21,17 @@
     {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
     {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
     {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
-    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {{- govukAttributes(params.attributes) }}>
 {%- endmacro -%}
 
 {%- macro _affixItem(affix, type) %}
-  <div class="govuk-input__{{ type }} {%- if affix.classes %} {{ affix.classes }}{% endif %}" aria-hidden="true" {%- for attribute, value in affix.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <div class="govuk-input__{{ type }} {%- if affix.classes %} {{ affix.classes }}{% endif %}" aria-hidden="true" {{- govukAttributes(affix.attributes) }}>
     {{- affix.html | safe | trim | indent(4) if affix.html else affix.text -}}
   </div>
 {%- endmacro -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
     html: params.label.html,
     text: params.label.text,

--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.njk
@@ -1,4 +1,6 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-inset-text {%- if params.classes %} {{ params.classes }}{% endif %}"
-{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   {{ caller() if caller else (params.html | safe | trim | indent(2) if params.html else params.text) }}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/label/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/label/template.njk
@@ -1,7 +1,9 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 {% if params.html or params.text %}
 {% set labelHtml %}
 <label class="govuk-label {%- if params.classes %} {{ params.classes }}{% endif %}"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+  {{- govukAttributes(params.attributes) -}}
   {%- if params.for %} for="{{ params.for }}"{% endif %}>
   {{ params.html | safe | trim | indent(2) if params.html else params.text }}
 </label>

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.njk
@@ -1,3 +1,5 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
+
 {%- if params.type == "success" %}
   {% set successBanner = true %}
 {% endif %}
@@ -28,7 +30,7 @@
 
 <div class="govuk-notification-banner {%- if typeClass %} {{ typeClass }}{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" role="{{ role }}" aria-labelledby="{{ params.titleId | default("govuk-notification-banner-title", true) }}" data-module="govuk-notification-banner"
   {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   <div class="govuk-notification-banner__header">
     <h{{ params.titleHeadingLevel | default(2, true) }} class="govuk-notification-banner__title" id="{{ params.titleId | default("govuk-notification-banner-title", true) }}">
       {{ title }}

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -1,9 +1,13 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 {% set blockLevel = not params.items and (params.next or params.previous) -%}
 
-<nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}" {%- endfor %}>
+<nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}"
+  {{- govukAttributes(params.attributes) }}>
   {%- if params.previous and params.previous.href -%}
     <div class="govuk-pagination__prev">
-      <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev" {%- for attribute, value in params.previous.attributes %} {{ attribute }}="{{ value }}" {%- endfor %}>
+      <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev"
+        {{- govukAttributes(params.previous.attributes) }}>
         <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
           <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
         </svg>
@@ -29,7 +33,9 @@
           <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
         {%- elseif item.number -%}
           <li class="govuk-pagination__item {%- if item.current %} govuk-pagination__item--current{% endif %}">
-            <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}" {%- if item.current %} aria-current="page" {%- endif -%} {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}" {%- endfor %}>
+            <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}"
+              {%- if item.current %} aria-current="page"{% endif %}
+              {{- govukAttributes(item.attributes) }}>
               {{ item.number }}
             </a>
           </li>
@@ -46,7 +52,8 @@
     {%- endset -%}
 
     <div class="govuk-pagination__next">
-      <a class="govuk-link govuk-pagination__link" href="{{ params.next.href }}" rel="next" {%- for attribute, value in params.next.attributes %} {{ attribute }}="{{ value }}" {%- endfor %}>
+      <a class="govuk-link govuk-pagination__link" href="{{ params.next.href }}" rel="next"
+        {{- govukAttributes(params.next.attributes) }}>
         {%- if blockLevel -%}
           {{- nextArrow | safe -}}
         {%- endif %}

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -1,8 +1,10 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
 <div class="govuk-panel govuk-panel--confirmation
   {%- if params.classes %} {{ params.classes }}{% endif %}"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {{- govukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
   </h{{ headingLevel }}>

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/template.njk
@@ -1,7 +1,9 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../tag/macro.njk" import govukTag -%}
 
 <div class="govuk-phase-banner
-  {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }}>
   <p class="govuk-phase-banner__content">
     {{ govukTag({
       text: params.tag.text,

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../fieldset/macro.njk" import govukFieldset %}
 {% from "../hint/macro.njk" import govukHint %}
@@ -40,7 +41,7 @@
   }) | trim | indent(2) }}
 {% endif %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-radios">
+    {{- govukAttributes(params.attributes) }} data-module="govuk-radios">
     {% if params.formGroup.beforeInputs %}
     {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
     {% endif %}
@@ -70,7 +71,7 @@
           {{-" disabled" if item.disabled }}
           {%- if item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
           {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
-          {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+          {{- govukAttributes(item.attributes) }}>
           {{ govukLabel({
             html: item.html,
             text: item.text,
@@ -102,7 +103,8 @@
   </div>
 {% endset -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- govukAttributes(params.formGroup.attributes) }}>
 {% if hasFieldset %}
   {{ govukFieldset({
     describedBy: describedBy,

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -5,7 +6,8 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
@@ -44,7 +46,7 @@
     {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
     {%- if params.disabled %} disabled{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {{- govukAttributes(params.attributes) }}>
   {% for item in params.items %}
     {% if item %}
     {#- Allow selecting by text content (the value for an option when no value attribute is specified) #}
@@ -52,7 +54,9 @@
     <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
       {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
       {{-" disabled" if item.disabled }}
-      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.text }}</option>
+      {{- govukAttributes(item.attributes) }}>
+      {{- item.text -}}
+    </option>
     {% endif %}
   {% endfor %}
   </select>

--- a/packages/govuk-frontend/src/govuk/components/skip-link/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/template.njk
@@ -1,3 +1,6 @@
-<a href="{{ params.href | default("#content", true) }}" class="govuk-skip-link {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-skip-link">
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
+<a href="{{ params.href | default("#content", true) }}" class="govuk-skip-link {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }} data-module="govuk-skip-link">
   {{- params.html | safe if params.html else params.text -}}
 </a>

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.njk
@@ -1,5 +1,8 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
+
 {%- macro _actionLink(action, cardTitle) %}
-  <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}"
+    {{- govukAttributes(action.attributes) }}>
     {{- action.html | safe if action.html else action.text -}}
     {%- if action.visuallyHiddenText or cardTitle -%}
       <span class="govuk-visually-hidden">
@@ -13,7 +16,8 @@
 {%- macro _summaryCard(params) %}
   {%- set headingLevel = params.title.headingLevel if params.title.headingLevel else 2 -%}
 
-  <div class="govuk-summary-card {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <div class="govuk-summary-card {%- if params.classes %} {{ params.classes }}{% endif %}"
+    {{- govukAttributes(params.attributes) }}>
     <div class="govuk-summary-card__title-wrapper">
       {%- if params.title -%}
         <h{{ headingLevel }} class="govuk-summary-card__title {%- if params.title.classes %} {{ params.title.classes }}{% endif %}">
@@ -51,7 +55,8 @@
 {% endfor -%}
 
 {%- set summaryList -%}
-  <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"
+    {{- govukAttributes(params.attributes) }}>
     {% for row in params.rows %}
       {% if row %}
         <div class="govuk-summary-list__row {%- if anyRowHasActions and not row.actions.items %} govuk-summary-list__row--no-actions{% endif %} {%- if row.classes %} {{ row.classes }}{% endif %}">

--- a/packages/govuk-frontend/src/govuk/components/table/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/table/template.njk
@@ -1,5 +1,8 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <table class="govuk-table
-  {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }}>
   {% if params.caption %}
   <caption class="govuk-table__caption
   {%- if params.captionClasses %} {{ params.captionClasses }}{% endif %}">{{ params.caption }}</caption>
@@ -12,7 +15,10 @@
       {%- if item.format %} govuk-table__header--{{ item.format }}{% endif %}
       {%- if item.classes %} {{ item.classes }}{% endif %}"
       {%- if item.colspan %} colspan="{{ item.colspan }}"{% endif %}
-      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.html |safe if item.html else item.text }}</th>
+      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %}
+      {{- govukAttributes(item.attributes) }}>
+      {{- item.html | safe if item.html else item.text -}}
+      </th>
     {% endfor %}
     </tr>
   </thead>
@@ -24,7 +30,8 @@
         {% for cell in row %}
           {% set commonAttributes %}
             {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-            {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+            {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}
+            {{- govukAttributes(cell.attributes) -}}
           {% endset %}
           {% if loop.first and params.firstCellIsHeader %}
           <th scope="row" class="govuk-table__header {%- if cell.classes %} {{ cell.classes }}{% endif %}"

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.njk
@@ -1,8 +1,11 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
+
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
   instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix -%}
 
-<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-tabs">
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }} data-module="govuk-tabs">
   <h2 class="govuk-tabs__title">
     {{ params.title | default ("Contents") }}
   </h2>
@@ -13,7 +16,7 @@
         {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
         <li class="govuk-tabs__list-item {%- if loop.index == 1 %} govuk-tabs__list-item--selected{% endif %}">
           <a class="govuk-tabs__tab" href="#{{ id }}"
-            {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+            {{- govukAttributes(item.attributes) }}>
             {{ item.label }}
           </a>
         </li>
@@ -24,7 +27,8 @@
   {% for item in params.items %}
     {% if item %}
       {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
-      <div class="govuk-tabs__panel {%- if loop.index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ id }}" {%- for attribute, value in item.panel.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+      <div class="govuk-tabs__panel {%- if loop.index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ id }}"
+        {{- govukAttributes(item.panel.attributes) }}>
         {% if item.panel.html %}
           {{ item.panel.html | safe }}
         {% elif item.panel.text %}

--- a/packages/govuk-frontend/src/govuk/components/tag/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/tag/template.njk
@@ -1,3 +1,6 @@
-<strong class="govuk-tag {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
+<strong class="govuk-tag {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }}>
   {{ params.html | safe if params.html else params.text }}
 </strong>

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -1,8 +1,10 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../tag/macro.njk" import govukTag %}
 
 {%- set idPrefix = params.idPrefix if params.idPrefix else "task-list" -%}
 
-<ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {{- govukAttributes(params.attributes) }}>
   {% for item in params.items %}
     {%- set hintId = idPrefix + "-" + loop.index + "-hint" -%}
     {%- set statusId = idPrefix + "-" + loop.index + "-status" -%}

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.njk
@@ -1,3 +1,4 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -5,7 +6,8 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
@@ -45,7 +47,7 @@
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ params.value }}</textarea>
+  {{- govukAttributes(params.attributes) }}>{{ params.value }}</textarea>
 {% if params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/warning-text/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/template.njk
@@ -1,6 +1,7 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+
 <div class="govuk-warning-text {%- if params.classes %} {{ params.classes }}{% endif %}"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}
-  >
+  {{- govukAttributes(params.attributes) }}>
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-visually-hidden">{{ params.iconFallbackText | default("Warning", true) }}</span>

--- a/packages/govuk-frontend/src/govuk/macros/attributes.njk
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.njk
@@ -2,11 +2,11 @@
   Renders component attributes as string
 
   @private
-  @param {{ [attribute: string]: string }} attributes - Component attributes param
+  @param {{ [attribute: string]: string } | string} attributes - Component attributes param
 #}
 {% macro govukAttributes(attributes) -%}
   {#- Default attributes output -#}
-  {% set attributesHtml = "" %}
+  {% set attributesHtml = attributes if attributes is string else "" %}
 
   {#- Append attribute name/value pairs -#}
   {%- if attributes is mapping %}

--- a/packages/govuk-frontend/src/govuk/macros/attributes.njk
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.njk
@@ -1,0 +1,19 @@
+{#
+  Renders component attributes as string
+
+  @private
+  @param {{ [attribute: string]: string }} attributes - Component attributes param
+#}
+{% macro govukAttributes(attributes) -%}
+  {#- Default attributes output -#}
+  {% set attributesHtml = "" %}
+
+  {#- Append attribute name/value pairs -#}
+  {%- if attributes is mapping %}
+    {% for name, value in attributes %}
+      {% set attributesHtml = attributesHtml + " " + name | escape + '="' + value | escape + '"' %}
+    {% endfor %}
+  {% endif -%}
+
+  {{- attributesHtml | safe -}}
+{%- endmacro %}

--- a/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
@@ -34,6 +34,18 @@ describe('attributes.njk', () => {
       )
     })
 
+    it('outputs attributes if already stringified', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: ' data-attribute="value"'
+        }
+      )
+
+      expect(attributes).toEqual(' data-attribute="value"')
+    })
+
     it('outputs nothing if there are no attributes', () => {
       const attributes = renderMacro(
         'govukAttributes',

--- a/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
@@ -1,0 +1,49 @@
+import { renderMacro } from '@govuk-frontend/lib/components'
+
+describe('attributes.njk', () => {
+  describe('govukAttributes', () => {
+    it('renders a single attribute', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            'data-attribute': 'value'
+          }
+        }
+      )
+
+      // Note the starting space so we ensure it doesn't stick to possible other previous attributes
+      expect(attributes).toEqual(' data-attribute="value"')
+    })
+
+    it('renders multiple attributes', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            'data-attribute': 'value',
+            'data-second-attribute': 'second-value'
+          }
+        }
+      )
+
+      expect(attributes).toEqual(
+        ' data-attribute="value" data-second-attribute="second-value"'
+      )
+    })
+
+    it('outputs nothing if there are no attributes', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {}
+        }
+      )
+
+      expect(attributes).toEqual('')
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -1,3 +1,4 @@
+{% from "./macros/attributes.njk" import govukAttributes -%}
 {% from "./components/skip-link/macro.njk" import govukSkipLink -%}
 {% from "./components/header/macro.njk" import govukHeader -%}
 {% from "./components/footer/macro.njk" import govukFooter -%}
@@ -24,7 +25,7 @@
     <meta property="og:image" content="{{ opengraphImageUrl | default(assetUrl + "/images/govuk-opengraph-image.png", true) }}">
     {% endif %}
   </head>
-  <body class="govuk-template__body {%- if bodyClasses %} {{ bodyClasses }}{% endif %}" {%- for attribute, value in bodyAttributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <body class="govuk-template__body {%- if bodyClasses %} {{ bodyClasses }}{% endif %}" {{- govukAttributes(bodyAttributes) }}>
     <script {%- if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     {% block bodyStart %}{% endblock %}
 

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -341,7 +341,7 @@ module.exports = {
  * Nunjucks macro render options
  *
  * @typedef {object} MacroRenderOptions
- * @property {MacroOptions} [context] - Nunjucks context object (optional)
+ * @property {MacroOptions | unknown} [context] - Nunjucks mixed context (optional)
  * @property {string} [callBlock] - Nunjucks macro `caller()` content (optional)
  * @property {import('nunjucks').Environment} [env] - Nunjucks environment (optional)
  * @property {ComponentFixture} [fixture] - Component fixture (optional)


### PR DESCRIPTION
This PR moves all attribute loops into a new `govukAttributes()` macro to close https://github.com/alphagov/govuk-frontend/issues/4666

It also supports `params.attributes` as strings to resolve [#4566 (comment)](https://github.com/alphagov/govuk-frontend/pull/4566#discussion_r1426926800)

## Before

Components use object-only attribute loops with no support for [boolean attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML), e.g. `hidden` and `checked`

```njk
<strong class="govuk-tag {%- if params.classes %} {{ params.classes }}{% endif %}"
  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
```

## After

Components use new `govukAttributes()` macro supporting already-stringified and [boolean attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML)

```njk
<strong class="govuk-tag {%- if params.classes %} {{ params.classes }}{% endif %}"
  {{- govukAttributes(params.attributes) }}>
```