### PR TITLE
Update Sass GitHub action to save built files

### DIFF
--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -45,6 +45,14 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/index.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        if: ${{ !cancelled() }}
+        with:
+          name: Dart Sass v1.0.0 output
+          path: .tmp/index.css
+          if-no-files-found: ignore
+
   dart-sass-latest:
     name: Dart Sass v1 (latest)
     runs-on: ubuntu-22.04
@@ -80,7 +88,15 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/index.css
 
-  # Node Sass v5.0.0 = LibSass v3.5.5
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        if: ${{ !cancelled() }}
+        with:
+          name: Dart Sass v1 (latest) output
+          path: .tmp/index.css
+          if-no-files-found: ignore
+
+  # Node Sass v3.4.0 = LibSass v3.3.0
   lib-sass:
     name: LibSass v3.5.5 (deprecated)
     runs-on: ubuntu-22.04
@@ -114,6 +130,14 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/index.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        if: ${{ !cancelled() }}
+        with:
+          name: LibSass v3.5.5 (deprecated) output
+          path: .tmp/index.css
+          if-no-files-found: ignore
+
   # Node Sass v8.x = LibSass v3 latest
   lib-sass-latest:
     name: LibSass v3 (latest, deprecated)
@@ -144,6 +168,14 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/index.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        if: ${{ !cancelled() }}
+        with:
+          name: LibSass v3 (latest, deprecated) output
+          path: .tmp/index.css
+          if-no-files-found: ignore
+
   ruby-sass:
     name: Ruby Sass v3.4.0 (deprecated)
     runs-on: ubuntu-22.04
@@ -172,6 +204,14 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/index.css
 
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        if: ${{ !cancelled() }}
+        with:
+          name: Ruby Sass v3.4.0 (deprecated) output
+          path: .tmp/index.css
+          if-no-files-found: ignore
+
   ruby-sass-latest:
     name: Ruby Sass v3 (latest, deprecated)
     runs-on: ubuntu-22.04
@@ -199,3 +239,11 @@ jobs:
       - name: Check output
         run: |
           ! grep "\$govuk-" .tmp/index.css
+
+      - name: Save compiled Sass
+        uses: actions/upload-artifact@v4.3.1
+        if: ${{ !cancelled() }}
+        with:
+          name: Ruby Sass v3 (latest, deprecated) output
+          path: .tmp/index.css
+          if-no-files-found: ignore


### PR DESCRIPTION
This will allow inspecting the output should an older version of Sass fail. 

Each job gets the output of the Sass compilation [uploaded as artifact](https://github.com/actions/upload-artifact), which we can then download for investigation from the Summary page of our GitHub Sass workflow (accessible by clicking 'Details' next to any of the Sass checks and then 'Summary').

The artifact upload is set up as a final step for each job, so that checking there's no more Sass variables in the output runs first. It is set up with `if: ${{ !cancelled() }}` so that it runs even if an error happens beforehand (but [respects the job having been cancelled, unlike `always()`](https://docs.github.com/en/actions/learn-github-actions/expressions#always)).