### PR TITLE
Fix skip link underline being removed when global styles are enabled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#4919: Use canvas colour for cookie banner over hardcoded grey](https://github.com/alphagov/govuk-frontend/pull/4919)
 - [#4899: Remove indents from conditional reveals in radios and checkboxes](https://github.com/alphagov/govuk-frontend/pull/4899)
 - [#4935: Fix password input button unexpectedly stretching](https://github.com/alphagov/govuk-frontend/pull/4935)
+- [#4936: Fix skip link underline being removed when global styles are enabled](https://github.com/alphagov/govuk-frontend/pull/4936)
 
 ## GOV.UK Frontend v5.3.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
@@ -27,6 +27,7 @@
 
       // Undo unwanted changes when global styles are enabled
       @if $govuk-global-styles {
+        @include govuk-link-decoration;
         box-shadow: none;
       }
     }


### PR DESCRIPTION
Fixes #4930.

## Changes
- Adds the `govuk-link-decoration` mixin (which sets the `text-decoration`, `text-decoration-thickness` and `text-decoration-offset` properties) to the list of styles re-added to the Skip link component when global styles are enabled.
- Update changelog.

## Thoughts
- Simply re-adding the underline with `text-decoration: underline` doesn't have the desired effect, as the `text-decoration: none` inherited from the global styles also resets the thickness and offset properties. We do need all three. 