### PR TITLE
Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 ### Fixes
 
 - [#4811: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Tabs component](https://github.com/alphagov/govuk-frontend/pull/4811)
+- [#4812: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Button component](https://github.com/alphagov/govuk-frontend/pull/4812)
 
 ## 5.2.0 (feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -3,7 +3,6 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
-const KEY_SPACE = 32
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
 
 /**
@@ -72,7 +71,7 @@ export class Button extends GOVUKFrontendComponent {
     const $target = event.target
 
     // Handle space bar only
-    if (event.keyCode !== KEY_SPACE) {
+    if (event.key !== ' ') {
       return
     }
 


### PR DESCRIPTION
`KeyboardEvent.keyCode` is deprecated. All of the browsers that now run our JavaScript support the modern `KeyboardEvent.key` property.

Update the button component to using `KeyboardEvent.key` instead, removing the `KEY_SPACE` constant.

Part of #4709 