### PR TITLE
Remove use of `innerHTML` from password input

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -192,7 +192,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     const prefixStatus = isHidden ? 'passwordHidden' : 'passwordShown'
 
     // Update button text
-    this.$showHideButton.innerHTML = this.i18n.t(`${prefixButton}Password`)
+    this.$showHideButton.innerText = this.i18n.t(`${prefixButton}Password`)
 
     // Update button aria-label
     this.$showHideButton.setAttribute(
@@ -258,9 +258,9 @@ export class PasswordInput extends GOVUKFrontendComponent {
  *
  * Messages displayed to the user indicating the state of the show/hide toggle.
  * @property {string} [showPassword] - Visible text of the button when the
- *   password is currently hidden. HTML is acceptable.
+ *   password is currently hidden. Plain text only.
  * @property {string} [hidePassword] - Visible text of the button when the
- *   password is currently visible. HTML is acceptable.
+ *   password is currently visible. Plain text only.
  * @property {string} [showPasswordAriaLabel] - aria-label of the button when
  *   the password is currently hidden. Plain text only.
  * @property {string} [hidePasswordAriaLabel] - aria-label of the button when


### PR DESCRIPTION
Removes the use of `innerHTML` from the Password input JavaScript, replacing it with `innerText`. 

- We want to avoid using `innerHTML` where possible as it presents a cross-site scripting (XSS) risk.
- i18n translation strings can only be provided as plain text anyway.
- The component's Nunjucks API already only allows plain text.

Does we think this warrants a changelog entry? It's a very minor change that undoubtedly makes little functional difference as the way `innerHTML` was being used meant it could never actually have HTML passed to it. 