### PR TITLE
Update macro `govukAttributes()` to support optional attributes

### DIFF
--- a/packages/govuk-frontend/src/govuk/macros/attributes.njk
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.njk
@@ -1,8 +1,14 @@
 {#
   Renders component attributes as string
 
+  * By default or using `optional: false`, attributes render as ` name="value"`
+  * Using `optional: true`, attributes with empty (`null`, `undefined` or `false`) values are omitted
+  * Using `optional: true`, attributes with `true` (boolean) values render `name` only without value
+
+  {@link https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML}
+
   @private
-  @param {{ [attribute: string]: string | { value: string } } | string} attributes - Component attributes param
+  @param {{ [attribute: string]: string | { value: string, optional?: boolean } } | string} attributes - Component attributes param
 #}
 {% macro govukAttributes(attributes) -%}
   {#- Default attributes output -#}
@@ -13,11 +19,17 @@
     {% for name, value in attributes %}
       {#- Set default attribute options -#}
       {% set options = value if value is mapping else {
-        value: value
+        value: value,
+        optional: false
       } %}
 
-      {#- Always render ` name="value"` pair -#}
-      {% set attributesHtml = attributesHtml + " " + name | escape + '="' + options.value | escape + '"' %}
+      {#- Output ` name` only (no value) for boolean attributes -#}
+      {% if options.optional === true and options.value === true %}
+        {% set attributesHtml = attributesHtml + " " + name | escape %}
+      {#- Skip optional empty attributes or output ` name="value"` pair by default -#}
+      {% elif (options.optional === true and not [undefined, null, false].includes(options.value)) or options.optional !== true %}
+        {% set attributesHtml = attributesHtml + " " + name | escape + '="' + options.value | escape + '"' %}
+      {% endif %}
     {% endfor %}
   {% endif -%}
 

--- a/packages/govuk-frontend/src/govuk/macros/attributes.njk
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.njk
@@ -2,7 +2,7 @@
   Renders component attributes as string
 
   @private
-  @param {{ [attribute: string]: string } | string} attributes - Component attributes param
+  @param {{ [attribute: string]: string | { value: string } } | string} attributes - Component attributes param
 #}
 {% macro govukAttributes(attributes) -%}
   {#- Default attributes output -#}
@@ -11,7 +11,13 @@
   {#- Append attribute name/value pairs -#}
   {%- if attributes is mapping %}
     {% for name, value in attributes %}
-      {% set attributesHtml = attributesHtml + " " + name | escape + '="' + value | escape + '"' %}
+      {#- Set default attribute options -#}
+      {% set options = value if value is mapping else {
+        value: value
+      } %}
+
+      {#- Always render ` name="value"` pair -#}
+      {% set attributesHtml = attributesHtml + " " + name | escape + '="' + options.value | escape + '"' %}
     {% endfor %}
   {% endif -%}
 

--- a/packages/govuk-frontend/src/govuk/macros/attributes.njk
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.njk
@@ -7,6 +7,57 @@
 
   {@link https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML}
 
+  @example
+  Output attribute ` aria-hidden="true"` when `true` (boolean) or `"true"` (string)
+
+  ```njk
+  govukAttributes({
+    "aria-hidden": true
+  })
+  ```
+
+  @example
+  Output attribute ` aria-hidden="false"` when `false` (boolean) or `"false"` (string)
+
+  ```njk
+  govukAttributes({
+    "aria-hidden": false
+  })
+  ```
+
+  @example
+  Output attribute ` hidden=""` when `null`, `undefined` or empty `""` (string)
+
+  ```njk
+  govukAttributes({
+    "hidden": undefined
+  })
+  ```
+
+  @example
+  Output attribute ` hidden` as boolean attribute when optional and `true`
+
+  ```njk
+  govukAttributes({
+    hidden: {
+      value: true,
+      optional: true
+    },
+  })
+  ```
+
+  @example
+  Output empty string when optional and `null`, `undefined` or `false`
+
+  ```njk
+  govukAttributes({
+    hidden: {
+      value: undefined,
+      optional: true
+    },
+  })
+  ```
+
   @private
   @param {{ [attribute: string]: string | { value: string, optional?: boolean } } | string} attributes - Component attributes param
 #}

--- a/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
@@ -57,6 +57,188 @@ describe('attributes.njk', () => {
       )
     })
 
+    it('renders attribute values as strings when `optional` not set', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            viewBox: '0 0 15 13',
+            focusable: {
+              value: false
+            },
+            'aria-hidden': {
+              value: true
+            }
+          }
+        }
+      )
+
+      // Note that `aria-hidden` and `focusable` are not converted to boolean attributes
+      expect(attributes).toEqual(
+        ' viewBox="0 0 15 13" focusable="false" aria-hidden="true"'
+      )
+    })
+
+    it('renders attribute values as strings when `optional: false`', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            // Treat null and undefined values as not provided
+            'example-empty-1': {
+              value: undefined,
+              optional: false
+            },
+            'example-empty-2': {
+              value: null,
+              optional: false
+            },
+
+            // But watch out for intentionally falsy values
+            // https://github.com/alphagov/govuk-frontend/issues/4669
+            'example-falsy-1': {
+              value: '',
+              optional: false
+            },
+            'example-falsy-2': {
+              value: 0,
+              optional: false
+            },
+
+            // Except false, always stringify unless optional
+            'example-falsy-3': {
+              value: false,
+              optional: false
+            }
+          }
+        }
+      )
+
+      // Note that all non-optional values are rendered to strings by Nunjucks,
+      // even true/false which only become boolean attributes when optional
+      expect(attributes).toEqual(
+        ' example-empty-1="" example-empty-2="" example-falsy-1="" example-falsy-2="0" example-falsy-3="false"'
+      )
+    })
+
+    it('skip attribute when falsy with `optional: true` and null, undefined or false', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            // Treat null and undefined values as not provided
+            'example-empty-1': {
+              value: undefined,
+              optional: true
+            },
+            'example-empty-2': {
+              value: null,
+              optional: true
+            },
+
+            // But watch out for intentionally falsy values
+            // https://github.com/alphagov/govuk-frontend/issues/4669
+            'example-falsy-1': {
+              value: '',
+              optional: true
+            },
+            'example-falsy-2': {
+              value: 0,
+              optional: true
+            },
+
+            // Except false, we remove `false` boolean attributes
+            'example-falsy-3': {
+              value: false,
+              optional: true
+            }
+          }
+        }
+      )
+
+      // Note that null, undefined and false are skipped, intentionally falsy values are preserved
+      expect(attributes).toEqual(' example-falsy-1="" example-falsy-2="0"')
+    })
+
+    it('renders attribute when (string) `"true"` with `optional: true` as strings`', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            type: 'radio',
+            checked: {
+              value: 'true',
+              optional: true
+            }
+          }
+        }
+      )
+
+      // Note that `checked` defaults to a string value unless strictly a boolean
+      expect(attributes).toEqual(' type="radio" checked="true"')
+    })
+
+    it('renders attribute when (string) `"false"` with `optional: true` as strings', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            type: 'radio',
+            checked: {
+              value: 'false',
+              optional: true
+            }
+          }
+        }
+      )
+
+      // Note that `checked` defaults to a string value unless strictly a boolean
+      expect(attributes).toEqual(' type="radio" checked="false"')
+    })
+
+    it('renders attribute when (boolean) `true` with `optional: true` as boolean attribute', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            type: 'radio',
+            checked: {
+              value: true,
+              optional: true
+            }
+          }
+        }
+      )
+
+      // Note that `checked` has no value is, e.g. `<input type="radio" checked>`
+      expect(attributes).toEqual(' type="radio" checked')
+    })
+
+    it('skip attribute when (boolean) `false` with `optional: true` as boolean attribute', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            type: 'radio',
+            checked: {
+              value: false,
+              optional: true
+            }
+          }
+        }
+      )
+
+      // Note that `checked` is removed when false
+      expect(attributes).toEqual(' type="radio"')
+    })
+
     it('outputs attributes if already stringified', () => {
       const attributes = renderMacro(
         'govukAttributes',

--- a/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
@@ -24,13 +24,36 @@ describe('attributes.njk', () => {
         {
           context: {
             'data-attribute': 'value',
-            'data-second-attribute': 'second-value'
+            'data-second-attribute': 'second-value',
+            'data-third-attribute': {
+              type: 'string',
+              value: 'third-value'
+            }
           }
         }
       )
 
       expect(attributes).toEqual(
-        ' data-attribute="value" data-second-attribute="second-value"'
+        ' data-attribute="value" data-second-attribute="second-value" data-third-attribute="third-value"'
+      )
+    })
+
+    it('renders attribute values as strings by default', () => {
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            viewBox: '0 0 15 13',
+            focusable: false,
+            'aria-hidden': true
+          }
+        }
+      )
+
+      // Note that `aria-hidden` and `focusable` are not converted to boolean attributes
+      expect(attributes).toEqual(
+        ' viewBox="0 0 15 13" focusable="false" aria-hidden="true"'
       )
     })
 


### PR DESCRIPTION
This PR was split out from https://github.com/alphagov/govuk-frontend/pull/4742 and closes https://github.com/alphagov/govuk-frontend/issues/2917

It extends `govukAttributes()` with a new object config to support:

1. Optional attributes that render only when `value` is set
2. Boolean attributes that render only a name, e.g. `<input type="radio" checked>`

For **Password input**, we can now render a show/hide button `hidden` by default, without failing on [**html-validate** `attribute-boolean-style`](https://html-validate.org/rules/attribute-boolean-style.html) linting errors due to unnecessary empty values

### Before

Renders attribute `'hidden="hidden"'` or `'hidden=""'`

```njk
{{ govukButton({
  attributes: {
    hidden: "hidden" if params.hidden
  })
}}
```

### After

Renders attribute `'hidden="hidden"'` or `''`

```njk
{{ govukButton({
  attributes: {
    hidden: {
      value: params.hidden,
      optional: true
    }
  })
}}
```

## No breaking changes

This PR continues to render `true`, `"true"`, `false` and `"false"` as strings for attributes such as:

* `aria-hidden="false"`
* `focusable="false"`

But adds a new object config with `optional: true` to "opt in" to make attributes and their values optional, where empty values such as `null`, `undefined` or `false` will affect how the attribute is rendered

This gives us the following new behaviours:

* By default or when using `optional: false`, attributes render as ` name="value"`
* When using `optional: true`, attributes with empty (`null`, `undefined` or `false`) values are omitted
* When using `optional: true`, attributes with `true` (boolean) values render `name` only without value

## Boolean attributes

Why do we need this PR?

The previous Nunjucks attribute loop couldn't add true/false [boolean attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) without them being stringified:

```html
<button hidden="hidden"> ❌
<button hidden="true"> ❌
<button hidden=""> ❌
<button hidden> ✅
```

But by using the example above, we now can 🙌

See https://github.com/alphagov/govuk-frontend/pull/1665 for previous work on this

## Other optional attributes

Not all optional attributes are [boolean attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML)

For example we add `data-nosnippet` to the [**Cookie banner** component](https://design-system.service.gov.uk/components/cookie-banner/) and could be used as shown:

### Nunjucks input

```html
<p class="govuk-body" {{- govukAttributes({
  "data-nosnippet": {
    value: true,
    optional: true
  }
}) }}>
  Exclude me from search engine result snippets
</p>
```

### HTML output

```html
<p class="govuk-body" data-nosnippet>
  Exclude me from search engine result snippets
</p>
```

This approach will close https://github.com/alphagov/govuk-frontend/issues/2917