### PR TITLE
[SPIKE] Throw attempting to override an object value with a non-object 

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -31,7 +31,7 @@ describe('Common JS utilities', () => {
     }
 
     it('ignores a single object', () => {
-      const config = mergeConfigs(config1)
+      const config = mergeConfigs([config1])
       expect(config).toEqual({
         a: 'antelope',
         c: { a: 'camel' }
@@ -39,7 +39,7 @@ describe('Common JS utilities', () => {
     })
 
     it('merges two objects', () => {
-      const config = mergeConfigs(config1, config2)
+      const config = mergeConfigs([config1, config2])
       expect(config).toEqual({
         a: 'aardvark',
         b: 'bee',
@@ -48,7 +48,7 @@ describe('Common JS utilities', () => {
     })
 
     it('merges three objects', () => {
-      const config = mergeConfigs(config1, config2, config3)
+      const config = mergeConfigs([config1, config2, config3])
       expect(config).toEqual({
         a: 'aardvark',
         b: 'bat',
@@ -63,35 +63,31 @@ describe('Common JS utilities', () => {
     })
 
     it('ignores empty objects when merging', () => {
-      const test1 = mergeConfigs({}, config1)
-      const test2 = mergeConfigs(config1, {}, config2)
-      const test3 = mergeConfigs(config3, {})
+      const test1 = mergeConfigs([{}, config1])
+      const test2 = mergeConfigs([config1, {}, config2])
+      const test3 = mergeConfigs([config3, {}])
 
-      expect(test1).toEqual(mergeConfigs(config1))
-      expect(test2).toEqual(mergeConfigs(config1, config2))
-      expect(test3).toEqual(mergeConfigs(config3))
+      expect(test1).toEqual(mergeConfigs([config1]))
+      expect(test2).toEqual(mergeConfigs([config1, config2]))
+      expect(test3).toEqual(mergeConfigs([config3]))
     })
 
-    it('ignores non-object values for keys that already hold an object', () => {
-      const config = mergeConfigs(config1, config2, config3, {
-        c: 'whoops',
-        e: { l: 'whoops again' }
-      })
-      expect(config).toEqual({
-        a: 'aardvark',
-        b: 'bat',
-        c: { a: 'cat', o: 'cow' },
-        d: 'dog',
-        e: {
-          l: {
-            e: 'elephant'
-          }
-        }
-      })
+    it('throws if attempting to merge non-object values for keys that already hold an object', () => {
+      expect(() =>
+        mergeConfigs([config1, config2, config3, { c: 'whoops' }])
+      ).toThrow(
+        'Trying to merge a non-object value over an object value for `c`'
+      )
+
+      expect(() =>
+        mergeConfigs([config1, config2, config3, { e: { l: 'whoops' } }])
+      ).toThrow(
+        'Trying to merge a non-object value over an object value for `e.l`'
+      )
     })
 
     it('prioritises the last parameter provided', () => {
-      const config = mergeConfigs(config1, config2, config3, config1)
+      const config = mergeConfigs([config1, config2, config3, config1])
       expect(config).toEqual({
         a: 'antelope',
         b: 'bat',
@@ -106,7 +102,7 @@ describe('Common JS utilities', () => {
     })
 
     it('returns an empty object if no parameters are provided', () => {
-      const config = mergeConfigs()
+      const config = mergeConfigs([])
       expect(config).toEqual({})
     })
   })

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -80,6 +80,10 @@ export function extractConfigByNamespace(dataset, namespace) {
     if (keyParts[0] === namespace) {
       keyParts.shift()
 
+      if (!keyParts.length) {
+        throw new TypeError(`\`data-${namespace}\` cannot exist on its own`)
+      }
+
       let current = newObject
 
       /**
@@ -88,8 +92,17 @@ export function extractConfigByNamespace(dataset, namespace) {
        * e.g. 'i18n.textareaDescription.other' becomes
        * `{ i18n: { textareaDescription: { other } } }`
        */
+      const path = []
       for (const name of keyParts) {
+        path.push(name)
+
         if (!isObject(current[name])) {
+          if (name in current) {
+            throw new TypeError(
+              `\`data-${namespace}.${keyParts.join('.')}\` cannot exist if \`data-${namespace}.${path.join('.')}\` is present`
+            )
+          }
+
           current[name] = {}
         }
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -129,11 +129,11 @@ export class Accordion extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs(
+    this.config = mergeConfigs([
       Accordion.defaults,
       config,
       normaliseDataset($module.dataset, Accordion.schema)
-    )
+    ])
 
     this.i18n = new I18n(this.config.i18n)
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -1,6 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -129,11 +129,17 @@ export class Accordion extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs([
-      Accordion.defaults,
-      config,
-      normaliseDataset($module.dataset, Accordion.schema)
-    ])
+    try {
+      this.config = mergeConfigs([
+        Accordion.defaults,
+        config,
+        normaliseDataset($module.dataset, Accordion.schema)
+      ])
+    } catch (error) {
+      throw new ConfigError(
+        `Accordion: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
 
     this.i18n = new I18n(this.config.i18n)
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -1,6 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 const KEY_SPACE = 32
@@ -44,11 +44,17 @@ export class Button extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs([
-      Button.defaults,
-      config,
-      normaliseDataset($module.dataset, Button.schema)
-    ])
+    try {
+      this.config = mergeConfigs([
+        Button.defaults,
+        config,
+        normaliseDataset($module.dataset, Button.schema)
+      ])
+    } catch (error) {
+      throw new ConfigError(
+        `Button: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
 
     this.$module.addEventListener('keydown', (event) =>
       this.handleKeyDown(event)

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -44,11 +44,11 @@ export class Button extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs(
+    this.config = mergeConfigs([
       Button.defaults,
       config,
       normaliseDataset($module.dataset, Button.schema)
-    )
+    ])
 
     this.$module.addEventListener('keydown', (event) =>
       this.handleKeyDown(event)

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -108,12 +108,18 @@ export class CharacterCount extends GOVUKFrontendComponent {
       }
     }
 
-    this.config = mergeConfigs([
-      CharacterCount.defaults,
-      config,
-      configOverrides,
-      datasetConfig
-    ])
+    try {
+      this.config = mergeConfigs([
+        CharacterCount.defaults,
+        config,
+        configOverrides,
+        datasetConfig
+      ])
+    } catch (error) {
+      throw new ConfigError(
+        `Character count: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
 
     // Check for valid config
     const errors = validateConfig(CharacterCount.schema, this.config)

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -108,12 +108,12 @@ export class CharacterCount extends GOVUKFrontendComponent {
       }
     }
 
-    this.config = mergeConfigs(
+    this.config = mergeConfigs([
       CharacterCount.defaults,
       config,
       configOverrides,
       datasetConfig
-    )
+    ])
 
     // Check for valid config
     const errors = validateConfig(CharacterCount.schema, this.config)

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -42,11 +42,11 @@ export class ErrorSummary extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs(
+    this.config = mergeConfigs([
       ErrorSummary.defaults,
       config,
       normaliseDataset($module.dataset, ErrorSummary.schema)
-    )
+    ])
 
     /**
      * Focus the error summary

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -4,7 +4,7 @@ import {
   setFocus
 } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -42,11 +42,17 @@ export class ErrorSummary extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs([
-      ErrorSummary.defaults,
-      config,
-      normaliseDataset($module.dataset, ErrorSummary.schema)
-    ])
+    try {
+      this.config = mergeConfigs([
+        ErrorSummary.defaults,
+        config,
+        normaliseDataset($module.dataset, ErrorSummary.schema)
+      ])
+    } catch (error) {
+      throw new ConfigError(
+        `Error summary: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
 
     /**
      * Focus the error summary

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -99,11 +99,11 @@ export class ExitThisPage extends GOVUKFrontendComponent {
       })
     }
 
-    this.config = mergeConfigs(
+    this.config = mergeConfigs([
       ExitThisPage.defaults,
       config,
       normaliseDataset($module.dataset, ExitThisPage.schema)
-    )
+    ])
 
     this.i18n = new I18n(this.config.i18n)
     this.$module = $module

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,6 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -99,11 +99,17 @@ export class ExitThisPage extends GOVUKFrontendComponent {
       })
     }
 
-    this.config = mergeConfigs([
-      ExitThisPage.defaults,
-      config,
-      normaliseDataset($module.dataset, ExitThisPage.schema)
-    ])
+    try {
+      this.config = mergeConfigs([
+        ExitThisPage.defaults,
+        config,
+        normaliseDataset($module.dataset, ExitThisPage.schema)
+      ])
+    } catch (error) {
+      throw new ConfigError(
+        `Exit this page: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
 
     this.i18n = new I18n(this.config.i18n)
     this.$module = $module

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -35,11 +35,11 @@ export class NotificationBanner extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs(
+    this.config = mergeConfigs([
       NotificationBanner.defaults,
       config,
       normaliseDataset($module.dataset, NotificationBanner.schema)
-    )
+    ])
 
     /**
      * Focus the notification banner

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,6 +1,6 @@
 import { mergeConfigs, setFocus } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
+import { ConfigError, ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -35,11 +35,17 @@ export class NotificationBanner extends GOVUKFrontendComponent {
 
     this.$module = $module
 
-    this.config = mergeConfigs([
-      NotificationBanner.defaults,
-      config,
-      normaliseDataset($module.dataset, NotificationBanner.schema)
-    ])
+    try {
+      this.config = mergeConfigs([
+        NotificationBanner.defaults,
+        config,
+        normaliseDataset($module.dataset, NotificationBanner.schema)
+      ])
+    } catch (error) {
+      throw new ConfigError(
+        `Notification banner: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
 
     /**
      * Focus the notification banner


### PR DESCRIPTION
Make both `mergeConfig` and `extractConfigByNamespace` throw if they try to merge a non-object value on a key that already stores an object value.

The errors would let users know that they are (likely unintentionally) passing a property or data-attribute that conflicts with deeper values (for example setting `data-i18n` which would default with the configuration for the default message). 

While this sounds a handy information:
- #4808 ignores merges of values for 'shallow' configuration keys when a deeper one is already set
- these error may cause some people to have to edit their code, are they cause for being a breaking change?

## Implementation note

Was a bit shy to pass `componentName` to the helper functions, but that could be an alternative solution that avoids catching and re-throwing the errors. Doesn't feel super tidy from a separation of responsibility point of view.