### PR TITLE
Remove duplicate `errorMessage` argument for the password input component

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -76,7 +76,6 @@
   },
   label: params.label,
   hint: params.hint,
-  errorMessage: params.errorMessage,
   classes: "govuk-password-input__input govuk-js-password-input-input" + (" " + params.classes if params.classes),
   errorMessage: params.errorMessage,
   id: params.id,


### PR DESCRIPTION
Fairly simple change for something I noticed while looking at the source code.

Remove duplicate `errorMessage` argument for the password input component.
