### PR TITLE
Set appropriate value for `color-scheme` in dark mode

### DIFF
--- a/packages/govuk-frontend/src/govuk/objects/_template.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.scss
@@ -50,6 +50,8 @@
 
   @include govuk-media-query($media-type: screen) {
     .govuk-template--dark {
+      color-scheme: dark;
+
       --govuk-canvas-background-colour: #333;
       --govuk-body-background-colour: #222;
       --govuk-text-colour: #fff;


### PR DESCRIPTION
Setting [`color-scheme: dark`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) swaps the native UI elements (like the file input) to their dark styles, enabling better contrast.

We'll probably want to dig into the support of that property inside webviews. This may vary depending of the OS versions app are meant to support.

For example on the file input:

| | `color-scheme: normal` |`color-scheme: dark`|
| --- | --- |---|
| Chrome | <img width="1001" alt="Screenshot of the file upload component showing light text on a light (default) background" src="https://github.com/alphagov/govuk-frontend/assets/396367/de5de538-2d7a-4c75-98c5-2969d57ddb99"> | <img width="1005" alt="Screenshot of the file uploadcomponent showing light text on a dark (default) background" src="https://github.com/alphagov/govuk-frontend/assets/396367/a46aaa60-fcf2-4578-9a7d-cdd7cd215516"> |
| Firefox | <img width="999" alt="Screenshot of the file upload component showing dark (unstyled) text on a light (default) background" src="https://github.com/alphagov/govuk-frontend/assets/396367/bcb7256c-5179-400d-9fd7-4b25eee55b53"> | <img width="999" alt="Screenshot of the file uploadcomponent showing light text on a dark (default) background" src="https://github.com/alphagov/govuk-frontend/assets/396367/6e2c0156-2ae5-4880-99da-dbc6f9649533"> | 
| Safari | <img width="995" alt="Screenshot of the file upload component showing light text on a light (default) background" src="https://github.com/alphagov/govuk-frontend/assets/396367/c4e2be69-206f-4013-be02-4aa55a0c4dc9"> | <img width="996" alt="Screenshot of the file uploadcomponent showing light text on a dark (default) background" src="https://github.com/alphagov/govuk-frontend/assets/396367/ac12a586-3748-4d0d-bdee-3af77ddb6983">|