### PR TITLE
Link to known issues project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 
     Your issue might already exist. If so, add a comment to the existing issue instead of creating a new one. You can find existing issues here:
     - an existing Github issue: https://github.com/alphagov/govuk-frontend/issues
-    - our known validation error/warning list: https://github.com/alphagov/govuk-frontend/issues/1280#issuecomment-509588851
+    - known validation errors or warnings: https://github.com/orgs/alphagov/projects/37
 -->
 
 ## Description of the issue

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Using Frontend will help your service meet [level AA of WCAG 2.1](https://www.go
 
 You should also use [the JavaScript from GOV.UK Frontend](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript) and read the [accessibility statement for the GOV.UK Design System](https://design-system.service.gov.uk/accessibility/).
 
-### Accessibility warnings
+## Known issues flagged by validators or automated testing tools
 
-If you get a warning from a linter or accessibility checker, check our list of [issues you should not need to fix](https://github.com/alphagov/govuk-frontend/issues/1280#issuecomment-509588851).
+Check our [list of known issues that may be reported by HTML Validators or automated testing tools](https://github.com/orgs/alphagov/projects/37).
 
 ## Security
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -32,7 +32,7 @@ You should use the bookmarklet if:
 
 If you can, fix any errors or warnings reported by either the validator or bookmarklet.
 
-You do not need to fix any [known issues with our components](https://github.com/alphagov/govuk-frontend/issues/1280#issuecomment-509588851) reported by either the validator or bookmarklet.
+You do not need to fix any [known issues with our components](https://github.com/orgs/alphagov/projects/37) reported by either the validator or bookmarklet.
 
 If you need help with fixing an error or a warning, leave a note in your pull request or [contact the Design System team](https://design-system.service.gov.uk/#support).
 


### PR DESCRIPTION
All of the known issues listed in the GitHub issue are now listed in a public GitHub Project which is easier for users to navigate.

Update the links in our readme and other documentation to point to the Project instead of the Issue, which we can now close.