### PR TITLE
Update title of PR for fix to `attributes` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#4899: Remove indents from conditional reveals in radios and checkboxes](https://github.com/alphagov/govuk-frontend/pull/4899)
 - [#4935: Fix password input button unexpectedly stretching](https://github.com/alphagov/govuk-frontend/pull/4935)
 - [#4936: Fix skip link underline being removed when global styles are enabled](https://github.com/alphagov/govuk-frontend/pull/4936)
-- [#4938: Fix `govukAttributes` macro not outputting values passed from the `safe` filter](https://github.com/alphagov/govuk-frontend/pull/4938)
+- [#4938: Fix `attributes` option ignoring values passed from the `safe` filter ](https://github.com/alphagov/govuk-frontend/pull/4938)
 
 ## GOV.UK Frontend v5.3.0 (Feature release)
 


### PR DESCRIPTION
The new title shifts the focus to what changed in the public API (the `attributes` option) rather than internal APIs that users are not aware of.