### PR TITLE
Fix mobile product name being misaligned in new type scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#4811: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Tabs component](https://github.com/alphagov/govuk-frontend/pull/4811)
 - [#4812: Use `KeyboardEvent.key` over deprecated `KeyboardEvent.keyCode` in the Button component](https://github.com/alphagov/govuk-frontend/pull/4812)
 - [#4813: Remove deprecated `KeyboardEvent` properties from the Exit this Page component](https://github.com/alphagov/govuk-frontend/pull/4813)
+- [#4855: Fix mobile product name being misaligned in new type scale](https://github.com/alphagov/govuk-frontend/pull/4855)
 
 ## 5.2.0 (feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -64,7 +64,7 @@
   }
 
   .govuk-header__product-name {
-    $product-name-offset: 10px;
+    $product-name-offset: if($govuk-new-typography-scale, 7px, 10px);
     $product-name-offset-tablet: 5px;
 
     @include govuk-font-size($size: 24, $line-height: 1);


### PR DESCRIPTION
Intended to be a 'quick fix' of the most visible issue mentioned in #4841. There are still potential alignment issues documented below.

## Changes
- Modifies the `margin-top` of the product name on the mobile breakpoint, if the new type scale is being used.

## Screenshots

(All screenshots are in Chromium.)

||Before|After|
|:-|:-:|:-:|
|Narrow mobile|![before-narrow-mobile](https://github.com/alphagov/govuk-frontend/assets/1253214/fb6aee68-abfc-4aa7-8655-62cd1af08aac)|![after-narrow-mobile](https://github.com/alphagov/govuk-frontend/assets/1253214/6c42ce1e-6c95-4a9b-b70b-2084c8815d54)|
|Mobile|![before-mobile](https://github.com/alphagov/govuk-frontend/assets/1253214/ae02b8aa-235a-44f9-af5c-28388bb9741e)|![after-mobile](https://github.com/alphagov/govuk-frontend/assets/1253214/7cd53de6-7848-4470-81a5-1c760340a5f9)|
|Tablet+|![before-tablet](https://github.com/alphagov/govuk-frontend/assets/1253214/4583cc18-da96-4247-aae5-3c82cd2ff360)|![after-tablet](https://github.com/alphagov/govuk-frontend/assets/1253214/88e3ed79-c968-4c23-82dd-6eba8efb9315)|

This change principally aims to fix the middle row here ("Mobile") although it does have repercussions on the narrow mobile view too, as the product name appears slightly higher than previously, which may be undesirable. 

(Note that the logo and product name always link to the same place, so proximity to one another shouldn't be a problem regarding accessibility.)

## Thoughts
In typically frustrating fashion, each browser and screen has a slightly different interpretation of how to align the product name with respect to the logo depending on our dreaded foe, **subpixel rounding**.

The baseline misalignment between GOV.UK logo and product name on my screens appears to be:

|Browser|MBP display<br>(3024×1964, 254 ppi)|External display<br>(2560×1440, 123 ppi)|
|:-|:-:|:-:|
|Chromium|0|-1px|
|Firefox (w/ -0.5px hack)|-1px|0|
|Firefox (w/o -0.5px hack)|0|0|
|Safari|+2px|-1px|

I'm not sure how much pixel nudging we're up to doing to try and minimise the difference between browsers. Experience would tell me that getting it dead-on everywhere is liable to become a caper. That's why this PR only really aims to fix the immediate "this is just _way_ off" alignment issue, rather than fix it in all circumstances.

## Todo
Add changelog.