### PR TITLE
Fix password input button unexpectedly stretching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#4906: Update the icon in the warning text component to match the defined text colour and background colour, rather than always being white on black](https://github.com/alphagov/govuk-frontend/pull/4906)
 - [#4919: Use canvas colour for cookie banner over hardcoded grey](https://github.com/alphagov/govuk-frontend/pull/4919)
 - [#4899: Remove indents from conditional reveals in radios and checkboxes](https://github.com/alphagov/govuk-frontend/pull/4899)
+- [#4935: Fix password input button unexpectedly stretching](https://github.com/alphagov/govuk-frontend/pull/4935)
 
 ## GOV.UK Frontend v5.3.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -20,7 +20,7 @@
     // IE 11 and Microsoft Edge comes with its own password reveal function. We want to hide it,
     // so that there aren't two controls presented to the user that do the same thing but aren't in
     // sync with one another. This doesn't affect the function that allows Edge users to toggle
-    // password visibility by pressing Alt+F8, which cannot be programatically disabled.
+    // password visibility by pressing Alt+F8, which cannot be programmatically disabled.
     &::-ms-reveal {
       display: none;
     }
@@ -41,7 +41,6 @@
     @include govuk-media-query($from: mobile) {
       // Buttons are normally 100% width on this breakpoint, but we don't want that in this case
       width: auto;
-      flex-grow: 1;
       flex-shrink: 0;
       flex-basis: 5em;
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -152,8 +152,15 @@ examples:
         isPageHeading: true
       id: password-input-with-page-heading
       name: test-name
+  - name: with input width class
+    options:
+      label:
+        text: Password
+      id: password-input-width
+      name: password
+      classes: govuk-input--width-10
   - name: with new-password autocomplete
-    description: Browsers and password managers should prompt to generate a password.
+    description: Supporting browsers and password managers should prompt to generate a password.
     options:
       label:
         text: Password


### PR DESCRIPTION
Fixes issue where the Password input toggle button unexpectedly stretched to fill any space not used by the text input, such as if the input has a restricted maximum width.

I think the `flex-grow` property may have been a leftover from earlier in the component's development, as it doesn't appear to serve any function in the current version of the component.

Fixes #4934. 

## Changes
- Removed the `flex-grow` property from the Password input toggle button.
- Added a review app example of a restricted width password input to help keep this in check in future.
- Tweaked wording of a few comments/documentation pieces. 