### PR TITLE
Fix `govukAttributes` macro not outputting values passed from the `safe` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#4899: Remove indents from conditional reveals in radios and checkboxes](https://github.com/alphagov/govuk-frontend/pull/4899)
 - [#4935: Fix password input button unexpectedly stretching](https://github.com/alphagov/govuk-frontend/pull/4935)
 - [#4936: Fix skip link underline being removed when global styles are enabled](https://github.com/alphagov/govuk-frontend/pull/4936)
+- [#4938: Fix `govukAttributes` macro not outputting values passed from the `safe` filter](https://github.com/alphagov/govuk-frontend/pull/4938)
 
 ## GOV.UK Frontend v5.3.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/macros/attributes.njk
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.njk
@@ -68,6 +68,12 @@
   {#- Append attribute name/value pairs -#}
   {%- if attributes is mapping %}
     {% for name, value in attributes %}
+      {#- Detect if this is a `safe` filtered value. Just pass the value through if so. -#}
+      {#- https://github.com/alphagov/govuk-frontend/issues/4937 -#}
+      {% if value is mapping and not [undefined, null].includes(value.val) and value.length %}
+        {% set value = value.val %}
+      {% endif %}
+
       {#- Set default attribute options -#}
       {% set options = value if value is mapping else {
         value: value,

--- a/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/attributes.unit.test.mjs
@@ -1,4 +1,5 @@
 import { renderMacro } from '@govuk-frontend/lib/components'
+import nunjucks from 'nunjucks'
 
 describe('attributes.njk', () => {
   describe('govukAttributes', () => {
@@ -261,6 +262,24 @@ describe('attributes.njk', () => {
       )
 
       expect(attributes).toBe('')
+    })
+
+    it('outputs values that are passed from the `safe` filter', () => {
+      // Set up a tiny Nunjucks environment, just so we can get the native `safe` filter
+      const nunjucksEnv = nunjucks.configure([])
+
+      const attributes = renderMacro(
+        'govukAttributes',
+        'govuk/macros/attributes.njk',
+        {
+          context: {
+            'data-text': 'Testing',
+            'data-safe-text': nunjucksEnv.getFilter('safe')('Testing')
+          }
+        }
+      )
+
+      expect(attributes).toBe(' data-text="Testing" data-safe-text="Testing"')
     })
   })
 })


### PR DESCRIPTION
Updates the `govukAttributes` macro to, when passed a set of key-value pairs, check if the value is an object that matches the shape of those returned by Nunjucks' `safe` filter (i.e. an object with `val` and `length` keys). 

If found, that object's `val` is used in place of the object. Previously, this would just be lost and the macro would return an empty string.

If the value is an object that doesn't have those specific keys, it is instead treated as one of our attribute configuration objects (which use the keys `value` and `optional` instead). 

Resolves https://github.com/alphagov/govuk-frontend/issues/4937.

## Changes
- Adds a check at the start of the `govukAttributes` attribute loop to look for objects resembling the output of the `safe` filter. If matched, the object's `val` value is mapped to the macro's working value.
- Adds a test to ensure that values passed via the `safe` filter are output by the macro as expected. 

## Thoughts
Checking for the existence of two keys is definitely not a foolproof way of ensuring that the object is actually one returned by the `safe` filter, however I'm not sure there is a more obvious way of detecting its use.

This does **not** create output that perfectly matches the expected output in #4937, as HTML is still returned escaped even if `safe` is used by the author. This is because the macro indiscriminately escapes all of the attributes and values it outputs.