### PR TITLE
Add Puppeteer tests for Password input

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -63,6 +63,12 @@ export class PasswordInput extends GOVUKFrontendComponent {
       })
     }
 
+    if ($input.type !== 'password') {
+      throw new ElementError(
+        'Password input: Form field (`.govuk-js-password-input-input`) must be of type `password`.'
+      )
+    }
+
     const $showHideButton = $module.querySelector(
       '.govuk-js-password-input-toggle'
     )
@@ -73,6 +79,12 @@ export class PasswordInput extends GOVUKFrontendComponent {
         expectedType: 'HTMLButtonElement',
         identifier: 'Button (`.govuk-js-password-input-toggle`)'
       })
+    }
+
+    if ($showHideButton.type !== 'button') {
+      throw new ElementError(
+        'Password input: Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
+      )
     }
 
     this.$module = $module

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -307,7 +307,7 @@ describe('/components/password-input', () => {
           })
         })
 
-        it('throws when the input element is not the right type', async () => {
+        it('throws when the input is not an <input> element', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
               beforeInitialisation($module, { selector }) {
@@ -324,6 +324,26 @@ describe('/components/password-input', () => {
               name: 'ElementError',
               message:
                 'Password input: Form field (`.govuk-js-password-input-input`) is not of type HTMLInputElement'
+            }
+          })
+        })
+
+        it('throws when the input is not a `password` type', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module, { selector }) {
+                // Make the input a number input instead
+                $module.querySelector(selector).setAttribute('type', 'number')
+              },
+              context: {
+                selector: inputSelector
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Form field (`.govuk-js-password-input-input`) must be of type `password`.'
             }
           })
         })
@@ -347,7 +367,7 @@ describe('/components/password-input', () => {
           })
         })
 
-        it('throws when the button is not the right type', async () => {
+        it('throws when the button is not a <button> element', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
               beforeInitialisation($module, { selector }) {
@@ -364,6 +384,26 @@ describe('/components/password-input', () => {
               name: 'ElementError',
               message:
                 'Password input: Button (`.govuk-js-password-input-toggle`) is not of type HTMLButtonElement'
+            }
+          })
+        })
+
+        it('throws when the button is not a `button` type', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module, { selector }) {
+                // Make the button a submit button
+                $module.querySelector(selector).setAttribute('type', 'submit')
+              },
+              context: {
+                selector: buttonSelector
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -25,24 +25,18 @@ describe('/components/password-input', () => {
       it('still renders an unmodified password input', async () => {
         await render(page, 'password-input', examples.default)
 
-        const inputType = await page.evaluate(
-          (inputSelector) =>
-            document.querySelector(inputSelector).getAttribute('type'),
-          inputSelector
+        const inputType = await page.$eval(inputSelector, (el) =>
+          el.getAttribute('type')
         )
-
         expect(inputType).toBe('password')
       })
 
       it('renders the toggle button hidden', async () => {
         await render(page, 'password-input', examples.default)
 
-        const buttonHiddenAttribute = await page.evaluate(
-          (buttonSelector) =>
-            document.querySelector(buttonSelector).hasAttribute('hidden'),
-          buttonSelector
+        const buttonHiddenAttribute = await page.$eval(buttonSelector, (el) =>
+          el.hasAttribute('hidden')
         )
-
         expect(buttonHiddenAttribute).toBeTruthy()
       })
     })
@@ -54,39 +48,31 @@ describe('/components/password-input', () => {
         })
 
         it('renders the status element', async () => {
-          const statusElement = await page.evaluate(
-            (statusSelector) => document.querySelector(statusSelector),
-            statusSelector
-          )
+          const statusElement = await page.$eval(statusSelector, (el) => el)
 
           expect(statusElement).toBeDefined()
         })
 
         it('renders the status element without aria-live', async () => {
-          const statusAriaLiveAttribute = await page.evaluate(
-            (statusSelector) =>
-              document.querySelector(statusSelector).hasAttribute('aria-live'),
-            statusSelector
+          const statusAriaLiveAttribute = await page.$eval(
+            statusSelector,
+            (el) => el.hasAttribute('aria-live')
           )
 
           expect(statusAriaLiveAttribute).toBeFalsy()
         })
 
         it('renders the status element empty', async () => {
-          const statusText = await page.evaluate(
-            (statusSelector) =>
-              document.querySelector(statusSelector).innerHTML.trim(),
-            statusSelector
+          const statusText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
           )
 
           expect(statusText).toBe('')
         })
 
         it('shows the toggle button', async () => {
-          const buttonHiddenAttribute = await page.evaluate(
-            (buttonSelector) =>
-              document.querySelector(buttonSelector).hasAttribute('hidden'),
-            buttonSelector
+          const buttonHiddenAttribute = await page.$eval(buttonSelector, (el) =>
+            el.hasAttribute('hidden')
           )
 
           expect(buttonHiddenAttribute).toBeFalsy()
@@ -100,50 +86,41 @@ describe('/components/password-input', () => {
         })
 
         it('changes the input to type="text"', async () => {
-          const inputType = await page.evaluate(
-            (inputSelector) =>
-              document.querySelector(inputSelector).getAttribute('type'),
-            inputSelector
+          const inputType = await page.$eval(inputSelector, (el) =>
+            el.getAttribute('type')
           )
 
           expect(inputType).toBe('text')
         })
 
         it('changes the status to aria-live="assertive"', async () => {
-          const statusAriaLiveAttribute = await page.evaluate(
-            (statusSelector) =>
-              document.querySelector(statusSelector).getAttribute('aria-live'),
-            statusSelector
+          const statusAriaLiveAttribute = await page.$eval(
+            statusSelector,
+            (el) => el.getAttribute('aria-live')
           )
 
           expect(statusAriaLiveAttribute).toBe('assertive')
         })
 
         it('changes the status to say the password is visible', async () => {
-          const statusText = await page.evaluate(
-            (statusSelector) =>
-              document.querySelector(statusSelector).innerHTML.trim(),
-            statusSelector
+          const statusText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
           )
 
           expect(statusText).toBe('Your password is visible')
         })
 
         it('changes the button text to "hide"', async () => {
-          const buttonText = await page.evaluate(
-            (buttonSelector) =>
-              document.querySelector(buttonSelector).innerHTML.trim(),
-            buttonSelector
+          const buttonText = await page.$eval(buttonSelector, (el) =>
+            el.innerHTML.trim()
           )
 
           expect(buttonText).toBe('Hide')
         })
 
         it('changes the button aria-label to "hide password"', async () => {
-          const buttonAriaLabel = await page.evaluate(
-            (buttonSelector) =>
-              document.querySelector(buttonSelector).getAttribute('aria-label'),
-            buttonSelector
+          const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
+            el.getAttribute('aria-label')
           )
 
           expect(buttonAriaLabel).toBe('Hide password')
@@ -158,40 +135,32 @@ describe('/components/password-input', () => {
         })
 
         it('changes the input to type="password"', async () => {
-          const inputType = await page.evaluate(
-            (inputSelector) =>
-              document.querySelector(inputSelector).getAttribute('type'),
-            inputSelector
+          const inputType = await page.$eval(inputSelector, (el) =>
+            el.getAttribute('type')
           )
 
           expect(inputType).toBe('password')
         })
 
         it('changes the status to say the password is hidden', async () => {
-          const statusText = await page.evaluate(
-            (statusSelector) =>
-              document.querySelector(statusSelector).innerHTML.trim(),
-            statusSelector
+          const statusText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
           )
 
           expect(statusText).toBe('Your password is hidden')
         })
 
         it('changes the button text to "show"', async () => {
-          const buttonText = await page.evaluate(
-            (buttonSelector) =>
-              document.querySelector(buttonSelector).innerHTML.trim(),
-            buttonSelector
+          const buttonText = await page.$eval(buttonSelector, (el) =>
+            el.innerHTML.trim()
           )
 
           expect(buttonText).toBe('Show')
         })
 
         it('changes the button aria-label to "show password"', async () => {
-          const buttonAriaLabel = await page.evaluate(
-            (buttonSelector) =>
-              document.querySelector(buttonSelector).getAttribute('aria-label'),
-            buttonSelector
+          const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
+            el.getAttribute('aria-label')
           )
 
           expect(buttonAriaLabel).toBe('Show password')
@@ -218,20 +187,16 @@ describe('/components/password-input', () => {
           await page.click(buttonSelector)
 
           // Check that the type change has occurred as expected
-          const beforeSubmitType = await page.evaluate(
-            (inputSelector) =>
-              document.querySelector(inputSelector).getAttribute('type'),
-            inputSelector
+          const beforeSubmitType = await page.$eval(inputSelector, (el) =>
+            el.getAttribute('type')
           )
 
           // Submit the form
           await page.click('[type="submit"]')
 
           // Check the input type again
-          const afterSubmitType = await page.evaluate(
-            (inputSelector) =>
-              document.querySelector(inputSelector).getAttribute('type'),
-            inputSelector
+          const afterSubmitType = await page.$eval(inputSelector, (el) =>
+            el.getAttribute('type')
           )
 
           expect(beforeSubmitType).toBe('text')

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -109,6 +109,16 @@ describe('/components/password-input', () => {
           expect(inputType).toEqual('text')
         })
 
+        it('changes the status to aria-live="assertive"', async () => {
+          const statusAriaLiveAttribute = await page.evaluate(
+            (statusClass) =>
+              document.querySelector(statusClass).getAttribute('aria-live'),
+            statusClass
+          )
+
+          expect(statusAriaLiveAttribute).toEqual('assertive')
+        })
+
         it('changes the status to say the password is visible', async () => {
           const statusText = await page.evaluate(
             (statusClass) =>

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -1,9 +1,9 @@
 const { render, goTo } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
-const inputClass = '.govuk-js-password-input-input'
-const buttonClass = '.govuk-js-password-input-toggle'
-const statusClass = '.govuk-password-input__sr-status'
+const inputSelector = '.govuk-js-password-input-input'
+const buttonSelector = '.govuk-js-password-input-toggle'
+const statusSelector = '.govuk-password-input__sr-status'
 
 describe('/components/password-input', () => {
   let examples
@@ -26,9 +26,9 @@ describe('/components/password-input', () => {
         await render(page, 'password-input', examples.default)
 
         const inputType = await page.evaluate(
-          (inputClass) =>
-            document.querySelector(inputClass).getAttribute('type'),
-          inputClass
+          (inputSelector) =>
+            document.querySelector(inputSelector).getAttribute('type'),
+          inputSelector
         )
 
         expect(inputType).toBe('password')
@@ -38,9 +38,9 @@ describe('/components/password-input', () => {
         await render(page, 'password-input', examples.default)
 
         const buttonHiddenAttribute = await page.evaluate(
-          (buttonClass) =>
-            document.querySelector(buttonClass).hasAttribute('hidden'),
-          buttonClass
+          (buttonSelector) =>
+            document.querySelector(buttonSelector).hasAttribute('hidden'),
+          buttonSelector
         )
 
         expect(buttonHiddenAttribute).toBeTruthy()
@@ -55,18 +55,18 @@ describe('/components/password-input', () => {
 
         it('renders the status element', async () => {
           const statusElement = await page.evaluate(
-            (statusClass) => document.querySelector(statusClass),
-            statusClass
+            (statusSelector) => document.querySelector(statusSelector),
+            statusSelector
           )
 
-          expect(statusElement).not.toBeUndefined()
+          expect(statusElement).toBeDefined()
         })
 
         it('renders the status element without aria-live', async () => {
           const statusAriaLiveAttribute = await page.evaluate(
-            (statusClass) =>
-              document.querySelector(statusClass).hasAttribute('aria-live'),
-            statusClass
+            (statusSelector) =>
+              document.querySelector(statusSelector).hasAttribute('aria-live'),
+            statusSelector
           )
 
           expect(statusAriaLiveAttribute).toBeFalsy()
@@ -74,9 +74,9 @@ describe('/components/password-input', () => {
 
         it('renders the status element empty', async () => {
           const statusText = await page.evaluate(
-            (statusClass) =>
-              document.querySelector(statusClass).innerHTML.trim(),
-            statusClass
+            (statusSelector) =>
+              document.querySelector(statusSelector).innerHTML.trim(),
+            statusSelector
           )
 
           expect(statusText).toBe('')
@@ -84,9 +84,9 @@ describe('/components/password-input', () => {
 
         it('shows the toggle button', async () => {
           const buttonHiddenAttribute = await page.evaluate(
-            (buttonClass) =>
-              document.querySelector(buttonClass).hasAttribute('hidden'),
-            buttonClass
+            (buttonSelector) =>
+              document.querySelector(buttonSelector).hasAttribute('hidden'),
+            buttonSelector
           )
 
           expect(buttonHiddenAttribute).toBeFalsy()
@@ -96,14 +96,14 @@ describe('/components/password-input', () => {
       describe('when the toggle button is clicked once', () => {
         beforeAll(async () => {
           await render(page, 'password-input', examples.default)
-          await page.click(buttonClass)
+          await page.click(buttonSelector)
         })
 
         it('changes the input to type="text"', async () => {
           const inputType = await page.evaluate(
-            (inputClass) =>
-              document.querySelector(inputClass).getAttribute('type'),
-            inputClass
+            (inputSelector) =>
+              document.querySelector(inputSelector).getAttribute('type'),
+            inputSelector
           )
 
           expect(inputType).toBe('text')
@@ -111,9 +111,9 @@ describe('/components/password-input', () => {
 
         it('changes the status to aria-live="assertive"', async () => {
           const statusAriaLiveAttribute = await page.evaluate(
-            (statusClass) =>
-              document.querySelector(statusClass).getAttribute('aria-live'),
-            statusClass
+            (statusSelector) =>
+              document.querySelector(statusSelector).getAttribute('aria-live'),
+            statusSelector
           )
 
           expect(statusAriaLiveAttribute).toBe('assertive')
@@ -121,9 +121,9 @@ describe('/components/password-input', () => {
 
         it('changes the status to say the password is visible', async () => {
           const statusText = await page.evaluate(
-            (statusClass) =>
-              document.querySelector(statusClass).innerHTML.trim(),
-            statusClass
+            (statusSelector) =>
+              document.querySelector(statusSelector).innerHTML.trim(),
+            statusSelector
           )
 
           expect(statusText).toBe('Your password is visible')
@@ -131,9 +131,9 @@ describe('/components/password-input', () => {
 
         it('changes the button text to "hide"', async () => {
           const buttonText = await page.evaluate(
-            (buttonClass) =>
-              document.querySelector(buttonClass).innerHTML.trim(),
-            buttonClass
+            (buttonSelector) =>
+              document.querySelector(buttonSelector).innerHTML.trim(),
+            buttonSelector
           )
 
           expect(buttonText).toBe('Hide')
@@ -141,9 +141,9 @@ describe('/components/password-input', () => {
 
         it('changes the button aria-label to "hide password"', async () => {
           const buttonAriaLabel = await page.evaluate(
-            (buttonClass) =>
-              document.querySelector(buttonClass).getAttribute('aria-label'),
-            buttonClass
+            (buttonSelector) =>
+              document.querySelector(buttonSelector).getAttribute('aria-label'),
+            buttonSelector
           )
 
           expect(buttonAriaLabel).toBe('Hide password')
@@ -153,15 +153,15 @@ describe('/components/password-input', () => {
       describe('when the toggle button is clicked twice', () => {
         beforeAll(async () => {
           await render(page, 'password-input', examples.default)
-          await page.click(buttonClass)
-          await page.click(buttonClass)
+          await page.click(buttonSelector)
+          await page.click(buttonSelector)
         })
 
         it('changes the input to type="password"', async () => {
           const inputType = await page.evaluate(
-            (inputClass) =>
-              document.querySelector(inputClass).getAttribute('type'),
-            inputClass
+            (inputSelector) =>
+              document.querySelector(inputSelector).getAttribute('type'),
+            inputSelector
           )
 
           expect(inputType).toBe('password')
@@ -169,9 +169,9 @@ describe('/components/password-input', () => {
 
         it('changes the status to say the password is hidden', async () => {
           const statusText = await page.evaluate(
-            (statusClass) =>
-              document.querySelector(statusClass).innerHTML.trim(),
-            statusClass
+            (statusSelector) =>
+              document.querySelector(statusSelector).innerHTML.trim(),
+            statusSelector
           )
 
           expect(statusText).toBe('Your password is hidden')
@@ -179,9 +179,9 @@ describe('/components/password-input', () => {
 
         it('changes the button text to "show"', async () => {
           const buttonText = await page.evaluate(
-            (buttonClass) =>
-              document.querySelector(buttonClass).innerHTML.trim(),
-            buttonClass
+            (buttonSelector) =>
+              document.querySelector(buttonSelector).innerHTML.trim(),
+            buttonSelector
           )
 
           expect(buttonText).toBe('Show')
@@ -189,9 +189,9 @@ describe('/components/password-input', () => {
 
         it('changes the button aria-label to "show password"', async () => {
           const buttonAriaLabel = await page.evaluate(
-            (buttonClass) =>
-              document.querySelector(buttonClass).getAttribute('aria-label'),
-            buttonClass
+            (buttonSelector) =>
+              document.querySelector(buttonSelector).getAttribute('aria-label'),
+            buttonSelector
           )
 
           expect(buttonAriaLabel).toBe('Show password')
@@ -215,13 +215,13 @@ describe('/components/password-input', () => {
           await page.type('[type="password"]', 'Hunter2')
 
           // Click the "show" button so the password is visible in plain text
-          await page.click(buttonClass)
+          await page.click(buttonSelector)
 
           // Check that the type change has occurred as expected
           const beforeSubmitType = await page.evaluate(
-            (inputClass) =>
-              document.querySelector(inputClass).getAttribute('type'),
-            inputClass
+            (inputSelector) =>
+              document.querySelector(inputSelector).getAttribute('type'),
+            inputSelector
           )
 
           // Submit the form
@@ -229,9 +229,9 @@ describe('/components/password-input', () => {
 
           // Check the input type again
           const afterSubmitType = await page.evaluate(
-            (inputClass) =>
-              document.querySelector(inputClass).getAttribute('type'),
-            inputClass
+            (inputSelector) =>
+              document.querySelector(inputSelector).getAttribute('type'),
+            inputSelector
           )
 
           expect(beforeSubmitType).toBe('text')
@@ -295,7 +295,7 @@ describe('/components/password-input', () => {
                 $module.querySelector(selector).remove()
               },
               context: {
-                selector: inputClass
+                selector: inputSelector
               }
             })
           ).rejects.toMatchObject({
@@ -316,7 +316,7 @@ describe('/components/password-input', () => {
                   '<textarea class="govuk-js-password-input-input"></textarea>'
               },
               context: {
-                selector: inputClass
+                selector: inputSelector
               }
             })
           ).rejects.toMatchObject({
@@ -335,7 +335,7 @@ describe('/components/password-input', () => {
                 $module.querySelector(selector).remove()
               },
               context: {
-                selector: buttonClass
+                selector: buttonSelector
               }
             })
           ).rejects.toMatchObject({
@@ -356,7 +356,7 @@ describe('/components/password-input', () => {
                   '<div class="govuk-js-password-input-toggle"></div>'
               },
               context: {
-                selector: buttonClass
+                selector: buttonSelector
               }
             })
           ).rejects.toMatchObject({

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -131,6 +131,60 @@ describe('/components/password-input', () => {
         })
       })
 
+      describe('i18n', () => {
+        it('uses the correct translations when the password is visible', async () => {
+          await render(page, 'password-input', examples['with translations'])
+          await page.click(buttonSelector)
+
+          const statusText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
+          )
+          const buttonText = await page.$eval(buttonSelector, (el) =>
+            el.innerHTML.trim()
+          )
+          const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
+            el.getAttribute('aria-label')
+          )
+
+          // Expect: passwordShownAnnouncementText
+          expect(statusText).toBe('Mae eich cyfrinair yn weladwy.')
+
+          // Expect: hidePasswordText
+          expect(buttonText).toBe('Cuddio')
+
+          // Expect: hidePasswordAriaLabelText
+          expect(buttonAriaLabel).toBe('Cuddio cyfrinair')
+        })
+
+        it('uses the correct translations when the password is hidden', async () => {
+          await render(page, 'password-input', examples['with translations'])
+
+          // This test clicks the toggle twice because the status element is not populated when
+          // the component is initialised, it only becomes populated after the first toggle.
+          await page.click(buttonSelector)
+          await page.click(buttonSelector)
+
+          const statusText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
+          )
+          const buttonText = await page.$eval(buttonSelector, (el) =>
+            el.innerHTML.trim()
+          )
+          const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
+            el.getAttribute('aria-label')
+          )
+
+          // Expect: passwordHiddenAnnouncementText
+          expect(statusText).toBe("Mae eich cyfrinair wedi'i guddio.")
+
+          // Expect: showPasswordText
+          expect(buttonText).toBe('Datguddia')
+
+          // Expect: showPasswordAriaLabelText
+          expect(buttonAriaLabel).toBe('Datgelu cyfrinair')
+        })
+      })
+
       describe('errors at instantiation', () => {
         it('can throw a SupportError if appropriate', async () => {
           await expect(

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -31,7 +31,7 @@ describe('/components/password-input', () => {
           inputClass
         )
 
-        expect(inputType).toEqual('password')
+        expect(inputType).toBe('password')
       })
 
       it('renders the toggle button hidden', async () => {
@@ -79,7 +79,7 @@ describe('/components/password-input', () => {
             statusClass
           )
 
-          expect(statusText).toEqual('')
+          expect(statusText).toBe('')
         })
 
         it('shows the toggle button', async () => {
@@ -106,7 +106,7 @@ describe('/components/password-input', () => {
             inputClass
           )
 
-          expect(inputType).toEqual('text')
+          expect(inputType).toBe('text')
         })
 
         it('changes the status to aria-live="assertive"', async () => {
@@ -116,7 +116,7 @@ describe('/components/password-input', () => {
             statusClass
           )
 
-          expect(statusAriaLiveAttribute).toEqual('assertive')
+          expect(statusAriaLiveAttribute).toBe('assertive')
         })
 
         it('changes the status to say the password is visible', async () => {
@@ -126,7 +126,7 @@ describe('/components/password-input', () => {
             statusClass
           )
 
-          expect(statusText).toEqual('Your password is visible')
+          expect(statusText).toBe('Your password is visible')
         })
 
         it('changes the button text to "hide"', async () => {
@@ -136,7 +136,7 @@ describe('/components/password-input', () => {
             buttonClass
           )
 
-          expect(buttonText).toEqual('Hide')
+          expect(buttonText).toBe('Hide')
         })
 
         it('changes the button aria-label to "hide password"', async () => {
@@ -146,7 +146,7 @@ describe('/components/password-input', () => {
             buttonClass
           )
 
-          expect(buttonAriaLabel).toEqual('Hide password')
+          expect(buttonAriaLabel).toBe('Hide password')
         })
       })
 
@@ -164,7 +164,7 @@ describe('/components/password-input', () => {
             inputClass
           )
 
-          expect(inputType).toEqual('password')
+          expect(inputType).toBe('password')
         })
 
         it('changes the status to say the password is hidden', async () => {
@@ -174,7 +174,7 @@ describe('/components/password-input', () => {
             statusClass
           )
 
-          expect(statusText).toEqual('Your password is hidden')
+          expect(statusText).toBe('Your password is hidden')
         })
 
         it('changes the button text to "show"', async () => {
@@ -184,7 +184,7 @@ describe('/components/password-input', () => {
             buttonClass
           )
 
-          expect(buttonText).toEqual('Show')
+          expect(buttonText).toBe('Show')
         })
 
         it('changes the button aria-label to "show password"', async () => {
@@ -194,7 +194,7 @@ describe('/components/password-input', () => {
             buttonClass
           )
 
-          expect(buttonAriaLabel).toEqual('Show password')
+          expect(buttonAriaLabel).toBe('Show password')
         })
       })
 
@@ -234,8 +234,8 @@ describe('/components/password-input', () => {
             inputClass
           )
 
-          expect(beforeSubmitType).toEqual('text')
-          expect(afterSubmitType).toEqual('password')
+          expect(beforeSubmitType).toBe('text')
+          expect(afterSubmitType).toBe('password')
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -79,92 +79,19 @@ describe('/components/password-input', () => {
         })
       })
 
-      describe('when the toggle button is clicked once', () => {
+      describe.each([
+        [1, itShowsThePassword],
+        [2, itHidesThePassword],
+        [3, itShowsThePassword]
+      ])('when clicked %i time(s)', (clicks, expectation) => {
         beforeAll(async () => {
           await render(page, 'password-input', examples.default)
-          await page.click(buttonSelector)
+          for (let i = 0; i < clicks; i++) {
+            await page.click(buttonSelector)
+          }
         })
 
-        it('changes the input to type="text"', async () => {
-          const inputType = await page.$eval(inputSelector, (el) =>
-            el.getAttribute('type')
-          )
-
-          expect(inputType).toBe('text')
-        })
-
-        it('changes the status to aria-live="assertive"', async () => {
-          const statusAriaLiveAttribute = await page.$eval(
-            statusSelector,
-            (el) => el.getAttribute('aria-live')
-          )
-
-          expect(statusAriaLiveAttribute).toBe('assertive')
-        })
-
-        it('changes the status to say the password is visible', async () => {
-          const statusText = await page.$eval(statusSelector, (el) =>
-            el.innerHTML.trim()
-          )
-
-          expect(statusText).toBe('Your password is visible')
-        })
-
-        it('changes the button text to "hide"', async () => {
-          const buttonText = await page.$eval(buttonSelector, (el) =>
-            el.innerHTML.trim()
-          )
-
-          expect(buttonText).toBe('Hide')
-        })
-
-        it('changes the button aria-label to "hide password"', async () => {
-          const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
-            el.getAttribute('aria-label')
-          )
-
-          expect(buttonAriaLabel).toBe('Hide password')
-        })
-      })
-
-      describe('when the toggle button is clicked twice', () => {
-        beforeAll(async () => {
-          await render(page, 'password-input', examples.default)
-          await page.click(buttonSelector)
-          await page.click(buttonSelector)
-        })
-
-        it('changes the input to type="password"', async () => {
-          const inputType = await page.$eval(inputSelector, (el) =>
-            el.getAttribute('type')
-          )
-
-          expect(inputType).toBe('password')
-        })
-
-        it('changes the status to say the password is hidden', async () => {
-          const statusText = await page.$eval(statusSelector, (el) =>
-            el.innerHTML.trim()
-          )
-
-          expect(statusText).toBe('Your password is hidden')
-        })
-
-        it('changes the button text to "show"', async () => {
-          const buttonText = await page.$eval(buttonSelector, (el) =>
-            el.innerHTML.trim()
-          )
-
-          expect(buttonText).toBe('Show')
-        })
-
-        it('changes the button aria-label to "show password"', async () => {
-          const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
-            el.getAttribute('aria-label')
-          )
-
-          expect(buttonAriaLabel).toBe('Show password')
-        })
+        expectation()
       })
 
       describe('when the form is submitted', () => {
@@ -376,3 +303,84 @@ describe('/components/password-input', () => {
     })
   })
 })
+
+// A bundle of tests for when the password has been shown via a user interaction.
+// It's been extracted out as multiple tests check for this state.
+function itShowsThePassword() {
+  it('changes the input to type="text"', async () => {
+    const inputType = await page.$eval(inputSelector, (el) =>
+      el.getAttribute('type')
+    )
+
+    expect(inputType).toBe('text')
+  })
+
+  it('changes the status to aria-live="assertive"', async () => {
+    const statusAriaLiveAttribute = await page.$eval(statusSelector, (el) =>
+      el.getAttribute('aria-live')
+    )
+
+    expect(statusAriaLiveAttribute).toBe('assertive')
+  })
+
+  it('changes the status to say the password is visible', async () => {
+    const statusText = await page.$eval(statusSelector, (el) =>
+      el.innerHTML.trim()
+    )
+
+    expect(statusText).toBe('Your password is visible')
+  })
+
+  it('changes the button text to "hide"', async () => {
+    const buttonText = await page.$eval(buttonSelector, (el) =>
+      el.innerHTML.trim()
+    )
+
+    expect(buttonText).toBe('Hide')
+  })
+
+  it('changes the button aria-label to "hide password"', async () => {
+    const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
+      el.getAttribute('aria-label')
+    )
+
+    expect(buttonAriaLabel).toBe('Hide password')
+  })
+}
+
+// A bundle of tests for when the password has been hidden via a user interaction.
+// (Note: NOT when the component is initially loaded.)
+// It's been extracted out as multiple tests check for this state.
+function itHidesThePassword() {
+  it('changes the input to type="password"', async () => {
+    const inputType = await page.$eval(inputSelector, (el) =>
+      el.getAttribute('type')
+    )
+
+    expect(inputType).toBe('password')
+  })
+
+  it('changes the status to say the password is hidden', async () => {
+    const statusText = await page.$eval(statusSelector, (el) =>
+      el.innerHTML.trim()
+    )
+
+    expect(statusText).toBe('Your password is hidden')
+  })
+
+  it('changes the button text to "show"', async () => {
+    const buttonText = await page.$eval(buttonSelector, (el) =>
+      el.innerHTML.trim()
+    )
+
+    expect(buttonText).toBe('Show')
+  })
+
+  it('changes the button aria-label to "show password"', async () => {
+    const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
+      el.getAttribute('aria-label')
+    )
+
+    expect(buttonAriaLabel).toBe('Show password')
+  })
+}

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -53,13 +53,13 @@ describe('/components/password-input', () => {
           expect(statusElement).toBeDefined()
         })
 
-        it('renders the status element without aria-live', async () => {
+        it('renders the status element with aria-live', async () => {
           const statusAriaLiveAttribute = await page.$eval(
             statusSelector,
-            (el) => el.hasAttribute('aria-live')
+            (el) => el.getAttribute('aria-live')
           )
 
-          expect(statusAriaLiveAttribute).toBeFalsy()
+          expect(statusAriaLiveAttribute).toBe('polite')
         })
 
         it('renders the status element empty', async () => {
@@ -369,12 +369,12 @@ function itShowsThePassword() {
     expect(inputType).toBe('text')
   })
 
-  it('changes the status to aria-live="assertive"', async () => {
+  it('changes the status to aria-live="polite"', async () => {
     const statusAriaLiveAttribute = await page.$eval(statusSelector, (el) =>
       el.getAttribute('aria-live')
     )
 
-    expect(statusAriaLiveAttribute).toBe('assertive')
+    expect(statusAriaLiveAttribute).toBe('polite')
   })
 
   it('changes the status to say the password is visible', async () => {

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -1,0 +1,363 @@
+const { render, goTo } = require('@govuk-frontend/helpers/puppeteer')
+const { getExamples } = require('@govuk-frontend/lib/components')
+
+const inputClass = '.govuk-js-password-input-input'
+const buttonClass = '.govuk-js-password-input-toggle'
+const statusClass = '.govuk-password-input__sr-status'
+
+describe('/components/password-input', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('password-input')
+  })
+
+  describe('/components/password-input/preview', () => {
+    describe('when JavaScript is unavailable or fails', () => {
+      beforeAll(async () => {
+        await page.setJavaScriptEnabled(false)
+      })
+
+      afterAll(async () => {
+        await page.setJavaScriptEnabled(true)
+      })
+
+      it('still renders an unmodified password input', async () => {
+        await render(page, 'password-input', examples.default)
+
+        const inputType = await page.evaluate(
+          (inputClass) =>
+            document.querySelector(inputClass).getAttribute('type'),
+          inputClass
+        )
+
+        expect(inputType).toEqual('password')
+      })
+
+      it('renders the toggle button hidden', async () => {
+        await render(page, 'password-input', examples.default)
+
+        const buttonHiddenAttribute = await page.evaluate(
+          (buttonClass) =>
+            document.querySelector(buttonClass).hasAttribute('hidden'),
+          buttonClass
+        )
+
+        expect(buttonHiddenAttribute).toBeTruthy()
+      })
+    })
+
+    describe('when JavaScript is available', () => {
+      describe('on page load', () => {
+        beforeAll(async () => {
+          await render(page, 'password-input', examples.default)
+        })
+
+        it('renders the status element', async () => {
+          const statusElement = await page.evaluate(
+            (statusClass) => document.querySelector(statusClass),
+            statusClass
+          )
+
+          expect(statusElement).not.toBeUndefined()
+        })
+
+        it('renders the status element without aria-live', async () => {
+          const statusAriaLiveAttribute = await page.evaluate(
+            (statusClass) =>
+              document.querySelector(statusClass).hasAttribute('aria-live'),
+            statusClass
+          )
+
+          expect(statusAriaLiveAttribute).toBeFalsy()
+        })
+
+        it('renders the status element empty', async () => {
+          const statusText = await page.evaluate(
+            (statusClass) =>
+              document.querySelector(statusClass).innerHTML.trim(),
+            statusClass
+          )
+
+          expect(statusText).toEqual('')
+        })
+
+        it('shows the toggle button', async () => {
+          const buttonHiddenAttribute = await page.evaluate(
+            (buttonClass) =>
+              document.querySelector(buttonClass).hasAttribute('hidden'),
+            buttonClass
+          )
+
+          expect(buttonHiddenAttribute).toBeFalsy()
+        })
+      })
+
+      describe('when the toggle button is clicked once', () => {
+        beforeAll(async () => {
+          await render(page, 'password-input', examples.default)
+          await page.click(buttonClass)
+        })
+
+        it('changes the input to type="text"', async () => {
+          const inputType = await page.evaluate(
+            (inputClass) =>
+              document.querySelector(inputClass).getAttribute('type'),
+            inputClass
+          )
+
+          expect(inputType).toEqual('text')
+        })
+
+        it('changes the status to say the password is visible', async () => {
+          const statusText = await page.evaluate(
+            (statusClass) =>
+              document.querySelector(statusClass).innerHTML.trim(),
+            statusClass
+          )
+
+          expect(statusText).toEqual('Your password is visible')
+        })
+
+        it('changes the button text to "hide"', async () => {
+          const buttonText = await page.evaluate(
+            (buttonClass) =>
+              document.querySelector(buttonClass).innerHTML.trim(),
+            buttonClass
+          )
+
+          expect(buttonText).toEqual('Hide')
+        })
+
+        it('changes the button aria-label to "hide password"', async () => {
+          const buttonAriaLabel = await page.evaluate(
+            (buttonClass) =>
+              document.querySelector(buttonClass).getAttribute('aria-label'),
+            buttonClass
+          )
+
+          expect(buttonAriaLabel).toEqual('Hide password')
+        })
+      })
+
+      describe('when the toggle button is clicked twice', () => {
+        beforeAll(async () => {
+          await render(page, 'password-input', examples.default)
+          await page.click(buttonClass)
+          await page.click(buttonClass)
+        })
+
+        it('changes the input to type="password"', async () => {
+          const inputType = await page.evaluate(
+            (inputClass) =>
+              document.querySelector(inputClass).getAttribute('type'),
+            inputClass
+          )
+
+          expect(inputType).toEqual('password')
+        })
+
+        it('changes the status to say the password is hidden', async () => {
+          const statusText = await page.evaluate(
+            (statusClass) =>
+              document.querySelector(statusClass).innerHTML.trim(),
+            statusClass
+          )
+
+          expect(statusText).toEqual('Your password is hidden')
+        })
+
+        it('changes the button text to "show"', async () => {
+          const buttonText = await page.evaluate(
+            (buttonClass) =>
+              document.querySelector(buttonClass).innerHTML.trim(),
+            buttonClass
+          )
+
+          expect(buttonText).toEqual('Show')
+        })
+
+        it('changes the button aria-label to "show password"', async () => {
+          const buttonAriaLabel = await page.evaluate(
+            (buttonClass) =>
+              document.querySelector(buttonClass).getAttribute('aria-label'),
+            buttonClass
+          )
+
+          expect(buttonAriaLabel).toEqual('Show password')
+        })
+      })
+
+      describe('when the form is submitted', () => {
+        it('reverts the input back to password type', async () => {
+          // Go to the full-page example
+          await goTo(page, `/full-page-examples/update-your-account-details`)
+
+          // Prevent form submissions so that we don't navigate away during the test
+          await page.evaluate(() => {
+            document.addEventListener('submit', (e) => e.preventDefault())
+          })
+
+          // Type something into the email field
+          await page.type('[type="email"]', 'test@example.com')
+
+          // Type something into the password field
+          await page.type('[type="password"]', 'Hunter2')
+
+          // Click the "show" button so the password is visible in plain text
+          await page.click(buttonClass)
+
+          // Check that the type change has occurred as expected
+          const beforeSubmitType = await page.evaluate(
+            (inputClass) =>
+              document.querySelector(inputClass).getAttribute('type'),
+            inputClass
+          )
+
+          // Submit the form
+          await page.click('[type="submit"]')
+
+          // Check the input type again
+          const afterSubmitType = await page.evaluate(
+            (inputClass) =>
+              document.querySelector(inputClass).getAttribute('type'),
+            inputClass
+          )
+
+          expect(beforeSubmitType).toEqual('text')
+          expect(afterSubmitType).toEqual('password')
+        })
+      })
+
+      describe('errors at instantiation', () => {
+        it('can throw a SupportError if appropriate', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation() {
+                document.body.classList.remove('govuk-frontend-supported')
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'SupportError',
+              message:
+                'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
+            }
+          })
+        })
+
+        it('throws when $module is not set', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module) {
+                $module.remove()
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message: 'Password input: Root element (`$module`) not found'
+            }
+          })
+        })
+
+        it('throws when receiving the wrong type for $module', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module) {
+                // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
+                $module.outerHTML = `<svg data-module="govuk-password-input"></svg>`
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Root element (`$module`) is not of type HTMLElement'
+            }
+          })
+        })
+
+        it('throws when the input element is missing', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module, { selector }) {
+                $module.querySelector(selector).remove()
+              },
+              context: {
+                selector: inputClass
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Form field (`.govuk-js-password-input-input`) not found'
+            }
+          })
+        })
+
+        it('throws when the input element is not the right type', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module, { selector }) {
+                // Replace the input with a textarea
+                $module.querySelector(selector).outerHTML =
+                  '<textarea class="govuk-js-password-input-input"></textarea>'
+              },
+              context: {
+                selector: inputClass
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Form field (`.govuk-js-password-input-input`) is not of type HTMLInputElement'
+            }
+          })
+        })
+
+        it('throws when the button is missing', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module, { selector }) {
+                $module.querySelector(selector).remove()
+              },
+              context: {
+                selector: buttonClass
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Button (`.govuk-js-password-input-toggle`) not found'
+            }
+          })
+        })
+
+        it('throws when the button is not the right type', async () => {
+          await expect(
+            render(page, 'password-input', examples.default, {
+              beforeInitialisation($module, { selector }) {
+                // Replace the button with a <div>
+                $module.querySelector(selector).outerHTML =
+                  '<div class="govuk-js-password-input-toggle"></div>'
+              },
+              context: {
+                selector: buttonClass
+              }
+            })
+          ).rejects.toMatchObject({
+            cause: {
+              name: 'ElementError',
+              message:
+                'Password input: Button (`.govuk-js-password-input-toggle`) is not of type HTMLButtonElement'
+            }
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds Puppeteer tests for the [Password input component](https://github.com/alphagov/govuk-frontend/pull/4442).

Separated out as I'm not most accustomed to writing tests or Puppeteer, so open to suggestions for improvements or other tests that could be added.

## Changes
- Adds Puppeteer tests for Password input's JavaScript functionality.

## Thoughts

The form submission test is a bit weird as it uses a full-page example as the test bed, which no other component test currently does, however the full-page examples are the only examples in the review app that currently seem to support form submission and routing properly.

There are no tests for configuration or localisation options provided via JavaScript. Other components didn't seem to have tests for this, so I wasn't sure if or how best to include them. 