### PR TITLE
Fix: automated axe testing custom options overridden by later configuration

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accessibility.puppeteer.test.mjs
@@ -2,13 +2,26 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/accordion', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Show all sections', 'Show' and 'Hide' toggle links
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('accordion')
 
       for (const exampleName in examples) {
         await render(page, 'accordion', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
@@ -2,13 +2,25 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/button', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Save and continue' button
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('button')
 
       for (const exampleName in examples) {
         await render(page, 'button', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.puppeteer.test.mjs
@@ -2,13 +2,27 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/cookie-banner', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Accept analytics cookies', 'Reject analytics cookies' buttons,
+       * and 'View cookie preferences' link
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('cookie-banner')
 
       for (const exampleName in examples) {
         await render(page, 'cookie-banner', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/details/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/details/accessibility.puppeteer.test.mjs
@@ -2,13 +2,26 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/details', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Help with nationality' summary text
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('details')
 
       for (const exampleName in examples) {
         await render(page, 'details', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.puppeteer.test.mjs
@@ -2,13 +2,25 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/exit-this-page', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects link to '/full-page-examples/announcements'
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('exit-this-page')
 
       for (const exampleName in examples) {
         await render(page, 'exit-this-page', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/header/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/accessibility.puppeteer.test.mjs
@@ -2,13 +2,26 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/header', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects header link 'Navigation item 1'
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('header')
 
       for (const exampleName in examples) {
         await render(page, 'header', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/hint/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/hint/accessibility.puppeteer.test.mjs
@@ -2,13 +2,26 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/hint', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'P60' link
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('hint')
 
       for (const exampleName in examples) {
         await render(page, 'hint', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.puppeteer.test.mjs
@@ -10,7 +10,13 @@ describe('/components/notification-banner', () => {
        * Ignore 'Element has a tabindex greater than 0' for custom
        * tabindex tests
        */
-      tabindex: { enabled: false }
+      tabindex: { enabled: false },
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'new planning guidance' link
+       */
+      'color-contrast-enhanced': { enabled: false }
     }
   })
 

--- a/packages/govuk-frontend/src/govuk/components/pagination/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/pagination/accessibility.puppeteer.test.mjs
@@ -2,13 +2,25 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/pagination', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Page one' and 'Page three' pagination links
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('pagination')
 
       for (const exampleName in examples) {
         await render(page, 'pagination', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.puppeteer.test.mjs
@@ -2,13 +2,26 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/phase-banner', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'feedback' link
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('phase-banner')
 
       for (const exampleName in examples) {
         await render(page, 'phase-banner', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.puppeteer.test.mjs
@@ -2,13 +2,25 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/summary-list', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'name', 'date of birth' and 'contact information' links
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('summary-list')
 
       for (const exampleName in examples) {
         await render(page, 'summary-list', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
@@ -2,6 +2,19 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/tabs', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Anchor' link
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('tabs')
@@ -11,7 +24,7 @@ describe('/components/tabs', () => {
           // Log errors for invalid examples
           .catch(({ message }) => console.warn(message))
 
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/tag/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tag/accessibility.puppeteer.test.mjs
@@ -2,13 +2,26 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/tag', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects '.govuk-tag--green' tag
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('tag')
 
       for (const exampleName in examples) {
         await render(page, 'tag', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/task-list/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/task-list/accessibility.puppeteer.test.mjs
@@ -2,13 +2,27 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/task-list', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects 'Company Directors', 'Registered company details' and
+       * 'Business plan' links
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('task-list')
 
       for (const exampleName in examples) {
         await render(page, 'task-list', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 60000)
   })

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -43,9 +43,7 @@ async function axe(page, overrides = {}) {
        * Ignore 'Some page content is not contained by landmarks'
        * {@link https://github.com/alphagov/govuk-frontend/issues/1604}
        */
-      region: { enabled: false },
-      // Ignore colour contrast (enhanced) from WCAG Level AAA
-      'color-contrast-enhanced': { enabled: false }
+      region: { enabled: false }
     }
   }
 

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -16,8 +16,19 @@ const slug = require('slug')
  * @returns {Promise<import('axe-core').AxeResults>} Axe Puppeteer instance
  */
 async function axe(page, overrides = {}) {
+  // Shared rules for GOV.UK Frontend
+  const rules = {
+    /**
+     * Ignore 'Some page content is not contained by landmarks'
+     * {@link https://github.com/alphagov/govuk-frontend/issues/1604}
+     */
+    region: { enabled: false },
+    ...overrides
+  }
+
   const reporter = new AxePuppeteer(page)
     .setLegacyMode(true) // Share single page via iframe
+    .options({ rules })
     .include('body')
     .withRules([
       'best-practice',
@@ -37,21 +48,11 @@ async function axe(page, overrides = {}) {
 
   // Ignore colour contrast for 'inactive' components
   if (page.url().includes('-disabled')) {
-    overrides['color-contrast'] = { enabled: false }
-  }
-
-  // Shared rules for GOV.UK Frontend
-  const rules = {
-    /**
-     * Ignore 'Some page content is not contained by landmarks'
-     * {@link https://github.com/alphagov/govuk-frontend/issues/1604}
-     */
-    region: { enabled: false },
-    ...overrides
+    reporter.disableRules('color-contrast')
   }
 
   // Create report
-  const report = await reporter.options({ rules }).analyze()
+  const report = await reporter.analyze()
 
   // Add preview URL to report violations
   report.violations.forEach((violation) => {

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -46,6 +46,9 @@ async function axe(page, overrides = {}) {
       'wcag22aa'
     ])
 
+  // Ignore colour contrast (enhanced) from WCAG Level AAA
+  reporter.disableRules('color-contrast-enhanced')
+
   // Ignore colour contrast for 'inactive' components
   if (page.url().includes('-disabled')) {
     reporter.disableRules('color-contrast')

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -20,24 +20,30 @@ async function axe(page, overrides = {}) {
     .setLegacyMode(true) // Share single page via iframe
     .include('body')
 
+  /**
+   * Shared options for GOV.UK Frontend
+   *
+   * @satisfies {import('axe-core').RunOptions}
+   */
   const defaultOptions = {
-    /** @type {import('axe-core').RunOnly} */
     runOnly: {
       type: 'tag',
       values: [
         'best-practice',
+
         // WCAG 2.x
         'wcag2a',
         'wcag2aa',
         'wcag2aaa',
+
         // WCAG 2.1
         'wcag21a',
         'wcag21aa',
+
         // WCAG 2.2
         'wcag22aa'
       ]
     },
-    /** @type {import('axe-core').RuleObject} */
     rules: {
       /**
        * Ignore 'Some page content is not contained by landmarks'

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -30,7 +30,7 @@ async function axe(page, overrides = {}) {
     .setLegacyMode(true) // Share single page via iframe
     .options({ rules })
     .include('body')
-    .withRules([
+    .withTags([
       'best-practice',
 
       // WCAG 2.x

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -25,7 +25,7 @@ async function axe(page, overrides = {}) {
    *
    * @satisfies {import('axe-core').RunOptions}
    */
-  const defaultOptions = {
+  const options = {
     runOnly: {
       type: 'tag',
       values: [
@@ -49,21 +49,18 @@ async function axe(page, overrides = {}) {
        * Ignore 'Some page content is not contained by landmarks'
        * {@link https://github.com/alphagov/govuk-frontend/issues/1604}
        */
-      region: { enabled: false }
+      region: { enabled: false },
+      ...overrides
     }
   }
 
   // Ignore colour contrast for 'inactive' components
   if (page.url().includes('-disabled')) {
-    defaultOptions.rules['color-contrast'] = { enabled: false }
+    options.rules['color-contrast'] = { enabled: false }
   }
 
-  const mergedOptions = defaultOptions
-
-  mergedOptions.rules = { ...defaultOptions.rules, ...overrides }
-
   // Create report
-  const report = await reporter.options(mergedOptions).analyze()
+  const report = await reporter.options(options).analyze()
 
   // Add preview URL to report violations
   report.violations.forEach((violation) => {


### PR DESCRIPTION
## Bug
When setting up our axe reporter, we define some default rules (using `.withRules()`), and we allow rule overrides.

Later, however, we run the reporter like this:

`const report = await reporter.options({ rules }).analyze()`

This call to `.options()` [overwrites all our previous rules](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer#axepuppeteeroptionsoptions-axerunoptions), resulting in us unknowingly not running the correct checks.

## Solution
Instead of using the AxePuppeteer chained methods, we define an AxeOptions object, which we can then merge with passed-in overrides.

At the moment, we only override `options.rules`, so I've kept that behaviour. However, it would be very simple to change this behaviour so that we can pass in a complete set of custom axe options for a particular test.

## Future
In the future, it'd be really nice to be able to pass in some kind of filter option, so we can get really specific about what cases we want to disable (eg: "Ignore the `aria-allowed-attr` for radios with `aria-controls="conditional-[id]""). At the moment it's quite brute force: "Disable this rule entirely for every radio example".