### PR TITLE
[WIP][SPIKE] Experiment with modifying header component with new top-level elements

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -127,7 +127,7 @@
 
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
-      padding-left: govuk-spacing(2);
+      padding-left: govuk-spacing(4);
       margin-left: govuk-spacing(2);
       border-left: 1px solid $govuk-header-separator-color;
     }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -4,7 +4,7 @@
   $govuk-header-border-color: $govuk-brand-colour;
   $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-link-underline-thickness: 3px;
-  $govuk-header-separator-color: #ffffff;
+  $govuk-header-separator-color: #2e3133;
   $govuk-header-toolbox-arrow-size: 12px;
 
   .govuk-header {
@@ -94,6 +94,28 @@
     }
   }
 
+  // TEMPORARY HACKY CODE TO POSITION ONE LOGIN ICON
+  .govuk-header__one-login-icon {
+    margin-top: -1px;
+    margin-left: govuk-spacing(1);
+    vertical-align: text-bottom;
+  }
+
+  // One Login icon focus code
+  .govuk-header__link--one-login:focus .govuk-header__one-login-icon {
+    .background {
+      fill: govuk-colour("black");
+    }
+
+    .border {
+      stroke: govuk-colour("black");
+    }
+
+    .person {
+      fill: govuk-colour("white");
+    }
+  }
+
   // Logo container
   .govuk-header__logo {
     display: block;
@@ -127,8 +149,8 @@
 
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
-      padding-left: govuk-spacing(4);
       margin-left: govuk-spacing(2);
+      padding-left: govuk-spacing(4);
       border-left: 1px solid $govuk-header-separator-color;
     }
   }
@@ -141,11 +163,39 @@
   .govuk-header__toolboxes {
     @include govuk-font-size(16);
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+    list-style: none;
 
-    @include govuk-media-query($from: tablet) {
+    @include govuk-media-query($from: mobile) {
+      flex-direction: row;
       margin-left: auto;
+    }
+  }
+
+  .govuk-header__toolboxes-item {
+    padding: govuk-spacing(2) 0;
+    border-bottom: 1px solid $govuk-header-separator-color;
+
+    @include govuk-media-query($from: mobile) {
+      padding: govuk-spacing(1) govuk-spacing(2);
+      border-bottom: none;
+
+      // Add separators between toolbox items
+      + .govuk-header__toolboxes-item {
+        border-left: 1px solid $govuk-header-separator-color;
+      }
+
+      // Remove left padding from first toolbox
+      &:first-child {
+        padding-left: 0;
+      }
+
+      // Remove right padding from last toolbox, to ensure alignment with container edge
+      &:last-child {
+        padding-right: 0;
+      }
     }
   }
 
@@ -153,14 +203,9 @@
     position: relative;
   }
 
-  .govuk-header__toolbox + .govuk-header__toolbox {
-    border-left: 1px solid $govuk-header-separator-color;
-  }
-
   .govuk-header__toolbox-summary {
     display: inline-block;
     position: relative;
-    padding: govuk-spacing(2) 0;
     padding-right: calc(#{$govuk-header-toolbox-arrow-size} + #{govuk-spacing(2)});
 
     &::-webkit-details-marker {
@@ -186,16 +231,6 @@
 
     &:focus {
       @include govuk-focused-text;
-    }
-
-    // Add margin-left to all toolboxes except the first
-    .govuk-header__toolbox:not(:first-child) & {
-      margin-left: govuk-spacing(2);
-    }
-
-    // Add margin-right to all toolboxes except the last
-    .govuk-header__toolbox:not(:last-child) & {
-      margin-right: govuk-spacing(2);
     }
   }
 
@@ -224,31 +259,6 @@
       li:last-child {
         margin-bottom: 0;
       }
-    }
-  }
-
-  // Toolbox - One Login specific code
-  .govuk-header__toolbox--one-login {
-    // Change colours of One Login icon when focused
-    .govuk-header__toolbox-summary:focus .govuk-header__one-login-icon {
-      .background {
-        fill: govuk-colour("black");
-      }
-
-      .border {
-        stroke: govuk-colour("black");
-      }
-
-      .person {
-        fill: govuk-colour("white");
-      }
-    }
-
-    // TEMPORARY HACKY CODE TO POSITION ONE LOGIN ICON
-    .govuk-header__one-login-icon {
-      margin-top: -1px;
-      margin-right: govuk-spacing(1);
-      vertical-align: text-bottom;
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -96,7 +96,7 @@
 
   // TEMPORARY HACKY CODE TO POSITION ONE LOGIN ICON
   .govuk-header__one-login-icon {
-    margin-top: -1px;
+    margin-top: -3px;
     margin-left: govuk-spacing(1);
     vertical-align: text-bottom;
   }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("govuk/component/header") {
   $govuk-header-background: govuk-colour("black");
   $govuk-header-text: govuk-colour("white");
-  $govuk-header-border-color: $govuk-border-colour;
+  $govuk-header-border-color: $govuk-brand-colour;
   $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-link-underline-thickness: 3px;
   $govuk-header-separator-color: $govuk-border-colour;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("govuk/component/header") {
   $govuk-header-background: govuk-colour("black");
   $govuk-header-text: govuk-colour("white");
-  $govuk-header-border-color: $govuk-brand-colour;
+  $govuk-header-border-color: $govuk-border-colour;
   $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-link-underline-thickness: 3px;
   $govuk-header-separator-color: #2e3133;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -4,7 +4,7 @@
   $govuk-header-border-color: $govuk-brand-colour;
   $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-link-underline-thickness: 3px;
-  $govuk-header-separator-color: #2e3133;
+  $govuk-header-separator-color: #ffffff;
   $govuk-header-toolbox-arrow-size: 12px;
 
   .govuk-header {
@@ -128,6 +128,7 @@
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
       padding-left: govuk-spacing(2);
+      margin-left: govuk-spacing(2);
       border-left: 1px solid $govuk-header-separator-color;
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -1,96 +1,48 @@
 @include govuk-exports("govuk/component/header") {
   $govuk-header-background: govuk-colour("black");
+  $govuk-header-text: govuk-colour("white");
   $govuk-header-border-color: $govuk-brand-colour;
   $govuk-header-border-width: govuk-spacing(2);
-  $govuk-header-text: govuk-colour("white");
-  $govuk-header-link-active: #1d8feb;
-  $govuk-header-nav-item-border-color: #2e3133;
   $govuk-header-link-underline-thickness: 3px;
-  $govuk-header-vertical-spacing-value: 2;
-  // This crown height is only used to calculate top offset of mobile menu button
-  // as the crown svg height is the only thing that controls the height of the header
-  $govuk-header-crown-height: 30px;
-  $govuk-header-menu-button-height: 24px;
-  $govuk-header-menu-button-width: 80px;
+  $govuk-header-separator-color: #2e3133;
+  $govuk-header-toolbox-arrow-size: 12px;
 
   .govuk-header {
-    @include govuk-font($size: 16, $line-height: 1);
-
-    border-bottom: govuk-spacing(2) solid govuk-colour("white");
+    @include govuk-font($size: 19, $line-height: 1);
+    border-bottom: $govuk-header-border-width solid $govuk-header-border-color;
     color: $govuk-header-text;
-    background: $govuk-header-background;
-  }
-
-  .govuk-header__container--full-width {
-    padding: 0 govuk-spacing(3);
-    border-color: $govuk-header-border-color;
-
-    .govuk-header__menu-button {
-      right: govuk-spacing(3);
-    }
+    background-color: $govuk-header-background;
   }
 
   .govuk-header__container {
     @include govuk-clearfix;
     position: relative;
-    margin-bottom: -$govuk-header-border-width;
-    padding-top: govuk-spacing($govuk-header-vertical-spacing-value);
-    border-bottom: $govuk-header-border-width solid $govuk-header-border-color;
   }
 
-  .govuk-header__logotype {
-    display: inline-block;
-    position: relative;
-    top: -3px;
-
-    // Add a gap after the logo in case it's followed by a product name. This
-    // gets removed later if the logotype is a :last-child.
-    margin-right: govuk-spacing(1);
-    fill: currentcolor;
-    vertical-align: top;
-
-    // Prevent readability backplate from obscuring underline in Windows High
-    // Contrast Mode
-    @media (forced-colors: active) {
-      forced-color-adjust: none;
-      color: linktext;
-    }
-
-    // Remove the gap after the logo if there's no product name to keep hover
-    // and focus states neat
-    &:last-child {
-      margin-right: 0;
-    }
+  .govuk-header__container--full-width {
+    padding: 0 govuk-spacing(3);
   }
 
-  .govuk-header__product-name {
-    $product-name-offset: if($govuk-new-typography-scale, 7px, 10px);
-    $product-name-offset-tablet: 5px;
-
-    @include govuk-font-size($size: 24, $line-height: 1);
-    @include govuk-typography-weight-regular;
-    display: inline-table;
-
-    // Maintain space below logo when wrapped
-    margin-top: $product-name-offset;
-
-    // Firefox places the GOV.UK logo one pixel higher, due to how it rounds
-    // subpixels, so nudge the product name in FF to still be aligned.
-    @-moz-document url-prefix() {
-      margin-top: $product-name-offset - 0.5px;
-    }
-
-    // Align vertically with logo when not wrapped
-    vertical-align: top;
+  .govuk-header__top,
+  .govuk-header__bottom {
+    padding: govuk-spacing(2) 0;
 
     @include govuk-media-query($from: tablet) {
-      margin-top: $product-name-offset-tablet;
-      @-moz-document url-prefix() {
-        margin-top: $product-name-offset-tablet - 0.5px;
-      }
+      display: flex;
+      gap: govuk-spacing(2);
     }
   }
 
+  .govuk-header__top {
+    align-items: baseline;
+  }
+
+  .govuk-header__bottom {
+    border-top: 1px solid $govuk-header-separator-color;
+    align-items: center;
+  }
+
+  // Links
   .govuk-header__link {
     // Avoid using the `govuk-link-common` mixin because the links in the header
     // get a special treatment, because:
@@ -121,18 +73,7 @@
     // Font size needs to be set on the link so that the box sizing is correct
     // in Firefox
     display: inline-block;
-    margin-right: govuk-spacing(2);
     font-size: 30px; // We don't have a mixin that produces 30px font size
-
-    @include govuk-media-query($from: desktop) {
-      display: inline;
-
-      &:focus {
-        // Replicate the focus box shadow but without the -2px y-offset of the first yellow shadow
-        // This is to stop the logo getting cut off by the box shadow when focused on above a product name
-        box-shadow: 0 0 $govuk-focus-colour;
-      }
-    }
 
     &:link,
     &:visited {
@@ -153,73 +94,92 @@
     }
   }
 
-  .govuk-header__service-name {
+  // Logo container
+  .govuk-header__logo {
+    display: block;
+
+    @include govuk-media-query($from: tablet) {
+      display: inline-block;
+    }
+  }
+
+  // Logo
+  .govuk-header__logotype {
     display: inline-block;
-    margin-bottom: govuk-spacing(2);
+    position: relative;
+    top: -3px;
+    fill: currentcolor;
+    vertical-align: top;
+
+    // Prevent readability backplate from obscuring underline in Windows High
+    // Contrast Mode
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+      color: linktext;
+    }
+  }
+
+  // Product or service name
+  .govuk-header__name {
+    display: inline-block;
+    margin-top: govuk-spacing(1);
     @include govuk-font-size($size: 24);
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: 0;
+      padding-left: govuk-spacing(2);
+      border-left: 1px solid $govuk-header-separator-color;
+    }
+  }
+
+  .govuk-header__name--product {
     @include govuk-typography-weight-bold;
   }
 
-  .govuk-header__logo,
-  .govuk-header__content {
-    box-sizing: border-box;
-  }
+  // Toolboxes
+  .govuk-header__toolboxes {
+    @include govuk-font-size(16);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
 
-  .govuk-header__logo {
-    @include govuk-responsive-margin($govuk-header-vertical-spacing-value, "bottom");
-    // Protect the absolute positioned menu button from overlapping with the
-    // logo with right padding using the button's width
-    padding-right: $govuk-header-menu-button-width;
-
-    @include govuk-media-query($from: desktop) {
-      width: 33.33%;
-      padding-right: $govuk-gutter-half;
-      float: left;
-      vertical-align: top;
-
-      // Reset float when logo is the last child, without a navigation
-      &:last-child {
-        width: auto;
-        padding-right: 0;
-        float: none;
-      }
+    @include govuk-media-query($from: tablet) {
+      margin-left: auto;
     }
   }
 
-  .govuk-header__content {
-    @include govuk-media-query($from: desktop) {
-      width: 66.66%;
-      padding-left: $govuk-gutter-half;
-      float: left;
-    }
+  .govuk-header__toolbox {
+    position: relative;
   }
 
-  .govuk-header__menu-button {
-    @include govuk-font($size: 16);
-    position: absolute;
-    // calculate top offset by:
-    // - getting the vertical spacing for the top and the bottom of the header
-    // - adding that to the crown height
-    // - dividing it by 2 so you have the vertical centre of the header
-    // - subtracting half the height of the menu button
-    top: (((govuk-spacing($govuk-header-vertical-spacing-value) * 2) + $govuk-header-crown-height) / 2) -
-      ($govuk-header-menu-button-height / 2);
-    right: 0;
-    max-width: $govuk-header-menu-button-width;
-    min-height: $govuk-header-menu-button-height;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    color: govuk-colour("white");
-    background: none;
-    word-break: break-all;
-    cursor: pointer;
+  .govuk-header__toolbox + .govuk-header__toolbox {
+    border-left: 1px solid $govuk-header-separator-color;
+  }
 
-    &:hover {
-      text-decoration: solid underline $govuk-header-link-underline-thickness;
+  .govuk-header__toolbox-summary {
+    display: inline-block;
+    position: relative;
+    padding: govuk-spacing(2) 0;
+    padding-right: calc(#{$govuk-header-toolbox-arrow-size} + #{govuk-spacing(2)});
 
-      @if $govuk-link-underline-offset {
-        text-underline-offset: $govuk-link-underline-offset;
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+
+      top: -1px;
+      right: 0;
+      bottom: 0;
+
+      margin: auto;
+
+      @include govuk-shape-arrow($direction: down, $base: $govuk-header-toolbox-arrow-size);
+
+      .govuk-header__toolbox[open] > & {
+        @include govuk-shape-arrow($direction: up, $base: $govuk-header-toolbox-arrow-size);
       }
     }
 
@@ -227,98 +187,101 @@
       @include govuk-focused-text;
     }
 
-    &::after {
-      @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
-      content: "";
-      margin-left: govuk-spacing(1);
+    // Add margin-left to all toolboxes except the first
+    .govuk-header__toolbox:not(:first-child) & {
+      margin-left: govuk-spacing(2);
     }
 
-    &[aria-expanded="true"]::after {
-      @include govuk-shape-arrow($direction: up, $base: 10px, $display: inline-block);
+    // Add margin-right to all toolboxes except the last
+    .govuk-header__toolbox:not(:last-child) & {
+      margin-right: govuk-spacing(2);
+    }
+  }
+
+  .govuk-header__toolbox-contents {
+    @include govuk-responsive-padding(2);
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: max-content;
+    background-color: $govuk-header-background;
+
+    @include govuk-media-query($from: tablet) {
+      right: 0;
+      left: auto;
+    }
+
+    // HACKY HACKY OVERRIDES
+    .govuk-list {
+      @include govuk-font-size(16);
+      margin-bottom: 0;
+
+      li {
+        text-align: start;
+      }
+
+      li:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  // Toolbox - One Login specific code
+  .govuk-header__toolbox--one-login {
+    // Change colours of One Login icon when focused
+    .govuk-header__toolbox-summary:focus .govuk-header__one-login-icon {
+      .background {
+        fill: govuk-colour("black");
+      }
+
+      .border {
+        stroke: govuk-colour("black");
+      }
+
+      .person {
+        fill: govuk-colour("white");
+      }
+    }
+
+    // TEMPORARY HACKY CODE TO POSITION ONE LOGIN ICON
+    .govuk-header__one-login-icon {
+      margin-top: -1px;
+      margin-right: govuk-spacing(1);
+      vertical-align: text-bottom;
+    }
+  }
+
+  // Search
+  // This should probably go into its own component, I think?
+  .govuk-header__search {
+    display: flex;
+    margin-bottom: govuk-spacing(2);
+
+    // If the search is the last thing on the row, it doesn't need the bottom margin
+    &:last-child {
+      margin-bottom: 0;
     }
 
     @include govuk-media-query($from: tablet) {
-      top: govuk-spacing(3);
+      margin-bottom: 0;
     }
 
-    .govuk-frontend-supported & {
-      display: block;
+    // TEMPORARY HACKY CODE
+    label {
+      flex-grow: 1;
     }
 
-    &[hidden],
-    .govuk-frontend-supported &[hidden] {
-      display: none;
-    }
-  }
-
-  .govuk-header__navigation {
-    @include govuk-media-query($from: desktop) {
-      margin-bottom: govuk-spacing(2);
-    }
-  }
-
-  .govuk-header__navigation-list {
-    // Reset user-agent default list styles
-    margin: 0;
-    padding: 0;
-    list-style: none;
-
-    &[hidden] {
-      display: none;
-    }
-  }
-
-  .govuk-header__navigation--end {
-    @include govuk-media-query($from: desktop) {
-      margin: 0;
-      padding: govuk-spacing(1) 0;
-      text-align: right;
-    }
-  }
-
-  .govuk-header__navigation-item {
-    padding: govuk-spacing(2) 0;
-    border-bottom: 1px solid $govuk-header-nav-item-border-color;
-
-    @include govuk-media-query($from: desktop) {
-      display: inline-block;
-      margin-right: govuk-spacing(3);
-      padding: govuk-spacing(1) 0;
-      border: 0;
+    // MORE TEMPORARY HACKY CODE
+    .govuk-input {
+      border-color: govuk-colour("white");
     }
 
-    a {
-      @include govuk-font-size($size: 16);
-      @include govuk-typography-weight-bold;
-      white-space: nowrap;
+    // EVEN MORE TEMPORARY HACKY CODE
+    .govuk-button {
+      width: auto;
+      margin-bottom: 0;
+      box-shadow: none;
     }
-  }
-
-  .govuk-header__navigation-item--active {
-    a {
-      &:link,
-      &:hover,
-      &:visited {
-        color: $govuk-header-link-active;
-      }
-
-      // When printing, use the normal blue as this contrasts better with the
-      // white printing header
-      @include govuk-media-query($media-type: print) {
-        color: $govuk-brand-colour;
-      }
-
-      // When focussed, the text colour needs to be darker to ensure that colour
-      // contrast is still acceptable
-      &:focus {
-        color: $govuk-focus-text-colour;
-      }
-    }
-  }
-
-  .govuk-header__navigation-item:last-child {
-    margin-right: 0;
-    border-bottom: 0;
   }
 
   @include govuk-media-query($media-type: print) {
@@ -338,6 +301,11 @@
       &::after {
         display: none;
       }
+    }
+
+    // Hide various elements that aren't useful when printed
+    .govuk-header__bottom {
+      display: none;
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -4,7 +4,7 @@
   $govuk-header-border-color: $govuk-border-colour;
   $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-link-underline-thickness: 3px;
-  $govuk-header-separator-color: #2e3133;
+  $govuk-header-separator-color: $govuk-border-colour;
   $govuk-header-toolbox-arrow-size: 12px;
 
   .govuk-header {

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -1,4 +1,3 @@
-import { getBreakpoint } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
@@ -11,35 +10,7 @@ export class Header extends GOVUKFrontendComponent {
   /** @private */
   $module
 
-  /** @private */
-  $menuButton
-
-  /** @private */
-  $menu
-
   /**
-   * Save the opened/closed state for the nav in memory so that we can
-   * accurately maintain state when the screen is changed from small to big and
-   * back to small
-   *
-   * @private
-   */
-  menuIsOpen = false
-
-  /**
-   * A global const for storing a matchMedia instance which we'll use to detect
-   * when a screen size change happens. We rely on it being null if the feature
-   * isn't available to initially apply hidden attributes
-   *
-   * @private
-   * @type {MediaQueryList | null}
-   */
-  mql = null
-
-  /**
-   * Apply a matchMedia for desktop which will trigger a state sync if the
-   * browser viewport moves between states.
-   *
    * @param {Element | null} $module - HTML element to use for header
    */
   constructor($module) {
@@ -54,115 +25,6 @@ export class Header extends GOVUKFrontendComponent {
     }
 
     this.$module = $module
-    const $menuButton = $module.querySelector('.govuk-js-header-toggle')
-
-    // Headers don't necessarily have a navigation. When they don't, the menu
-    // toggle won't be rendered by our macro (or may be omitted when writing
-    // plain HTML)
-    if (!$menuButton) {
-      return this
-    }
-
-    const menuId = $menuButton.getAttribute('aria-controls')
-    if (!menuId) {
-      throw new ElementError({
-        componentName: 'Header',
-        identifier:
-          'Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`)'
-      })
-    }
-
-    const $menu = document.getElementById(menuId)
-    if (!$menu) {
-      throw new ElementError({
-        componentName: 'Header',
-        element: $menu,
-        identifier: `Navigation (\`<ul id="${menuId}">\`)`
-      })
-    }
-
-    this.$menu = $menu
-    this.$menuButton = $menuButton
-
-    this.setupResponsiveChecks()
-
-    this.$menuButton.addEventListener('click', () =>
-      this.handleMenuButtonClick()
-    )
-  }
-
-  /**
-   * Setup viewport resize check
-   *
-   * @private
-   */
-  setupResponsiveChecks() {
-    const breakpoint = getBreakpoint('desktop')
-
-    if (!breakpoint.value) {
-      throw new ElementError({
-        componentName: 'Header',
-        identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
-      })
-    }
-
-    // Media query list for GOV.UK Frontend desktop breakpoint
-    this.mql = window.matchMedia(`(min-width: ${breakpoint.value})`)
-
-    // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
-    // to be able to fall back to the deprecated MediaQueryList.addListener
-    if ('addEventListener' in this.mql) {
-      this.mql.addEventListener('change', () => this.checkMode())
-    } else {
-      // @ts-expect-error Property 'addListener' does not exist
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      this.mql.addListener(() => this.checkMode())
-    }
-
-    this.checkMode()
-  }
-
-  /**
-   * Sync menu state
-   *
-   * Uses the global variable menuIsOpen to correctly set the accessible and
-   * visual states of the menu and the menu button.
-   * Additionally will force the menu to be visible and the menu button to be
-   * hidden if the matchMedia is triggered to desktop.
-   *
-   * @private
-   */
-  checkMode() {
-    if (!this.mql || !this.$menu || !this.$menuButton) {
-      return
-    }
-
-    if (this.mql.matches) {
-      this.$menu.removeAttribute('hidden')
-      this.$menuButton.setAttribute('hidden', '')
-    } else {
-      this.$menuButton.removeAttribute('hidden')
-      this.$menuButton.setAttribute('aria-expanded', this.menuIsOpen.toString())
-
-      if (this.menuIsOpen) {
-        this.$menu.removeAttribute('hidden')
-      } else {
-        this.$menu.setAttribute('hidden', '')
-      }
-    }
-  }
-
-  /**
-   * Handle menu button click
-   *
-   * When the menu button is clicked, change the visibility of the menu and then
-   * sync the accessibility state and menu button state
-   *
-   * @private
-   */
-  handleMenuButtonClick() {
-    this.menuIsOpen = !this.menuIsOpen
-    this.checkMode()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -98,129 +98,20 @@ examples:
     description: The standard header as used on information pages on GOV.UK
     options: {}
 
-  - name: with St Edward's crown
-    description: Legacy header with Queen Elizabeth II's crown.
-    options:
-      useTudorCrown: false
-
   - name: with service name
     description: If your service is more than a few pages long, you can help users understand where they are by adding the service name.
     options:
       serviceName: Service Name
       serviceUrl: '/components/header'
 
+  - name: with long service name
+    options:
+      serviceName: Apply to receive a rare, shiny Charizard Pokémon card
+      serviceUrl: '/components/header'
+
   - name: with service name but no service url
     options:
       serviceName: Service Name
-
-  - name: with navigation
-    options:
-      navigation:
-        - href: '#1'
-          text: Navigation item 1
-          active: true
-        - href: '#2'
-          text: Navigation item 2
-        - href: '#3'
-          text: Navigation item 3
-        - href: '#4'
-          text: Navigation item 4
-
-  - name: with custom navigation label
-    options:
-      navigationLabel: Custom navigation label
-      navigation:
-        - href: '#1'
-          text: Navigation item 1
-          active: true
-        - href: '#2'
-          text: Navigation item 2
-        - href: '#3'
-          text: Navigation item 3
-        - href: '#4'
-          text: Navigation item 4
-
-  - name: with custom menu button text
-    description: Button translated into Welsh
-    options:
-      menuButtonText: Dewislen
-      navigation:
-        - href: '#1'
-          text: Eitem llywio 1
-          active: true
-        - href: '#2'
-          text: Eitem llywio 2
-        - href: '#3'
-          text: Eitem llywio 3
-        - href: '#4'
-          text: Eitem llywio 4
-
-  - name: with custom menu button label
-    options:
-      menuButtonLabel: Custom button label
-      navigation:
-        - href: '#1'
-          text: Navigation item 1
-          active: true
-        - href: '#2'
-          text: Navigation item 2
-        - href: '#3'
-          text: Navigation item 3
-        - href: '#4'
-          text: Navigation item 4
-
-  - name: with service name and navigation
-    description: If you need to include basic navigation, contact or account management links.
-    options:
-      serviceName: Service Name
-      serviceUrl: '/components/header'
-      navigation:
-        - href: '#1'
-          text: Navigation item 1
-          active: true
-        - href: '#2'
-          text: Navigation item 2
-        - href: '#3'
-          text: Navigation item 3
-        - href: '#4'
-          text: Navigation item 4
-
-  - name: with large navigation
-    description: An edge case example with a large number of navigation items with long names used to test wrapping
-    options:
-      navigation:
-        - href: '/browse/benefits'
-          text: Benefits
-        - href: '/browse/births-deaths-marriages'
-          text: Births, deaths, marriages and care
-        - href: '/browse/business'
-          text: Business and self-employed
-        - href: '/browse/childcare-parenting'
-          text: Childcare and parenting
-        - href: '/browse/citizenship'
-          text: Citizenship and living in the UK
-        - href: '/browse/justice'
-          text: Crime, justice and the law
-        - href: '/browse/disabilities'
-          text: Disabled people
-        - href: '/browse/driving'
-          text: Driving and transport
-        - href: '/browse/education'
-          text: Education and learning
-        - href: '/browse/employing-people'
-          text: Employing people
-        - href: '/browse/environment-countryside'
-          text: Environment and countryside
-        - href: '/browse/housing-local-services'
-          text: Housing and local services
-        - href: '/browse/tax'
-          text: Money and tax
-        - href: '/browse/abroad'
-          text: Passports, travel and living abroad
-        - href: '/browse/visas-immigration'
-          text: Visas and immigration
-        - href: '/browse/working'
-          text: Working, jobs and pensions
 
   - name: with product name
     options:
@@ -233,41 +124,74 @@ examples:
       navigationClasses: govuk-header__navigation--end
       productName: Product Name
 
-  - name: full width with navigation
+  - name: with search form
     options:
-      containerClasses: govuk-header__container--full-width
-      navigationClasses: govuk-header__navigation--end
-      productName: Product Name
-      navigation:
-        - href: '#1'
-          text: Navigation item 1
-          active: true
-        - href: '#2'
-          text: Navigation item 2
-        - href: '#3'
-          text: Navigation item 3
+      search:
+        name: query
+        labelText: Search this service
+        button:
+          text: Go
 
-  - name: navigation item with html
+  - name: with language selector
     options:
-      serviceName: Service Name
-      serviceUrl: '/components/header'
-      navigation:
-        - href: '#1'
-          html: <em>Navigation item 1</em>
-          active: true
-        - href: '#2'
-          html: <em>Navigation item 2</em>
-        - href: '#3'
-          html: <em>Navigation item 3</em>
+      languages:
+        currentLanguageText: English
+        links:
+          - locale: ar
+            href: '#'
+            name: 'العربيَّة'
+            rtl: true
+          - locale: cy
+            href: '#'
+            name: Cymraeg
+          - locale: en
+            href: '#'
+            name: English
+            current: true
+          - locale: jp
+            href: '#'
+            name: 日本語
 
-  - name: navigation item with text without link
+  - name: with GOV.UK One Login links
     options:
-      serviceName: Service Name
-      serviceUrl: '/components/header'
-      navigation:
-        - text: Navigation item 1
-        - text: Navigation item 2
-        - text: Navigation item 3
+      oneLogin:
+        links:
+          - href: '#'
+            text: Manage account
+          - href: '#'
+            text: Sign out
+
+  - name: kitchen sink
+    options:
+      serviceName: Service name
+      search:
+        name: query
+        labelText: Search this service
+        button:
+          text: Go
+      languages:
+        currentLanguageText: English
+        links:
+          - locale: ar
+            href: '#'
+            name: 'العربيَّة'
+            rtl: true
+          - locale: cy
+            href: '#'
+            name: Cymraeg
+          - locale: en
+            href: '#'
+            name: English
+            current: true
+          - locale: jp
+            href: '#'
+            name: 日本語
+      oneLogin:
+        links:
+          - href: '#'
+            text: Manage account
+          - href: '#'
+            text: Sign out
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -135,22 +135,23 @@ examples:
   - name: with language selector
     options:
       languages:
-        currentLanguageText: English
-        links:
+        label:
+          html: <span class="govuk-visually-hidden">Select language</span> English
+        options:
           - locale: ar
             href: '#'
-            name: 'العربيَّة'
+            text: 'العربيَّة'
             rtl: true
           - locale: cy
             href: '#'
-            name: Cymraeg
+            text: Cymraeg
           - locale: en
             href: '#'
-            name: English
+            text: English
             current: true
           - locale: jp
             href: '#'
-            name: 日本語
+            text: 日本語
 
   - name: with GOV.UK One Login links
     options:
@@ -170,22 +171,23 @@ examples:
         button:
           text: Go
       languages:
-        currentLanguageText: English
-        links:
+        label:
+          html: <span class="govuk-visually-hidden">Select language</span> English
+        options:
           - locale: ar
             href: '#'
-            name: 'العربيَّة'
+            text: 'العربيَّة'
             rtl: true
           - locale: cy
             href: '#'
-            name: Cymraeg
+            text: Cymraeg
           - locale: en
             href: '#'
-            name: English
+            text: English
             current: true
           - locale: jp
             href: '#'
-            name: 日本語
+            text: 日本語
       oneLogin:
         links:
           - href: '#'

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -1,96 +1,134 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
+{% from "../button/macro.njk" import govukButton %}
 
-{%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
-
-{%- set _stEdwardsCrown %}
-<svg
-  focusable="false"
-  role="img"
-  class="govuk-header__logotype"
-  xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 152 30"
-  height="30"
-  width="152"
-  aria-label="GOV.UK"
->
-  <title>GOV.UK</title>
-  <path d="M6.7 12.2c1 .4 2.1-.1 2.5-1s-.1-2.1-1-2.5c-1-.4-2.1.1-2.5 1-.4 1 0 2.1 1 2.5m-4.3 2.5c1 .4 2.1-.1 2.5-1s-.1-2.1-1-2.5c-1-.4-2.1.1-2.5 1-.5 1 0 2.1 1 2.5m-1.3 4.8c1 .4 2.1-.1 2.5-1 .4-1-.1-2.1-1-2.5-1-.4-2.1.1-2.5 1-.4 1 0 2.1 1 2.5m10.4-5.8c1 .4 2.1-.1 2.5-1s-.1-2.1-1-2.5c-1-.4-2.1.1-2.5 1s0 2.1 1 2.5m17.4-1.5c-1 .4-2.1-.1-2.5-1s.1-2.1 1-2.5c1-.4 2.1.1 2.5 1 .5 1 0 2.1-1 2.5m4.3 2.5c-1 .4-2.1-.1-2.5-1s.1-2.1 1-2.5c1-.4 2.1.1 2.5 1 .5 1 0 2.1-1 2.5m1.3 4.8c-1 .4-2.1-.1-2.5-1-.4-1 .1-2.1 1-2.5 1-.4 2.1.1 2.5 1 .4 1 0 2.1-1 2.5m-10.4-5.8c-1 .4-2.1-.1-2.5-1s.1-2.1 1-2.5c1-.4 2.1.1 2.5 1s0 2.1-1 2.5m-5.3-4.9 2.4 1.3V6.5l-2.4.8c-.1-.1-.1-.2-.2-.2s1-3 1-3h-3.4l1 3c-.1.1-.2.1-.2.2-.1.1-2.4-.7-2.4-.7v3.5L17 8.8c-.1.1 0 .2.1.3l-1.4 4.2c-.1.2-.1.4-.1.7 0 1.1.8 2.1 1.9 2.2h.6C19.2 16 20 15.1 20 14c0-.2 0-.4-.1-.7l-1.4-4.2c.2-.1.3-.2.3-.3m-1 20.3c4.6 0 8.9.3 12.8.9 1.1-4.6 2.4-7.2 3.8-9.1l-2.6-.9c.3 1.3.3 1.9 0 2.8-.4-.4-.8-1.2-1.1-2.4l-1.2 4.2c.8-.5 1.4-.9 2-.9-1.2 2.6-2.7 3.2-3.6 3-1.2-.2-1.7-1.3-1.5-2.2.3-1.3 1.6-1.6 2.2-.1 1.2-2.4-.8-3.1-2.1-2.4 1.9-1.9 2.2-3.6.6-5.7-2.2 1.7-2.2 3.3-1.2 5.6-1.3-1.5-3.3-.7-2.5 1.7.9-1.4 2.1-.5 2 .8-.2 1.2-1.7 2.1-3.7 2-2.8-.2-3-2.2-3-3.7.7-.1 1.9.5 3 2l.4-4.4c-1.1 1.2-2.2 1.4-3.3 1.4.4-1.2 2.1-3.1 2.1-3.1h-5.5s1.8 2 2.1 3.1c-1.1 0-2.2-.3-3.3-1.4l.4 4.4c1.1-1.5 2.3-2.1 3-2-.1 1.6-.2 3.5-3 3.7-1.9.2-3.5-.8-3.7-2-.2-1.3 1-2.2 1.9-.8.7-2.4-1.3-3.1-2.6-1.7 1-2.3 1-4-1.2-5.6-1.6 2.1-1.3 3.8.6 5.7-1.3-.7-3.2 0-2.1 2.4.6-1.5 1.9-1.1 2.2.1.2.9-.4 1.9-1.5 2.2-1 .2-2.5-.5-3.7-3 .7 0 1.3.4 2 .9L5 20.4c-.3 1.2-.7 1.9-1.2 2.4-.3-.8-.2-1.5 0-2.8l-2.6.9C2.7 22.8 4 25.4 5.1 30c3.8-.5 8.2-.9 12.7-.9m30.5-11.5c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H59v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zm36.4-4.3c-.4-1.3-1.1-2.4-2-3.4-.9-1-1.9-1.7-3.1-2.3-1.2-.6-2.6-.8-4.2-.8s-2.9.3-4.2.8c-1.1.6-2.2 1.4-3 2.3-.9 1-1.5 2.1-2 3.4-.4 1.3-.7 2.7-.7 4.2s.2 2.9.7 4.2c.4 1.3 1.1 2.4 2 3.4.9 1 1.9 1.7 3.1 2.3 1.2.6 2.6.8 4.2.8 1.5 0 2.9-.3 4.2-.8 1.2-.6 2.3-1.3 3.1-2.3.9-1 1.5-2.1 2-3.4.4-1.3.7-2.7.7-4.2-.1-1.5-.3-2.9-.8-4.2zM81 17.6c0 1-.1 1.9-.4 2.7-.2.8-.6 1.6-1.1 2.2-.5.6-1.1 1.1-1.7 1.4-.7.3-1.5.5-2.4.5-.9 0-1.7-.2-2.4-.5s-1.3-.8-1.7-1.4c-.5-.6-.8-1.3-1.1-2.2-.2-.8-.4-1.7-.4-2.7v-.1c0-1 .1-1.9.4-2.7.2-.8.6-1.6 1.1-2.2.5-.6 1.1-1.1 1.7-1.4.7-.3 1.5-.5 2.4-.5.9 0 1.7.2 2.4.5s1.3.8 1.7 1.4c.5.6.8 1.3 1.1 2.2.2.8.4 1.7.4 2.7v.1zM92.9 28 87 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L152 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-</svg>
-{% endset %}
-
-{%- set _tudorCrown %}
-<svg
-  focusable="false"
-  role="img"
-  class="govuk-header__logotype"
-  xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 148 30"
-  height="30"
-  width="148"
-  aria-label="GOV.UK"
->
-  <title>GOV.UK</title>
-  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-</svg>
-{% endset -%}
-
-<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
+<header class="govuk-header" {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
-    <div class="govuk-header__logo">
-      <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
-        {#- The SVG needs `focusable="false"` so that Internet Explorer does
-        not treat it as an interactive element - without this it will be
-        'focusable' when using the keyboard to navigate.
+    {# Top row #}
+    <div class="govuk-header__top">
 
-        We use a single compound path for the logo to prevent subpixel rounding
-        shifting different elements unevenly relative to one another. #}
-        {{ (_stEdwardsCrown if (params.useTudorCrown !== undefined and params.useTudorCrown === false) else _tudorCrown) | safe | trim | indent(8) }}
-        {% if (params.productName) %}
-        <span class="govuk-header__product-name">
+      {# GOV.UK logo #}
+      <div class="govuk-header__logo">
+        <a href="//gov.uk" class="govuk-header__link govuk-header__link--homepage">
+          {#- The SVG needs `focusable="false"` so that Internet Explorer does
+          not treat it as an interactive element - without this it will be
+          'focusable' when using the keyboard to navigate.
+
+          We use a single compound path for the logo to prevent subpixel rounding
+          shifting different elements unevenly relative to one another. #}
+
+          <svg
+            focusable="false"
+            role="img"
+            class="govuk-header__logotype"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 148 30"
+            height="30"
+            width="148"
+            aria-label="GOV.UK"
+          >
+            <title>GOV.UK</title>
+            <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+          </svg>
+        </a>
+      </div>
+
+      {# Product or service name #}
+      {% if params.productName %}
+        <a class="govuk-header__link govuk-header__name govuk-header__name--product" href="{{ params.homepageUrl | default('/', true) }}">
           {{ params.productName }}
-        </span>
+        </a>
+      {% elif params.serviceName %}
+        {% if params.serviceUrl %}
+          <a class="govuk-header__link govuk-header__name" href="{{ params.serviceUrl }}">
+            {{ params.serviceName }}
+          </a>
+        {% else %}
+          <span class="govuk-header__name">
+            {{ params.serviceName }}
+          </span>
         {% endif %}
-      </a>
-    </div>
-  {% if params.serviceName or params.navigation | length %}
-    <div class="govuk-header__content">
-    {% if params.serviceName %}
-      {% if params.serviceUrl %}
-      <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__service-name">
-        {{ params.serviceName }}
-      </a>
-      {% else %}
-      <span class="govuk-header__service-name">
-        {{ params.serviceName }}
-      </span>
       {% endif %}
-    {% endif %}
-    {% if params.navigation | length %}
-      <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
-          {{ menuButtonText }}
-        </button>
 
-        <ul id="navigation" class="govuk-header__navigation-list">
-        {% for item in params.navigation %}
-          {% if item.text or item.html %}
-          <li class="govuk-header__navigation-item {%- if item.active %} govuk-header__navigation-item--active{% endif %}">
-            {% if item.href %}
-            <a class="govuk-header__link" href="{{ item.href }}"
-              {{- govukAttributes(item.attributes) -}}>
-            {% endif %}
-              {{ item.html | safe | trim | indent(14) if item.html else item.text }}
-            {% if item.href %}
-            </a>
-            {% endif %}
-          </li>
-          {% endif %}
-        {% endfor %}
-        </ul>
-      </nav>
-    {% endif %}
     </div>
-  {% endif %}
+
+    {# Bottom row #}
+    {% if params.search or params.languages or params.oneLogin %}
+    <div class="govuk-header__bottom">
+
+      {# Search form #}
+      {% if params.search %}
+      <form class="govuk-header__search" method="{{ params.search.method | default('get', true) }}" action="{{ params.search.action | default('/', true) }}">
+        <label>
+          <span class="govuk-visually-hidden">{{ params.search.labelText }}</span>
+          <input class="govuk-input" type="search" name="{{ params.search.name }}" placeholder="{{ params.search.labelText }}">
+        </label>
+        {{ govukButton({
+          classes: "govuk-button--secondary",
+          type: "submit",
+          html: params.search.button.html,
+          text: params.search.button.text
+        }) }}
+      </form>
+      {% endif %}
+
+      {% if params.languages or params.oneLogin %}
+      <div class="govuk-header__toolboxes">
+
+        {# Language selector #}
+        {% if params.languages %}
+        <details class="govuk-header__toolbox govuk-js-header-toolbox" name="govuk-header-toolbox">
+          <summary class="govuk-header__toolbox-summary">
+            <span class="govuk-visually-hidden">
+              {{- params.languages.labelText | default('Select language') -}}
+            </span>
+            {{- params.languages.currentLanguageText -}}
+          </summary>
+          <div class="govuk-header__toolbox-contents">
+            <ul class="govuk-list govuk-list--spaced">
+              {% for item in params.languages.links %}
+              <li lang="{{ item.locale }}" dir="{{ 'rtl' if item.rtl else 'ltr' }}">
+                <a class="govuk-header__link" href="{{ item.href }}" hreflang="{{ item.locale }}" {%- if item.current %} aria-current="page"{% endif %}>
+                  {{- item.name -}}
+                </a>
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </details>
+        {% endif %}
+
+        {# One Login #}
+        {% if params.oneLogin %}
+        <details class="govuk-header__toolbox govuk-header__toolbox--one-login govuk-js-header-toolbox" name="govuk-header-toolbox">
+          <summary class="govuk-header__toolbox-summary">
+            <svg class="govuk-header__one-login-icon" width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+              <circle class="background" cx="11" cy="11" r="11" fill="white"></circle>
+              <path class="person" fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"></path>
+              <circle class="person" cx="11" cy="7.75" r="3.75" fill="#1D70B8"></circle>
+              <circle class="border" cx="11" cy="11" r="10" stroke="white" stroke-width="2"></circle>
+            </svg>
+            {{- params.oneLogin.labelText | default('One Login') -}}
+          </summary>
+          <div class="govuk-header__toolbox-contents">
+            <ul class="govuk-list govuk-list--spaced">
+              {% for item in params.oneLogin.links %}
+              <li>
+                <a class="govuk-header__link" href="{{ item.href }}">
+                  {{- item.html | safe if item.html else item.text -}}
+                </a>
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </details>
+        {% endif %}
+
+      </div>
+      {% endif %}
+
+    </div>
+    {% endif %}
+
   </div>
 </header>

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -1,6 +1,21 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../button/macro.njk" import govukButton %}
 
+{% macro _govukHeaderToolboxDetails(box) %}
+<details class="govuk-header__toolbox govuk-js-header-toolbox" name="govuk-header-toolbox">
+  <summary class="govuk-header__toolbox-summary">
+    {{- box.label.html | safe if box.label.html else box.label.text -}}
+  </summary>
+  <div class="govuk-header__toolbox-contents">
+    {% if caller %}
+      {{ caller() }}
+    {% else %}
+      {{ box.html | safe if box.html else box.text }}
+    {% endif %}
+  </div>
+</details>
+{% endmacro %}
+
 <header class="govuk-header" {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
@@ -53,7 +68,7 @@
     </div>
 
     {# Bottom row #}
-    {% if params.search or params.languages or params.oneLogin %}
+    {% if params.search or params.toolboxes or params.languages or params.oneLogin %}
     <div class="govuk-header__bottom">
 
       {# Search form #}
@@ -72,59 +87,66 @@
       </form>
       {% endif %}
 
-      {% if params.languages or params.oneLogin %}
-      <div class="govuk-header__toolboxes">
+      {% if params.toolboxes or params.languages or params.oneLogin %}
+      <ul class="govuk-header__toolboxes">
 
-        {# Language selector #}
+        {% for box in params.toolboxes %}
+          <li class="govuk-header__toolboxes-item">
+            {% if (box.options | length) > 1 %}
+              {% call _govukHeaderToolboxDetails(box) %}
+                <ul class="govuk-list govuk-list--spaced">
+                  {% for link in box.options %}
+                  <li>
+                    <a class="govuk-header__link" href="{{ link.href }}">
+                      {{- link.html | safe if link.html else link.text -}}
+                    </a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              {% endcall %}
+            {% else %}
+              {% set link = box.options[0] %}
+              <a class="govuk-header__link" href="{{ link.href }}">
+                {{- link.html | safe if link.html else link.text -}}
+              </a>
+            {% endif %}
+          </li>
+        {% endfor %}
+
         {% if params.languages %}
-        <details class="govuk-header__toolbox govuk-js-header-toolbox" name="govuk-header-toolbox">
-          <summary class="govuk-header__toolbox-summary">
-            <span class="govuk-visually-hidden">
-              {{- params.languages.labelText | default('Select language') -}}
-            </span>
-            {{- params.languages.currentLanguageText -}}
-          </summary>
-          <div class="govuk-header__toolbox-contents">
-            <ul class="govuk-list govuk-list--spaced">
-              {% for item in params.languages.links %}
-              <li lang="{{ item.locale }}" dir="{{ 'rtl' if item.rtl else 'ltr' }}">
-                <a class="govuk-header__link" href="{{ item.href }}" hreflang="{{ item.locale }}" {%- if item.current %} aria-current="page"{% endif %}>
-                  {{- item.name -}}
-                </a>
-              </li>
-              {% endfor %}
-            </ul>
-          </div>
-        </details>
+          <li class="govuk-header__toolboxes-item">
+            {% call _govukHeaderToolboxDetails(params.languages) %}
+              <ul class="govuk-list govuk-list--spaced">
+                {% for link in box.options %}
+                <li lang="{{ link.locale }}" dir="{{ 'rtl' if link.rtl else 'ltr' }}">
+                  <a class="govuk-header__link" href="{{ link.href }}" hreflang="{{ link.locale }}" {%- if link.current %} aria-current="page"{% endif %}>
+                    {{- link.html | safe if link.html else link.text -}}
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            {% endcall %}
+          </li>
         {% endif %}
 
-        {# One Login #}
         {% if params.oneLogin %}
-        <details class="govuk-header__toolbox govuk-header__toolbox--one-login govuk-js-header-toolbox" name="govuk-header-toolbox">
-          <summary class="govuk-header__toolbox-summary">
-            <svg class="govuk-header__one-login-icon" width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle class="background" cx="11" cy="11" r="11" fill="white"></circle>
-              <path class="person" fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"></path>
-              <circle class="person" cx="11" cy="7.75" r="3.75" fill="#1D70B8"></circle>
-              <circle class="border" cx="11" cy="11" r="10" stroke="white" stroke-width="2"></circle>
-            </svg>
-            {{- params.oneLogin.labelText | default('One Login') -}}
-          </summary>
-          <div class="govuk-header__toolbox-contents">
-            <ul class="govuk-list govuk-list--spaced">
-              {% for item in params.oneLogin.links %}
-              <li>
-                <a class="govuk-header__link" href="{{ item.href }}">
-                  {{- item.html | safe if item.html else item.text -}}
-                </a>
-              </li>
-              {% endfor %}
-            </ul>
-          </div>
-        </details>
+          <li class="govuk-header__toolboxes-item">
+            <a class="govuk-header__link govuk-header__link--one-login" href="#">
+              {{- (params.oneLogin.label.html | safe if params.oneLogin.label.html else params.oneLogin.label.text) | default('GOV.UK One Login') -}}
+              <svg class="govuk-header__one-login-icon" width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+                <circle class="background" cx="11" cy="11" r="11" fill="white"></circle>
+                <path class="person" fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"></path>
+                <circle class="person" cx="11" cy="7.75" r="3.75" fill="#1D70B8"></circle>
+                <circle class="border" cx="11" cy="11" r="10" stroke="white" stroke-width="2"></circle>
+              </svg>
+            </a>
+          </li>
+          <li class="govuk-header__toolboxes-item">
+            <a class="govuk-header__link" href="#">Sign out</a>
+          </li>
         {% endif %}
 
-      </div>
+      </ul>
       {% endif %}
 
     </div>


### PR DESCRIPTION
Spike of https://github.com/alphagov/govuk-design-system/issues/3714. Still a work in progress but wanted to PR it for visibility and so I could write out thoughts. 

**[Look at the thing.](https://govuk-frontend-pr-4917.herokuapp.com/components/header)**

This PR aims to update the header component to make the following changes:

- Remove the navigation.
- Add the ability to show account management options.
- Add the ability to show language selection options.
- Add the ability to show a search field. 

It must continue to show the GOV.UK logo and product or service name. 

> [!NOTE]
> This is an experiment and is not production-ready code. Many elements are hardcoded for the purposes of the spike. Some hacky CSS overrides are used, as well as components utilised in vaguely non-standard ways. Tests and documentation will not be written for it.

## Changes

- Basically completely refactors the thing. 

## Todo 
- Toolbox dropdowns are jank on browsers that don't support `details`/`summary`, like IE 11. 
- This currently uses [the `name` attribute on `details` elements](https://caniuse.com/mdn-html_elements_details_name) to ensure that only one toolbox is open at once. This is a relatively new feature of the HTML spec and is not yet supported by Firefox, nor likely the older versions of our other supported browsers.

## Thoughts

### General thoughts
I've split the header into two rows. The top row shows the GOV.UK logo and service or product name. The bottom row shows the search and what I have nicknamed 'toolboxes', little (intended to be) dropdowns that contain additional links inside of them. The thought behind this separation is that 'top row' elements will virtually always be present, whereas the bottom row could be entirely removed if unneeded. 

I wonder how suitable it is to have the search function in the header. In my mind, search is hierarchically on the same level as primary navigation, however we've already decided to demote primary nav to outside of the header. Personally, it feels a little weird for search to still be here. 

### Product and service names
The service name has been moved to the same position as the product name. To differentiate them, I've swapped their text styling, so that service names are more visually distinct compared to the 'GOV.UK' logo, whereas product names are more similar.

Product names are now separate from the GOV.UK logo link. This would allow us to potentially enforce the GOV.UK logo always linking to the GOV.UK homepage, rather than the current different approaches depending on whether it's a service or product.

### Toolboxes 
I'm wondering how best to do the 'toolbox' links. The megamenu approach that GOV.UK uses doesn't feel like it makes sense here, as a toolbox can contain as few as two links in some scenarios. GOV.UK depends on having dedicated pages to fall back to if JavaScript is unavailable, which we cannot guarantee services will want or be able to do. Any solution here must thus degrade gracefully.

As the toolboxes currently use `details`/`summary` elements to work, they will look totally jank on IE 11.

An approach that I've seen before (on GitHub, in fact) is to style the content of `details` like a modal. This could be one method of resolving exactly how these 'dropdowns' should work and avoids the pains that shifting alignment and space can cause across viewport sizes, but it would open the whole can of modal worms again. 

