### PR TITLE
Prevent non-object values from being merged into config keys already set to an object

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -160,6 +160,22 @@ describe('Common JS utilities', () => {
       const result = extractConfigByNamespace($element.dataset, 'i18n')
       expect(result).toEqual({ key1: 'One', key2: 'Two' })
     })
+
+    it('can handle multiple levels of nesting', () => {
+      document.body.outerHTML = outdent`
+        <div id="app-example2"
+          data-i18n.key1="One"
+          data-i18n.key2.other="Two"
+          data-i18n.key2>
+          data-i18n
+        </div>
+      `
+
+      $element = document.getElementById('app-example2')
+
+      const result = extractConfigByNamespace($element.dataset, 'i18n')
+      expect(result).toEqual({ key1: 'One', key2: { other: 'Two' } })
+    })
   })
 
   describe('isSupported', () => {

--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -72,6 +72,24 @@ describe('Common JS utilities', () => {
       expect(test3).toEqual(mergeConfigs(config3))
     })
 
+    it('ignores non-object values for keys that already hold an object', () => {
+      const config = mergeConfigs(config1, config2, config3, {
+        c: 'whoops',
+        e: { l: 'whoops again' }
+      })
+      expect(config).toEqual({
+        a: 'aardvark',
+        b: 'bat',
+        c: { a: 'cat', o: 'cow' },
+        d: 'dog',
+        e: {
+          l: {
+            e: 'elephant'
+          }
+        }
+      })
+    })
+
     it('prioritises the last parameter provided', () => {
       const config = mergeConfigs(config1, config2, config3, config1)
       expect(config).toEqual({

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -57,7 +57,12 @@ export function mergeConfigs(...configObjects) {
 export function extractConfigByNamespace(dataset, namespace) {
   const newObject = /** @type {ObjectNested} */ ({})
 
-  for (const [key, value] of Object.entries(dataset)) {
+  // Iterate over dataset keys sorted as strings so that deeper keys
+  // are processed after shallower ones and override them
+  const datasetKeys = Object.keys(dataset).sort()
+
+  for (const key of datasetKeys) {
+    const value = dataset[key]
     // Split the key into parts, using . as our namespace separator
     const keyParts = key.split('.')
 
@@ -75,7 +80,11 @@ export function extractConfigByNamespace(dataset, namespace) {
        * `{ i18n: { textareaDescription: { other } } }`
        */
       for (const name of keyParts) {
-        const next = (current[name] = current[name] ?? {})
+        if (!isObject(current[name])) {
+          current[name] = {}
+        }
+
+        const next = current[name]
 
         // Add them to our new object
         if (name === keyParts[keyParts.length - 1]) {

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -29,15 +29,19 @@ export function mergeConfigs(...configObjects) {
       const option = formattedConfigObject[key]
       const override = configObject[key]
 
-      // Push their keys one-by-one into formattedConfigObject. Any duplicate
-      // keys with object values will be merged, otherwise the new value will
-      // override the existing value.
-      if (isObject(option) && isObject(override)) {
-        // @ts-expect-error Index signature for type 'string' is missing
-        formattedConfigObject[key] = mergeConfigs(option, override)
-      } else {
-        // Apply override
-        formattedConfigObject[key] = override
+      const nonObjectOverridesObject = isObject(option) && !isObject(override)
+
+      if (!nonObjectOverridesObject) {
+        // Push their keys one-by-one into formattedConfigObject. Any duplicate
+        // keys with object values will be merged, otherwise the new value will
+        // override the existing value.
+        if (isObject(option) && isObject(override)) {
+          // @ts-expect-error Index signature for type 'string' is missing
+          formattedConfigObject[key] = mergeConfigs(option, override)
+        } else {
+          // Apply override
+          formattedConfigObject[key] = override
+        }
       }
     }
   }


### PR DESCRIPTION
This limits the risk of mistaken JavaScript keys or data attributes completely wiping some config values that use an object (`i18n` messages and plural forms).

It takes advantage of the fact that everything is merged onto the default config, so object values will already be set, allowing us to detect that we'd be replacing them with a non-object one.

Similarly, when going through the data attributes, going in order allows deeper keys (eg. `data-i18n.messageKey`) to properly override a non-object value (eg. `data-i18n`), ensuring an object is created.

This bring the behaviour of the new merging closer to the one with flatten objects, which guaranteed access to nested keys set by the default when the config or dataset would set shallower keys to a non-object value.

## Why

In its current form #4792 doesn't quite behave like the flattened attributes. 

Because of the flattening, merging the following together:

```js
mergeConfigs({
  a: 'antelope',
  'c.a': 'camel'
},
{
  b: 'bee',
  c: 'whoops!'
})
```
Would create the following:

```js
({
  a: 'antelope'
  b: 'bee',
  'c.a': 'camel',
  c: 'whoops!'
})
```

But #4792 creates:

```js
({
  a: 'antelope',
  b: 'bee',
  c: 'whoops!'
})
```

We'd lost the access the nested value `c.a`.