### PR TITLE
Use canvas colour for cookie banner over hardcoded grey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#4906: Update the icon in the warning text component to match the defined text colour and background colour, rather than always being white on black](https://github.com/alphagov/govuk-frontend/pull/4906)
+- [#4919: Use canvas colour for cookie banner over hardcoded grey](https://github.com/alphagov/govuk-frontend/pull/4919)
 
 ## GOV.UK Frontend v5.3.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
@@ -11,7 +11,7 @@
     // when user changes colours in their browser.
     border-bottom: $border-bottom-width solid transparent;
 
-    background-color: govuk-colour("light-grey");
+    background-color: $govuk-canvas-background-colour;
   }
 
   // Support older browsers which don't hide elements with the `hidden` attribute


### PR DESCRIPTION
The cookie banner is hardcoded to use light-grey as a background colour. Wherever possible, we should use the ‘applied’ colours rather than specific colours from the palette.

We think (although this is somewhat post-rationalising) that the cookie banner uses light-grey for the same reason the footer does. Light grey is the 'canvas' colour used for the `<html>` element and everything outside of the <body>, including any viewport after the footer and the overscroll area. As the cookie banner appears above the header, it's conceptually outside of the body of the page.

Update the cookie banner to reference the canvas background colour rather than the hardcoded light-grey.