### PR TITLE
Tweak Sassdoc groups

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_measurements.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_measurements.scss
@@ -1,5 +1,5 @@
 ////
-/// @group settings/measurements
+/// @group settings/layout
 ////
 
 // =========================================================

--- a/packages/govuk-frontend/src/govuk/settings/_media-queries.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_media-queries.scss
@@ -1,5 +1,5 @@
 ////
-/// @group settings/media-queries
+/// @group settings/layout
 ////
 
 /// Breakpoint definitions


### PR DESCRIPTION
Remove the settings/measurements and settings/media-queries groups and move everything from those groups into settings/layout.

This affects how the settings are grouped when displayed in [our Sass API docs][1]. Grouping these settings together under layout mirrors how the helpers are organised under the helpers/layout group.

Closes #1828.

[1]: https://frontend.design-system.service.gov.uk/sass-api-reference/