### PR TITLE
Tidy up release docs so that they're up to date

### DIFF
--- a/docs/releasing/after-publishing-a-release.md
+++ b/docs/releasing/after-publishing-a-release.md
@@ -8,7 +8,7 @@ Developers should update [govuk-design-system](https://github.com/alphagov/govuk
 
 ## Let the community know about the new release
 
-We now need to update or comms channels.
+We now need to update our comms channels.
 
 ### The mailing list
 
@@ -46,6 +46,6 @@ We should check if we need to update the following places on the website:
 
 Finally, we should make sure that our issue list and sprint board are tidy by making sure:
 
-- issues created for this release are all complete, closed, and moved into the **Done** column on the [Design System sprint board](https://github.com/orgs/alphagov/projects/4)
+- issues created for this release are all complete, closed, and moved into the **Done** column on the [Design System cycle board](https://github.com/orgs/alphagov/projects/53)
 - that all the issues (on the same board) solved and/or published in this release have been moved from the **Ready to Release** column to **Done**
 - any associated milestones are closed

--- a/docs/releasing/before-publishing-a-release.md
+++ b/docs/releasing/before-publishing-a-release.md
@@ -4,11 +4,9 @@ When preparing to publish a release of GOV.UK Frontend we need to ensure we are 
 
 ## Kick off the release
 
-Both squads should coordinate when either wants to publish a new release. Choose a team member to lead on the release, typically a developer.
+The whole team should coordinate whether to publish a new release. Choose a team member to lead on the release, typically a developer.
 
 We next need to define a cutoff date for this release. Once the cutoff date passes, do not add any further major changes. We can still add small fixes before we publish as long as we notify the team. However, we should try to avoid adding too many fixes in this way, as it requires us to have to repeat steps of the release process.
-
-Optionally, we can also let the prototype kit know that we are coordinating a release. The prototype kit team have [their own release process](https://github.com/alphagov/govuk-prototype-kit/tree/main/internal_docs) and we don't need to run releases synchronously.
 
 ## Raise release issues
 
@@ -16,7 +14,7 @@ Release issues should be created in the team GitHub repositories: [govuk-fronten
 
 All these issues should be:
 
-- added to the [Design System sprint board](https://github.com/orgs/alphagov/projects/53) backlog
+- added to the [Design System cycle board](https://github.com/orgs/alphagov/projects/53) backlog
 - added to that release's milestone
 - tagged with the '🚀 release' label
 

--- a/docs/releasing/publishing-a-preview.md
+++ b/docs/releasing/publishing-a-preview.md
@@ -9,7 +9,8 @@ Use previews when you:
 - [work on developing a component or pattern](https://design-system.service.gov.uk/community/develop-a-component-or-pattern/) for the GOV.UK Design System
 - want to trial an experimental feature (guidance on trialing experimental features is in development)
 
-> **Warning** Your projects should never depend on a preview GOV.UK Frontend package. This is because someone could remove the GitHub branch containing the preview package at any time. For this reason, never use a preview package in a production setting.
+> [!WARNING]
+> Your projects should never depend on a preview GOV.UK Frontend package. This is because someone could remove the GitHub branch containing the preview package at any time. For this reason, never use a preview package in a production setting.
 
 ## What happens when you preview GOV.UK Frontend
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -23,10 +23,10 @@ Developers should pair on releases. When remote working, it can be useful to be 
 4. Pick a new version number according to the [versioning documentation](/docs/contributing/versioning.md) and apply it by running:
 
    ```shell
-   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
+   npm version --no-git-tag-version --workspace govuk-frontend <NEW VERSION NUMBER>
    ```
 
-   This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
+   ...where `<NEW VERSION NUMBER>` is the literal number without a 'v' in front of it. This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
 
@@ -60,7 +60,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 1. Check out the **main** branch and pull the latest changes.
 
-2. Sign in to npm (`npm login`), using the credentials for the govuk-patterns-and-tools npm user from Bitwarden.
+2. Sign in to npm (`npm login`), using the credentials for the **govuk-patterns-and-tools** npm user from Bitwarden.
 
 3. Run `npm run publish-release`, which will prompt you to check whether the npm tag looks as expected.
 


### PR DESCRIPTION
## What/Why
A general sweep of our release docs following the release of 5.3.1. Specific changes:

- Update places where we reference our "sprint board" with the correct link and the word "cycle" instead of "sprint"
- Remove a reference to squads as we've abandoned the 2 squad way of working following the release of 5.0
- Make use of github's [alerts markdown](https://github.com/orgs/community/discussions/16925) for the warning in the docs on preview publishing
- Reformat the `npm version` command so that the version number placeholder is at the end of the command, meaning it's easier to replace it when the command is copy/pasted into a terminal
- Clarify that the version number required in the `npm version` command is just the number, no v's
- Fix a stray typo