### PR TITLE
[SPIKE] Check behaviour of older Sass compilers with CSS custom properties

### DIFF
--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -45,6 +45,13 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/all.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: Dart Sass v1.0.0 output
+          path: .tmp/all.css
+          if-no-files-found: ignore
+
   dart-sass-latest:
     name: Dart Sass v1 (latest)
     runs-on: ubuntu-latest
@@ -80,6 +87,13 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/all.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: Dart Sass v1 (latest) output
+          path: .tmp/all.css
+          if-no-files-found: ignore
+
   # Node Sass v3.4.0 = LibSass v3.3.0
   lib-sass:
     name: LibSass v3.3.0 (deprecated)
@@ -109,6 +123,13 @@ jobs:
       - name: Check output
         run: |
           ! grep "\$govuk-" .tmp/all.css
+
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: LibSass v3.3.0 (deprecated) output
+          path: .tmp/all.css
+          if-no-files-found: ignore
 
   # Node Sass v8.x = LibSass v3 latest
   lib-sass-latest:
@@ -140,6 +161,13 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/all.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: LibSass v3 (latest, deprecated) output
+          path: .tmp/all.css
+          if-no-files-found: ignore
+
   ruby-sass:
     name: Ruby Sass v3.4.0 (deprecated)
     runs-on: ubuntu-latest
@@ -168,6 +196,13 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/all.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: Ruby Sass v3.4.0 (deprecated) output
+          path: .tmp/all.css
+          if-no-files-found: ignore
+
   ruby-sass-latest:
     name: Ruby Sass v3 (latest, deprecated)
     runs-on: ubuntu-latest
@@ -195,3 +230,10 @@ jobs:
       - name: Check output
         run: |
           ! grep "\$govuk-" .tmp/all.css
+
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: Ruby Sass v3 (latest, deprecated) output
+          path: .tmp/all.css
+          if-no-files-found: ignore

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -186,7 +186,7 @@
 
   // Force a colour change on hover to work around a bug in Safari
   // https://bugs.webkit.org/show_bug.cgi?id=224483
-  --govuk-link-hover-colour: hsl(from var(--govuk-text-colour) h s l / 0.99);
+  --govuk-link-hover-colour: #{"hsl(from var(--govuk-text-colour) h s l / 0.99)"};
   --govuk-link-active-colour: var(--govuk-text-colour);
 }
 


### PR DESCRIPTION
This PR fixes how the `hsl` call is made (as older versions of Sass, including Dart Sass v1.0.0, confuse it with [Sass' own `hsl` function](https://sass-lang.com/documentation/modules/#hsl)).

It also adds an update to GitHub actions storing the compiled result for each Sass version we test, so we can peek at what's being generated.

For the purposes of using CSS Custom Properties, looks like everything is in order:
- custom properties starting with `--` are present as expected in the output
- so are the `var()` calls