### PR TITLE
Fix Nunjucks HTML indentation: Task list, Tag

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/tag/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/tag/template.njk
@@ -2,5 +2,5 @@
 
 <strong class="govuk-tag {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
-  {{ params.html | safe if params.html else params.text }}
+  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
 </strong>

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -3,31 +3,35 @@
 
 {%- set idPrefix = params.idPrefix if params.idPrefix else "task-list" -%}
 
+{%- macro _taskListItem(params, item, index) %}
+  {%- set hintId = idPrefix + "-" + index + "-hint" -%}
+  {%- set statusId = idPrefix + "-" + index + "-status" -%}
+  <li class="govuk-task-list__item {%- if item.href %} govuk-task-list__item--with-link{% endif %}{%- if item.classes %} {{ item.classes }}{% endif %}">
+    <div class="govuk-task-list__name-and-hint">
+      {% if item.href %}
+        <a class="govuk-link govuk-task-list__link {%- if item.title.classes %} {{ item.title.classes }}{% endif %}" href="{{ item.href }}" aria-describedby="{{ hintId + " " if item.hint }}{{ statusId }}">{{ item.title.html | safe if item.title.html else item.title.text }}</a>
+      {% else %}
+        <div {%- if item.title.classes %} class="{{ item.title.classes }}"{% endif %}>{{ item.title.html | safe if item.title.html else item.title.text }}</div>
+      {% endif %}
+      {% if item.hint %}
+        <div id="{{ hintId }}" class="govuk-task-list__hint">
+          {{ item.hint.html | safe if item.hint.html else item.hint.text }}
+        </div>
+      {% endif %}
+    </div>
+    <div class="govuk-task-list__status {%- if item.status.classes %} {{ item.status.classes }}{% endif %}" id="{{ statusId }}">
+      {% if item.status.tag %}
+        {{ govukTag(item.status.tag) | trim | indent(4) }}
+      {% else %}
+        {{ item.status.html | safe if item.status.html else item.status.text }}
+      {% endif %}
+    </div>
+  </li>
+{%- endmacro %}
+
 <ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   {% for item in params.items %}
-    {%- set hintId = idPrefix + "-" + loop.index + "-hint" -%}
-    {%- set statusId = idPrefix + "-" + loop.index + "-status" -%}
-    <li class="govuk-task-list__item {%- if item.href %} govuk-task-list__item--with-link{% endif %}{%- if item.classes %} {{ item.classes }}{% endif %}">
-      <div class="govuk-task-list__name-and-hint">
-        {% if item.href %}
-          <a class="govuk-link govuk-task-list__link {%- if item.title.classes %} {{ item.title.classes }}{% endif %}" href="{{ item.href }}" aria-describedby="{{ hintId + " " if item.hint }}{{ statusId }}">{{ item.title.html | safe if item.title.html else item.title.text }}</a>
-        {% else %}
-          <div {%- if item.title.classes %} class="{{ item.title.classes }}"{% endif %}>{{ item.title.html | safe if item.title.html else item.title.text }}</div>
-        {% endif %}
-        {% if item.hint %}
-          <div id="{{ hintId }}" class="govuk-task-list__hint">
-            {{ item.hint.html | safe if item.hint.html else item.hint.text }}
-          </div>
-        {% endif %}
-      </div>
-      <div class="govuk-task-list__status {%- if item.status.classes %} {{ item.status.classes }}{% endif %}" id="{{ statusId }}">
-        {% if item.status.tag %}
-          {{ govukTag(item.status.tag) | trim | indent(4) }}
-        {% else %}
-          {{ item.status.html | safe if item.status.html else item.status.text }}
-        {% endif %}
-      </div>
-    </li>
+    {{ _taskListItem(params, item, loop.index) }}
   {% endfor %}
 </ul>

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -4,27 +4,31 @@
 {%- set idPrefix = params.idPrefix if params.idPrefix else "task-list" -%}
 
 {%- macro _taskListItem(params, item, index) %}
-  {%- set hintId = idPrefix + "-" + index + "-hint" -%}
-  {%- set statusId = idPrefix + "-" + index + "-status" -%}
+  {%- set hintId = idPrefix + "-" + index + "-hint" %}
+  {%- set statusId = idPrefix + "-" + index + "-status" %}
   <li class="govuk-task-list__item {%- if item.href %} govuk-task-list__item--with-link{% endif %}{%- if item.classes %} {{ item.classes }}{% endif %}">
     <div class="govuk-task-list__name-and-hint">
-      {% if item.href %}
-        <a class="govuk-link govuk-task-list__link {%- if item.title.classes %} {{ item.title.classes }}{% endif %}" href="{{ item.href }}" aria-describedby="{{ hintId + " " if item.hint }}{{ statusId }}">{{ item.title.html | safe if item.title.html else item.title.text }}</a>
-      {% else %}
-        <div {%- if item.title.classes %} class="{{ item.title.classes }}"{% endif %}>{{ item.title.html | safe if item.title.html else item.title.text }}</div>
-      {% endif %}
-      {% if item.hint %}
-        <div id="{{ hintId }}" class="govuk-task-list__hint">
-          {{ item.hint.html | safe if item.hint.html else item.hint.text }}
-        </div>
-      {% endif %}
+    {% if item.href %}
+      <a class="govuk-link govuk-task-list__link {%- if item.title.classes %} {{ item.title.classes }}{% endif %}" href="{{ item.href }}" aria-describedby="{{ hintId + " " if item.hint }}{{ statusId }}">
+        {{ item.title.html | safe | trim | indent(8) if item.title.html else item.title.text }}
+      </a>
+    {% else %}
+      <div {%- if item.title.classes %} class="{{ item.title.classes }}"{% endif %}>
+        {{ item.title.html | safe | trim | indent(8) if item.title.html else item.title.text }}
+      </div>
+    {% endif %}
+    {% if item.hint %}
+      <div id="{{ hintId }}" class="govuk-task-list__hint">
+        {{ item.hint.html | safe | trim | indent(8) if item.hint.html else item.hint.text }}
+      </div>
+    {% endif %}
     </div>
     <div class="govuk-task-list__status {%- if item.status.classes %} {{ item.status.classes }}{% endif %}" id="{{ statusId }}">
-      {% if item.status.tag %}
-        {{ govukTag(item.status.tag) | trim | indent(4) }}
-      {% else %}
-        {{ item.status.html | safe if item.status.html else item.status.text }}
-      {% endif %}
+    {% if item.status.tag %}
+      {{ govukTag(item.status.tag) | trim | indent(6) }}
+    {% else %}
+      {{ item.status.html | safe | trim | indent(6) if item.status.html else item.status.text }}
+    {% endif %}
     </div>
   </li>
 {%- endmacro %}
@@ -32,6 +36,6 @@
 <ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   {% for item in params.items %}
-    {{ _taskListItem(params, item, loop.index) }}
+    {{- _taskListItem(params, item, loop.index) }}
   {% endfor %}
 </ul>

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -87,7 +87,9 @@ describe('Task List', () => {
 
       const $itemWithLink = $('.govuk-task-list__item:first-child')
       const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
-      expect($itemWithLinkTitle.text()).toEqual('<strong>Linked Title</strong>')
+      expect($itemWithLinkTitle.text().trim()).toEqual(
+        '<strong>Linked Title</strong>'
+      )
     })
 
     it('allows HTML in the title when passed as html', () => {
@@ -95,7 +97,9 @@ describe('Task List', () => {
 
       const $itemWithLink = $('.govuk-task-list__item:first-child')
       const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
-      expect($itemWithLinkTitle.html()).toEqual('<strong>Linked Title</strong>')
+      expect($itemWithLinkTitle.html().trim()).toEqual(
+        '<strong>Linked Title</strong>'
+      )
     })
   })
 


### PR DESCRIPTION
Task list and Tag changes, split out from https://github.com/alphagov/govuk-frontend/pull/4448 to partially resolve #3211

This PR adds `| trim | indent(8)` etc to task list titles, hints and tags to ensure nested HTML lines are indented, using:

* `_taskListItem()`