### PR TITLE
Enable the `no-multi-assign` rule of ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,10 @@ module.exports = {
         // Flow control – avoid continue and else blocks after return statements
         // in if statements
         'no-continue': 'error',
-        'no-else-return': 'error'
+        'no-else-return': 'error',
+
+        // Avoid hard to read multi assign statements
+        'no-multi-assign': 'error'
       },
       settings: {
         jsdoc: {


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-multi-assign

Code that does multiple assignment in one expression (eg. `const x = y = someComputation()`) can be pretty hard to read, so let's avoid using it