### PR TITLE
Fix imports of ‘core’ from full page examples

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/campaign-page.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/campaign-page.scss
@@ -1,5 +1,5 @@
 @import "govuk/base";
-@import "govuk/core/all";
+@import "govuk/core";
 
 .app-header--campaign {
   padding-bottom: govuk-spacing(2);

--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/search.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/search.scss
@@ -1,5 +1,5 @@
 @import "govuk/base";
-@import "govuk/core/all";
+@import "govuk/core";
 
 .app-document-list > li {
   padding-top: govuk-spacing(4);


### PR DESCRIPTION
After the changes in #4955 we need to follow the instructions in our own deprecation message to update the imports from our full-page examples:

> Importing using `govuk/core/all` is deprecated. Update your import statement to import `govuk/core/index`.