### PR TITLE
Remove deprecated `KeyboardEvent` properties from the Exit this Page component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 - [#4811: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Tabs component](https://github.com/alphagov/govuk-frontend/pull/4811)
 - [#4812: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Button component](https://github.com/alphagov/govuk-frontend/pull/4812)
+- [#4813: Remove deprecated `KeyboardEvent` properties from the Exit this Page component](https://github.com/alphagov/govuk-frontend/pull/4813)
 
 ## 5.2.0 (feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -284,10 +284,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     // This works because using Shift as a modifier key (e.g. pressing Shift + A)
     // will fire TWO keyup events, one for A (with e.shiftKey: true) and the other
     // for Shift (with e.shiftKey: false).
-    if (
-      (event.key === 'Shift' || event.keyCode === 16 || event.which === 16) &&
-      !this.lastKeyWasModified
-    ) {
+    if (event.key === 'Shift' && !this.lastKeyWasModified) {
       this.keypressCounter += 1
 
       // Update the indicator before the below if statement can reset it back to 0


### PR DESCRIPTION
`KeyboardEvent.keyCode` and `UIEvent.which` are both deprecated.

`KeyboardEvent.key` is supported in all browsers that run our JavaScript, so we can safely remove the fallback references to these deprecated properties.

Part of #4709 