### PR TITLE
Delineate code block in Sassdoc

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -129,6 +129,7 @@
 ///
 /// Example font map:
 ///
+/// ```scss
 /// 19: (
 ///   null: (
 ///     font-size: 16px,
@@ -143,6 +144,7 @@
 ///     line-height: 1.15
 ///   )
 /// );
+/// ```
 ///
 /// @param {Number | String} $size - Point from the type scale (the size as
 ///   it would appear on tablet and above)


### PR DESCRIPTION
Mark the code example that shows an example font map up as a code block to improve how it displays in [our Sass API reference](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-typography-responsive-usage).

Without it, the code is displayed as normal text without any whitespace.

## Before

![Code example displays as normal variable-width text with no whitespace or syntax highlighting.](https://github.com/alphagov/govuk-frontend/assets/121939/1597e785-0f2d-4d3b-8e9b-b1a063f9d7a5)

## After

![Code example displays as a code block, with monospaced text, appropriate whitespace and syntax highlighting.](https://github.com/alphagov/govuk-frontend/assets/121939/1ca35b0c-ea6c-44aa-8c06-d2bd111e45fe)