### PR TITLE
Fix typo in release docs

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -75,7 +75,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    This step will also automatically create a tag in Github which you can use to create a Github release in the following section.
 
-6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
+6. Verify the presence of the release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
 
    If the release has been assigned the wrong tag (mistakes happen),
    you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.


### PR DESCRIPTION
Noticed this tiny little typo while helping with the 5.2.0 release earlier today.