### PR TITLE
Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Tabs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+- [#4811: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Tabs component](https://github.com/alphagov/govuk-frontend/pull/4811)
+
 ## 5.2.0 (feature release)
 
 In this release, we’ve adjusted our responsive type scale, which is available behind a feature flag. The type scale change is to make text easier to read on smaller screens. We’ve also deprecated the `useTudorCrown` parameter.

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -21,9 +21,6 @@ export class Tabs extends GOVUKFrontendComponent {
   $tabListItems
 
   /** @private */
-  keys = { left: 37, right: 39, up: 38, down: 40 }
-
-  /** @private */
   jsHiddenClass = 'govuk-tabs__panel--hidden'
 
   /** @private */
@@ -375,14 +372,19 @@ export class Tabs extends GOVUKFrontendComponent {
    * @param {KeyboardEvent} event - Keydown event
    */
   onTabKeydown(event) {
-    switch (event.keyCode) {
-      case this.keys.left:
-      case this.keys.up:
+    switch (event.key) {
+      // 'Left', 'Right', 'Up' and 'Down' required for Edge 16 support.
+      case 'ArrowLeft':
+      case 'ArrowUp':
+      case 'Left':
+      case 'Up':
         this.activatePreviousTab()
         event.preventDefault()
         break
-      case this.keys.right:
-      case this.keys.down:
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case 'Right':
+      case 'Down':
         this.activateNextTab()
         event.preventDefault()
         break


### PR DESCRIPTION
`KeyboardEvent.keyCode` is deprecated. All of the browsers that now run our JavaScript support the modern `KeyboardEvent.key` property.

Update the button component to using `KeyboardEvent.key` instead, removing hardcoded ASCII values in the `keys` map.

Unfortunately Edge 16 uses e.g. “Left" instead of “ArrowLeft”, so we need to add those possible values as well if we want keyboard navigation for tabs to work in that browser (see the question I've left further down as to whether that's sensible or not).

[1]: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#navigation_keys

Part of #4709 