### PR TITLE
Enable 'style' rule configuration for eslint-plugin-jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
       extends: [
         'eslint:recommended',
         'plugin:import/recommended',
-        'plugin:jest/recommended',
+        'plugin:jest/style',
         'plugin:jsdoc/recommended-typescript-flavor',
         'plugin:n/recommended',
         'plugin:promise/recommended',

--- a/packages/govuk-frontend-review/src/app.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/app.puppeteer.test.mjs
@@ -51,7 +51,7 @@ describe('Home page', () => {
     const componentNames = await getComponentNames()
     const componentsList = await page.$$('li a[href^="/components/"]')
 
-    await expect(componentsList.length).toEqual(componentNames.length)
+    await expect(componentsList).toHaveLength(componentNames.length)
   })
 
   it('should display the banner by default', async () => {
@@ -60,7 +60,7 @@ describe('Home page', () => {
     const $title = await page.$('title')
 
     // Check the page responded correctly
-    await expect(getProperty($title, 'textContent')).resolves.toEqual(
+    await expect(getProperty($title, 'textContent')).resolves.toBe(
       `GOV.UK Frontend`
     )
 
@@ -74,7 +74,7 @@ describe('Home page', () => {
     const $title = await page.$('title')
 
     // Check the page responded correctly
-    await expect(getProperty($title, 'textContent')).resolves.toEqual(
+    await expect(getProperty($title, 'textContent')).resolves.toBe(
       `GOV.UK Frontend`
     )
 

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs
@@ -29,7 +29,7 @@ describe('Full page examples', () => {
       const titleText = await getProperty($title, 'textContent')
 
       // Check for matching title
-      expect(titleText).toEqual(`${example.title} - GOV.UK`)
+      expect(titleText).toBe(`${example.title} - GOV.UK`)
     }
   })
 })
@@ -85,7 +85,7 @@ describe('Full page examples (with form submit)', () => {
       const $title = await page.$('title')
 
       // Check the page responded correctly
-      await expect(getProperty($title, 'textContent')).resolves.toEqual(
+      await expect(getProperty($title, 'textContent')).resolves.toBe(
         `${title} - GOV.UK`
       )
 
@@ -104,7 +104,7 @@ describe('Full page examples (with form submit)', () => {
       const $title = await page.$('title')
 
       // Check the page responded with an error
-      await expect(getProperty($title, 'textContent')).resolves.toEqual(
+      await expect(getProperty($title, 'textContent')).resolves.toBe(
         `Error: ${title} - GOV.UK`
       )
 

--- a/packages/govuk-frontend/postcss.config.unit.test.mjs
+++ b/packages/govuk-frontend/postcss.config.unit.test.mjs
@@ -69,7 +69,7 @@ describe('PostCSS config', () => {
         const property = { value: 'development' }
         await Declaration['--govuk-frontend-version'](property)
 
-        expect(property.value).toEqual('"development"')
+        expect(property.value).toBe('"development"')
       })
 
       it('Adds version number for NODE_ENV=production', async () => {
@@ -83,7 +83,7 @@ describe('PostCSS config', () => {
         const property = { value: 'development' }
         await Declaration['--govuk-frontend-version'](property)
 
-        expect(property.value).toEqual(`"${pkg.version}"`)
+        expect(property.value).toBe(`"${pkg.version}"`)
       })
 
       it('Adds version number for NODE_ENV=test', async () => {
@@ -97,7 +97,7 @@ describe('PostCSS config', () => {
         const property = { value: 'development' }
         await Declaration['--govuk-frontend-version'](property)
 
-        expect(property.value).toEqual(`"${pkg.version}"`)
+        expect(property.value).toBe(`"${pkg.version}"`)
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/common/closest-attribute-value.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/closest-attribute-value.jsdom.test.mjs
@@ -5,7 +5,7 @@ describe('closestAttributeValue', () => {
     const $element = document.createElement('div')
     $element.setAttribute('lang', 'en-GB')
 
-    expect(closestAttributeValue($element, 'lang')).toEqual('en-GB')
+    expect(closestAttributeValue($element, 'lang')).toBe('en-GB')
   })
 
   it('returns the value of the closest parent with the attribute if it exists', () => {
@@ -21,7 +21,7 @@ describe('closestAttributeValue', () => {
       `
 
     const $element = template.content.querySelector('.target')
-    expect(closestAttributeValue($element, 'lang')).toEqual('en-GB')
+    expect(closestAttributeValue($element, 'lang')).toBe('en-GB')
   })
 
   it('returns null if neither the element or a parent have the attribute', () => {

--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -161,15 +161,15 @@ describe('Common JS utilities', () => {
       )
 
       // With known namespace but non-object type, default to no config
-      expect(nonObject1).toEqual(undefined)
-      expect(nonObject2).toEqual(undefined)
-      expect(nonObject3).toEqual(undefined)
+      expect(nonObject1).toBeUndefined()
+      expect(nonObject2).toBeUndefined()
+      expect(nonObject3).toBeUndefined()
 
       // With known namespace, default to empty config
       expect(namespaceKnown).toEqual({})
 
       // With unknown namespace, default to no config
-      expect(namespaceUnknown).toEqual(undefined)
+      expect(namespaceUnknown).toBeUndefined()
     })
 
     it('can extract config from key-value pairs', () => {

--- a/packages/govuk-frontend/src/govuk/common/normalise-string.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/normalise-string.unit.test.mjs
@@ -2,66 +2,66 @@ import { normaliseString } from './normalise-string.mjs'
 
 describe('normaliseString', () => {
   it('normalises the string "true" to boolean true', () => {
-    expect(normaliseString('true')).toEqual(true)
+    expect(normaliseString('true')).toBe(true)
   })
 
   it('normalises the string "false" to boolean false', () => {
-    expect(normaliseString('false')).toEqual(false)
+    expect(normaliseString('false')).toBe(false)
   })
 
   it('normalises the string " true " to boolean true', () => {
-    expect(normaliseString(' true ')).toEqual(true)
+    expect(normaliseString(' true ')).toBe(true)
   })
 
   it('normalises the string " false " to boolean false', () => {
-    expect(normaliseString(' false ')).toEqual(false)
+    expect(normaliseString(' false ')).toBe(false)
   })
 
   it('does not normalise non-lowercase booleans', () => {
-    expect(normaliseString('TRUE')).toEqual('TRUE')
-    expect(normaliseString('True')).toEqual('True')
-    expect(normaliseString('FALSE')).toEqual('FALSE')
-    expect(normaliseString('False')).toEqual('False')
+    expect(normaliseString('TRUE')).toBe('TRUE')
+    expect(normaliseString('True')).toBe('True')
+    expect(normaliseString('FALSE')).toBe('FALSE')
+    expect(normaliseString('False')).toBe('False')
   })
 
   it('does not normalise strings that contain booleans', () => {
-    expect(normaliseString('true!')).toEqual('true!')
+    expect(normaliseString('true!')).toBe('true!')
   })
 
   it('normalises the string "0" to the number 0', () => {
-    expect(normaliseString('0')).toEqual(0)
+    expect(normaliseString('0')).toBe(0)
   })
 
   it('normalises strings representing positive numbers to numbers', () => {
-    expect(normaliseString('1337')).toEqual(1337)
+    expect(normaliseString('1337')).toBe(1337)
   })
 
   it('normalises strings representing negative numbers to numbers', () => {
-    expect(normaliseString('-1337')).toEqual(-1337)
+    expect(normaliseString('-1337')).toBe(-1337)
   })
 
   it('converts strings representing decimal numbers to numbers', () => {
-    expect(normaliseString('0.5')).toEqual(0.5)
+    expect(normaliseString('0.5')).toBe(0.5)
   })
 
   it('normalises strings representing decimal numbers with extra precision to numbers', () => {
-    expect(normaliseString('100.500')).toEqual(100.5)
+    expect(normaliseString('100.500')).toBe(100.5)
   })
 
   it('normalises strings representing decimal numbers with no integer-part to numbers', () => {
-    expect(normaliseString('.5')).toEqual(0.5)
+    expect(normaliseString('.5')).toBe(0.5)
   })
 
   it('normalises strings representing numbers with whitespace to numbers', () => {
-    expect(normaliseString('   1337   ')).toEqual(1337)
+    expect(normaliseString('   1337   ')).toBe(1337)
   })
 
   it('does not normalise the string "NaN"', () => {
-    expect(normaliseString('NaN')).toEqual('NaN')
+    expect(normaliseString('NaN')).toBe('NaN')
   })
 
   it('does not normalise the string "Infinity"', () => {
-    expect(normaliseString('Infinity')).toEqual('Infinity')
+    expect(normaliseString('Infinity')).toBe('Infinity')
   })
 
   it('normalises strings that represent very big positive numbers to numbers', () => {
@@ -70,14 +70,14 @@ describe('normaliseString', () => {
   })
 
   it('does not normalise strings that contain numbers', () => {
-    expect(normaliseString('100%')).toEqual('100%')
+    expect(normaliseString('100%')).toBe('100%')
   })
 
   it('does not normalise empty strings', () => {
-    expect(normaliseString('')).toEqual('')
+    expect(normaliseString('')).toBe('')
   })
 
   it('does not normalise whitespace only strings', () => {
-    expect(normaliseString('   ')).toEqual('   ')
+    expect(normaliseString('   ')).toBe('   ')
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -47,7 +47,7 @@ describe('/components/accordion', () => {
               '.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron'
             ).length
         )
-        expect(numberOfIcons).toEqual(0)
+        expect(numberOfIcons).toBe(0)
       })
     })
 
@@ -73,7 +73,7 @@ describe('/components/accordion', () => {
               .getAttribute('aria-expanded')
           }, i)
 
-          expect(sectionHeaderButtonExpanded).toEqual('false')
+          expect(sectionHeaderButtonExpanded).toBe('false')
         }
       })
 
@@ -94,7 +94,7 @@ describe('/components/accordion', () => {
         )
         await page.click('.govuk-accordion__show-all')
 
-        expect(openOrCloseAllButtonText).toEqual('Hide all sections')
+        expect(openOrCloseAllButtonText).toBe('Hide all sections')
       })
 
       it('should open both sections when the Show all sections button is clicked', async () => {
@@ -143,7 +143,7 @@ describe('/components/accordion', () => {
               .getAttribute('aria-expanded')
           }, i)
 
-          expect(sectionHeaderButtonExpanded).toEqual('true')
+          expect(sectionHeaderButtonExpanded).toBe('true')
         }
 
         const openOrCloseAllButtonText = await page.evaluate(
@@ -152,7 +152,7 @@ describe('/components/accordion', () => {
               .textContent
         )
 
-        expect(openOrCloseAllButtonText).toEqual('Hide all sections')
+        expect(openOrCloseAllButtonText).toBe('Hide all sections')
       })
 
       it('should maintain the expanded state after a page refresh', async () => {
@@ -222,7 +222,7 @@ describe('/components/accordion', () => {
             ).tagName
         )
 
-        expect(buttonTag).toEqual('BUTTON')
+        expect(buttonTag).toBe('BUTTON')
       })
 
       it('should contain a heading text container', async () => {
@@ -311,11 +311,11 @@ describe('/components/accordion', () => {
               ).nextElementSibling.innerHTML
           )
 
-          expect(commaAfterHeadingTextClassName).toEqual(
+          expect(commaAfterHeadingTextClassName).toBe(
             'govuk-visually-hidden govuk-accordion__section-heading-divider'
           )
 
-          expect(commaAfterHeadingTextContent).toEqual(', ')
+          expect(commaAfterHeadingTextContent).toBe(', ')
         })
 
         it('should contain hidden comma " ," after the summary line for when CSS does not load', async () => {
@@ -337,11 +337,11 @@ describe('/components/accordion', () => {
                 .nextElementSibling.innerHTML
           )
 
-          expect(commaAfterHeadingTextClassName).toEqual(
+          expect(commaAfterHeadingTextClassName).toBe(
             'govuk-visually-hidden govuk-accordion__section-heading-divider'
           )
 
-          expect(commaAfterHeadingTextContent).toEqual(', ')
+          expect(commaAfterHeadingTextContent).toBe(', ')
         })
       })
 
@@ -400,7 +400,7 @@ describe('/components/accordion', () => {
               .textContent
         )
 
-        expect(ShowOrHideButtonText).toEqual('Hide')
+        expect(ShowOrHideButtonText).toBe('Hide')
       })
 
       it('should have a data-nosnippet attribute on the "Show / hide" container to hide it from search result snippets', async () => {
@@ -412,7 +412,7 @@ describe('/components/accordion', () => {
             .getAttribute('data-nosnippet')
         )
 
-        expect(dataNoSnippetAttribute).toEqual('')
+        expect(dataNoSnippetAttribute).toBe('')
       })
 
       describe('accessible name', () => {
@@ -679,10 +679,10 @@ describe('/components/accordion', () => {
                   .querySelector('.govuk-accordion__section-toggle-text')
                   .innerHTML.trim()
               }))
-            expect(toggleAllContent).toEqual(
+            expect(toggleAllContent).toBe(
               'Show &lt;strong&gt;all sections&lt;/strong&gt;'
             )
-            expect(firstSectionToggleContent).toEqual(
+            expect(firstSectionToggleContent).toBe(
               'Show &lt;strong&gt;this section&lt;/strong&gt;'
             )
           })

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.test.js
@@ -13,7 +13,7 @@ describe('Accordion', () => {
       const $ = render('accordion', examples.default)
       const $componentHeadingButton = $('.govuk-accordion__section-button')
 
-      expect($componentHeadingButton.html().trim()).toEqual('Section A')
+      expect($componentHeadingButton.html().trim()).toBe('Section A')
     })
 
     it('renders with content as text, wrapped in styled paragraph', () => {
@@ -21,7 +21,7 @@ describe('Accordion', () => {
       const $componentContent = $('.govuk-accordion__section-content').first()
 
       expect($componentContent.find('p').hasClass('govuk-body')).toBeTruthy()
-      expect($componentContent.text().trim()).toEqual(
+      expect($componentContent.text().trim()).toBe(
         'We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.'
       )
     })
@@ -30,15 +30,15 @@ describe('Accordion', () => {
       const $ = render('accordion', examples.default)
       const $componentContent = $('.govuk-accordion__section-content').last()
 
-      expect($componentContent.find('p.gvouk-body').length).toEqual(0)
-      expect($componentContent.text().trim()).toEqual('Example item 2')
+      expect($componentContent.find('p.gvouk-body')).toHaveLength(0)
+      expect($componentContent.text().trim()).toBe('Example item 2')
     })
 
     it('renders with id', () => {
       const $ = render('accordion', examples.default)
 
       const $component = $('.govuk-accordion')
-      expect($component.attr('id')).toEqual('default-example')
+      expect($component.attr('id')).toBe('default-example')
     })
   })
 
@@ -53,21 +53,21 @@ describe('Accordion', () => {
     it('renders with attributes', () => {
       const $ = render('accordion', examples.attributes)
       const $component = $('.govuk-accordion')
-      expect($component.attr('data-attribute')).toEqual('value')
+      expect($component.attr('data-attribute')).toBe('value')
     })
 
     it('renders with specified heading level', () => {
       const $ = render('accordion', examples['custom heading level'])
       const $componentHeading = $('.govuk-accordion__section-heading')
 
-      expect($componentHeading.get(0).tagName).toEqual('h3')
+      expect($componentHeading.get(0).tagName).toBe('h3')
     })
 
     it('renders with heading button html', () => {
       const $ = render('accordion', examples['heading html'])
       const $componentHeadingButton = $('.govuk-accordion__section-button')
 
-      expect($componentHeadingButton.html().trim()).toEqual(
+      expect($componentHeadingButton.html().trim()).toBe(
         '<span class="myClass">Section A</span>'
       )
     })
@@ -85,7 +85,7 @@ describe('Accordion', () => {
       const $ = render('accordion', examples['with additional descriptions'])
       const $componentSummary = $('.govuk-accordion__section-summary').first()
 
-      expect($componentSummary.text().trim()).toEqual('Additional description')
+      expect($componentSummary.text().trim()).toBe('Additional description')
     })
 
     it('renders list without falsely values', () => {
@@ -93,25 +93,25 @@ describe('Accordion', () => {
       const $component = $('.govuk-accordion')
       const $items = $component.find('.govuk-accordion__section')
 
-      expect($items.length).toEqual(2)
+      expect($items).toHaveLength(2)
     })
 
     it('renders with localisation data attributes', () => {
       const $ = render('accordion', examples['with translations'])
       const $component = $('.govuk-accordion')
 
-      expect($component.attr('data-i18n.hide-all-sections')).toEqual(
+      expect($component.attr('data-i18n.hide-all-sections')).toBe(
         'Collapse all sections'
       )
-      expect($component.attr('data-i18n.show-all-sections')).toEqual(
+      expect($component.attr('data-i18n.show-all-sections')).toBe(
         'Expand all sections'
       )
-      expect($component.attr('data-i18n.hide-section')).toEqual('Collapse')
-      expect($component.attr('data-i18n.hide-section-aria-label')).toEqual(
+      expect($component.attr('data-i18n.hide-section')).toBe('Collapse')
+      expect($component.attr('data-i18n.hide-section-aria-label')).toBe(
         'Collapse this section'
       )
-      expect($component.attr('data-i18n.show-section')).toEqual('Expand')
-      expect($component.attr('data-i18n.show-section-aria-label')).toEqual(
+      expect($component.attr('data-i18n.show-section')).toBe('Expand')
+      expect($component.attr('data-i18n.show-section-aria-label')).toBe(
         'Expand this section'
       )
     })
@@ -120,7 +120,7 @@ describe('Accordion', () => {
       const $ = render('accordion', examples['with remember expanded off'])
       const $component = $('.govuk-accordion')
 
-      expect($component.attr('data-remember-expanded')).toEqual('false')
+      expect($component.attr('data-remember-expanded')).toBe('false')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/back-link/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/back-link/template.test.js
@@ -12,9 +12,9 @@ describe('back-link component', () => {
     const $ = render('back-link', examples.default)
 
     const $component = $('.govuk-back-link')
-    expect($component.get(0).tagName).toEqual('a')
-    expect($component.attr('href')).toEqual('#')
-    expect($component.text()).toEqual('Back')
+    expect($component.get(0).tagName).toBe('a')
+    expect($component.attr('href')).toBe('#')
+    expect($component.text()).toBe('Back')
   })
 
   it('renders classes correctly', () => {
@@ -28,36 +28,36 @@ describe('back-link component', () => {
     const $ = render('back-link', examples['with custom text'])
 
     const $component = $('.govuk-back-link')
-    expect($component.html()).toEqual('Back to home')
+    expect($component.html()).toBe('Back to home')
   })
 
   it('renders escaped html when passed to text', () => {
     const $ = render('back-link', examples['html as text'])
 
     const $component = $('.govuk-back-link')
-    expect($component.html()).toEqual('&lt;b&gt;Home&lt;/b&gt;')
+    expect($component.html()).toBe('&lt;b&gt;Home&lt;/b&gt;')
   })
 
   it('renders html correctly', () => {
     const $ = render('back-link', examples.html)
 
     const $component = $('.govuk-back-link')
-    expect($component.html()).toEqual('<b>Back</b>')
+    expect($component.html()).toBe('<b>Back</b>')
   })
 
   it('renders default text correctly', () => {
     const $ = render('back-link', examples.default)
 
     const $component = $('.govuk-back-link')
-    expect($component.html()).toEqual('Back')
+    expect($component.html()).toBe('Back')
   })
 
   it('renders attributes correctly', () => {
     const $ = render('back-link', examples.attributes)
 
     const $component = $('.govuk-back-link')
-    expect($component.attr('data-test')).toEqual('attribute')
-    expect($component.attr('aria-label')).toEqual('Back to home')
+    expect($component.attr('data-test')).toBe('attribute')
+    expect($component.attr('aria-label')).toBe('Back to home')
   })
 
   it('renders with inverted colours if specified', () => {

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.test.js
@@ -13,23 +13,23 @@ describe('Breadcrumbs', () => {
       const $ = render('breadcrumbs', examples.default)
 
       const $items = $('.govuk-breadcrumbs__list-item')
-      expect($items.length).toEqual(2)
+      expect($items).toHaveLength(2)
     })
 
     it('renders 2 items', () => {
       const $ = render('breadcrumbs', examples.default)
       const $items = $('.govuk-breadcrumbs__list-item')
-      expect($items.length).toEqual(2)
+      expect($items).toHaveLength(2)
     })
 
     it('renders item with anchor', () => {
       const $ = render('breadcrumbs', examples.default)
 
       const $anchor = $('.govuk-breadcrumbs__list-item a').first()
-      expect($anchor.get(0).tagName).toEqual('a')
-      expect($anchor.attr('class')).toEqual('govuk-breadcrumbs__link')
-      expect($anchor.attr('href')).toEqual('/section')
-      expect($anchor.text()).toEqual('Section')
+      expect($anchor.get(0).tagName).toBe('a')
+      expect($anchor.attr('class')).toBe('govuk-breadcrumbs__link')
+      expect($anchor.attr('href')).toBe('/section')
+      expect($anchor.text()).toBe('Section')
     })
   })
 
@@ -41,36 +41,36 @@ describe('Breadcrumbs', () => {
       )
 
       const $item = $('.govuk-breadcrumbs__list-item').last()
-      expect($item.text()).toEqual('Travel abroad')
+      expect($item.text()).toBe('Travel abroad')
     })
 
     it('renders item with escaped entities in text', () => {
       const $ = render('breadcrumbs', examples['html as text'])
 
       const $item = $('.govuk-breadcrumbs__list-item')
-      expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
+      expect($item.html()).toBe('&lt;span&gt;Section 1&lt;/span&gt;')
     })
 
     it('renders item with html', () => {
       const $ = render('breadcrumbs', examples.html)
 
       const $item = $('.govuk-breadcrumbs__list-item').first()
-      expect($item.html()).toEqual('<em>Section 1</em>')
+      expect($item.html()).toBe('<em>Section 1</em>')
     })
 
     it('renders item with html inside anchor', () => {
       const $ = render('breadcrumbs', examples.html)
 
       const $anchor = $('.govuk-breadcrumbs__list-item a').last()
-      expect($anchor.html()).toEqual('<em>Section 2</em>')
+      expect($anchor.html()).toBe('<em>Section 2</em>')
     })
 
     it('renders item anchor with attributes', () => {
       const $ = render('breadcrumbs', examples['item attributes'])
 
       const $breadcrumbLink = $('.govuk-breadcrumbs__link')
-      expect($breadcrumbLink.attr('data-attribute')).toEqual('my-attribute')
-      expect($breadcrumbLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($breadcrumbLink.attr('data-attribute')).toBe('my-attribute')
+      expect($breadcrumbLink.attr('data-attribute-2')).toBe('my-attribute-2')
     })
 
     it('renders with classes', () => {
@@ -86,8 +86,8 @@ describe('Breadcrumbs', () => {
       const $ = render('breadcrumbs', examples.attributes)
 
       const $component = $('.govuk-breadcrumbs')
-      expect($component.attr('id')).toEqual('my-navigation')
-      expect($component.attr('role')).toEqual('navigation')
+      expect($component.attr('id')).toBe('my-navigation')
+      expect($component.attr('role')).toBe('navigation')
     })
 
     it('renders item as collapse on mobile if specified', () => {

--- a/packages/govuk-frontend/src/govuk/components/button/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/template.test.js
@@ -13,7 +13,7 @@ describe('Button', () => {
       const $ = render('button', examples.default)
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('button')
+      expect($component.get(0).tagName).toBe('button')
       expect($component.text()).toContain('Save and continue')
     })
   })
@@ -23,8 +23,8 @@ describe('Button', () => {
       const $ = render('button', examples.attributes)
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-controls')).toEqual('test-target-element')
-      expect($component.attr('data-tracking-dimension')).toEqual('123')
+      expect($component.attr('aria-controls')).toBe('test-target-element')
+      expect($component.attr('data-tracking-dimension')).toBe('123')
     })
 
     it('renders with classes', () => {
@@ -38,36 +38,36 @@ describe('Button', () => {
       const $ = render('button', examples.disabled)
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-disabled')).toEqual('true')
-      expect($component.attr('disabled')).toEqual('disabled')
+      expect($component.attr('aria-disabled')).toBe('true')
+      expect($component.attr('disabled')).toBe('disabled')
     })
 
     it('renders with name', () => {
       const $ = render('button', examples.name)
 
       const $component = $('.govuk-button')
-      expect($component.attr('name')).toEqual('start-now')
+      expect($component.attr('name')).toBe('start-now')
     })
 
     it('renders with id', () => {
       const $ = render('button', examples.id)
 
       const $component = $('.govuk-button')
-      expect($component.attr('id')).toEqual('submit')
+      expect($component.attr('id')).toBe('submit')
     })
 
     it('renders with value', () => {
       const $ = render('button', examples.value)
 
       const $component = $('.govuk-button')
-      expect($component.attr('value')).toEqual('start')
+      expect($component.attr('value')).toBe('start')
     })
 
     it('renders with type', () => {
       const $ = render('button', examples.type)
 
       const $component = $('.govuk-button')
-      expect($component.attr('type')).toEqual('button')
+      expect($component.attr('type')).toBe('button')
     })
 
     it('renders with html', () => {
@@ -89,14 +89,14 @@ describe('Button', () => {
         const $ = render('button', examples['prevent double click'])
 
         const $component = $('.govuk-button')
-        expect($component.attr('data-prevent-double-click')).toEqual('true')
+        expect($component.attr('data-prevent-double-click')).toBe('true')
       })
 
       it('renders with preventDoubleClick attribute set to false', () => {
         const $ = render('button', examples["don't prevent double click"])
 
         const $component = $('.govuk-button')
-        expect($component.attr('data-prevent-double-click')).toEqual('false')
+        expect($component.attr('data-prevent-double-click')).toBe('false')
       })
     })
   })
@@ -106,9 +106,9 @@ describe('Button', () => {
       const $ = render('button', examples['explicit link'])
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('a')
-      expect($component.attr('href')).toEqual('/')
-      expect($component.attr('role')).toEqual('button')
+      expect($component.get(0).tagName).toBe('a')
+      expect($component.attr('href')).toBe('/')
+      expect($component.attr('role')).toBe('button')
       expect($component.text()).toContain('Continue')
     })
 
@@ -116,15 +116,15 @@ describe('Button', () => {
       const $ = render('button', examples['no href'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('href')).toEqual('#')
+      expect($component.attr('href')).toBe('#')
     })
 
     it('renders with attributes', () => {
       const $ = render('button', examples['link attributes'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-controls')).toEqual('test-target-element')
-      expect($component.attr('data-tracking-dimension')).toEqual('123')
+      expect($component.attr('aria-controls')).toBe('test-target-element')
+      expect($component.attr('data-tracking-dimension')).toBe('123')
     })
 
     it('renders with classes', () => {
@@ -140,16 +140,16 @@ describe('Button', () => {
       const $ = render('button', examples.input)
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('input')
-      expect($component.attr('type')).toEqual('submit')
+      expect($component.get(0).tagName).toBe('input')
+      expect($component.attr('type')).toBe('submit')
     })
 
     it('renders with attributes', () => {
       const $ = render('button', examples['input attributes'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-controls')).toEqual('test-target-element')
-      expect($component.attr('data-tracking-dimension')).toEqual('123')
+      expect($component.attr('aria-controls')).toBe('test-target-element')
+      expect($component.attr('data-tracking-dimension')).toBe('123')
     })
 
     it('renders with classes', () => {
@@ -163,22 +163,22 @@ describe('Button', () => {
       const $ = render('button', examples['input disabled'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-disabled')).toEqual('true')
-      expect($component.attr('disabled')).toEqual('disabled')
+      expect($component.attr('aria-disabled')).toBe('true')
+      expect($component.attr('disabled')).toBe('disabled')
     })
 
     it('renders with name', () => {
       const $ = render('button', examples.input)
 
       const $component = $('.govuk-button')
-      expect($component.attr('name')).toEqual('start-now')
+      expect($component.attr('name')).toBe('start-now')
     })
 
     it('renders with type', () => {
       const $ = render('button', examples['input type'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('type')).toEqual('button')
+      expect($component.attr('type')).toBe('button')
     })
   })
 
@@ -187,14 +187,14 @@ describe('Button', () => {
       const $ = render('button', examples.link)
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('a')
+      expect($component.get(0).tagName).toBe('a')
     })
 
     it("renders a button if you don't pass anything", () => {
       const $ = render('button', examples['no type'])
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('button')
+      expect($component.get(0).tagName).toBe('button')
     })
   })
 
@@ -203,7 +203,7 @@ describe('Button', () => {
       const $ = render('button', examples['start link'])
 
       const $component = $('.govuk-button .govuk-button__start-icon')
-      expect($component.get(0).tagName).toEqual('svg')
+      expect($component.get(0).tagName).toBe('svg')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.jsdom.test.mjs
@@ -71,12 +71,12 @@ describe('CharacterCount', () => {
       )
 
       it('formats the number inserted in the message', () => {
-        expect(
-          componentWithMaxWords.formatCountMessage(10000, 'words')
-        ).toEqual('You have 10,000 words remaining')
-        expect(
-          componentWithMaxWords.formatCountMessage(-10000, 'words')
-        ).toEqual('You have 10,000 words too many')
+        expect(componentWithMaxWords.formatCountMessage(10000, 'words')).toBe(
+          'You have 10,000 words remaining'
+        )
+        expect(componentWithMaxWords.formatCountMessage(-10000, 'words')).toBe(
+          'You have 10,000 words too many'
+        )
       })
     })
 
@@ -92,13 +92,13 @@ describe('CharacterCount', () => {
           })
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(1, 'characters')).toEqual(
+          expect(component.formatCountMessage(1, 'characters')).toBe(
             'Custom text. Count: 1'
           )
 
           // Other keys remain untouched
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10, 'characters')).toEqual(
+          expect(component.formatCountMessage(10, 'characters')).toBe(
             'You have 10 characters remaining'
           )
         })
@@ -123,10 +123,10 @@ describe('CharacterCount', () => {
           expect(
             // @ts-expect-error Property 'formatCountMessage' is private
             componentWithMaxLength.formatCountMessage(0, 'characters')
-          ).toEqual('Custom text.')
+          ).toBe('Custom text.')
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(componentWithMaxWords.formatCountMessage(0, 'words')).toEqual(
+          expect(componentWithMaxWords.formatCountMessage(0, 'words')).toBe(
             'Different custom text.'
           )
         })
@@ -140,7 +140,7 @@ describe('CharacterCount', () => {
           const component = new CharacterCount($div, { maxwords: 20000 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10000, 'words')).toEqual(
+          expect(component.formatCountMessage(10000, 'words')).toBe(
             'You have 10.000 words remaining'
           )
         })
@@ -153,7 +153,7 @@ describe('CharacterCount', () => {
           const component = new CharacterCount($div, { maxwords: 20000 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10000, 'words')).toEqual(
+          expect(component.formatCountMessage(10000, 'words')).toBe(
             'You have 10.000 words remaining'
           )
         })
@@ -170,13 +170,13 @@ describe('CharacterCount', () => {
           const component = new CharacterCount($div, { maxlength: 100 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(1, 'characters')).toEqual(
+          expect(component.formatCountMessage(1, 'characters')).toBe(
             'Custom text. Count: 1'
           )
 
           // Other keys remain untouched
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10, 'characters')).toEqual(
+          expect(component.formatCountMessage(10, 'characters')).toBe(
             'You have 10 characters remaining'
           )
         })
@@ -199,18 +199,18 @@ describe('CharacterCount', () => {
             })
 
             // @ts-expect-error Property 'formatCountMessage' is private
-            expect(component.formatCountMessage(1, 'characters')).toEqual(
+            expect(component.formatCountMessage(1, 'characters')).toBe(
               'Custom text. Count: 1'
             )
 
             // Other keys remain untouched
             // @ts-expect-error Property 'formatCountMessage' is private
-            expect(component.formatCountMessage(-10, 'characters')).toEqual(
+            expect(component.formatCountMessage(-10, 'characters')).toBe(
               'You have 10 characters too many'
             )
 
             // @ts-expect-error Property 'formatCountMessage' is private
-            expect(component.formatCountMessage(0, 'characters')).toEqual(
+            expect(component.formatCountMessage(0, 'characters')).toBe(
               'You have 0 characters remaining'
             )
           })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -34,7 +34,7 @@ describe('Character count', () => {
         (el) => el.innerHTML.trim()
       )
 
-      expect(message).toEqual('You can enter up to 10 characters')
+      expect(message).toBe('You can enter up to 10 characters')
     })
   })
 
@@ -73,13 +73,13 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 10 characters remaining')
+        expect(message).toBe('You have 10 characters remaining')
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 10 characters remaining')
+        expect(srMessage).toBe('You have 10 characters remaining')
       })
 
       it('shows the characters remaining if the field is pre-filled', async () => {
@@ -89,13 +89,13 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 67 characters remaining')
+        expect(message).toBe('You have 67 characters remaining')
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 67 characters remaining')
+        expect(srMessage).toBe('You have 67 characters remaining')
       })
 
       it('counts down to the character limit', async () => {
@@ -109,7 +109,7 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 9 characters remaining')
+        expect(message).toBe('You have 9 characters remaining')
 
         // Wait for debounced update to happen
         await setTimeout(debouncedWaitTime)
@@ -118,7 +118,7 @@ describe('Character count', () => {
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 9 characters remaining')
+        expect(srMessage).toBe('You have 9 characters remaining')
       })
 
       it('uses the singular when there is only one character remaining', async () => {
@@ -132,7 +132,7 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 1 character remaining')
+        expect(message).toBe('You have 1 character remaining')
 
         // Wait for debounced update to happen
         await setTimeout(debouncedWaitTime)
@@ -141,7 +141,7 @@ describe('Character count', () => {
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 1 character remaining')
+        expect(srMessage).toBe('You have 1 character remaining')
       })
 
       describe('when the character limit is exceeded', () => {
@@ -158,7 +158,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 character too many')
+          expect(message).toBe('You have 1 character too many')
 
           // Wait for debounced update to happen
           await setTimeout(debouncedWaitTime)
@@ -167,7 +167,7 @@ describe('Character count', () => {
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 1 character too many')
+          expect(srMessage).toBe('You have 1 character too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
@@ -179,7 +179,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 2 characters too many')
+          expect(message).toBe('You have 2 characters too many')
 
           // Wait for debounced update to happen
           await setTimeout(debouncedWaitTime)
@@ -188,7 +188,7 @@ describe('Character count', () => {
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 2 characters too many')
+          expect(srMessage).toBe('You have 2 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
@@ -222,13 +222,13 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 23 characters too many')
+          expect(message).toBe('You have 23 characters too many')
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 23 characters too many')
+          expect(srMessage).toBe('You have 23 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
@@ -258,7 +258,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => window.getComputedStyle(el).visibility
           )
-          expect(visibility).toEqual('hidden')
+          expect(visibility).toBe('hidden')
 
           // Wait for debounced update to happen
           await setTimeout(debouncedWaitTime)
@@ -268,7 +268,7 @@ describe('Character count', () => {
             '.govuk-character-count__sr-status',
             (el) => el.getAttribute('aria-hidden')
           )
-          expect(ariaHidden).toEqual('true')
+          expect(ariaHidden).toBe('true')
         })
 
         it('becomes visible once the threshold is reached', async () => {
@@ -280,7 +280,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => window.getComputedStyle(el).visibility
           )
-          expect(visibility).toEqual('visible')
+          expect(visibility).toBe('visible')
 
           // Wait for debounced update to happen
           await setTimeout(debouncedWaitTime)
@@ -309,13 +309,13 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 10 characters remaining')
+          expect(message).toBe('You have 10 characters remaining')
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 10 characters remaining')
+          expect(srMessage).toBe('You have 10 characters remaining')
         })
       })
 
@@ -333,13 +333,13 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 10 characters remaining')
+          expect(message).toBe('You have 10 characters remaining')
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 10 characters remaining')
+          expect(srMessage).toBe('You have 10 characters remaining')
         })
       })
 
@@ -369,13 +369,13 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 10 words remaining')
+        expect(message).toBe('You have 10 words remaining')
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 10 words remaining')
+        expect(srMessage).toBe('You have 10 words remaining')
       })
 
       it('counts down to the word limit', async () => {
@@ -389,7 +389,7 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 8 words remaining')
+        expect(message).toBe('You have 8 words remaining')
 
         // Wait for debounced update to happen
         await setTimeout(debouncedWaitTime)
@@ -398,7 +398,7 @@ describe('Character count', () => {
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 8 words remaining')
+        expect(srMessage).toBe('You have 8 words remaining')
       })
 
       it('uses the singular when there is only one word remaining', async () => {
@@ -412,7 +412,7 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual('You have 1 word remaining')
+        expect(message).toBe('You have 1 word remaining')
 
         // Wait for debounced update to happen
         await setTimeout(debouncedWaitTime)
@@ -421,7 +421,7 @@ describe('Character count', () => {
           '.govuk-character-count__sr-status',
           (el) => el.innerHTML.trim()
         )
-        expect(srMessage).toEqual('You have 1 word remaining')
+        expect(srMessage).toBe('You have 1 word remaining')
       })
 
       describe('when the word limit is exceeded', () => {
@@ -438,7 +438,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 word too many')
+          expect(message).toBe('You have 1 word too many')
 
           // Wait for debounced update to happen
           await setTimeout(debouncedWaitTime)
@@ -447,7 +447,7 @@ describe('Character count', () => {
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 1 word too many')
+          expect(srMessage).toBe('You have 1 word too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
@@ -459,7 +459,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 2 words too many')
+          expect(message).toBe('You have 2 words too many')
 
           // Wait for debounced update to happen
           await setTimeout(debouncedWaitTime)
@@ -468,7 +468,7 @@ describe('Character count', () => {
             '.govuk-character-count__sr-status',
             (el) => el.innerHTML.trim()
           )
-          expect(srMessage).toEqual('You have 2 words too many')
+          expect(srMessage).toBe('You have 2 words too many')
         })
 
         it('adds error styles to the textarea', async () => {
@@ -511,7 +511,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 character too many')
+          expect(message).toBe('You have 1 character too many')
         })
 
         it('configures the number of words', async () => {
@@ -534,7 +534,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 word too many')
+          expect(message).toBe('You have 1 word too many')
         })
 
         it('configures the threshold', async () => {
@@ -558,7 +558,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => window.getComputedStyle(el).visibility
           )
-          expect(visibility).toEqual('visible')
+          expect(visibility).toBe('visible')
         })
 
         it('configures the description of the textarea', async () => {
@@ -587,7 +587,7 @@ describe('Character count', () => {
             '.govuk-character-count__message',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('No more than 10 characters')
+          expect(message).toBe('No more than 10 characters')
         })
       })
 
@@ -612,7 +612,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 character too many')
+          expect(message).toBe('You have 1 character too many')
         })
 
         it('configures the number of words', async () => {
@@ -635,7 +635,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 word too many')
+          expect(message).toBe('You have 1 word too many')
         })
 
         it('configures the threshold', async () => {
@@ -659,7 +659,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => window.getComputedStyle(el).visibility
           )
-          expect(visibility).toEqual('visible')
+          expect(visibility).toBe('visible')
         })
       })
 
@@ -679,7 +679,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 character too many')
+          expect(message).toBe('You have 1 character too many')
         })
 
         it("uses `maxlength` data attribute instead of JS's `maxwords`", async () => {
@@ -697,7 +697,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 character too many')
+          expect(message).toBe('You have 1 character too many')
         })
 
         it('uses `maxwords` data attribute instead of the JS one', async () => {
@@ -715,7 +715,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 word too many')
+          expect(message).toBe('You have 1 word too many')
         })
 
         it("uses `maxwords` data attribute instead of the JS's `maxlength`", async () => {
@@ -733,7 +733,7 @@ describe('Character count', () => {
             '.govuk-character-count__status',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('You have 1 word too many')
+          expect(message).toBe('You have 1 word too many')
         })
 
         it('interpolates the textarea description in data attributes with the maximum set in JavaScript', async () => {
@@ -758,7 +758,7 @@ describe('Character count', () => {
             '.govuk-character-count__message',
             (el) => el.innerHTML.trim()
           )
-          expect(message).toEqual('No more than 10 characters')
+          expect(message).toBe('No more than 10 characters')
         })
       })
     })
@@ -785,9 +785,7 @@ describe('Character count', () => {
           '.govuk-character-count__status',
           (el) => el.innerHTML.trim()
         )
-        expect(message).toEqual(
-          '&lt;strong&gt;10&lt;/strong&gt; characters left'
-        )
+        expect(message).toBe('&lt;strong&gt;10&lt;/strong&gt; characters left')
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
@@ -16,21 +16,21 @@ describe('Character count', () => {
       const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('id')).toEqual('more-detail')
+      expect($component.attr('id')).toBe('more-detail')
     })
 
     it('renders with name', () => {
       const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('name')).toEqual('more-detail')
+      expect($component.attr('name')).toBe('more-detail')
     })
 
     it('renders with default number of rows', () => {
       const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('rows')).toEqual('5')
+      expect($component.attr('rows')).toBe('5')
     })
   })
 
@@ -48,21 +48,21 @@ describe('Character count', () => {
       const $ = render('character-count', examples['with custom rows'])
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('rows')).toEqual('8')
+      expect($component.attr('rows')).toBe('8')
     })
 
     it('renders with value', () => {
       const $ = render('character-count', examples['with default value'])
 
       const $component = $('.govuk-js-character-count')
-      expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
+      expect($component.text()).toBe('221B Baker Street\nLondon\nNW1 6XE\n')
     })
 
     it('renders with attributes', () => {
       const $ = render('character-count', examples.attributes)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
 
     it('renders with formGroup', () => {
@@ -121,14 +121,14 @@ describe('Character count', () => {
       const $ = render('character-count', examples['spellcheck enabled'])
 
       const $component = $('.govuk-character-count .govuk-textarea')
-      expect($component.attr('spellcheck')).toEqual('true')
+      expect($component.attr('spellcheck')).toBe('true')
     })
 
     it('renders the textarea with spellcheck attribute set to false', () => {
       const $ = render('character-count', examples['spellcheck disabled'])
 
       const $component = $('.govuk-character-count .govuk-textarea')
-      expect($component.attr('spellcheck')).toEqual('false')
+      expect($component.attr('spellcheck')).toBe('false')
     })
 
     it('renders the textarea without spellcheck attribute by default', () => {
@@ -230,7 +230,7 @@ describe('Character count', () => {
       const $ = render('character-count', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('more-detail')
+      expect($label.attr('for')).toBe('more-detail')
     })
   })
 
@@ -239,7 +239,7 @@ describe('Character count', () => {
       const $ = render('character-count', examples['with threshold'])
 
       const $component = $('.govuk-character-count')
-      expect($component.attr('data-threshold')).toEqual('75')
+      expect($component.attr('data-threshold')).toBe('75')
     })
   })
 
@@ -251,7 +251,7 @@ describe('Character count', () => {
       )
 
       const message = $('.govuk-character-count__message').text().trim()
-      expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
+      expect(message).toBe('Gallwch ddefnyddio hyd at 10 nod')
     })
   })
 
@@ -291,7 +291,7 @@ describe('Character count', () => {
 
         // Fallback hint is passed as data attribute
         const $component = $('[data-module]')
-        expect($component.attr('data-i18n.textarea-description.other')).toEqual(
+        expect($component.attr('data-i18n.textarea-description.other')).toBe(
           'No more than %{count} characters'
         )
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -56,8 +56,8 @@ describe('Checkboxes', () => {
         })
 
         it('includes the expected number of inputs and conditionals', () => {
-          expect($inputs.length).toBe(3)
-          expect($conditionals.length).toBe(3)
+          expect($inputs).toHaveLength(3)
+          expect($conditionals).toHaveLength(3)
         })
 
         it('has no ARIA attributes applied', async () => {
@@ -68,8 +68,8 @@ describe('Checkboxes', () => {
             '.govuk-checkboxes__input[aria-controls]'
           )
 
-          expect($inputsWithAriaExpanded.length).toBe(0)
-          expect($inputsWithAriaControls.length).toBe(0)
+          expect($inputsWithAriaExpanded).toHaveLength(0)
+          expect($inputsWithAriaControls).toHaveLength(0)
         })
 
         it('falls back to making all conditional content visible', async () => {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -23,8 +23,8 @@ describe('Checkboxes', () => {
     const $firstLabel = $component.find(
       '.govuk-checkboxes__item:first-child label'
     )
-    expect($firstInput.attr('name')).toEqual('nationality')
-    expect($firstInput.val()).toEqual('british')
+    expect($firstInput.attr('name')).toBe('nationality')
+    expect($firstInput.val()).toBe('british')
     expect($firstLabel.text()).toContain('British')
 
     const $lastInput = $component.find(
@@ -33,8 +33,8 @@ describe('Checkboxes', () => {
     const $lastLabel = $component.find(
       '.govuk-checkboxes__item:last-child label'
     )
-    expect($lastInput.attr('name')).toEqual('nationality')
-    expect($lastInput.val()).toEqual('other')
+    expect($lastInput.attr('name')).toBe('nationality')
+    expect($lastInput.val()).toBe('other')
     expect($lastLabel.text()).toContain('Citizen of another country')
   })
 
@@ -44,7 +44,7 @@ describe('Checkboxes', () => {
     const $component = $('.govuk-checkboxes')
     const $items = $component.find('.govuk-checkboxes__item')
 
-    expect($items.length).toEqual(2)
+    expect($items).toHaveLength(2)
   })
 
   it('render example with a divider and ‘None’ checkbox with exclusive behaviour', () => {
@@ -53,13 +53,13 @@ describe('Checkboxes', () => {
     const $component = $('.govuk-checkboxes')
 
     const $divider = $component.find('.govuk-checkboxes__divider').first()
-    expect($divider.text().trim()).toEqual('or')
+    expect($divider.text().trim()).toBe('or')
 
     const $items = $component.find('.govuk-checkboxes__item')
-    expect($items.length).toEqual(4)
+    expect($items).toHaveLength(4)
 
     const $orItemInput = $items.last().find('input').first()
-    expect($orItemInput.attr('data-behaviour')).toEqual('exclusive')
+    expect($orItemInput.attr('data-behaviour')).toBe('exclusive')
   })
 
   it('render additional label classes', () => {
@@ -90,8 +90,8 @@ describe('Checkboxes', () => {
 
     const $component = $('.govuk-checkboxes')
 
-    expect($component.attr('data-attribute')).toEqual('value')
-    expect($component.attr('data-second-attribute')).toEqual('second-value')
+    expect($component.attr('data-attribute')).toBe('value')
+    expect($component.attr('data-second-attribute')).toBe('second-value')
   })
 
   it('renders with a form group wrapper', () => {
@@ -123,8 +123,8 @@ describe('Checkboxes', () => {
       const $firstLabel = $component.find(
         '.govuk-checkboxes__item:first-child label'
       )
-      expect($firstInput.attr('id')).toEqual('nationality')
-      expect($firstLabel.attr('for')).toEqual('nationality')
+      expect($firstInput.attr('id')).toBe('nationality')
+      expect($firstLabel.attr('for')).toBe('nationality')
 
       const $lastInput = $component.find(
         '.govuk-checkboxes__item:last-child input'
@@ -132,8 +132,8 @@ describe('Checkboxes', () => {
       const $lastLabel = $component.find(
         '.govuk-checkboxes__item:last-child label'
       )
-      expect($lastInput.attr('id')).toEqual('nationality-3')
-      expect($lastLabel.attr('for')).toEqual('nationality-3')
+      expect($lastInput.attr('id')).toBe('nationality-3')
+      expect($lastLabel.attr('for')).toBe('nationality-3')
     })
 
     it('render a matching label and input using custom idPrefix', () => {
@@ -147,8 +147,8 @@ describe('Checkboxes', () => {
       const $firstLabel = $component.find(
         '.govuk-checkboxes__item:first-child label'
       )
-      expect($firstInput.attr('id')).toEqual('nationality')
-      expect($firstLabel.attr('for')).toEqual('nationality')
+      expect($firstInput.attr('id')).toBe('nationality')
+      expect($firstLabel.attr('for')).toBe('nationality')
 
       const $lastInput = $component.find(
         '.govuk-checkboxes__item:last-child input'
@@ -156,8 +156,8 @@ describe('Checkboxes', () => {
       const $lastLabel = $component.find(
         '.govuk-checkboxes__item:last-child label'
       )
-      expect($lastInput.attr('id')).toEqual('nationality-2')
-      expect($lastLabel.attr('for')).toEqual('nationality-2')
+      expect($lastInput.attr('id')).toBe('nationality-2')
+      expect($lastLabel.attr('for')).toBe('nationality-2')
     })
 
     it('render explicitly passed item ids', () => {
@@ -177,7 +177,7 @@ describe('Checkboxes', () => {
         '.govuk-checkboxes__item:first-child label'
       )
       expect($firstInput.attr('id')).toBe('item_british')
-      expect($firstLabel.attr('for')).toEqual('item_british')
+      expect($firstLabel.attr('for')).toBe('item_british')
     })
 
     it('render explicitly passed item names', () => {
@@ -199,7 +199,7 @@ describe('Checkboxes', () => {
       const $disabledInput = $component.find(
         '.govuk-checkboxes__item:last-child input'
       )
-      expect($disabledInput.attr('disabled')).toEqual('disabled')
+      expect($disabledInput.attr('disabled')).toBe('disabled')
     })
 
     it('render checked', () => {
@@ -212,8 +212,8 @@ describe('Checkboxes', () => {
       const $lastInput = $component.find(
         '.govuk-checkboxes__item:last-child input'
       )
-      expect($secondInput.attr('checked')).toEqual('checked')
-      expect($lastInput.attr('checked')).toEqual('checked')
+      expect($secondInput.attr('checked')).toBe('checked')
+      expect($lastInput.attr('checked')).toBe('checked')
     })
 
     it('checks the checkboxes in values', () => {
@@ -221,10 +221,10 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
       const $british = $component.find('input[value="british"]')
-      expect($british.attr('checked')).toEqual('checked')
+      expect($british.attr('checked')).toBe('checked')
 
       const $other = $component.find('input[value="other"]')
-      expect($other.attr('checked')).toEqual('checked')
+      expect($other.attr('checked')).toBe('checked')
     })
 
     it('allows item.checked to override values', () => {
@@ -243,14 +243,14 @@ describe('Checkboxes', () => {
         const $firstInput = $component.find(
           '.govuk-checkboxes__item:first-child input'
         )
-        expect($firstInput.attr('data-attribute')).toEqual('ABC')
-        expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
+        expect($firstInput.attr('data-attribute')).toBe('ABC')
+        expect($firstInput.attr('data-second-attribute')).toBe('DEF')
 
         const $lastInput = $component.find(
           '.govuk-checkboxes__item:last-child input'
         )
-        expect($lastInput.attr('data-attribute')).toEqual('GHI')
-        expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
+        expect($lastInput.attr('data-attribute')).toBe('GHI')
+        expect($lastInput.attr('data-second-attribute')).toBe('JKL')
       })
     })
   })
@@ -344,9 +344,7 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['empty conditional'])
 
       const $component = $('.govuk-checkboxes')
-      expect($component.find('.govuk-checkboxes__conditional').length).toEqual(
-        0
-      )
+      expect($component.find('.govuk-checkboxes__conditional')).toHaveLength(0)
     })
 
     it('does not associate checkboxes with empty conditionals', () => {
@@ -368,14 +366,14 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['with error and idPrefix'])
 
       const errorMessageId = $('.govuk-error-message').attr('id')
-      expect(errorMessageId).toEqual('id-prefix-error')
+      expect(errorMessageId).toBe('id-prefix-error')
     })
 
     it('falls back to using the name for the error message id', () => {
       const $ = render('checkboxes', examples['with error message'])
 
       const errorMessageId = $('.govuk-error-message').attr('id')
-      expect(errorMessageId).toEqual('waste-error')
+      expect(errorMessageId).toBe('waste-error')
     })
 
     it('associates the fieldset as "described by" the error message', () => {

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/template.test.js
@@ -13,16 +13,14 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $heading = $('.govuk-cookie-banner__heading')
-      expect($heading.text().trim()).toEqual(
-        'Cookies on this government service'
-      )
+      expect($heading.text().trim()).toBe('Cookies on this government service')
     })
 
     it('renders heading as escaped html when passed as text', () => {
       const $ = render('cookie-banner', examples['heading html as text'])
 
       const $heading = $('.govuk-cookie-banner__heading')
-      expect($heading.html().trim()).toEqual(
+      expect($heading.html().trim()).toBe(
         'Cookies on &lt;span&gt;my service&lt;/span&gt;'
       )
     })
@@ -31,16 +29,14 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['heading html'])
 
       const $heading = $('.govuk-cookie-banner__heading')
-      expect($heading.html().trim()).toEqual(
-        'Cookies on <span>my service</span>'
-      )
+      expect($heading.html().trim()).toBe('Cookies on <span>my service</span>')
     })
 
     it('renders main content text', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $content = $('.govuk-cookie-banner__content')
-      expect($content.text().trim()).toEqual(
+      expect($content.text().trim()).toBe(
         'We use analytics cookies to help understand how users use our service.'
       )
     })
@@ -49,7 +45,7 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.html)
 
       const $content = $('.govuk-cookie-banner__content')
-      expect($content.html().trim()).toEqual(
+      expect($content.html().trim()).toBe(
         '<p class="govuk-body">We use cookies in <span>our service</span>.</p>'
       )
     })
@@ -67,7 +63,7 @@ describe('Cookie Banner', () => {
 
       const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__message')
 
-      expect($banner.attr('data-attribute')).toEqual('my-value')
+      expect($banner.attr('data-attribute')).toBe('my-value')
     })
   })
 
@@ -76,21 +72,21 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
-      expect($component.attr('role')).toEqual('region')
+      expect($component.attr('role')).toBe('region')
     })
 
     it('has a default aria-label', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
-      expect($component.attr('aria-label')).toEqual('Cookie banner')
+      expect($component.attr('aria-label')).toBe('Cookie banner')
     })
 
     it('renders a custom aria label', () => {
       const $ = render('cookie-banner', examples['custom aria label'])
 
       const $component = $('.govuk-cookie-banner')
-      expect($component.attr('aria-label')).toEqual('Cookies on GOV.UK')
+      expect($component.attr('aria-label')).toBe('Cookies on GOV.UK')
     })
   })
 
@@ -111,7 +107,7 @@ describe('Cookie Banner', () => {
 
       const $component = $('.govuk-cookie-banner')
       const $banner = $component.find('.govuk-cookie-banner__message')
-      expect($banner.attr('role')).toEqual('alert')
+      expect($banner.attr('role')).toBe('alert')
     })
 
     it('hides banner if hidden option set to true', () => {
@@ -134,14 +130,14 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['default action'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.get(0).tagName).toEqual('button')
+      expect($actions.get(0).tagName).toBe('button')
     })
 
     it('renders as a link if href provided', () => {
       const $ = render('cookie-banner', examples.link)
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.get(0).tagName).toEqual('a')
+      expect($actions.get(0).tagName).toBe('a')
     })
 
     it('ignores other button options if href provided', () => {
@@ -151,9 +147,9 @@ describe('Cookie Banner', () => {
       )
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.get(0).tagName).toEqual('a')
-      expect($actions.text()).toEqual('This is a link')
-      expect($actions.attr('href')).toEqual('/link')
+      expect($actions.get(0).tagName).toBe('a')
+      expect($actions.text()).toBe('This is a link')
+      expect($actions.attr('href')).toBe('/link')
 
       expect($actions.attr('value')).toBeUndefined()
       expect($actions.attr('name')).toBeUndefined()
@@ -163,45 +159,45 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['link as a button'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.get(0).tagName).toEqual('a')
-      expect($actions.text().trim()).toEqual('This is a link')
-      expect($actions.attr('href')).toEqual('/link')
-      expect($actions.attr('role')).toEqual('button')
+      expect($actions.get(0).tagName).toBe('a')
+      expect($actions.text().trim()).toBe('This is a link')
+      expect($actions.attr('href')).toBe('/link')
+      expect($actions.attr('role')).toBe('button')
     })
 
     it('renders button text', () => {
       const $ = render('cookie-banner', examples['default action'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.text().trim()).toEqual('This is a button')
+      expect($actions.text().trim()).toBe('This is a button')
     })
 
     it('renders button with custom type', () => {
       const $ = render('cookie-banner', examples.type)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.attr('type')).toEqual('button')
+      expect($actions.attr('type')).toBe('button')
     })
 
     it('renders button with name', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.attr('name')).toEqual('cookies')
+      expect($actions.attr('name')).toBe('cookies')
     })
 
     it('renders button with value', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.attr('value')).toEqual('accept')
+      expect($actions.attr('value')).toBe('accept')
     })
 
     it('renders button with additional classes', () => {
       const $ = render('cookie-banner', examples['button classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.attr('class')).toEqual(
+      expect($actions.attr('class')).toBe(
         'govuk-button my-button-class app-button-class'
       )
     })
@@ -210,22 +206,22 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['button attributes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.attr('data-button-attribute')).toEqual('my-value')
+      expect($actions.attr('data-button-attribute')).toBe('my-value')
     })
 
     it('renders link text and href', () => {
       const $ = render('cookie-banner', examples.link)
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.text()).toEqual('This is a link')
-      expect($actions.attr('href')).toEqual('/link')
+      expect($actions.text()).toBe('This is a link')
+      expect($actions.attr('href')).toBe('/link')
     })
 
     it('renders link with additional classes', () => {
       const $ = render('cookie-banner', examples['link classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.attr('class')).toEqual(
+      expect($actions.attr('class')).toBe(
         'govuk-link my-link-class app-link-class'
       )
     })
@@ -234,7 +230,7 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['link attributes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.attr('data-link-attribute')).toEqual('my-value')
+      expect($actions.attr('data-link-attribute')).toBe('my-value')
     })
   })
 
@@ -243,21 +239,21 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['client-side implementation'])
 
       const $actions = $('.govuk-cookie-banner__message')
-      expect($actions.length).toEqual(3)
+      expect($actions).toHaveLength(3)
     })
 
     it('2 banners are hidden', () => {
       const $ = render('cookie-banner', examples['client-side implementation'])
 
       const $actions = $('.govuk-cookie-banner__message[hidden]')
-      expect($actions.length).toEqual(2)
+      expect($actions).toHaveLength(2)
     })
 
     it('has a data-nosnippet attribute to hide it from search result snippets', () => {
       const $ = render('cookie-banner', examples['client-side implementation'])
 
       const $parentContainer = $('.govuk-cookie-banner')
-      expect($parentContainer.attr('data-nosnippet')).toEqual('')
+      expect($parentContainer.attr('data-nosnippet')).toBe('')
     })
   })
 
@@ -266,14 +262,14 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $messages = $('.govuk-cookie-banner__message')
-      expect($messages.length).toEqual(3)
+      expect($messages).toHaveLength(3)
     })
 
     it('parent banner is hidden', () => {
       const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $cookieBanner = $('.govuk-cookie-banner[hidden]')
-      expect($cookieBanner.length).toEqual(1)
+      expect($cookieBanner).toHaveLength(1)
     })
 
     it('adds classes to parent container when provided', () => {
@@ -287,7 +283,7 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $cookieBanner = $('.govuk-cookie-banner')
-      expect($cookieBanner.attr('data-hide-cookie-banner')).toEqual('true')
+      expect($cookieBanner.attr('data-hide-cookie-banner')).toBe('true')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -17,35 +17,35 @@ describe('Date input', () => {
       const $ = render('date-input', examples.default)
 
       const $component = $('.govuk-date-input')
-      expect($component.attr('id')).toEqual('dob')
+      expect($component.attr('id')).toBe('dob')
     })
 
     it('renders default inputs', () => {
       const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
-      expect($items.length).toEqual(3)
+      expect($items).toHaveLength(3)
     })
 
     it('renders item with capitalised label text', () => {
       const $ = render('date-input', examples.default)
 
       const $firstItems = $('.govuk-date-input__item:first-child')
-      expect($firstItems.text().trim()).toEqual('Day')
+      expect($firstItems.text().trim()).toBe('Day')
     })
 
     it('renders inputs with type="text"', () => {
       const $ = render('date-input', examples.default)
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('type')).toEqual('text')
+      expect($firstInput.attr('type')).toBe('text')
     })
 
     it('renders inputs with inputmode="numeric"', () => {
       const $ = render('date-input', examples.default)
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('inputmode')).toEqual('numeric')
+      expect($firstInput.attr('inputmode')).toBe('numeric')
     })
 
     it('renders item with implicit class for label', () => {
@@ -75,7 +75,7 @@ describe('Date input', () => {
       const $ = render('date-input', examples['with empty items'])
 
       const $items = $('.govuk-date-input__item')
-      expect($items.length).toEqual(3)
+      expect($items).toHaveLength(3)
     })
 
     it('renders with default items', () => {
@@ -86,36 +86,36 @@ describe('Date input', () => {
         '.govuk-date-input:first-child .govuk-date-input__input'
       )
 
-      expect($items.length).toEqual(3)
-      expect($firstItemInput.attr('name')).toEqual('day')
+      expect($items).toHaveLength(3)
+      expect($firstItemInput.attr('name')).toBe('day')
     })
 
     it('renders item with suffixed name for input', () => {
       const $ = render('date-input', examples['complete question'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('name')).toEqual('dob-day')
+      expect($firstItems.attr('name')).toBe('dob-day')
     })
 
     it('renders items with id', () => {
       const $ = render('date-input', examples['with id on items'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('id')).toEqual('day')
+      expect($firstItems.attr('id')).toBe('day')
     })
 
     it('renders item with suffixed id for input', () => {
       const $ = render('date-input', examples['suffixed id'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('id')).toEqual('my-date-input-day')
+      expect($firstItems.attr('id')).toBe('my-date-input-day')
     })
 
     it('renders items with value', () => {
       const $ = render('date-input', examples['with values'])
 
       const $lastItems = $('.govuk-date-input__item:last-child input')
-      expect($lastItems.val()).toEqual('2018')
+      expect($lastItems.val()).toBe('2018')
     })
   })
 
@@ -133,7 +133,7 @@ describe('Date input', () => {
       const $ = render('date-input', examples.attributes)
 
       const $component = $('.govuk-date-input')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
 
     it('renders with item attributes', () => {
@@ -143,30 +143,30 @@ describe('Date input', () => {
       const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
       const $input3 = $('.govuk-date-input__item:nth-of-type(3) input')
 
-      expect($input1.attr('data-example-day')).toEqual('day')
-      expect($input2.attr('data-example-month')).toEqual('month')
-      expect($input3.attr('data-example-year')).toEqual('year')
+      expect($input1.attr('data-example-day')).toBe('day')
+      expect($input2.attr('data-example-month')).toBe('month')
+      expect($input3.attr('data-example-year')).toBe('year')
     })
 
     it('renders items with name', () => {
       const $ = render('date-input', examples['with nested name'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('name')).toEqual('day[dd]')
+      expect($firstItems.attr('name')).toBe('day[dd]')
     })
 
     it('renders inputs with custom pattern attribute', () => {
       const $ = render('date-input', examples['custom pattern'])
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('pattern')).toEqual('[0-8]*')
+      expect($firstInput.attr('pattern')).toBe('[0-8]*')
     })
 
     it('renders inputs with custom inputmode="text"', () => {
       const $ = render('date-input', examples['custom inputmode'])
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('inputmode')).toEqual('text')
+      expect($firstInput.attr('inputmode')).toBe('text')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
@@ -224,7 +224,7 @@ describe('Date input', () => {
 
       const $errorMessage = $('.govuk-error-message')
 
-      expect($errorMessage.attr('id')).toEqual('dob-errors-error')
+      expect($errorMessage.attr('id')).toBe('dob-errors-error')
     })
 
     it('associates the fieldset as "described by" the error message', () => {
@@ -264,7 +264,7 @@ describe('Date input', () => {
 
       const $fieldset = $('.govuk-fieldset')
 
-      expect($fieldset.attr('role')).toEqual('group')
+      expect($fieldset.attr('role')).toBe('group')
     })
 
     it('associates the fieldset as described by both the hint and the error message', () => {
@@ -348,7 +348,7 @@ describe('Date input', () => {
       const $ = render('date-input', examples['with autocomplete values'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('autocomplete')).toEqual('bday-day')
+      expect($firstItems.attr('autocomplete')).toBe('bday-day')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/details/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/details/template.test.js
@@ -12,14 +12,14 @@ describe('Details', () => {
     const $ = render('details', examples.default)
 
     const $component = $('.govuk-details')
-    expect($component.get(0).tagName).toEqual('details')
+    expect($component.get(0).tagName).toBe('details')
   })
 
   it('renders with a custom id', () => {
     const $ = render('details', examples.id)
 
     const $component = $('.govuk-details')
-    expect($component.attr('id')).toEqual('my-details-element')
+    expect($component.attr('id')).toBe('my-details-element')
   })
 
   it('is collapsed by default', () => {
@@ -41,7 +41,7 @@ describe('Details', () => {
 
     // Look for the summary element _within_ the details element
     const $summary = $('.govuk-details .govuk-details__summary')
-    expect($summary.get(0).tagName).toEqual('summary')
+    expect($summary.get(0).tagName).toBe('summary')
   })
 
   it('renders nested components using `call`', () => {
@@ -56,28 +56,28 @@ describe('Details', () => {
     const $ = render('details', examples['html as text'])
 
     const detailsText = $('.govuk-details__text').html().trim()
-    expect(detailsText).toEqual('More about the greater than symbol (&gt;)')
+    expect(detailsText).toBe('More about the greater than symbol (&gt;)')
   })
 
   it('allows HTML to be passed un-escaped', () => {
     const $ = render('details', examples.html)
 
     const detailsText = $('.govuk-details__text').html().trim()
-    expect(detailsText).toEqual('More about <b>bold text</b>')
+    expect(detailsText).toBe('More about <b>bold text</b>')
   })
 
   it('allows summary text to be passed whilst escaping HTML entities', () => {
     const $ = render('details', examples['summary html as text'])
 
     const detailsText = $('.govuk-details__summary-text').html().trim()
-    expect(detailsText).toEqual('The greater than symbol (&gt;) is the best')
+    expect(detailsText).toBe('The greater than symbol (&gt;) is the best')
   })
 
   it('allows summary HTML to be passed un-escaped', () => {
     const $ = render('details', examples['summary html'])
 
     const detailsText = $('.govuk-details__summary-text').html().trim()
-    expect(detailsText).toEqual('Use <b>bold text</b> sparingly')
+    expect(detailsText).toBe('Use <b>bold text</b> sparingly')
   })
 
   it('allows additional classes to be added to the details element', () => {
@@ -91,7 +91,7 @@ describe('Details', () => {
     const $ = render('details', examples.attributes)
 
     const $component = $('.govuk-details')
-    expect($component.attr('data-some-data-attribute')).toEqual('i-love-data')
-    expect($component.attr('another-attribute')).toEqual('foo')
+    expect($component.attr('data-some-data-attribute')).toBe('i-love-data')
+    expect($component.attr('another-attribute')).toBe('foo')
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-message/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-message/template.test.js
@@ -12,7 +12,7 @@ describe('Error message', () => {
     const $ = render('error-message', examples.id)
 
     const $component = $('.govuk-error-message')
-    expect($component.attr('id')).toEqual('my-error-message-id')
+    expect($component.attr('id')).toBe('my-error-message-id')
   })
 
   it('allows additional classes to specified', () => {
@@ -40,15 +40,15 @@ describe('Error message', () => {
     const $ = render('error-message', examples.attributes)
 
     const $component = $('.govuk-error-message')
-    expect($component.attr('data-test')).toEqual('attribute')
-    expect($component.attr('id')).toEqual('my-error-message')
+    expect($component.attr('data-test')).toBe('attribute')
+    expect($component.attr('id')).toBe('my-error-message')
   })
 
   it('includes a visually hidden "Error" prefix by default', () => {
     const $ = render('error-message', examples.default)
 
     const $component = $('.govuk-error-message')
-    expect($component.text().trim()).toEqual(
+    expect($component.text().trim()).toBe(
       'Error: Error message about full name goes here'
     )
   })
@@ -57,14 +57,14 @@ describe('Error message', () => {
     const $ = render('error-message', examples['with visually hidden text'])
 
     const $component = $('.govuk-error-message')
-    expect($component.text().trim()).toEqual('Gwall: Rhowch eich enw llawn')
+    expect($component.text().trim()).toBe('Gwall: Rhowch eich enw llawn')
   })
 
   it('allows the visually hidden prefix to be removed', () => {
     const $ = render('error-message', examples['visually hidden text removed'])
 
     const $component = $('.govuk-error-message')
-    expect($component.text().trim()).toEqual('There is an error on line 42')
+    expect($component.text().trim()).toBe('There is an error on line 42')
   })
 
   it('allows the visually hidden prefix to be removed and then manually added with HTML', () => {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -15,7 +15,7 @@ describe('Error Summary', () => {
       el.getAttribute('tabindex')
     )
 
-    expect(tabindex).toEqual('-1')
+    expect(tabindex).toBe('-1')
   })
 
   it('is automatically focused when the page loads', async () => {
@@ -105,7 +105,7 @@ describe('Error Summary', () => {
         const tabindex = await page.$eval('.govuk-error-summary', (el) =>
           el.getAttribute('tabindex')
         )
-        expect(tabindex).toEqual('-1')
+        expect(tabindex).toBe('-1')
       })
 
       it('is automatically focused when the page loads', async () => {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
@@ -15,14 +15,14 @@ describe('Error-summary', () => {
         'role'
       )
 
-      expect(childRoleAttr).toEqual('alert')
+      expect(childRoleAttr).toBe('alert')
     })
 
     it('renders title text', () => {
       const $ = render('error-summary', examples.default)
       const summaryTitle = $('.govuk-error-summary__title').text().trim()
 
-      expect(summaryTitle).toEqual('There is a problem')
+      expect(summaryTitle).toBe('There is a problem')
     })
 
     it('number of error items matches the number of items specified', () => {
@@ -38,7 +38,7 @@ describe('Error-summary', () => {
       const errorItem = $(
         '.govuk-error-summary .govuk-error-summary__list li:first-child'
       )
-      expect(errorItem.children().get(0).tagName).toEqual('a')
+      expect(errorItem.children().get(0).tagName).toBe('a')
     })
 
     it('render anchor tag href attribute is correctly', () => {
@@ -47,7 +47,7 @@ describe('Error-summary', () => {
       const errorItem = $(
         '.govuk-error-summary .govuk-error-summary__list li:first-child a'
       )
-      expect(errorItem.attr('href')).toEqual('#example-error-1')
+      expect(errorItem.attr('href')).toBe('#example-error-1')
     })
   })
 
@@ -56,35 +56,35 @@ describe('Error-summary', () => {
       const $ = render('error-summary', examples['html as titleText'])
 
       const summaryTitle = $('.govuk-error-summary__title').html().trim()
-      expect(summaryTitle).toEqual('Alert, &lt;em&gt;alert&lt;/em&gt;')
+      expect(summaryTitle).toBe('Alert, &lt;em&gt;alert&lt;/em&gt;')
     })
 
     it('allows title HTML to be passed un-escaped', () => {
       const $ = render('error-summary', examples['title html'])
 
       const summaryTitle = $('.govuk-error-summary__title').html().trim()
-      expect(summaryTitle).toEqual('Alert, <em>alert</em>')
+      expect(summaryTitle).toBe('Alert, <em>alert</em>')
     })
 
     it('renders description text', () => {
       const $ = render('error-summary', examples.description)
       const summaryDescription = $('.govuk-error-summary__body p').text().trim()
 
-      expect(summaryDescription).toEqual('Lorem ipsum')
+      expect(summaryDescription).toBe('Lorem ipsum')
     })
 
     it('allows description text to be passed whilst escaping HTML entities', () => {
       const $ = render('error-summary', examples['html as descriptionText'])
 
       const summaryDescription = $('.govuk-error-summary__body p').html().trim()
-      expect(summaryDescription).toEqual('See errors below (&gt;)')
+      expect(summaryDescription).toBe('See errors below (&gt;)')
     })
 
     it('allows description HTML to be passed un-escaped', () => {
       const $ = render('error-summary', examples['description html'])
 
       const summaryDescription = $('.govuk-error-summary__body p').html().trim()
-      expect(summaryDescription).toEqual('See <span>errors</span> below')
+      expect(summaryDescription).toBe('See <span>errors</span> below')
     })
 
     it('renders nested components in description using `call`', () => {
@@ -108,16 +108,16 @@ describe('Error-summary', () => {
       const $ = render('error-summary', examples.attributes)
 
       const $component = $('.govuk-error-summary')
-      expect($component.attr('first-attribute')).toEqual('foo')
-      expect($component.attr('second-attribute')).toEqual('bar')
+      expect($component.attr('first-attribute')).toBe('foo')
+      expect($component.attr('second-attribute')).toBe('bar')
     })
 
     it('renders anchor tag with attributes', () => {
       const $ = render('error-summary', examples['error list with attributes'])
 
       const $component = $('.govuk-error-summary__list a')
-      expect($component.attr('data-attribute')).toEqual('my-attribute')
-      expect($component.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($component.attr('data-attribute')).toBe('my-attribute')
+      expect($component.attr('data-attribute-2')).toBe('my-attribute-2')
     })
 
     it('renders error item text', () => {
@@ -128,7 +128,7 @@ describe('Error-summary', () => {
         .text()
         .trim()
 
-      expect(errorItemText).toEqual('Invalid username or password')
+      expect(errorItemText).toBe('Invalid username or password')
     })
 
     it('allows error item HTML to be passed un-escaped', () => {
@@ -140,7 +140,7 @@ describe('Error-summary', () => {
         .html()
         .trim()
 
-      expect(errorItemText).toEqual(
+      expect(errorItemText).toBe(
         'The date your passport was issued <b>must</b> be in the past'
       )
     })
@@ -157,7 +157,7 @@ describe('Error-summary', () => {
         .html()
         .trim()
 
-      expect(errorItemText).toEqual(
+      expect(errorItemText).toBe(
         'Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error'
       )
     })
@@ -171,7 +171,7 @@ describe('Error-summary', () => {
         .html()
         .trim()
 
-      expect(errorItemText).toEqual(
+      expect(errorItemText).toBe(
         'Descriptive link to the <b>question</b> with an error'
       )
     })
@@ -188,7 +188,7 @@ describe('Error-summary', () => {
         .html()
         .trim()
 
-      expect(errorItemText).toEqual(
+      expect(errorItemText).toBe(
         'Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error'
       )
     })

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
@@ -19,28 +19,28 @@ describe('fieldset', () => {
     const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
-    expect($legend.get(0).tagName).toEqual('legend')
+    expect($legend.get(0).tagName).toBe('legend')
   })
 
   it('nests the legend within the fieldset', () => {
     const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
-    expect($legend.parent().get(0).tagName).toEqual('fieldset')
+    expect($legend.parent().get(0).tagName).toBe('fieldset')
   })
 
   it('allows you to set the legend text', () => {
     const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
-    expect($legend.text().trim()).toEqual('What is your address?')
+    expect($legend.text().trim()).toBe('What is your address?')
   })
 
   it('allows you to set the aria-describedby attribute', () => {
     const $ = render('fieldset', examples['with describedBy'])
 
     const $component = $('.govuk-fieldset')
-    expect($component.attr('aria-describedby')).toEqual('test-target-element')
+    expect($component.attr('aria-describedby')).toBe('test-target-element')
   })
 
   it('escapes HTML in the text argument', () => {
@@ -67,7 +67,7 @@ describe('fieldset', () => {
   it('renders html when passed as fieldset content', () => {
     const $ = render('fieldset', examples['html fieldset content'])
 
-    expect($('.govuk-fieldset .my-content').text().trim()).toEqual(
+    expect($('.govuk-fieldset .my-content').text().trim()).toBe(
       'This is some content to put inside the fieldset'
     )
   })
@@ -98,13 +98,13 @@ describe('fieldset', () => {
     const $ = render('fieldset', examples.role)
 
     const $component = $('.govuk-fieldset')
-    expect($component.attr('role')).toEqual('group')
+    expect($component.attr('role')).toBe('group')
   })
 
   it('can have additional attributes', () => {
     const $ = render('fieldset', examples.attributes)
 
     const $component = $('.govuk-fieldset')
-    expect($component.attr('data-attribute')).toEqual('value')
+    expect($component.attr('data-attribute')).toBe('value')
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -17,14 +17,14 @@ describe('File upload', () => {
       const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('id')).toEqual('file-upload-1')
+      expect($component.attr('id')).toBe('file-upload-1')
     })
 
     it('renders with name', () => {
       const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('name')).toEqual('file-upload-1')
+      expect($component.attr('name')).toBe('file-upload-1')
     })
 
     it('renders with a form group wrapper', () => {
@@ -49,7 +49,7 @@ describe('File upload', () => {
       const $ = render('file-upload', examples['with value'])
 
       const $component = $('.govuk-file-upload')
-      expect($component.val()).toEqual('C:\\fakepath\\myphoto.jpg')
+      expect($component.val()).toBe('C:\\fakepath\\myphoto.jpg')
     })
 
     it('renders with aria-describedby', () => {
@@ -63,7 +63,7 @@ describe('File upload', () => {
       const $ = render('file-upload', examples.attributes)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('accept')).toEqual('.jpg, .jpeg, .png')
+      expect($component.attr('accept')).toBe('.jpg, .jpeg, .png')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
@@ -212,7 +212,7 @@ describe('File upload', () => {
       const $ = render('file-upload', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('file-upload-1')
+      expect($label.attr('for')).toBe('file-upload-1')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -12,15 +12,15 @@ describe('footer', () => {
     const $ = render('footer', examples.default)
 
     const $component = $('.govuk-footer')
-    expect($component.attr('role')).toEqual('contentinfo')
+    expect($component.attr('role')).toBe('contentinfo')
   })
 
   it('renders attributes correctly', () => {
     const $ = render('footer', examples.attributes)
 
     const $component = $('.govuk-footer')
-    expect($component.attr('data-test-attribute')).toEqual('value')
-    expect($component.attr('data-test-attribute-2')).toEqual('value-2')
+    expect($component.attr('data-test-attribute')).toBe('value')
+    expect($component.attr('data-test-attribute-2')).toBe('value-2')
   })
 
   it('renders classes', () => {
@@ -45,7 +45,7 @@ describe('footer', () => {
 
       const $component = $('.govuk-footer')
       const $heading = $component.find('h2.govuk-visually-hidden')
-      expect($heading.text()).toEqual('Items')
+      expect($heading.text()).toBe('Items')
     })
 
     it('renders default heading when none supplied', () => {
@@ -53,13 +53,13 @@ describe('footer', () => {
 
       const $component = $('.govuk-footer')
       const $heading = $component.find('h2.govuk-visually-hidden')
-      expect($heading.text()).toEqual('Support links')
+      expect($heading.text()).toBe('Support links')
     })
 
     it("doesn't render footer link list when no items are provided", () => {
       const $ = render('footer', examples['with empty meta items'])
 
-      expect($('.govuk-footer__inline-list').length).toEqual(0)
+      expect($('.govuk-footer__inline-list')).toHaveLength(0)
     })
 
     it('renders links', () => {
@@ -68,8 +68,8 @@ describe('footer', () => {
       const $list = $('ul.govuk-footer__inline-list')
       const $items = $list.find('li.govuk-footer__inline-list-item')
       const $firstItem = $items.find('a.govuk-footer__link:first-child')
-      expect($items.length).toEqual(3)
-      expect($firstItem.attr('href')).toEqual('#1')
+      expect($items).toHaveLength(3)
+      expect($firstItem.attr('href')).toBe('#1')
       expect($firstItem.text()).toContain('Item 1')
     })
 
@@ -100,8 +100,8 @@ describe('footer', () => {
       const $ = render('footer', examples['with meta item attributes'])
 
       const $metaLink = $('.govuk-footer__meta .govuk-footer__link')
-      expect($metaLink.attr('data-attribute')).toEqual('my-attribute')
-      expect($metaLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($metaLink.attr('data-attribute')).toBe('my-attribute')
+      expect($metaLink.attr('data-attribute-2')).toBe('my-attribute-2')
     })
   })
 
@@ -109,7 +109,7 @@ describe('footer', () => {
     it('no items displayed when no item array is provided', () => {
       const $ = render('footer', examples['with empty navigation'])
 
-      expect($('.govuk-footer__navigation').length).toEqual(0)
+      expect($('.govuk-footer__navigation')).toHaveLength(0)
     })
 
     it('renders headings', () => {
@@ -119,8 +119,8 @@ describe('footer', () => {
       const $lastSection = $('.govuk-footer__section:last-child')
       const $firstHeading = $firstSection.find('h2.govuk-footer__heading')
       const $lastHeading = $lastSection.find('h2.govuk-footer__heading')
-      expect($firstHeading.text()).toEqual('Two column list')
-      expect($lastHeading.text()).toEqual('Single column list')
+      expect($firstHeading.text()).toBe('Two column list')
+      expect($lastHeading.text()).toBe('Single column list')
     })
 
     it('renders lists of links', () => {
@@ -129,8 +129,8 @@ describe('footer', () => {
       const $list = $('ul.govuk-footer__list')
       const $items = $list.find('li.govuk-footer__list-item')
       const $firstItem = $items.find('a.govuk-footer__link:first-child')
-      expect($items.length).toEqual(9)
-      expect($firstItem.attr('href')).toEqual('#1')
+      expect($items).toHaveLength(9)
+      expect($firstItem.attr('href')).toBe('#1')
       expect($firstItem.text()).toContain('Navigation item 1')
     })
 
@@ -138,8 +138,8 @@ describe('footer', () => {
       const $ = render('footer', examples['with navigation item attributes'])
 
       const $navigationLink = $('.govuk-footer__list .govuk-footer__link')
-      expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
-      expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($navigationLink.attr('data-attribute')).toBe('my-attribute')
+      expect($navigationLink.attr('data-attribute-2')).toBe('my-attribute-2')
     })
 
     it('renders lists in columns', () => {

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -25,7 +25,7 @@ describe('GOV.UK Frontend', () => {
         'initAll'
       )
 
-      expect(typeofInitAll).toEqual('function')
+      expect(typeofInitAll).toBe('function')
     })
 
     it('exports Components', async () => {

--- a/packages/govuk-frontend/src/govuk/components/header/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/template.test.js
@@ -13,7 +13,7 @@ describe('header', () => {
       const $ = render('header', examples.default)
 
       const $component = $('.govuk-header')
-      expect($component.attr('role')).toEqual('banner')
+      expect($component.attr('role')).toBe('banner')
     })
   })
 
@@ -22,8 +22,8 @@ describe('header', () => {
       const $ = render('header', examples.attributes)
 
       const $component = $('.govuk-header')
-      expect($component.attr('data-test-attribute')).toEqual('value')
-      expect($component.attr('data-test-attribute-2')).toEqual('value-2')
+      expect($component.attr('data-test-attribute')).toBe('value')
+      expect($component.attr('data-test-attribute-2')).toBe('value-2')
     })
 
     it('renders classes', () => {
@@ -58,7 +58,7 @@ describe('header', () => {
 
       const $component = $('.govuk-header')
       const $homepageLink = $component.find('.govuk-header__link--homepage')
-      expect($homepageLink.attr('href')).toEqual('/')
+      expect($homepageLink.attr('href')).toBe('/')
     })
   })
 
@@ -68,7 +68,7 @@ describe('header', () => {
 
       const $component = $('.govuk-header')
       const $productName = $component.find('.govuk-header__product-name')
-      expect($productName.text().trim()).toEqual('Product Name')
+      expect($productName.text().trim()).toBe('Product Name')
     })
   })
 
@@ -78,7 +78,7 @@ describe('header', () => {
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
-      expect($serviceName.text().trim()).toEqual('Service Name')
+      expect($serviceName.text().trim()).toBe('Service Name')
     })
 
     it('wraps the service name with a link when a url is provided', () => {
@@ -86,8 +86,8 @@ describe('header', () => {
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
-      expect($serviceName.get(0).tagName).toEqual('a')
-      expect($serviceName.attr('href')).toEqual('/components/header')
+      expect($serviceName.get(0).tagName).toBe('a')
+      expect($serviceName.attr('href')).toBe('/components/header')
     })
 
     it('does not use a link when no service url is provided', () => {
@@ -98,7 +98,7 @@ describe('header', () => {
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
-      expect($serviceName.get(0).tagName).toEqual('span')
+      expect($serviceName.get(0).tagName).toBe('span')
       expect($serviceName.attr('href')).toBeUndefined()
     })
   })
@@ -111,8 +111,8 @@ describe('header', () => {
       const $list = $component.find('ul.govuk-header__navigation-list')
       const $items = $list.find('li.govuk-header__navigation-item')
       const $firstItem = $items.find('a.govuk-header__link:first-child')
-      expect($items.length).toEqual(4)
-      expect($firstItem.attr('href')).toEqual('#1')
+      expect($items).toHaveLength(4)
+      expect($firstItem.attr('href')).toBe('#1')
       expect($firstItem.text()).toContain('Navigation item 1')
     })
 
@@ -122,7 +122,7 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
 
-      expect($nav.attr('aria-label')).toEqual('Menu')
+      expect($nav.attr('aria-label')).toBe('Menu')
     })
 
     it('renders navigation label correctly when custom menu button text is set', () => {
@@ -131,7 +131,7 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
 
-      expect($nav.attr('aria-label')).toEqual('Dewislen')
+      expect($nav.attr('aria-label')).toBe('Dewislen')
     })
 
     it('allows navigation label to be customised', () => {
@@ -140,7 +140,7 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
 
-      expect($nav.attr('aria-label')).toEqual('Custom navigation label')
+      expect($nav.attr('aria-label')).toBe('Custom navigation label')
     })
 
     it('renders navigation label and menu button text when these are both set', () => {
@@ -153,8 +153,8 @@ describe('header', () => {
       const $nav = $component.find('nav')
       const $button = $component.find('.govuk-header__menu-button')
 
-      expect($nav.attr('aria-label')).toEqual('Custom navigation label')
-      expect($button.text().trim()).toEqual('Custom menu button text')
+      expect($nav.attr('aria-label')).toBe('Custom navigation label')
+      expect($button.text().trim()).toBe('Custom menu button text')
     })
 
     it('renders navigation with active item', () => {
@@ -189,7 +189,7 @@ describe('header', () => {
       )
 
       const $navigationItem = $('.govuk-header__navigation-item')
-      expect($navigationItem.html().trim()).toEqual('Navigation item 1')
+      expect($navigationItem.html().trim()).toBe('Navigation item 1')
     })
 
     it('renders navigation item with html without a link', () => {
@@ -206,8 +206,8 @@ describe('header', () => {
       const $ = render('header', examples['navigation item with attributes'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
-      expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
-      expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($navigationLink.attr('data-attribute')).toBe('my-attribute')
+      expect($navigationLink.attr('data-attribute-2')).toBe('my-attribute-2')
     })
 
     describe('menu button', () => {
@@ -216,7 +216,7 @@ describe('header', () => {
 
         const $button = $('.govuk-header__menu-button')
 
-        expect($button.attr('type')).toEqual('button')
+        expect($button.attr('type')).toBe('button')
       })
       it('has a hidden attribute on load so that it does not show an unusable button without js', () => {
         const $ = render('header', examples['with navigation'])
@@ -230,21 +230,21 @@ describe('header', () => {
 
         const $button = $('.govuk-header__menu-button')
 
-        expect($button.attr('aria-label')).toEqual('Custom button label')
+        expect($button.attr('aria-label')).toBe('Custom button label')
       })
       it('renders default text correctly', () => {
         const $ = render('header', examples['with navigation'])
 
         const $button = $('.govuk-header__menu-button')
 
-        expect($button.text().trim()).toEqual('Menu')
+        expect($button.text().trim()).toBe('Menu')
       })
       it('allows text to be customised', () => {
         const $ = render('header', examples['with custom menu button text'])
 
         const $button = $('.govuk-header__menu-button')
 
-        expect($button.text().trim()).toEqual('Dewislen')
+        expect($button.text().trim()).toBe('Dewislen')
       })
     })
   })
@@ -282,19 +282,19 @@ describe('header', () => {
     })
 
     it('defaults to Tudor crown', () => {
-      expect($svg.attr('viewBox')).toEqual('0 0 148 30')
+      expect($svg.attr('viewBox')).toBe('0 0 148 30')
     })
 
     it('sets focusable="false" so that IE does not treat it as an interactive element', () => {
-      expect($svg.attr('focusable')).toEqual('false')
+      expect($svg.attr('focusable')).toBe('false')
     })
 
     it('sets role="img" so that assistive technologies do not treat it as an embedded document', () => {
-      expect($svg.attr('role')).toEqual('img')
+      expect($svg.attr('role')).toBe('img')
     })
 
     it('sets aria-label so that assistive technologies have an accessible name to fall back to', () => {
-      expect($svg.attr('aria-label')).toEqual('GOV.UK')
+      expect($svg.attr('aria-label')).toBe('GOV.UK')
     })
 
     it('has an embedded <title> element to serve as alternative text', () => {
@@ -305,7 +305,7 @@ describe('header', () => {
       $ = render('header', examples["with St Edward's crown"])
       $svg = $('.govuk-header__logotype')
 
-      expect($svg.attr('viewBox')).toEqual('0 0 152 30')
+      expect($svg.attr('viewBox')).toBe('0 0 152 30')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/hint/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/hint/template.test.js
@@ -15,7 +15,7 @@ describe('Hint', () => {
       const $ = render('hint', examples.default)
 
       const content = $('.govuk-hint').text()
-      expect(content).toEqual(
+      expect(content).toBe(
         "\n  It's on your National Insurance card, benefit letter, payslip or P60.\nFor example, 'QQ 12 34 56 C'.\n\n"
       )
     })
@@ -31,14 +31,14 @@ describe('Hint', () => {
       const $ = render('hint', examples.id)
 
       const $component = $('.govuk-hint')
-      expect($component.attr('id')).toEqual('my-hint')
+      expect($component.attr('id')).toBe('my-hint')
     })
 
     it('allows text to be passed whilst escaping HTML entities', () => {
       const $ = render('hint', examples['html as text'])
 
       const content = $('.govuk-hint').html().trim()
-      expect(content).toEqual(
+      expect(content).toBe(
         'Unexpected &lt;strong&gt;bold text&lt;/strong&gt; in body'
       )
     })
@@ -62,7 +62,7 @@ describe('Hint', () => {
       const $ = render('hint', examples.attributes)
 
       const $component = $('.govuk-hint')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.test.js
@@ -17,21 +17,21 @@ describe('Input', () => {
       const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
-      expect($component.attr('id')).toEqual('input-example')
+      expect($component.attr('id')).toBe('input-example')
     })
 
     it('renders with name', () => {
       const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
-      expect($component.attr('name')).toEqual('test-name')
+      expect($component.attr('name')).toBe('test-name')
     })
 
     it('renders with type="text" by default', () => {
       const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
-      expect($component.attr('type')).toEqual('text')
+      expect($component.attr('type')).toBe('text')
     })
 
     it('renders with a form group wrapper', () => {
@@ -54,21 +54,21 @@ describe('Input', () => {
       const $ = render('input', examples['custom type'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('type')).toEqual('number')
+      expect($component.attr('type')).toBe('number')
     })
 
     it('renders with pattern attribute', () => {
       const $ = render('input', examples['with pattern attribute'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('pattern')).toEqual('[0-9]*')
+      expect($component.attr('pattern')).toBe('[0-9]*')
     })
 
     it('renders with value', () => {
       const $ = render('input', examples.value)
 
       const $component = $('.govuk-input')
-      expect($component.val()).toEqual('QQ 12 34 56 C')
+      expect($component.val()).toBe('QQ 12 34 56 C')
     })
 
     it('renders with aria-describedby', () => {
@@ -82,7 +82,7 @@ describe('Input', () => {
       const $ = render('input', examples.attributes)
 
       const $component = $('.govuk-input')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
@@ -187,14 +187,14 @@ describe('Input', () => {
       const $ = render('input', examples['with spellcheck enabled'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('spellcheck')).toEqual('true')
+      expect($component.attr('spellcheck')).toBe('true')
     })
 
     it('renders with spellcheck attribute set to false', () => {
       const $ = render('input', examples['with spellcheck disabled'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('spellcheck')).toEqual('false')
+      expect($component.attr('spellcheck')).toBe('false')
     })
 
     it('renders without spellcheck attribute by default', () => {
@@ -253,7 +253,7 @@ describe('Input', () => {
       const $ = render('input', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('input-example')
+      expect($label.attr('for')).toBe('input-example')
     })
   })
 
@@ -262,7 +262,7 @@ describe('Input', () => {
       const $ = render('input', examples['with autocomplete attribute'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('autocomplete')).toEqual('postal-code')
+      expect($component.attr('autocomplete')).toBe('postal-code')
     })
   })
 
@@ -271,7 +271,7 @@ describe('Input', () => {
       const $ = render('input', examples.inputmode)
 
       const $component = $('.govuk-form-group > .govuk-input')
-      expect($component.attr('inputmode')).toEqual('decimal')
+      expect($component.attr('inputmode')).toBe('decimal')
     })
   })
 
@@ -299,7 +299,7 @@ describe('Input', () => {
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
       )
 
-      expect($prefix.html()).toEqual('£')
+      expect($prefix.html()).toBe('£')
     })
 
     it('allows prefix text to be passed whilst escaping HTML entities', () => {
@@ -309,7 +309,7 @@ describe('Input', () => {
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
       )
 
-      expect($prefix.html()).toEqual('&lt;span&gt;£&lt;/span&gt;')
+      expect($prefix.html()).toBe('&lt;span&gt;£&lt;/span&gt;')
     })
 
     it('allows prefix HTML to be passed un-escaped', () => {
@@ -319,7 +319,7 @@ describe('Input', () => {
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
       )
 
-      expect($prefix.html()).toEqual('<span>£</span>')
+      expect($prefix.html()).toBe('<span>£</span>')
     })
 
     it('hides the prefix from screen readers using the aria-hidden attribute', () => {
@@ -328,7 +328,7 @@ describe('Input', () => {
       const $prefix = $(
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
       )
-      expect($prefix.attr('aria-hidden')).toEqual('true')
+      expect($prefix.attr('aria-hidden')).toBe('true')
     })
 
     it('renders with classes', () => {
@@ -348,7 +348,7 @@ describe('Input', () => {
       const $prefix = $(
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
       )
-      expect($prefix.attr('data-attribute')).toEqual('value')
+      expect($prefix.attr('data-attribute')).toBe('value')
     })
   })
 
@@ -376,7 +376,7 @@ describe('Input', () => {
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
       )
 
-      expect($prefix.html()).toEqual('£')
+      expect($prefix.html()).toBe('£')
     })
 
     it('allows suffix text to be passed whilst escaping HTML entities', () => {
@@ -386,7 +386,7 @@ describe('Input', () => {
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
       )
 
-      expect($suffix.html()).toEqual('&lt;span&gt;kg&lt;/span&gt;')
+      expect($suffix.html()).toBe('&lt;span&gt;kg&lt;/span&gt;')
     })
 
     it('allows suffix HTML to be passed un-escaped', () => {
@@ -396,7 +396,7 @@ describe('Input', () => {
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
       )
 
-      expect($suffix.html()).toEqual('<span>kg</span>')
+      expect($suffix.html()).toBe('<span>kg</span>')
     })
 
     it('hides the suffix from screen readers using the aria-hidden attribute', () => {
@@ -405,7 +405,7 @@ describe('Input', () => {
       const $suffix = $(
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
       )
-      expect($suffix.attr('aria-hidden')).toEqual('true')
+      expect($suffix.attr('aria-hidden')).toBe('true')
     })
 
     it('renders with classes', () => {
@@ -425,7 +425,7 @@ describe('Input', () => {
       const $suffix = $(
         '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
       )
-      expect($suffix.attr('data-attribute')).toEqual('value')
+      expect($suffix.attr('data-attribute')).toBe('value')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
@@ -24,7 +24,7 @@ describe('Inset text', () => {
       const $ = render('inset-text', examples.id)
 
       const $component = $('.govuk-inset-text')
-      expect($component.attr('id')).toEqual('my-inset-text')
+      expect($component.attr('id')).toBe('my-inset-text')
     })
 
     it('renders nested components using `call`', () => {
@@ -39,7 +39,7 @@ describe('Inset text', () => {
       const $ = render('inset-text', examples['html as text'])
 
       const content = $('.govuk-inset-text').html().trim()
-      expect(content).toEqual(
+      expect(content).toBe(
         'It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.'
       )
     })
@@ -55,7 +55,7 @@ describe('Inset text', () => {
         .text()
         .trim()
 
-      expect(mainContent).toEqual(
+      expect(mainContent).toBe(
         'It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.'
       )
 
@@ -74,7 +74,7 @@ describe('Inset text', () => {
       const $ = render('inset-text', examples.attributes)
 
       const $component = $('.govuk-inset-text')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/label/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/label/template.test.js
@@ -13,7 +13,7 @@ describe('Label', () => {
       const $ = render('label', examples.default)
 
       const $component = $('.govuk-label')
-      expect($component.get(0).tagName).toEqual('label')
+      expect($component.get(0).tagName).toBe('label')
     })
 
     it('does not output anything if no html or text is provided', () => {
@@ -21,7 +21,7 @@ describe('Label', () => {
 
       const $component = $('.govuk-label')
 
-      expect($component.length).toEqual(0)
+      expect($component).toHaveLength(0)
     })
 
     it('allows additional classes to be added to the component', () => {
@@ -35,14 +35,14 @@ describe('Label', () => {
       const $ = render('label', examples.default)
       const labelText = $('.govuk-label').text().trim()
 
-      expect(labelText).toEqual('National Insurance number')
+      expect(labelText).toBe('National Insurance number')
     })
 
     it('allows label text to be passed whilst escaping HTML entities', () => {
       const $ = render('label', examples['html as text'])
 
       const labelText = $('.govuk-label').html().trim()
-      expect(labelText).toEqual(
+      expect(labelText).toBe(
         'National Insurance number, &lt;em&gt;NINO&lt;/em&gt;'
       )
     })
@@ -51,14 +51,14 @@ describe('Label', () => {
       const $ = render('label', examples.html)
 
       const labelText = $('.govuk-label').html().trim()
-      expect(labelText).toEqual('National Insurance number <em>NINO</em>')
+      expect(labelText).toBe('National Insurance number <em>NINO</em>')
     })
 
     it('renders for attribute if specified', () => {
       const $ = render('label', examples.for)
 
       const labelForAttr = $('.govuk-label').attr('for')
-      expect(labelForAttr).toEqual('test-target-element')
+      expect(labelForAttr).toBe('test-target-element')
     })
 
     it('can be nested inside an H1 using isPageHeading', () => {
@@ -72,8 +72,8 @@ describe('Label', () => {
       const $ = render('label', examples.attributes)
 
       const $component = $('.govuk-label')
-      expect($component.attr('first-attribute')).toEqual('foo')
-      expect($component.attr('second-attribute')).toEqual('bar')
+      expect($component.attr('first-attribute')).toBe('foo')
+      expect($component.attr('second-attribute')).toBe('bar')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -20,7 +20,7 @@ describe('Notification banner', () => {
         el.getAttribute('tabindex')
       )
 
-      expect(tabindex).toEqual('-1')
+      expect(tabindex).toBe('-1')
     })
 
     it('is automatically focused when the page loads', async () => {
@@ -162,7 +162,7 @@ describe('Notification banner', () => {
           el.getAttribute('tabindex')
         )
 
-        expect(tabindex).toEqual('-1')
+        expect(tabindex).toBe('-1')
       })
 
       it('is automatically focused when the page loads', async () => {
@@ -214,7 +214,7 @@ describe('Notification banner', () => {
         const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
           el.getAttribute('tabindex')
         )
-        expect(tabindex).toEqual('2')
+        expect(tabindex).toBe('2')
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
@@ -23,16 +23,14 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples.default)
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('role')).toEqual('region')
+      expect($component.attr('role')).toBe('region')
     })
 
     it('has data-module attribute to initialise JavaScript', () => {
       const $ = render('notification-banner', examples.default)
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('data-module')).toEqual(
-        'govuk-notification-banner'
-      )
+      expect($component.attr('data-module')).toBe('govuk-notification-banner')
     })
 
     it('renders header container', () => {
@@ -46,21 +44,21 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples.default)
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.get(0).tagName).toEqual('h2')
+      expect($title.get(0).tagName).toBe('h2')
     })
 
     it('renders default title text', () => {
       const $ = render('notification-banner', examples.default)
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.html().trim()).toEqual('Important')
+      expect($title.html().trim()).toBe('Important')
     })
 
     it('renders content', () => {
       const $ = render('notification-banner', examples.default)
       const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual(
+      expect($content.html().trim()).toBe(
         'This publication was withdrawn on 7 March 2014.'
       )
     })
@@ -71,14 +69,14 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['custom title'])
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.html().trim()).toEqual('Important information')
+      expect($title.html().trim()).toBe('Important information')
     })
 
     it('renders custom content', () => {
       const $ = render('notification-banner', examples['custom text'])
       const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual(
+      expect($content.html().trim()).toBe(
         'This publication was withdrawn on 7 March 2014.'
       )
     })
@@ -90,14 +88,14 @@ describe('Notification-banner', () => {
       )
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.get(0).tagName).toEqual('h3')
+      expect($title.get(0).tagName).toBe('h3')
     })
 
     it('renders custom role', () => {
       const $ = render('notification-banner', examples['custom role'])
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('role')).toEqual('banner')
+      expect($component.attr('role')).toBe('banner')
     })
 
     it('renders aria-labelledby attribute matching the title id when role overridden to region', () => {
@@ -115,14 +113,14 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['custom title id'])
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.attr('id')).toEqual('my-id')
+      expect($title.attr('id')).toBe('my-id')
     })
 
     it('has an aria-labelledby attribute matching the title id', () => {
       const $ = render('notification-banner', examples['custom title id'])
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
 
-      expect(ariaAttr).toEqual('my-id')
+      expect(ariaAttr).toBe('my-id')
     })
 
     it('adds data-disable-auto-focus="true" if disableAutoFocus is true', () => {
@@ -156,7 +154,7 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples.attributes)
 
       const $component = $('.govuk-notification-banner')
-      expect($component.attr('my-attribute')).toEqual('value')
+      expect($component.attr('my-attribute')).toBe('value')
     })
   })
 
@@ -165,7 +163,7 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['title html as text'])
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.html().trim()).toEqual(
+      expect($title.html().trim()).toBe(
         '&lt;span&gt;Important information&lt;/span&gt;'
       )
     })
@@ -184,7 +182,7 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['title as html'])
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.html().trim()).toEqual('<span>Important information</span>')
+      expect($title.html().trim()).toBe('<span>Important information</span>')
     })
 
     it('renders content as escaped html when passed as text', () => {
@@ -235,14 +233,14 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['with type as success'])
 
       const $component = $('.govuk-notification-banner')
-      expect($component.attr('role')).toEqual('alert')
+      expect($component.attr('role')).toBe('alert')
     })
 
     it('does render aria-labelledby', () => {
       const $ = render('notification-banner', examples['with type as success'])
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('aria-labelledby')).toEqual(
+      expect($component.attr('aria-labelledby')).toBe(
         'govuk-notification-banner-title'
       )
     })
@@ -251,14 +249,14 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['with type as success'])
       const $component = $('.govuk-notification-banner__title')
 
-      expect($component.attr('id')).toEqual('govuk-notification-banner-title')
+      expect($component.attr('id')).toBe('govuk-notification-banner-title')
     })
 
     it('renders default success title text', () => {
       const $ = render('notification-banner', examples['with type as success'])
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.html().trim()).toEqual('Success')
+      expect($title.html().trim()).toBe('Success')
     })
 
     it('renders custom title id and aria-labelledby', () => {
@@ -269,8 +267,8 @@ describe('Notification-banner', () => {
       const $component = $('.govuk-notification-banner')
       const $title = $('.govuk-notification-banner__title')
 
-      expect($component.attr('aria-labelledby')).toEqual('my-id')
-      expect($title.attr('id')).toEqual('my-id')
+      expect($component.attr('aria-labelledby')).toBe('my-id')
+      expect($title.attr('id')).toBe('my-id')
     })
   })
 
@@ -279,7 +277,7 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['with invalid type'])
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('role')).toEqual('region')
+      expect($component.attr('role')).toBe('region')
     })
 
     it('aria-labelledby attribute matches the title id', () => {

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
@@ -23,11 +23,11 @@ describe('Pagination', () => {
         '.govuk-pagination__item:last-child .govuk-pagination__link'
       )
 
-      expect($previous.attr('href')).toEqual('/previous')
-      expect($next.attr('href')).toEqual('/next')
-      expect($firstNumber.attr('href')).toEqual('/page/1')
-      expect($secondNumber.attr('href')).toEqual('/page/2')
-      expect($thirdNumber.attr('href')).toEqual('/page/3')
+      expect($previous.attr('href')).toBe('/previous')
+      expect($next.attr('href')).toBe('/next')
+      expect($firstNumber.attr('href')).toBe('/page/1')
+      expect($secondNumber.attr('href')).toBe('/page/2')
+      expect($thirdNumber.attr('href')).toBe('/page/3')
     })
 
     it('renders the correct number within each pagination item', () => {
@@ -36,9 +36,9 @@ describe('Pagination', () => {
       const $secondNumber = $('.govuk-pagination__item:nth-child(2)')
       const $thirdNumber = $('.govuk-pagination__item:last-child')
 
-      expect($firstNumber.text().trim()).toEqual('1')
-      expect($secondNumber.text().trim()).toEqual('2')
-      expect($thirdNumber.text().trim()).toEqual('3')
+      expect($firstNumber.text().trim()).toBe('1')
+      expect($secondNumber.text().trim()).toBe('2')
+      expect($thirdNumber.text().trim()).toBe('3')
     })
 
     // The current item is marked up with a visually hidden span and an aria-hidden span side by side
@@ -49,7 +49,7 @@ describe('Pagination', () => {
       const $currentNumber = $('.govuk-pagination__item--current')
       const $currentNumberLink = $currentNumber.find('.govuk-pagination__link')
 
-      expect($currentNumberLink.attr('aria-current')).toEqual('page')
+      expect($currentNumberLink.attr('aria-current')).toBe('page')
     })
 
     it('marks up pagination items as ellipses when specified', () => {
@@ -60,7 +60,7 @@ describe('Pagination', () => {
 
       expect($firstEllipsis).toBeTruthy()
       // Test for the unicode character of &ctdot;
-      expect($firstEllipsis.text().trim()).toEqual('\u22ef')
+      expect($firstEllipsis.text().trim()).toBe('\u22ef')
     })
   })
 
@@ -72,7 +72,7 @@ describe('Pagination', () => {
       )
       const $nav = $('.govuk-pagination')
 
-      expect($nav.attr('aria-label')).toEqual('search')
+      expect($nav.attr('aria-label')).toBe('search')
     })
 
     it('renders custom pagination item and prev/next link text', () => {
@@ -83,11 +83,11 @@ describe('Pagination', () => {
       const $secondNumber = $('.govuk-pagination__item:nth-child(2)')
       const $thirdNumber = $('.govuk-pagination__item:last-child')
 
-      expect($previous.text().trim()).toEqual('Previous page')
-      expect($next.text().trim()).toEqual('Next page')
-      expect($firstNumber.text().trim()).toEqual('one')
-      expect($secondNumber.text().trim()).toEqual('two')
-      expect($thirdNumber.text().trim()).toEqual('three')
+      expect($previous.text().trim()).toBe('Previous page')
+      expect($next.text().trim()).toBe('Next page')
+      expect($firstNumber.text().trim()).toBe('one')
+      expect($secondNumber.text().trim()).toBe('two')
+      expect($thirdNumber.text().trim()).toBe('three')
     })
 
     it('renders custom accessible labels for pagination items', () => {
@@ -105,11 +105,11 @@ describe('Pagination', () => {
         '.govuk-pagination__item:last-child .govuk-pagination__link'
       )
 
-      expect($firstNumber.attr('aria-label')).toEqual('1st page')
-      expect($secondNumber.attr('aria-label')).toEqual(
+      expect($firstNumber.attr('aria-label')).toBe('1st page')
+      expect($secondNumber.attr('aria-label')).toBe(
         '2nd page (you are currently on this page)'
       )
-      expect($thirdNumber.attr('aria-label')).toEqual('3rd page')
+      expect($thirdNumber.attr('aria-label')).toBe('3rd page')
     })
   })
 
@@ -119,8 +119,8 @@ describe('Pagination', () => {
       const $previous = $('.govuk-pagination__prev .govuk-pagination__link')
       const $next = $('.govuk-pagination__next .govuk-pagination__link')
 
-      expect($previous.attr('rel')).toEqual('prev')
-      expect($next.attr('rel')).toEqual('next')
+      expect($previous.attr('rel')).toBe('prev')
+      expect($next.attr('rel')).toBe('next')
     })
 
     it('sets aria-hidden="true" to each link so that they are ignored by assistive technology', () => {
@@ -128,8 +128,8 @@ describe('Pagination', () => {
       const $previousSvg = $('.govuk-pagination__icon--prev')
       const $nextSvg = $('.govuk-pagination__icon--next')
 
-      expect($previousSvg.attr('aria-hidden')).toEqual('true')
-      expect($nextSvg.attr('aria-hidden')).toEqual('true')
+      expect($previousSvg.attr('aria-hidden')).toBe('true')
+      expect($nextSvg.attr('aria-hidden')).toBe('true')
     })
 
     it('sets focusable="false" so that IE does not treat it as an interactive element', () => {
@@ -137,8 +137,8 @@ describe('Pagination', () => {
       const $previousSvg = $('.govuk-pagination__icon--prev')
       const $nextSvg = $('.govuk-pagination__icon--next')
 
-      expect($previousSvg.attr('focusable')).toEqual('false')
-      expect($nextSvg.attr('focusable')).toEqual('false')
+      expect($previousSvg.attr('focusable')).toBe('false')
+      expect($nextSvg.attr('focusable')).toBe('false')
     })
   })
 
@@ -166,8 +166,8 @@ describe('Pagination', () => {
         '.govuk-pagination__next .govuk-pagination__link-label'
       )
 
-      expect($prevLabel.text()).toEqual('Paying VAT and duty')
-      expect($nextLabel.text()).toEqual('Registering an imported vehicle')
+      expect($prevLabel.text()).toBe('Paying VAT and duty')
+      expect($nextLabel.text()).toBe('Registering an imported vehicle')
     })
 
     // This is for when pagination is in block mode but there isn't a label
@@ -198,8 +198,8 @@ describe('Pagination', () => {
       const $ = render('pagination', examples['with custom attributes'])
       const $nav = $('.govuk-pagination')
 
-      expect($nav.attr('data-attribute-1')).toEqual('value-1')
-      expect($nav.attr('data-attribute-2')).toEqual('value-2')
+      expect($nav.attr('data-attribute-1')).toBe('value-1')
+      expect($nav.attr('data-attribute-2')).toBe('value-2')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -13,21 +13,21 @@ describe('Panel', () => {
       const $ = render('panel', examples.default)
       const panelTitle = $('.govuk-panel__title').text().trim()
 
-      expect(panelTitle).toEqual('Application complete')
+      expect(panelTitle).toBe('Application complete')
     })
 
     it('renders title as h1 (as the default heading level)', () => {
       const $ = render('panel', examples.default)
       const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
 
-      expect(panelTitleHeadingLevel).toEqual('h1')
+      expect(panelTitleHeadingLevel).toBe('h1')
     })
 
     it('renders body text', () => {
       const $ = render('panel', examples.default)
       const panelBodyText = $('.govuk-panel__body').text().trim()
 
-      expect(panelBodyText).toEqual('Your reference number: HDJ2123F')
+      expect(panelBodyText).toBe('Your reference number: HDJ2123F')
     })
 
     it('doesnt render panel body if no body text is passed', () => {
@@ -43,7 +43,7 @@ describe('Panel', () => {
       const $ = render('panel', examples['title html as text'])
 
       const panelTitle = $('.govuk-panel__title').html().trim()
-      expect(panelTitle).toEqual(
+      expect(panelTitle).toBe(
         'Application &lt;strong&gt;not&lt;/strong&gt; complete'
       )
     })
@@ -52,14 +52,14 @@ describe('Panel', () => {
       const $ = render('panel', examples['custom heading level'])
       const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
 
-      expect(panelTitleHeadingLevel).toEqual('h2')
+      expect(panelTitleHeadingLevel).toBe('h2')
     })
 
     it('allows title HTML to be passed un-escaped', () => {
       const $ = render('panel', examples['title html'])
 
       const panelTitle = $('.govuk-panel__title').html().trim()
-      expect(panelTitle).toEqual('Application <strong>not</strong> complete')
+      expect(panelTitle).toBe('Application <strong>not</strong> complete')
     })
 
     it('renders nested components using `call`', () => {
@@ -74,7 +74,7 @@ describe('Panel', () => {
       const $ = render('panel', examples['body html as text'])
 
       const panelBodyText = $('.govuk-panel__body').html().trim()
-      expect(panelBodyText).toEqual(
+      expect(panelBodyText).toBe(
         'Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;'
       )
     })
@@ -83,7 +83,7 @@ describe('Panel', () => {
       const $ = render('panel', examples['body html'])
 
       const panelBodyText = $('.govuk-panel__body').html().trim()
-      expect(panelBodyText).toEqual(
+      expect(panelBodyText).toBe(
         'Your reference number<br><strong>HDJ2123F</strong>'
       )
     })
@@ -99,8 +99,8 @@ describe('Panel', () => {
       const $ = render('panel', examples.attributes)
 
       const $component = $('.govuk-panel')
-      expect($component.attr('first-attribute')).toEqual('foo')
-      expect($component.attr('second-attribute')).toEqual('bar')
+      expect($component.attr('first-attribute')).toBe('foo')
+      expect($component.attr('second-attribute')).toBe('bar')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/template.test.js
@@ -21,7 +21,7 @@ describe('Phase banner', () => {
       const $ = render('phase-banner', examples.text)
       const phaseBannerText = $('.govuk-phase-banner__text').text().trim()
 
-      expect(phaseBannerText).toEqual(
+      expect(phaseBannerText).toBe(
         'This is a new service – your feedback will help us to improve it'
       )
     })
@@ -30,7 +30,7 @@ describe('Phase banner', () => {
       const $ = render('phase-banner', examples['html as text'])
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
-      expect(phaseBannerText).toEqual(
+      expect(phaseBannerText).toBe(
         'This is a new service - your &lt;a href="#" class="govuk-link"&gt;feedback&lt;/a&gt; will help us to improve it.'
       )
     })
@@ -39,7 +39,7 @@ describe('Phase banner', () => {
       const $ = render('phase-banner', examples.default)
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
-      expect(phaseBannerText).toEqual(
+      expect(phaseBannerText).toBe(
         'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
       )
     })
@@ -48,8 +48,8 @@ describe('Phase banner', () => {
       const $ = render('phase-banner', examples.attributes)
 
       const $component = $('.govuk-phase-banner')
-      expect($component.attr('first-attribute')).toEqual('foo')
-      expect($component.attr('second-attribute')).toEqual('bar')
+      expect($component.attr('first-attribute')).toBe('foo')
+      expect($component.attr('second-attribute')).toBe('bar')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -56,8 +56,8 @@ describe('Radios', () => {
         })
 
         it('includes the expected number of inputs and conditionals', () => {
-          expect($inputs.length).toBe(3)
-          expect($conditionals.length).toBe(3)
+          expect($inputs).toHaveLength(3)
+          expect($conditionals).toHaveLength(3)
         })
 
         it('has no ARIA attributes applied', async () => {
@@ -68,8 +68,8 @@ describe('Radios', () => {
             '.govuk-radios__input[aria-controls]'
           )
 
-          expect($inputsWithAriaExpanded.length).toBe(0)
-          expect($inputsWithAriaControls.length).toBe(0)
+          expect($inputsWithAriaExpanded).toHaveLength(0)
+          expect($inputsWithAriaControls).toHaveLength(0)
         })
 
         it('falls back to making all conditional content visible', async () => {

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -19,14 +19,14 @@ describe('Radios', () => {
 
     const $firstInput = $component.find('.govuk-radios__item:first-child input')
     const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-    expect($firstInput.attr('name')).toEqual('example-default')
-    expect($firstInput.val()).toEqual('yes')
+    expect($firstInput.attr('name')).toBe('example-default')
+    expect($firstInput.val()).toBe('yes')
     expect($firstLabel.text()).toContain('Yes')
 
     const $lastInput = $component.find('.govuk-radios__item:last-child input')
     const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-    expect($lastInput.attr('name')).toEqual('example-default')
-    expect($lastInput.val()).toEqual('no')
+    expect($lastInput.attr('name')).toBe('example-default')
+    expect($lastInput.val()).toBe('no')
     expect($lastLabel.text()).toContain('No')
   })
 
@@ -35,7 +35,7 @@ describe('Radios', () => {
 
     const $component = $('.govuk-radios')
     const $items = $component.find('.govuk-radios__item input')
-    expect($items.length).toEqual(2)
+    expect($items).toHaveLength(2)
   })
 
   it('render classes', () => {
@@ -60,8 +60,8 @@ describe('Radios', () => {
 
     const $component = $('.govuk-radios')
 
-    expect($component.attr('data-attribute')).toEqual('value')
-    expect($component.attr('data-second-attribute')).toEqual('second-value')
+    expect($component.attr('data-attribute')).toBe('value')
+    expect($component.attr('data-second-attribute')).toBe('second-value')
   })
 
   it('render a custom class on the form group', () => {
@@ -86,13 +86,13 @@ describe('Radios', () => {
       const $firstLabel = $component.find(
         '.govuk-radios__item:first-child label'
       )
-      expect($firstInput.attr('id')).toEqual('example-default')
-      expect($firstLabel.attr('for')).toEqual('example-default')
+      expect($firstInput.attr('id')).toBe('example-default')
+      expect($firstLabel.attr('for')).toBe('example-default')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('example-default-2')
-      expect($lastLabel.attr('for')).toEqual('example-default-2')
+      expect($lastInput.attr('id')).toBe('example-default-2')
+      expect($lastLabel.attr('for')).toBe('example-default-2')
     })
 
     it('render a matching label and input using custom idPrefix', () => {
@@ -106,13 +106,13 @@ describe('Radios', () => {
       const $firstLabel = $component.find(
         '.govuk-radios__item:first-child label'
       )
-      expect($firstInput.attr('id')).toEqual('example-id-prefix')
-      expect($firstLabel.attr('for')).toEqual('example-id-prefix')
+      expect($firstInput.attr('id')).toBe('example-id-prefix')
+      expect($firstLabel.attr('for')).toBe('example-id-prefix')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('example-id-prefix-2')
-      expect($lastLabel.attr('for')).toEqual('example-id-prefix-2')
+      expect($lastInput.attr('id')).toBe('example-id-prefix-2')
+      expect($lastLabel.attr('for')).toBe('example-id-prefix-2')
     })
 
     it('render disabled', () => {
@@ -121,7 +121,7 @@ describe('Radios', () => {
       const $component = $('.govuk-radios')
 
       const $lastInput = $component.find('input[value="verify"]')
-      expect($lastInput.attr('disabled')).toEqual('disabled')
+      expect($lastInput.attr('disabled')).toBe('disabled')
     })
 
     it('render checked', () => {
@@ -129,7 +129,7 @@ describe('Radios', () => {
 
       const $component = $('.govuk-radios')
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
-      expect($lastInput.attr('checked')).toEqual('checked')
+      expect($lastInput.attr('checked')).toBe('checked')
     })
 
     it('checks the radio that matches value', () => {
@@ -137,7 +137,7 @@ describe('Radios', () => {
 
       const $component = $('.govuk-radios')
       const $lastInput = $component.find('input[value="no"]')
-      expect($lastInput.attr('checked')).toEqual('checked')
+      expect($lastInput.attr('checked')).toBe('checked')
     })
 
     it('allows item.checked to override value', () => {
@@ -156,14 +156,14 @@ describe('Radios', () => {
         const $firstInput = $component.find(
           '.govuk-radios__item:first-child input'
         )
-        expect($firstInput.attr('data-attribute')).toEqual('ABC')
-        expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
+        expect($firstInput.attr('data-attribute')).toBe('ABC')
+        expect($firstInput.attr('data-second-attribute')).toBe('DEF')
 
         const $lastInput = $component.find(
           '.govuk-radios__item:last-child input'
         )
-        expect($lastInput.attr('data-attribute')).toEqual('GHI')
-        expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
+        expect($lastInput.attr('data-attribute')).toBe('GHI')
+        expect($lastInput.attr('data-second-attribute')).toBe('JKL')
       })
     })
 
@@ -253,7 +253,7 @@ describe('Radios', () => {
         const $ = render('radios', examples['with empty conditional'])
 
         const $component = $('.govuk-radios')
-        expect($component.find('.govuk-radios__conditional').length).toEqual(0)
+        expect($component.find('.govuk-radios__conditional')).toHaveLength(0)
       })
 
       it('does not associate radios with empty conditionals', () => {
@@ -324,7 +324,7 @@ describe('Radios', () => {
       const $ = render('radios', examples['with error message and idPrefix'])
       const $errorMessage = $('.govuk-error-message')
 
-      expect($errorMessage.attr('id')).toEqual('id-prefix-error')
+      expect($errorMessage.attr('id')).toBe('id-prefix-error')
     })
 
     it('falls back to using the name for the error message id', () => {
@@ -332,7 +332,7 @@ describe('Radios', () => {
 
       const $errorMessage = $('.govuk-error-message')
 
-      expect($errorMessage.attr('id')).toEqual('example-error-message-error')
+      expect($errorMessage.attr('id')).toBe('example-error-message-error')
     })
 
     it('associates the fieldset as "described by" the error message', () => {

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -17,48 +17,48 @@ describe('Select', () => {
       const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
-      expect($component.attr('id')).toEqual('select-1')
+      expect($component.attr('id')).toBe('select-1')
     })
 
     it('renders with name', () => {
       const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
-      expect($component.attr('name')).toEqual('select-1')
+      expect($component.attr('name')).toBe('select-1')
     })
 
     it('renders with items', () => {
       const $ = render('select', examples.default)
       const $items = $('.govuk-select option')
-      expect($items.length).toEqual(3)
+      expect($items).toHaveLength(3)
     })
 
     it('includes the value attribute', () => {
       const $ = render('select', examples.default)
 
       const $firstItem = $('.govuk-select option:first-child')
-      expect($firstItem.attr('value')).toEqual('1')
+      expect($firstItem.attr('value')).toBe('1')
     })
 
     it('includes the value attribute when the value option is an empty string', () => {
       const $ = render('select', examples['with falsey values'])
 
       const $firstItem = $('.govuk-select option:nth(0)')
-      expect($firstItem.attr('value')).toEqual('')
+      expect($firstItem.attr('value')).toBe('')
     })
 
     it('includes the value attribute when the value option is false', () => {
       const $ = render('select', examples['with falsey values'])
 
       const $secondItem = $('.govuk-select option:nth(1)')
-      expect($secondItem.attr('value')).toEqual('false')
+      expect($secondItem.attr('value')).toBe('false')
     })
 
     it('includes the value attribute when the value option is 0', () => {
       const $ = render('select', examples['with falsey values'])
 
       const $thirdItem = $('.govuk-select option:nth(2)')
-      expect($thirdItem.attr('value')).toEqual('0')
+      expect($thirdItem.attr('value')).toBe('0')
     })
 
     it('omits the value attribute if no value option is provided', () => {
@@ -74,7 +74,7 @@ describe('Select', () => {
       const $ = render('select', examples.default)
 
       const $firstItem = $('.govuk-select option:first-child')
-      expect($firstItem.text()).toEqual('GOV.UK frontend option 1')
+      expect($firstItem.text()).toBe('GOV.UK frontend option 1')
     })
 
     it('renders item with selected', () => {
@@ -130,7 +130,7 @@ describe('Select', () => {
       const $ = render('select', examples['with falsey items'])
 
       const $items = $('.govuk-select option')
-      expect($items.length).toEqual(2)
+      expect($items).toHaveLength(2)
     })
   })
 
@@ -153,7 +153,7 @@ describe('Select', () => {
       const $ = render('select', examples.attributes)
 
       const $component = $('.govuk-select')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
 
     it('renders with attributes on items', () => {
@@ -162,12 +162,12 @@ describe('Select', () => {
       const $component = $('.govuk-select')
 
       const $firstInput = $component.find('option:first-child')
-      expect($firstInput.attr('data-attribute')).toEqual('ABC')
-      expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
+      expect($firstInput.attr('data-attribute')).toBe('ABC')
+      expect($firstInput.attr('data-second-attribute')).toBe('DEF')
 
       const $secondInput = $component.find('option:last-child')
-      expect($secondInput.attr('data-attribute')).toEqual('GHI')
-      expect($secondInput.attr('data-second-attribute')).toEqual('JKL')
+      expect($secondInput.attr('data-attribute')).toBe('GHI')
+      expect($secondInput.attr('data-second-attribute')).toBe('JKL')
     })
   })
 
@@ -287,7 +287,7 @@ describe('Select', () => {
       const $ = render('select', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('select-1')
+      expect($label.attr('for')).toBe('select-1')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/template.test.js
@@ -13,14 +13,14 @@ describe('Skip link', () => {
       const $ = render('skip-link', examples.default)
 
       const $component = $('.govuk-skip-link')
-      expect($component.html()).toEqual('Skip to main content')
+      expect($component.html()).toBe('Skip to main content')
     })
 
     it('renders default href', () => {
       const $ = render('skip-link', examples['no href'])
 
       const $component = $('.govuk-skip-link')
-      expect($component.attr('href')).toEqual('#content')
+      expect($component.attr('href')).toBe('#content')
     })
   })
 
@@ -29,28 +29,28 @@ describe('Skip link', () => {
       const $ = render('skip-link', examples['custom href'])
 
       const $component = $('.govuk-skip-link')
-      expect($component.attr('href')).toEqual('#custom')
+      expect($component.attr('href')).toBe('#custom')
     })
 
     it('renders text', () => {
       const $ = render('skip-link', examples['custom text'])
 
       const $component = $('.govuk-skip-link')
-      expect($component.html()).toEqual('skip')
+      expect($component.html()).toBe('skip')
     })
 
     it('renders escaped html in text', () => {
       const $ = render('skip-link', examples['html as text'])
 
       const $component = $('.govuk-skip-link')
-      expect($component.html()).toEqual('&lt;p&gt;skip&lt;/p&gt;')
+      expect($component.html()).toBe('&lt;p&gt;skip&lt;/p&gt;')
     })
 
     it('renders html', () => {
       const $ = render('skip-link', examples.html)
 
       const $component = $('.govuk-skip-link')
-      expect($component.html()).toEqual('<p>skip</p>')
+      expect($component.html()).toBe('<p>skip</p>')
     })
 
     it('renders classes', () => {
@@ -64,8 +64,8 @@ describe('Skip link', () => {
       const $ = render('skip-link', examples.attributes)
 
       const $component = $('.govuk-skip-link')
-      expect($component.attr('data-test')).toEqual('attribute')
-      expect($component.attr('aria-label')).toEqual('Skip to content')
+      expect($component.attr('data-test')).toBe('attribute')
+      expect($component.attr('aria-label')).toBe('Skip to content')
     })
 
     it('renders a data-module attribute to initialise JavaScript', () => {
@@ -73,7 +73,7 @@ describe('Skip link', () => {
 
       const $component = $('.govuk-skip-link')
 
-      expect($component.attr('data-module')).toEqual('govuk-skip-link')
+      expect($component.attr('data-module')).toBe('govuk-skip-link')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
@@ -20,8 +20,8 @@ describe('Summary list', () => {
       const $ = render('summary-list', examples.attributes)
 
       const $component = $('.govuk-summary-list')
-      expect($component.attr('data-attribute-1')).toEqual('value-1')
-      expect($component.attr('data-attribute-2')).toEqual('value-2')
+      expect($component.attr('data-attribute-1')).toBe('value-1')
+      expect($component.attr('data-attribute-2')).toBe('value-2')
     })
   })
 
@@ -31,7 +31,7 @@ describe('Summary list', () => {
 
       const $component = $('.govuk-summary-list')
       const $row = $component.find('.govuk-summary-list__row')
-      expect($row.length).toBe(2)
+      expect($row).toHaveLength(2)
     })
 
     it('renders classes', async () => {
@@ -162,8 +162,8 @@ describe('Summary list', () => {
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
 
-        expect($actionLink.attr('data-test-attribute')).toEqual('value')
-        expect($actionLink.attr('data-test-attribute-2')).toEqual('value-2')
+        expect($actionLink.attr('data-test-attribute')).toBe('value')
+        expect($actionLink.attr('data-test-attribute-2')).toBe('value-2')
       })
 
       it('renders a single anchor with one action', async () => {
@@ -202,7 +202,7 @@ describe('Summary list', () => {
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
 
-        expect($action.length).toEqual(0)
+        expect($action).toHaveLength(0)
       })
 
       it('skips the action column when no items are in the array provided', async () => {
@@ -211,7 +211,7 @@ describe('Summary list', () => {
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
 
-        expect($action.length).toEqual(0)
+        expect($action).toHaveLength(0)
       })
 
       describe('when only some rows have actions', () => {
@@ -278,7 +278,7 @@ describe('Summary list', () => {
         )
 
         const $actionItems = $('.govuk-summary-card__action')
-        expect($actionItems.length).toBe(2)
+        expect($actionItems).toHaveLength(2)
       })
 
       it('does not render a list if only one action is present', () => {
@@ -289,7 +289,7 @@ describe('Summary list', () => {
 
         const $singleAction = $('.govuk-summary-card__actions > a')
         const $actionItems = $('.govuk-summary-card__action')
-        expect($actionItems.length).toBe(0)
+        expect($actionItems).toHaveLength(0)
         expect($singleAction.text().trim()).toBe(
           'My lonely action (Undergraduate teaching assistant)'
         )
@@ -326,7 +326,7 @@ describe('Summary list', () => {
         )
 
         const $title = $('.govuk-summary-card__title')
-        expect($title.get(0).tagName).toEqual('h3')
+        expect($title.get(0).tagName).toBe('h3')
       })
     })
 
@@ -353,8 +353,8 @@ describe('Summary list', () => {
         const $card = $('.govuk-summary-card')
         expect($list.attr('data-attribute-1')).toBeFalsy()
         expect($list.attr('data-attribute-2')).toBeFalsy()
-        expect($card.attr('data-attribute-1')).toEqual('value-1')
-        expect($card.attr('data-attribute-2')).toEqual('value-2')
+        expect($card.attr('data-attribute-1')).toBe('value-1')
+        expect($card.attr('data-attribute-2')).toBe('value-2')
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/table/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/table/template.test.js
@@ -17,7 +17,7 @@ describe('Table', () => {
   it('can have additional attributes', () => {
     const $ = render('table', examples.attributes)
 
-    expect($('.govuk-table').attr('data-foo')).toEqual('bar')
+    expect($('.govuk-table').attr('data-foo')).toBe('bar')
   })
 
   // =========================================================
@@ -66,7 +66,7 @@ describe('Table', () => {
 
       const $th = $('.govuk-table thead tr th')
 
-      expect($th.html()).toEqual(
+      expect($th.html()).toBe(
         'Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;'
       )
     })
@@ -76,7 +76,7 @@ describe('Table', () => {
 
       const $th = $('.govuk-table thead tr th')
 
-      expect($th.html()).toEqual('Foo <span>bar</span>')
+      expect($th.html()).toBe('Foo <span>bar</span>')
     })
 
     it('can have a format specified', () => {
@@ -100,7 +100,7 @@ describe('Table', () => {
 
       const $th = $('.govuk-table thead tr th')
 
-      expect($th.attr('rowspan')).toEqual('2')
+      expect($th.attr('rowspan')).toBe('2')
     })
 
     it('can have colspan specified', () => {
@@ -108,7 +108,7 @@ describe('Table', () => {
 
       const $th = $('.govuk-table thead tr th')
 
-      expect($th.attr('colspan')).toEqual('2')
+      expect($th.attr('colspan')).toBe('2')
     })
 
     it('can have additional attributes', () => {
@@ -116,7 +116,7 @@ describe('Table', () => {
 
       const $th = $('.govuk-table thead tr th')
 
-      expect($th.attr('data-fizz')).toEqual('buzz')
+      expect($th.attr('data-fizz')).toBe('buzz')
     })
   })
 
@@ -168,7 +168,7 @@ describe('Table', () => {
 
         const $th = $('.govuk-table tbody tr th')
 
-        expect($th.html()).toEqual(
+        expect($th.html()).toBe(
           'Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;'
         )
       })
@@ -178,7 +178,7 @@ describe('Table', () => {
 
         const $th = $('.govuk-table tbody tr th')
 
-        expect($th.html()).toEqual('Foo <span>bar</span>')
+        expect($th.html()).toBe('Foo <span>bar</span>')
       })
 
       it('are associated with their rows using scope="row"', () => {
@@ -186,7 +186,7 @@ describe('Table', () => {
 
         const $th = $('.govuk-table').find('tbody tr th')
 
-        expect($th.attr('scope')).toEqual('row')
+        expect($th.attr('scope')).toBe('row')
       })
 
       it('have the govuk-table__header class', () => {
@@ -213,7 +213,7 @@ describe('Table', () => {
 
         const $th = $('.govuk-table').find('tbody tr th')
 
-        expect($th.attr('rowspan')).toEqual('2')
+        expect($th.attr('rowspan')).toBe('2')
       })
 
       it('can have colspan specified', () => {
@@ -224,7 +224,7 @@ describe('Table', () => {
 
         const $th = $('.govuk-table').find('tbody tr th')
 
-        expect($th.attr('colspan')).toEqual('2')
+        expect($th.attr('colspan')).toBe('2')
       })
 
       it('can have additional attributes', () => {
@@ -232,7 +232,7 @@ describe('Table', () => {
 
         const $th = $('.govuk-table').find('tbody tr th')
 
-        expect($th.attr('data-fizz')).toEqual('buzz')
+        expect($th.attr('data-fizz')).toBe('buzz')
       })
     })
   })
@@ -291,7 +291,7 @@ describe('Table', () => {
 
       const $td = $('.govuk-table td')
 
-      expect($td.html()).toEqual(
+      expect($td.html()).toBe(
         'Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;'
       )
     })
@@ -301,7 +301,7 @@ describe('Table', () => {
 
       const $td = $('.govuk-table td')
 
-      expect($td.html()).toEqual('Foo <span>bar</span>')
+      expect($td.html()).toBe('Foo <span>bar</span>')
     })
 
     it('can have a format specified', () => {
@@ -325,7 +325,7 @@ describe('Table', () => {
 
       const $td = $('.govuk-table td')
 
-      expect($td.attr('rowspan')).toEqual('2')
+      expect($td.attr('rowspan')).toBe('2')
     })
 
     it('can have colspan specified', () => {
@@ -333,7 +333,7 @@ describe('Table', () => {
 
       const $td = $('.govuk-table td')
 
-      expect($td.attr('colspan')).toEqual('2')
+      expect($td.attr('colspan')).toBe('2')
     })
 
     it('can have additional attributes', () => {
@@ -341,7 +341,7 @@ describe('Table', () => {
 
       const $td = $('.govuk-table td')
 
-      expect($td.attr('data-fizz')).toEqual('buzz')
+      expect($td.attr('data-fizz')).toBe('buzz')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -44,7 +44,7 @@ describe('/components/tabs', () => {
             )
             .getAttribute('aria-selected')
         )
-        expect(firstTabAriaSelected).toEqual('true')
+        expect(firstTabAriaSelected).toBe('true')
 
         const firstTabClasses = await page.evaluate(
           () =>
@@ -91,7 +91,7 @@ describe('/components/tabs', () => {
             )
             .getAttribute('aria-selected')
         )
-        expect(secondTabAriaSelected).toEqual('true')
+        expect(secondTabAriaSelected).toBe('true')
 
         const secondTabClasses = await page.evaluate(
           () =>
@@ -169,7 +169,7 @@ describe('/components/tabs', () => {
             )
             .getAttribute('aria-selected')
         )
-        expect(secondTabAriaSelected).toEqual('true')
+        expect(secondTabAriaSelected).toBe('true')
 
         const secondTabClasses = await page.evaluate(
           () =>
@@ -211,7 +211,7 @@ describe('/components/tabs', () => {
             .querySelector('.govuk-tabs__tab[href="#past-week"]')
             .getAttribute('aria-selected')
         )
-        expect(currentTabAriaSelected).toEqual('true')
+        expect(currentTabAriaSelected).toBe('true')
 
         const currentTabClasses = await page.evaluate(
           () =>
@@ -236,7 +236,7 @@ describe('/components/tabs', () => {
         const activeElementId = await page.evaluate(
           () => document.activeElement.id
         )
-        expect(activeElementId).toEqual('anchor')
+        expect(activeElementId).toBe('anchor')
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
@@ -39,21 +39,21 @@ describe('Tabs', () => {
       const $ = render('tabs', examples.id)
 
       const $component = $('.govuk-tabs')
-      expect($component.attr('id')).toEqual('my-tabs')
+      expect($component.attr('id')).toBe('my-tabs')
     })
 
     it('allows custom title text to be passed', () => {
       const $ = render('tabs', examples.title)
 
       const content = $('.govuk-tabs__title').html().trim()
-      expect(content).toEqual('Custom title for Contents')
+      expect(content).toBe('Custom title for Contents')
     })
 
     it('renders with attributes', () => {
       const $ = render('tabs', examples.attributes)
 
       const $component = $('.govuk-tabs')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
   })
 
@@ -62,14 +62,14 @@ describe('Tabs', () => {
       const $ = render('tabs', examples['no item list'])
 
       const $component = $('.govuk-tabs')
-      expect($component.find('.govuk-tabs__list').length).toEqual(0)
+      expect($component.find('.govuk-tabs__list')).toHaveLength(0)
     })
 
     it("doesn't render a list if items is empty", () => {
       const $ = render('tabs', examples['empty item list'])
 
       const $component = $('.govuk-tabs')
-      expect($component.find('.govuk-tabs__list').length).toEqual(0)
+      expect($component.find('.govuk-tabs__list')).toHaveLength(0)
     })
 
     it('render a matching tab and panel using item id', () => {
@@ -81,8 +81,8 @@ describe('Tabs', () => {
         '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
       )
       const $firstPanel = $component.find('.govuk-tabs__panel')
-      expect($firstTab.attr('href')).toEqual('#past-day')
-      expect($firstPanel.attr('id')).toEqual('past-day')
+      expect($firstTab.attr('href')).toBe('#past-day')
+      expect($firstPanel.attr('id')).toBe('past-day')
     })
 
     it('render without falsey values', () => {
@@ -91,7 +91,7 @@ describe('Tabs', () => {
       const $component = $('.govuk-tabs')
 
       const $items = $component.find('.govuk-tabs__list-item')
-      expect($items.length).toEqual(2)
+      expect($items).toHaveLength(2)
     })
 
     it('render a matching tab and panel using custom idPrefix', () => {
@@ -103,8 +103,8 @@ describe('Tabs', () => {
         '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
       )
       const $firstPanel = $component.find('.govuk-tabs__panel')
-      expect($firstTab.attr('href')).toEqual('#custom-1')
-      expect($firstPanel.attr('id')).toEqual('custom-1')
+      expect($firstTab.attr('href')).toBe('#custom-1')
+      expect($firstPanel.attr('id')).toBe('custom-1')
     })
 
     it('render the label', () => {
@@ -115,7 +115,7 @@ describe('Tabs', () => {
       const $firstTab = $component.find(
         '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
       )
-      expect($firstTab.text().trim()).toEqual('Past day')
+      expect($firstTab.text().trim()).toBe('Past day')
     })
 
     it('render with panel content as text, wrapped in styled paragraph', () => {
@@ -124,7 +124,7 @@ describe('Tabs', () => {
       const $lastTab = $component.find('.govuk-tabs__panel').last()
 
       expect($lastTab.find('p').hasClass('govuk-body')).toBeTruthy()
-      expect($lastTab.text().trim()).toEqual(
+      expect($lastTab.text().trim()).toBe(
         'There is no data for this year yet, check back later'
       )
     })
@@ -135,7 +135,7 @@ describe('Tabs', () => {
       const $component = $('.govuk-tabs')
 
       const $firstPanel = $component.find('.govuk-tabs__panel .govuk-body')
-      expect($firstPanel.html().trim()).toEqual(
+      expect($firstPanel.html().trim()).toBe(
         '&lt;p&gt;Panel 1 content&lt;/p&gt;'
       )
     })
@@ -146,23 +146,23 @@ describe('Tabs', () => {
       const $component = $('.govuk-tabs')
 
       const $firstPanel = $component.find('.govuk-tabs__panel')
-      expect($firstPanel.html().trim()).toEqual('<p>Panel 1 content</p>')
+      expect($firstPanel.html().trim()).toBe('<p>Panel 1 content</p>')
     })
 
     it('render a tab anchor with attributes', () => {
       const $ = render('tabs', examples['item with attributes'])
 
       const $tabItemLink = $('.govuk-tabs__tab')
-      expect($tabItemLink.attr('data-attribute')).toEqual('my-attribute')
-      expect($tabItemLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($tabItemLink.attr('data-attribute')).toBe('my-attribute')
+      expect($tabItemLink.attr('data-attribute-2')).toBe('my-attribute-2')
     })
 
     it('render a tab panel with attributes', () => {
       const $ = render('tabs', examples['panel with attributes'])
 
       const $tabPanelItems = $('.govuk-tabs__panel')
-      expect($tabPanelItems.attr('data-attribute')).toEqual('my-attribute')
-      expect($tabPanelItems.attr('data-attribute-2')).toEqual('my-attribute-2')
+      expect($tabPanelItems.attr('data-attribute')).toBe('my-attribute')
+      expect($tabPanelItems.attr('data-attribute-2')).toBe('my-attribute-2')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tag/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tag/template.test.js
@@ -13,7 +13,7 @@ describe('Tag', () => {
       const $ = render('tag', examples.default)
 
       const $component = $('.govuk-tag')
-      expect($component.get(0).tagName).toEqual('strong')
+      expect($component.get(0).tagName).toBe('strong')
       expect($component.text()).toContain('Alpha')
     })
 
@@ -37,8 +37,8 @@ describe('Tag', () => {
       const $ = render('tag', examples.attributes)
 
       const $component = $('.govuk-tag')
-      expect($component.attr('data-test')).toEqual('attribute')
-      expect($component.attr('id')).toEqual('my-tag')
+      expect($component.attr('data-test')).toBe('attribute')
+      expect($component.attr('id')).toBe('my-tag')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -12,7 +12,7 @@ describe('Task List', () => {
     const $ = render('task-list', examples.default)
 
     const $component = $('.govuk-task-list')
-    expect($component.get(0).tagName).toEqual('ul')
+    expect($component.get(0).tagName).toBe('ul')
   })
 
   it('allows for custom classes on the root of the component', () => {
@@ -40,7 +40,7 @@ describe('Task List', () => {
     const $ = render('task-list', examples['custom attributes'])
 
     const $component = $('.govuk-task-list')
-    expect($component.attr('data-custom-attribute')).toEqual('custom-value')
+    expect($component.attr('data-custom-attribute')).toBe('custom-value')
   })
 
   describe('when a task has an href set', () => {
@@ -53,7 +53,7 @@ describe('Task List', () => {
 
     it('wraps the task title in a link', async () => {
       const $itemLink = $component.find('a.govuk-task-list__link')
-      expect($itemLink.attr('href')).toEqual('#')
+      expect($itemLink.attr('href')).toBe('#')
     })
 
     it('adds a with-link modifier class to the task', async () => {
@@ -87,7 +87,7 @@ describe('Task List', () => {
 
       const $itemWithLink = $('.govuk-task-list__item:first-child')
       const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
-      expect($itemWithLinkTitle.text().trim()).toEqual(
+      expect($itemWithLinkTitle.text().trim()).toBe(
         '<strong>Linked Title</strong>'
       )
     })
@@ -97,7 +97,7 @@ describe('Task List', () => {
 
       const $itemWithLink = $('.govuk-task-list__item:first-child')
       const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
-      expect($itemWithLinkTitle.html().trim()).toEqual(
+      expect($itemWithLinkTitle.html().trim()).toBe(
         '<strong>Linked Title</strong>'
       )
     })
@@ -178,7 +178,7 @@ describe('Task List', () => {
       const $ = render('task-list', examples['custom attributes'])
 
       const $component = $('.govuk-tag')
-      expect($component.attr('data-tag-attribute')).toEqual('tag-value')
+      expect($component.attr('data-tag-attribute')).toBe('tag-value')
     })
   })
 
@@ -218,7 +218,7 @@ describe('Task List', () => {
 
     it('associates the hint text with the task link using aria', () => {
       const $hintText = $component.find('.govuk-task-list__hint')
-      expect($hintText.attr('id')).toEqual('task-list-3-hint')
+      expect($hintText.attr('id')).toBe('task-list-3-hint')
 
       const $itemAssociatedWithHint = $component.find(
         `.govuk-task-list__link[aria-describedby~="${$hintText.attr('id')}"]`
@@ -251,17 +251,17 @@ describe('Task List', () => {
 
     it('uses the id prefix for the hint id', () => {
       const $hint = $component.find('.govuk-task-list__hint')
-      expect($hint.attr('id')).toEqual('my-custom-id-1-hint')
+      expect($hint.attr('id')).toBe('my-custom-id-1-hint')
     })
 
     it('uses the id prefix for the status', () => {
       const $hint = $component.find('.govuk-task-list__status')
-      expect($hint.attr('id')).toEqual('my-custom-id-1-status')
+      expect($hint.attr('id')).toBe('my-custom-id-1-status')
     })
 
     it('uses the id prefix for the aria-describedby association', () => {
       const $hint = $component.find('.govuk-task-list__link')
-      expect($hint.attr('aria-describedby')).toEqual(
+      expect($hint.attr('aria-describedby')).toBe(
         'my-custom-id-1-hint my-custom-id-1-status'
       )
     })

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
@@ -17,21 +17,21 @@ describe('Textarea', () => {
       const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('id')).toEqual('more-detail')
+      expect($component.attr('id')).toBe('more-detail')
     })
 
     it('renders with name', () => {
       const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('name')).toEqual('more-detail')
+      expect($component.attr('name')).toBe('more-detail')
     })
 
     it('renders with default number of rows', () => {
       const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('rows')).toEqual('5')
+      expect($component.attr('rows')).toBe('5')
     })
 
     it('renders with a form group wrapper', () => {
@@ -54,14 +54,14 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with default value'])
 
       const $component = $('.govuk-textarea')
-      expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
+      expect($component.text()).toBe('221B Baker Street\nLondon\nNW1 6XE\n')
     })
 
     it('renders with attributes', () => {
       const $ = render('textarea', examples.attributes)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toBe('my data value')
     })
 
     it('renders with aria-describedby', () => {
@@ -75,7 +75,7 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with custom rows'])
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('rows')).toEqual('8')
+      expect($component.attr('rows')).toBe('8')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
@@ -91,14 +91,14 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with spellcheck enabled'])
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('spellcheck')).toEqual('true')
+      expect($component.attr('spellcheck')).toBe('true')
     })
 
     it('renders with spellcheck attribute set to false', () => {
       const $ = render('textarea', examples['with spellcheck disabled'])
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('spellcheck')).toEqual('false')
+      expect($component.attr('spellcheck')).toBe('false')
     })
 
     it('renders without spellcheck attribute by default', () => {
@@ -245,7 +245,7 @@ describe('Textarea', () => {
       const $ = render('textarea', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('more-detail')
+      expect($label.attr('for')).toBe('more-detail')
     })
 
     it('renders label as page heading', () => {
@@ -253,7 +253,7 @@ describe('Textarea', () => {
 
       const $label = $('.govuk-label')
       expect($('.govuk-label-wrapper')).toBeTruthy()
-      expect($label.attr('for')).toEqual('textarea-with-page-heading')
+      expect($label.attr('for')).toBe('textarea-with-page-heading')
     })
   })
 
@@ -262,7 +262,7 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with autocomplete attribute'])
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('autocomplete')).toEqual('street-address')
+      expect($component.attr('autocomplete')).toBe('street-address')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/warning-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/template.test.js
@@ -22,14 +22,14 @@ describe('Warning text', () => {
       const $ = render('warning-text', examples.default)
 
       const $assistiveText = $('.govuk-visually-hidden')
-      expect($assistiveText.text()).toEqual('Warning')
+      expect($assistiveText.text()).toBe('Warning')
     })
 
     it('hides the icon from screen readers using the aria-hidden attribute', () => {
       const $ = render('warning-text', examples.default)
 
       const $icon = $('.govuk-warning-text__icon')
-      expect($icon.attr('aria-hidden')).toEqual('true')
+      expect($icon.attr('aria-hidden')).toBe('true')
     })
   })
 
@@ -54,8 +54,8 @@ describe('Warning text', () => {
       const $ = render('warning-text', examples.attributes)
 
       const $component = $('.govuk-warning-text')
-      expect($component.attr('data-test')).toEqual('attribute')
-      expect($component.attr('id')).toEqual('my-warning-text')
+      expect($component.attr('data-test')).toBe('attribute')
+      expect($component.attr('id')).toBe('my-warning-text')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
@@ -14,7 +14,7 @@ describe('attributes.njk', () => {
       )
 
       // Note the starting space so we ensure it doesn't stick to possible other previous attributes
-      expect(attributes).toEqual(' data-attribute="value"')
+      expect(attributes).toBe(' data-attribute="value"')
     })
 
     it('renders multiple attributes', () => {
@@ -33,7 +33,7 @@ describe('attributes.njk', () => {
         }
       )
 
-      expect(attributes).toEqual(
+      expect(attributes).toBe(
         ' data-attribute="value" data-second-attribute="second-value" data-third-attribute="third-value"'
       )
     })
@@ -52,7 +52,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that `aria-hidden` and `focusable` are not converted to boolean attributes
-      expect(attributes).toEqual(
+      expect(attributes).toBe(
         ' viewBox="0 0 15 13" focusable="false" aria-hidden="true"'
       )
     })
@@ -75,7 +75,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that `aria-hidden` and `focusable` are not converted to boolean attributes
-      expect(attributes).toEqual(
+      expect(attributes).toBe(
         ' viewBox="0 0 15 13" focusable="false" aria-hidden="true"'
       )
     })
@@ -118,7 +118,7 @@ describe('attributes.njk', () => {
 
       // Note that all non-optional values are rendered to strings by Nunjucks,
       // even true/false which only become boolean attributes when optional
-      expect(attributes).toEqual(
+      expect(attributes).toBe(
         ' example-empty-1="" example-empty-2="" example-falsy-1="" example-falsy-2="0" example-falsy-3="false"'
       )
     })
@@ -160,7 +160,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that null, undefined and false are skipped, intentionally falsy values are preserved
-      expect(attributes).toEqual(' example-falsy-1="" example-falsy-2="0"')
+      expect(attributes).toBe(' example-falsy-1="" example-falsy-2="0"')
     })
 
     it('renders attribute when (string) `"true"` with `optional: true` as strings`', () => {
@@ -179,7 +179,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that `checked` defaults to a string value unless strictly a boolean
-      expect(attributes).toEqual(' type="radio" checked="true"')
+      expect(attributes).toBe(' type="radio" checked="true"')
     })
 
     it('renders attribute when (string) `"false"` with `optional: true` as strings', () => {
@@ -198,7 +198,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that `checked` defaults to a string value unless strictly a boolean
-      expect(attributes).toEqual(' type="radio" checked="false"')
+      expect(attributes).toBe(' type="radio" checked="false"')
     })
 
     it('renders attribute when (boolean) `true` with `optional: true` as boolean attribute', () => {
@@ -217,7 +217,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that `checked` has no value is, e.g. `<input type="radio" checked>`
-      expect(attributes).toEqual(' type="radio" checked')
+      expect(attributes).toBe(' type="radio" checked')
     })
 
     it('skip attribute when (boolean) `false` with `optional: true` as boolean attribute', () => {
@@ -236,7 +236,7 @@ describe('attributes.njk', () => {
       )
 
       // Note that `checked` is removed when false
-      expect(attributes).toEqual(' type="radio"')
+      expect(attributes).toBe(' type="radio"')
     })
 
     it('outputs attributes if already stringified', () => {
@@ -248,7 +248,7 @@ describe('attributes.njk', () => {
         }
       )
 
-      expect(attributes).toEqual(' data-attribute="value"')
+      expect(attributes).toBe(' data-attribute="value"')
     })
 
     it('outputs nothing if there are no attributes', () => {
@@ -260,7 +260,7 @@ describe('attributes.njk', () => {
         }
       )
 
-      expect(attributes).toEqual('')
+      expect(attributes).toBe('')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
@@ -17,7 +17,7 @@ describe('i18n.njk', () => {
       )
 
       // Note the starting space so we ensure it doesn't stick to possible other previous attributes
-      expect(attributes).toEqual(
+      expect(attributes).toBe(
         ' data-i18n.translation-key.other="You have %{count} characters remaining."'
       )
     })
@@ -37,7 +37,7 @@ describe('i18n.njk', () => {
         }
       )
 
-      expect(attributes).toEqual(
+      expect(attributes).toBe(
         ' data-i18n.translation-key.other="You have %{count} characters remaining." data-i18n.translation-key.one="One character remaining"'
       )
     })
@@ -53,7 +53,7 @@ describe('i18n.njk', () => {
         }
       )
 
-      expect(attributes).toEqual('')
+      expect(attributes).toBe('')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/settings/warnings.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/warnings.unit.test.js
@@ -43,7 +43,7 @@ describe('Warnings mixin', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the test message
-    expect(mockWarnFunction.mock.calls.length).toEqual(1)
+    expect(mockWarnFunction.mock.calls).toHaveLength(1)
   })
 
   it('Does not fire a @warn if the key is already in $govuk-suppressed-warnings', async () => {

--- a/packages/govuk-frontend/src/govuk/template.test.js
+++ b/packages/govuk-frontend/src/govuk/template.test.js
@@ -14,7 +14,7 @@ describe('Template', () => {
       })
 
       const output = env.render('./govuk/template.njk')
-      expect(output.charAt(0)).toEqual('<')
+      expect(output.charAt(0)).toBe('<')
     })
   })
 
@@ -26,14 +26,14 @@ describe('Template', () => {
       })
 
       const output = env.render('./govuk/template.njk')
-      expect(output.charAt(0)).toEqual('<')
+      expect(output.charAt(0)).toBe('<')
     })
   })
 
   describe('<html>', () => {
     it('defaults to lang="en"', () => {
       const $ = renderTemplate('govuk/template.njk')
-      expect($('html').attr('lang')).toEqual('en')
+      expect($('html').attr('lang')).toBe('en')
     })
 
     it('can have a custom lang set using htmlLang', () => {
@@ -43,7 +43,7 @@ describe('Template', () => {
         }
       })
 
-      expect($('html').attr('lang')).toEqual('zu')
+      expect($('html').attr('lang')).toBe('zu')
     })
 
     it('can have custom classes added using htmlClasses', () => {
@@ -89,14 +89,14 @@ describe('Template', () => {
         }
       })
 
-      expect($('head meta[property="foo"]').attr('content')).toEqual('bar')
+      expect($('head meta[property="foo"]').attr('content')).toBe('bar')
     })
 
     it('uses a default assets path of /assets', () => {
       const $ = renderTemplate('govuk/template.njk')
       const $icon = $('link[rel="icon"][sizes="48x48"]')
 
-      expect($icon.attr('href')).toEqual('/assets/images/favicon.ico')
+      expect($icon.attr('href')).toBe('/assets/images/favicon.ico')
     })
 
     it('can have the assets path overridden using assetPath', () => {
@@ -107,7 +107,7 @@ describe('Template', () => {
       })
       const $icon = $('link[rel="icon"][sizes="48x48"]')
 
-      expect($icon.attr('href')).toEqual('/whatever/images/favicon.ico')
+      expect($icon.attr('href')).toBe('/whatever/images/favicon.ico')
     })
 
     describe('favicons', () => {
@@ -115,38 +115,38 @@ describe('Template', () => {
         const $ = renderTemplate('govuk/template.njk')
         const $icon = $('link[rel="icon"][href$=".ico"]')
 
-        expect($icon.attr('sizes')).toEqual('48x48')
-        expect($icon.attr('href')).toEqual('/assets/images/favicon.ico')
+        expect($icon.attr('sizes')).toBe('48x48')
+        expect($icon.attr('href')).toBe('/assets/images/favicon.ico')
       })
 
       it('has an .svg icon', () => {
         const $ = renderTemplate('govuk/template.njk')
         const $icon = $('link[rel="icon"][href$=".svg"]')
 
-        expect($icon.attr('sizes')).toEqual('any')
-        expect($icon.attr('href')).toEqual('/assets/images/favicon.svg')
+        expect($icon.attr('sizes')).toBe('any')
+        expect($icon.attr('href')).toBe('/assets/images/favicon.svg')
       })
 
       it('has a mask-icon', () => {
         const $ = renderTemplate('govuk/template.njk')
         const $icon = $('link[rel="mask-icon"]')
 
-        expect($icon.attr('color')).toEqual('#0b0c0c')
-        expect($icon.attr('href')).toEqual('/assets/images/govuk-icon-mask.svg')
+        expect($icon.attr('color')).toBe('#0b0c0c')
+        expect($icon.attr('href')).toBe('/assets/images/govuk-icon-mask.svg')
       })
 
       it('has an apple-touch-icon', () => {
         const $ = renderTemplate('govuk/template.njk')
         const $icon = $('link[rel="apple-touch-icon"]')
 
-        expect($icon.attr('href')).toEqual('/assets/images/govuk-icon-180.png')
+        expect($icon.attr('href')).toBe('/assets/images/govuk-icon-180.png')
       })
 
       it('has a linked web manifest file', () => {
         const $ = renderTemplate('govuk/template.njk')
         const $icon = $('link[rel="manifest"]')
 
-        expect($icon.attr('href')).toEqual('/assets/manifest.json')
+        expect($icon.attr('href')).toBe('/assets/manifest.json')
       })
     })
 
@@ -155,7 +155,7 @@ describe('Template', () => {
         const $ = renderTemplate('govuk/template.njk')
         const $ogImage = $('meta[property="og:image"]')
 
-        expect($ogImage.length).toBe(0)
+        expect($ogImage).toHaveLength(0)
       })
 
       it('is included using default path and filename if assetUrl is set', () => {
@@ -167,7 +167,7 @@ describe('Template', () => {
 
         const $ogImage = $('meta[property="og:image"]')
 
-        expect($ogImage.attr('content')).toEqual(
+        expect($ogImage.attr('content')).toBe(
           'https://foo.com/my-assets/images/govuk-opengraph-image.png'
         )
       })
@@ -181,7 +181,7 @@ describe('Template', () => {
 
         const $ogImage = $('meta[property="og:image"]')
 
-        expect($ogImage.attr('content')).toEqual(
+        expect($ogImage.attr('content')).toBe(
           'https://foo.com/custom/og-image.png'
         )
       })
@@ -190,7 +190,7 @@ describe('Template', () => {
     describe('<meta name="theme-color">', () => {
       it('has a default content of #0b0c0c', () => {
         const $ = renderTemplate('govuk/template.njk')
-        expect($('meta[name="theme-color"]').attr('content')).toEqual('#0b0c0c')
+        expect($('meta[name="theme-color"]').attr('content')).toBe('#0b0c0c')
       })
 
       it('can be overridden using themeColor', () => {
@@ -200,7 +200,7 @@ describe('Template', () => {
           }
         })
 
-        expect($('meta[name="theme-color"]').attr('content')).toEqual('#ff69b4')
+        expect($('meta[name="theme-color"]').attr('content')).toBe('#ff69b4')
       })
     })
 
@@ -222,7 +222,7 @@ describe('Template', () => {
           }
         })
 
-        expect($('head > title').text()).toEqual('Foo')
+        expect($('head > title').text()).toBe('Foo')
       })
 
       it('does not have a lang attribute by default', () => {
@@ -237,7 +237,7 @@ describe('Template', () => {
           }
         })
 
-        expect($('head > title').attr('lang')).toEqual('zu')
+        expect($('head > title').attr('lang')).toBe('zu')
       })
     })
   })
@@ -260,7 +260,7 @@ describe('Template', () => {
         }
       })
 
-      expect($('body').attr('data-foo')).toEqual('bar')
+      expect($('body').attr('data-foo')).toBe('bar')
     })
 
     it('can have additional content added after the opening tag using bodyStart block', () => {
@@ -270,7 +270,7 @@ describe('Template', () => {
         }
       })
 
-      expect($('body > div:first-of-type').text()).toEqual('bodyStart')
+      expect($('body > div:first-of-type').text()).toBe('bodyStart')
     })
 
     it('can have additional content added before the closing tag using bodyEnd block', () => {
@@ -280,7 +280,7 @@ describe('Template', () => {
         }
       })
 
-      expect($('body > div:last-of-type').text()).toEqual('bodyEnd')
+      expect($('body > div:last-of-type').text()).toBe('bodyEnd')
     })
 
     describe('inline script that adds "js-enabled" and "govuk-frontend-supported" classes', () => {
@@ -293,7 +293,7 @@ describe('Template', () => {
 
         // A change to the inline script would be a breaking change, and it would also require
         // updating the hash published in https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-isn-t-working-properly
-        expect(`sha256-${hash}`).toEqual(
+        expect(`sha256-${hash}`).toBe(
           'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='
         )
       })
@@ -302,7 +302,7 @@ describe('Template', () => {
         const $ = renderTemplate('govuk/template.njk')
         const scriptTag = $('body > script').first()
 
-        expect(scriptTag.attr('nonce')).toEqual(undefined)
+        expect(scriptTag.attr('nonce')).toBeUndefined()
       })
 
       it('should have a nonce attribute when nonce is provided', () => {
@@ -314,7 +314,7 @@ describe('Template', () => {
 
         const scriptTag = $('body > script').first()
 
-        expect(scriptTag.attr('nonce')).toEqual('abcdef')
+        expect(scriptTag.attr('nonce')).toBe('abcdef')
       })
     })
 
@@ -326,8 +326,8 @@ describe('Template', () => {
           }
         })
 
-        expect($('.my-skip-link').length).toEqual(1)
-        expect($('.govuk-skip-link').length).toEqual(0)
+        expect($('.my-skip-link')).toHaveLength(1)
+        expect($('.govuk-skip-link')).toHaveLength(0)
       })
     })
 
@@ -339,15 +339,15 @@ describe('Template', () => {
           }
         })
 
-        expect($('.my-header').length).toEqual(1)
-        expect($('.govuk-header').length).toEqual(0)
+        expect($('.my-header')).toHaveLength(1)
+        expect($('.govuk-header')).toHaveLength(0)
       })
     })
 
     describe('<main>', () => {
       it('has role="main", supporting browsers that do not natively support HTML5 elements', () => {
         const $ = renderTemplate('govuk/template.njk')
-        expect($('main').attr('role')).toEqual('main')
+        expect($('main').attr('role')).toBe('main')
       })
 
       it('can have custom classes added using mainClasses', () => {
@@ -372,7 +372,7 @@ describe('Template', () => {
           }
         })
 
-        expect($('main').attr('lang')).toEqual('zu')
+        expect($('main').attr('lang')).toBe('zu')
       })
 
       it('can be overridden using the main block', () => {
@@ -382,7 +382,7 @@ describe('Template', () => {
           }
         })
 
-        expect($('main').length).toEqual(1)
+        expect($('main')).toHaveLength(1)
         expect($('main').hasClass('my-main')).toBe(true)
       })
 
@@ -403,7 +403,7 @@ describe('Template', () => {
           }
         })
 
-        expect($('main').text().trim()).toEqual('Foo')
+        expect($('main').text().trim()).toBe('Foo')
       })
     })
 
@@ -415,8 +415,8 @@ describe('Template', () => {
           }
         })
 
-        expect($('.my-footer').length).toEqual(1)
-        expect($('.govuk-footer').length).toEqual(0)
+        expect($('.my-footer')).toHaveLength(1)
+        expect($('.govuk-footer')).toHaveLength(0)
       })
     })
   })

--- a/packages/govuk-frontend/tasks/build/release.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/release.unit.test.mjs
@@ -144,7 +144,7 @@ describe('dist/', () => {
     })
 
     it('should contain the correct version', () => {
-      expect(version).toEqual(`${pkg.version}\n`)
+      expect(version).toBe(`${pkg.version}\n`)
     })
   })
 })


### PR DESCRIPTION
Using the `style` configuration over the `recommended` config enables three more opinionated rules:

- `prefer-to-be` – Suggest using `toBe()` for primitive literals
- `prefer-to-contain` – Suggest using `toContain()`
- `prefer-to-have-length` - Suggest using `toHaveLength()`

These rules are all automagically fixable using `--fix`.

Raised for discussion as to whether these would be useful in addition to the recommended rules enabled in #4842.