### PR TITLE
Allow values for the default date input

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -15,19 +15,22 @@
   {% set dateInputItems = params.items %}
 {% else %}
   {% set dateInputItems = [
-    {
-      name: "day",
-      classes: "govuk-input--width-2"
-    },
-    {
-      name: "month",
-      classes: "govuk-input--width-2"
-    },
-    {
-      name: "year",
-      classes: "govuk-input--width-4"
-    }
-  ] %}
+  {
+    name: "day",
+    classes: "govuk-input--width-2" + (" govuk-input--error" if params.errors[0] else ""),
+    value: params.values[0]
+  },
+  {
+    name: "month",
+    classes: "govuk-input--width-2" + (" govuk-input--error" if params.errors[1] else ""),
+    value: params.values[1]
+  },
+  {
+    name: "year",
+    classes: "govuk-input--width-4" + (" govuk-input--error" if params.errors[2] else ""),
+    value: params.values[2]
+  }
+] %}
 {% endif %}
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}


### PR DESCRIPTION
There are two ways to use `govukDateInput`, by passing `items` or leaving that blank and getting the default Day, Month and Year that most services need.

However you nearly always need to set the values, at which point you can't use the default mode, you have to set all the items individually.

This PR adds a `values` option similar to the checkboxes component, so you can keep using the default mode. This is particularly useful in prototyping, where the current approach is much more complex for non-developers.

In usage this looks like:

```
{{ govukDateInput({
  id: "passport-issued",
  namePrefix: "passport-issued",
  fieldset: {
    legend: {
      text: "When was your passport issued?",
      isPageHeading: true,
      classes: "govuk-fieldset__legend--l"
    }
  },
  hint: {
    text: "For example, 27 3 2007"
  },
  values: [27, 3, 2007]
}) }}
```

compared to the existing approach:

```
{{ govukDateInput({
  id: "passport-issued",
  namePrefix: "passport-issued",
  fieldset: {
    legend: {
      text: "When was your passport issued?",
      isPageHeading: true,
      classes: "govuk-fieldset__legend--l"
    }
  },
  hint: {
    text: "For example, 27 3 2007"
  },
  items: [
    {
      classes: "govuk-input--width-2",
      name: "day",
      value: "27"
    },
    {
      classes: "govuk-input--width-2",
      name: "month",
      value: "3"
    },
    {
      classes: "govuk-input--width-4",
      name: "year",
      value: "2007"
    }
  ]
}) }}
```

It also supports errors:

```
{{ govukDateInput({
  id: "passport-issued",
  namePrefix: "passport-issued",
  fieldset: {
    legend: {
      text: "When was your passport issued?",
      isPageHeading: true,
      classes: "govuk-fieldset__legend--l"
    }
  },
  hint: {
    text: "For example, 27 3 2007"
  },
  errorMessage: {
    text: "The date your passport was issued must be in the past"
  },
  values: [27, 3, 2047],
  errors: [true, true, true]
}) }}
```

compared to

```
{{ govukDateInput({
  id: "passport-issued",
  namePrefix: "passport-issued",
  fieldset: {
    legend: {
      text: "When was your passport issued?",
      isPageHeading: true,
      classes: "govuk-fieldset__legend--l"
    }
  },
  hint: {
    text: "For example, 27 3 2007"
  },
  errorMessage: {
    text: "The date your passport was issued must be in the past"
  },
  items: [
    {
      classes: "govuk-input--width-2 govuk-input--error",
      name: "day",
      value: "27"
    },
    {
      classes: "govuk-input--width-2 govuk-input--error",
      name: "month",
      value: "3"
    },
    {
      classes: "govuk-input--width-4 govuk-input--error",
      name: "year",
      value: "2076"
    }
  ]
}) }}
```