### PR TITLE
Update the icon in the warning text component to match the defined text colour and background colour, rather than always being white on black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#4906: Update the icon in the warning text component to match the defined text colour and background colour, rather than always being white on black](https://github.com/alphagov/govuk-frontend/pull/4906)
+
 ## GOV.UK Frontend v5.3.0 (Feature release)
 
 ### New features

--- a/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
@@ -27,11 +27,11 @@
 
     // When a user customises their colours the background colour will often be removed.
     // Adding a border to the component keeps it's shape as a circle.
-    border: 3px solid govuk-colour("black");
+    border: 3px solid $govuk-text-colour;
     border-radius: 50%;
 
-    color: govuk-colour("white");
-    background: govuk-colour("black");
+    color: $govuk-body-background-colour;
+    background: $govuk-text-colour;
 
     font-size: 30px;
     line-height: 29px;


### PR DESCRIPTION
## What
Swaps out calls to `govuk-colour` in warning text to references to `$govuk-text-colour` and `$govuk-body-background-colour`.

## Why
During investigations into CSS custom properties as part of https://github.com/alphagov/govuk-frontend/issues/4900, we noticed a number of places where a hypothetical change of colour scheme wouldn't properly permeate throughout the codebase. This establishes a direct relationship between the warning text component and the text colour and body background colour.