### PR TITLE
Add Rollup stats for minified files

### DIFF
--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -122,7 +122,10 @@ export async function commentStats(
       const statsPath = `docs/stats/${modulePath.replace('mjs', 'html')}`
       const statsURL = new URL(statsPath, reviewAppURL)
 
-      return [`[${modulePath}](${statsURL})`, moduleSize]
+      return [
+        `[${modulePath}](${statsURL})`,
+        `${moduleSize.bundled} (bundled)<br>${moduleSize.minified} (minified)`
+      ]
     }
   )
 

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { basename, join } from 'path'
+import { basename, join, parse } from 'path'
 
 import { getFileSizes } from '@govuk-frontend/lib/files'
 import { getStats, modulePaths } from '@govuk-frontend/stats'
@@ -119,14 +119,12 @@ export async function commentStats(
   const modulesTitle = '### Modules'
   const modulesRows = (await Promise.all(modulePaths.map(getStats))).map(
     ([modulePath, moduleSize]) => {
-      const statsPath = `docs/stats/${modulePath.replace('mjs', 'html')}`
+      const { base, dir, name } = parse(modulePath)
+
+      const statsPath = `docs/stats/${dir}/${name}.html`
       const statsURL = new URL(statsPath, reviewAppURL)
 
-      return [
-        `[${modulePath}](${statsURL})`,
-        moduleSize.bundled,
-        moduleSize.minified
-      ]
+      return [`[${base}](${statsURL})`, moduleSize.bundled, moduleSize.minified]
     }
   )
 

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -124,12 +124,13 @@ export async function commentStats(
 
       return [
         `[${modulePath}](${statsURL})`,
-        `${moduleSize.bundled} (bundled)<br>${moduleSize.minified} (minified)`
+        moduleSize.bundled,
+        moduleSize.minified
       ]
     }
   )
 
-  const modulesHeaders = ['File', 'Size']
+  const modulesHeaders = ['File', 'Size (bundled)', 'Size (minified)']
   const modulesTable = renderTable(modulesHeaders, modulesRows)
   const modulesFooter = `[View stats and visualisations on the review app](${reviewAppURL})`
   const modulesText = [modulesTitle, modulesTable, modulesFooter].join('\n')

--- a/docs/examples/webpack/webpack.config.js
+++ b/docs/examples/webpack/webpack.config.js
@@ -89,6 +89,7 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
       new TerserPlugin({
         extractComments: true,
         terserOptions: {
+          // Allow Terser to remove @preserve comments
           format: { comments: false },
 
           // Compatibility workarounds

--- a/package-lock.json
+++ b/package-lock.json
@@ -31661,6 +31661,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
         "govuk-frontend": "*",
         "rollup": "^4.12.0",
         "rollup-plugin-visualizer": "^5.12.0"

--- a/packages/govuk-frontend-review/rollup.config.mjs
+++ b/packages/govuk-frontend-review/rollup.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig(({ i: input }) => ({
      */
     plugins: [
       terser({
+        // Allow Terser to remove @preserve comments
         format: { comments: false },
 
         // Include sources content from source maps to inspect

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -73,7 +73,7 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <h2 class="govuk-heading-l">Documentation</h2>
 
       <div class="govuk-grid-row">
@@ -108,49 +108,76 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      <h2 class="govuk-heading-l">JavaScript modules</h2>
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-2">JavaScript modules</h2>
 
       {% set bundleKey = "all" %}
       {% set bundleSize = stats[bundleKey + ".mjs"] %}
 
       {% set bundleHtml %}
-        Total bundle size<br>
         <a href="/docs/stats/{{ bundleKey }}.html" class="govuk-body-s govuk-link govuk-!-font-weight-regular"><code>{{ bundleKey }}.mjs</code></a>
       {% endset %}
 
-      {% set rows = [{
-        key: {
-          classes: "govuk-!-width-three-quarters",
-          html: bundleHtml
-        },
-        value: {
-          text: bundleSize
-        }
-      }] %}
+      {{ govukSummaryList({
+        classes: "govuk-summary-list--no-border",
+        rows: [
+          {
+            key: {
+              text: "Entry file name"
+            },
+            value: {
+              html: bundleHtml
+            }
+          },
+          {
+            key: {
+              text: "Total file size"
+            },
+            value: {
+              html:
+                bundleSize.bundled + " (bundled) <br>" +
+                bundleSize.minified + " (minified)"
+            }
+          }
+        ]
+      }) }}
 
       {% for componentName in componentNamesWithJavaScript | sort %}
         {% set componentKey = "components/" + componentName + "/" + componentName %}
         {% set componentSize = stats[componentKey + ".mjs"] %}
 
         {% set componentHtml %}
-          {{ componentName | unslugify }}<br>
           <a href="/docs/stats/{{ componentKey }}.html" class="govuk-body-s govuk-link govuk-!-font-weight-regular"><code>{{ componentName }}.mjs</code></a>
         {% endset %}
 
-        {% set rows = (rows.push({
-          key: {
-            classes: "govuk-!-width-three-quarters",
-            html: componentHtml
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: componentName | unslugify,
+              headingLevel: 3
+            }
           },
-          value: {
-            text: componentSize
-          }
-        }), rows) %}
+          rows: [
+            {
+              key: {
+                text: "File name"
+              },
+              value: {
+                html: componentHtml
+              }
+            },
+            {
+              key: {
+                text: "File size"
+              },
+              value: {
+                html:
+                  componentSize.bundled + " (bundled) <br>" +
+                  componentSize.minified + " (minified)"
+              }
+            }
+          ]
+        }) }}
       {% endfor %}
-
-      {{ govukSummaryList({
-        rows: rows
-      }) }}
     </div>
   </div>
   {% endif %}

--- a/packages/govuk-frontend/rollup.release.config.mjs
+++ b/packages/govuk-frontend/rollup.release.config.mjs
@@ -29,7 +29,9 @@ export default defineConfig(({ i: input }) => ({
      */
     plugins: [
       terser({
+        // Allow Terser to remove @preserve comments
         format: { comments: false },
+
         mangle: {
           keep_classnames: true,
           keep_fnames: true,

--- a/shared/stats/package.json
+++ b/shared/stats/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
     "govuk-frontend": "*",
     "rollup": "^4.12.0",
     "rollup-plugin-visualizer": "^5.12.0"

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -86,8 +86,8 @@ export default defineConfig(
             projectRoot: dirname(packagePath),
             template: 'treemap',
 
-            // Skip sourcemaps to use original file sizes
-            sourcemap: false
+            // Use sourcemaps to calculate minified sizes
+            sourcemap: true
           })
         ]
       })

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -3,6 +3,7 @@ import { dirname, join, parse } from 'path'
 import { paths } from '@govuk-frontend/config'
 import { packageTypeToPath } from '@govuk-frontend/lib/names'
 import resolve from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
 import { defineConfig } from 'rollup'
 import { visualizer } from 'rollup-plugin-visualizer'
 
@@ -28,7 +29,26 @@ export default defineConfig(
          */
         output: {
           file: join('dist', modulePath),
-          format: 'es'
+          format: 'es',
+          sourcemap: true,
+
+          /**
+           * Output plugins
+           */
+          plugins: [
+            terser({
+              format: { comments: false },
+
+              // Include sources content from source maps to inspect
+              // GOV.UK Frontend and other dependencies' source code
+              sourceMap: {
+                includeSources: true
+              },
+
+              // Compatibility workarounds
+              safari10: true
+            })
+          ]
         },
 
         /**
@@ -39,24 +59,35 @@ export default defineConfig(
 
           // Stats: File size
           visualizer({
-            filename: join(
-              'dist',
-              dirname(modulePath),
-              `${parse(modulePath).name}.yaml`
-            ),
+            emitFile: true,
+            filename: `${parse(modulePath).name}.yaml`,
             projectRoot: dirname(packagePath),
-            template: 'list'
+            template: 'list',
+
+            // Skip sourcemaps to use original file sizes
+            sourcemap: false
+          }),
+
+          // Stats: File size (minified)
+          visualizer({
+            emitFile: true,
+            filename: `${parse(modulePath).name}.min.yaml`,
+            projectRoot: dirname(packagePath),
+            template: 'list',
+
+            // Use sourcemaps to calculate minified sizes
+            sourcemap: true
           }),
 
           // Stats: Module tree map
           visualizer({
-            filename: join(
-              'dist',
-              dirname(modulePath),
-              `${parse(modulePath).name}.html`
-            ),
+            emitFile: true,
+            filename: `${parse(modulePath).name}.html`,
             projectRoot: dirname(packagePath),
-            template: 'treemap'
+            template: 'treemap',
+
+            // Skip sourcemaps to use original file sizes
+            sourcemap: false
           })
         ]
       })

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -34,9 +34,16 @@ export default defineConfig(
 
           /**
            * Output plugins
+           *
+           * Note: File sizes in both Rollup stats and the Review app are
+           * smaller than GOV.UK Frontend GitHub releases because classes,
+           * functions and export names are mangled by Terser defaults
+           *
+           * {@link file://./../../packages/govuk-frontend/rollup.release.config.mjs}
            */
           plugins: [
             terser({
+              // Allow Terser to remove @preserve comments
               format: { comments: false },
 
               // Include sources content from source maps to inspect


### PR DESCRIPTION
This PR splits Rollup stats into "bundled" versus "minified" file sizes

It adds another call to [rollup-plugin-visualizer](https://www.npmjs.com/package/rollup-plugin-visualizer) with minified sizes as the default for tree maps

<img width="703" alt="Rollup minified file stats" src="https://github.com/alphagov/govuk-frontend/assets/415517/5f3f8b42-15c6-417f-95d3-ca248758b5ce">
