### PR TITLE
Add override class for tabular numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### New features
+
+#### Use tabular numbers easily with `govuk-!-font-tabular-numbers`
+
+We've added a new override class for tabular number styling: `govuk-!-font-tabular-numbers`.
+
+Tabular numbers are useful when numbers are intended to be compared, for numerical sequences that may otherwise be difficult to read, or for numbers that dynamically update.
+
+It was previously only possible to use tabular numbers by using the `govuk-font-tabular-numbers` Sass mixin.
+
+This change was introduced in [pull request #4973: Add override class for tabular numbers](https://github.com/alphagov/govuk-frontend/pull/4973).
+
 ### Deprecations
 
 #### Importing layers using `all` files

--- a/packages/govuk-frontend/src/govuk/overrides/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_typography.scss
@@ -27,4 +27,10 @@
   .govuk-\!-font-weight-bold {
     @include govuk-typography-weight-bold($important: true);
   }
+
+  // Tabular numbers
+
+  .govuk-\!-font-tabular-numbers {
+    @include govuk-font-tabular-numbers($important: true);
+  }
 }


### PR DESCRIPTION
Adds an override class that invokes the `govuk-font-tabular-numbers` mixin. 

I think this is a necessary feature to help meet https://github.com/alphagov/govuk-design-system/issues/1233, as users are currently unable to use tabular numbers without using Sass—which in turn requires having a Sass build pipeline set up and authoring bespoke code—which is a bit of a faff, really. 