### PR TITLE
[SPIKE] Password input component - hybrid using new params

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -21,6 +21,7 @@
     {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
     {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
     {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
+    {%- if params.autocapitalize %} autocapitalize="{{ params.autocapitalize }}"{% endif %}
     {{- govukAttributes(params.attributes) }}>
 {%- endmacro -%}
 
@@ -65,7 +66,8 @@
 {% endif %}
 
 {%- if hasPrefix or hasSuffix or hasBeforeInput or hasAfterInput %}
-  <div class="govuk-input__wrapper">
+  <div class="govuk-input__wrapper {%- if params.inputWrapper.classes %} {{ params.inputWrapper.classes }}{% endif %}"
+    {{- govukAttributes(params.inputWrapper.attributes) }}>
     {% if hasBeforeInput %}
       {{- params.formGroup.beforeInput.html | safe | trim | indent(4, true) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
     {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -1,13 +1,11 @@
 @import "../button/index";
-@import "../error-message/index";
-@import "../hint/index";
 @import "../input/index";
-@import "../label/index";
 
 @include govuk-exports("govuk/component/password-input") {
-  .govuk-password-input {
-    display: flex;
-    flex-direction: column;
+  .govuk-password-input__wrapper {
+    // This element inherits styles from .govuk-input__wrapper, including:
+    // - being display: block with contents in a stacked column below the mobile breakpoint
+    // - being display: flex above the mobile breakpoint
 
     @include govuk-media-query($from: mobile) {
       flex-direction: row;
@@ -34,6 +32,11 @@
 
     // Remove default margin-bottom from button
     margin-bottom: 0;
+
+    // Hide the button by default, JS removes this attribute
+    &[hidden] {
+      display: none;
+    }
 
     @include govuk-media-query($from: mobile) {
       // Buttons are normally 100% width on this breakpoint, but we don't want that in this case

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -23,12 +23,6 @@ export class PasswordInput extends GOVUKFrontendComponent {
 
   /**
    * @private
-   * @type {HTMLButtonElement | null}
-   */
-  $showHideButton = null
-
-  /**
-   * @private
    * @type {HTMLElement | null}
    */
   $statusText = null
@@ -48,15 +42,25 @@ export class PasswordInput extends GOVUKFrontendComponent {
       })
     }
 
-    this.$wrapper = $module
-    this.$input = $module.querySelector('input')
-
+    this.$input = $module.querySelector('.govuk-js-password-input-input')
     if (!(this.$input instanceof HTMLInputElement)) {
       throw new ElementError({
         componentName: 'Password input',
         element: this.$input,
         expectedType: 'HTMLInputElement',
-        identifier: 'Form field (`.govuk-password-input`)'
+        identifier: 'Form field (`.govuk-js-password-input-input`)'
+      })
+    }
+
+    this.$showHideButton = $module.querySelector(
+      '.govuk-js-password-input-toggle'
+    )
+    if (!(this.$showHideButton instanceof HTMLButtonElement)) {
+      throw new ElementError({
+        componentName: 'Password input',
+        element: this.$showHideButton,
+        expectedType: 'HTMLButtonElement',
+        identifier: 'Button (`.govuk-js-password-input-toggle`)'
       })
     }
 
@@ -77,25 +81,21 @@ export class PasswordInput extends GOVUKFrontendComponent {
       locale: closestAttributeValue($module, 'lang')
     })
 
-    // Create and append the button element
-    this.$showHideButton = document.createElement('button')
-    this.$showHideButton.className =
-      'govuk-button govuk-button--secondary govuk-password-input__toggle'
-    this.$showHideButton.setAttribute('aria-controls', this.$input.id)
-    this.$showHideButton.setAttribute('type', 'button')
-    this.$showHideButton.setAttribute(
-      'aria-label',
-      this.i18n.t('showPasswordAriaLabel')
-    )
-    this.$showHideButton.innerHTML = this.i18n.t('showPassword')
-    this.$wrapper.insertBefore(this.$showHideButton, this.$input.nextSibling)
+    // Show the toggle button element
+    this.$showHideButton.removeAttribute('hidden')
 
-    // Create and append the status text for screen readers
+    // Create and append the status text for screen readers.
+    // This is injected between the input and button so that users get a sensible reading order if
+    // moving through the page content linearly:
+    // [password input] -> [your password is visible/hidden] -> [show/hide password]
     this.$statusText = document.createElement('span')
     this.$statusText.className = 'govuk-visually-hidden'
     this.$statusText.innerText = this.i18n.t('passwordHiddenAnnouncement')
     this.$statusText.setAttribute('aria-live', 'polite')
-    this.$wrapper.insertBefore(this.$statusText, this.$input.nextSibling)
+    this.$input.parentNode?.insertBefore(
+      this.$statusText,
+      this.$input.nextSibling
+    )
 
     // Bind toggle button
     this.$showHideButton.addEventListener(
@@ -117,7 +117,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
   togglePassword(event) {
     event.preventDefault()
 
-    if (!this.$showHideButton || !this.$statusText) {
+    if (!this.$statusText) {
       return
     }
 
@@ -145,7 +145,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
    * user agents potentially saving or caching the plain text password.
    */
   revertToPasswordOnFormSubmit() {
-    if (!this.$showHideButton || !this.$statusText) {
+    if (!this.$statusText) {
       return
     }
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -42,7 +42,7 @@ examples:
     options:
       label:
         text: Password
-      newPassword: true
+      autocomplete: new-password
       id: password-input-new-password
       name: password
   - name: with translations

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -1,68 +1,62 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
+{% from "../button/macro.njk" import govukButton -%}
+{% from "../input/macro.njk" import govukInput -%}
 
-{#- a record of other elements that we need to associate with the input using
-  aria-describedby – for example hints or error messages -#}
-{% set describedBy = params.describedBy if params.describedBy else "" %}
+{% set moduleAttributes %}
+  data-module="govuk-password-input"
+  {%- if params.disableFormSubmitCheck %} data-disable-form-submit-check="true"{% endif %}
+  {{- govukI18nAttributes({ key: 'show-password', message: params.showPasswordText }) -}}
+  {{- govukI18nAttributes({ key: 'hide-password', message: params.hidePasswordText }) -}}
+  {{- govukI18nAttributes({ key: 'show-password-aria-label', message: params.showPasswordAriaLabelText }) -}}
+  {{- govukI18nAttributes({ key: 'hide-password-aria-label', message: params.hidePasswordAriaLabelText }) -}}
+  {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
+  {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}
+{% endset %}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-  {{ govukLabel({
-    html: params.label.html,
-    text: params.label.text,
-    classes: params.label.classes,
-    isPageHeading: params.label.isPageHeading,
-    attributes: params.label.attributes,
-    for: params.id
-  }) | indent(2) | trim }}
-{% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{% set afterInput %}
+  {{ govukButton({
+    type: "button",
+    classes: "govuk-button--secondary govuk-password-input__toggle govuk-js-password-input-toggle" + (" " + params.button.classes if params.button.classes),
+    text: params.showPasswordText | default("Show"),
+    attributes: {
+      "aria-controls": params.id,
+      "aria-label": params.showPasswordAriaLabelText | default("Show password"),
+      "hidden": ""
+    }
+  }) }}
 
-  <div class="govuk-password-input" data-module="govuk-password-input"
-    {%- if params.disableFormSubmitCheck %} data-disable-form-submit-check="true"{% endif %}
-    {{- govukI18nAttributes({ key: 'show-password', message: params.showPasswordText }) -}}
-    {{- govukI18nAttributes({ key: 'hide-password', message: params.hidePasswordText }) -}}
-    {{- govukI18nAttributes({ key: 'show-password-aria-label', message: params.showPasswordAriaLabelText }) -}}
-    {{- govukI18nAttributes({ key: 'hide-password-aria-label', message: params.hidePasswordAriaLabelText }) -}}
-    {{- govukI18nAttributes({ key: 'password-shown-announcement', message: params.passwordShownAnnouncementText }) -}}
-    {{- govukI18nAttributes({ key: 'password-hidden-announcement', message: params.passwordHiddenAnnouncementText }) -}}>
+  {% if params.formGroup.afterInput %}
+    {{- params.formGroup.afterInput.html | safe if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
+  {% endif %}
+{% endset %}
 
-    <input
-      class="govuk-input govuk-password-input__input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}"
-      id="{{ params.id }}"
-      name="{{ params.name }}"
-      type="password"
-      spellcheck="false"
-      autocapitalize="off"
-      autocomplete="{{ 'new-password' if params.newPassword else 'current-password' }}"
-      {%- if params.value %} value="{{ params.value}}"{% endif %}
-      {%- if params.disabled %} disabled{% endif %}
-      {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-      {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
-
-  </div>
-
-</div>
+{{ govukInput({
+  formGroup: {
+    classes: "govuk-password-input",
+    attributes: moduleAttributes,
+    beforeInput: params.beforeInput,
+    afterInput: {
+      html: afterInput
+    }
+  },
+  inputWrapper: {
+    "classes": "govuk-password-input__wrapper"
+  },
+  label: params.label,
+  hint: params.hint,
+  errorMessage: params.errorMessage,
+  classes: "govuk-password-input__input govuk-js-password-input-input" + (" " + params.classes if params.classes),
+  errorMessage: params.errorMessage,
+  id: params.id,
+  name: params.name,
+  type: "password",
+  spellcheck: "false",
+  autocapitalize: "off",
+  autocomplete: params.autocomplete if params.autocomplete else "current-password",
+  value: params.value,
+  disabled: params.disabled,
+  describedBy: params.describedBy,
+  attributes: params.attributes
+}) }}


### PR DESCRIPTION
A remix of #4442 using the `govukInput` macro alongside the new additions of `beforeInput`, `afterInput`, form group level `attributes`, and `attribute` values as strings.

Generally speaking, the reduction in duplication and greater dependency on our own macros is a good thing for long-term maintainability (assuming that there are guards preventing changing a thing in the parent macros immediately breaking their dependents...)

But there are a few things that I'm not so keen on:
- Duplication of default configuration as some parts are needed in Nunjucks now, whereas previously they could be entirely confined to the JavaScript module.
- Personally I'm not a fan of the "hide this in the HTML in case JavaScript needs it" way of doing things, but that's inevitable with this approach.
- Needing higher specificity CSS selector as we're targeting and overriding parts of `govuk-input` from within `govuk-password-input`. 
- It involves adding more new parameters to `govukInput`, which is something I tried to avoid previously. 