### PR TITLE
Fix browser grade listing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To help manage the ever-growing number of browser versions, we group browsers in
 
 - **grade A** - Most recent stable versions of Chrome, Firefox, Edge, Samsung Internet and Safari
 - **grade B** - All stable versions of Chrome, Firefox and Edge released in the last 6 months and the last 4 major stable releases of Safari which are not supported in Grade A
-- **grade C** - [All browsers that support <script type="module">](https://caniuse.com/es6-module) (Chrome 61+, Edge 16-18, Edge 79+
+- **grade C** - [All browsers that support `<script type="module">`](https://caniuse.com/es6-module) (Chrome 61+, Edge 16-18, Edge 79+, Firefox 60+, Safari 11+)
 - **grade X** - All other browsers (including IE11 and older)
 
 > **Note: Only browsers in grades A, B and C will run our JavaScript enhancements. We will not support our JavaScript enhancements for older browsers in grade X.**


### PR DESCRIPTION
The angle brackets in the script example snippet break markdown rendering. Wrapping them in backticks solves it.

Also continue listing the 'main' desktop browsers within the brackets as it stops rather abruptly.
