### PR TITLE
Fix tree-shaking of inner modules for the Webpack integration

### DIFF
--- a/.github/workflows/bundler-integrations.yml
+++ b/.github/workflows/bundler-integrations.yml
@@ -35,8 +35,17 @@ jobs:
         run: npm run ${{matrix.bundler}} -w @govuk-frontend/bundler-integrations
 
       # Check output for modules that should not be included
-      - name: Check output
+      - name: Check absence of unused modules in `single-component.js`
         working-directory: ./.github/workflows/bundler-integrations
         run: |
           ! grep "Accordion" dist/${{matrix.bundler}}/single-component.js -q
+
+      - name: Check absence of unused utility functions in `single-component.js`
+        working-directory: ./.github/workflows/bundler-integrations
+        run: |
+          ! grep "getFragmentFromUrl" dist/${{matrix.bundler}}/single-component.js -q
+
+      - name: Check presence of modules in `initAll.js`
+        working-directory: ./.github/workflows/bundler-integrations
+        run: |
           grep "Accordion" dist/${{matrix.bundler}}/initAll.js -q

--- a/.github/workflows/bundler-integrations/package.json
+++ b/.github/workflows/bundler-integrations/package.json
@@ -18,6 +18,7 @@
     "del-cli": "^5.1.0",
     "govuk-frontend": "*",
     "rollup": "^4.17.2",
+    "terser-webpack-plugin": "^5.3.10",
     "vite": "^5.2.10",
     "webpack": "^5.91.0"
   }

--- a/.github/workflows/bundler-integrations/webpack.config.js
+++ b/.github/workflows/bundler-integrations/webpack.config.js
@@ -1,11 +1,28 @@
+const TerserPlugin = require('terser-webpack-plugin')
+
 /** @type {import('webpack').Configuration} */
 module.exports = {
+  // Enable production mode for Webpack, as tree-shaking is a combination of
+  // - `usedExports` including, but not exporting code `export`s that are not used
+  // - `TerserPlugin` clearing unused code, effectively clearing the unused exports
+  //
+  // More details: https://webpack.js.org/guides/tree-shaking/
+  // (especially the end of 'Add a Utility', and 'Minify the Output')
+  mode: 'production',
   optimization: {
-    // Configure WebPack to drop exports that are not used from the code
-    // so we can disable Terser and still check what's being included
-    usedExports: true,
-    // Prevent minification so we can see what's going on in the built file
-    minimize: false
+    minimizer: [
+      new TerserPlugin({
+        extractComments: false,
+        terserOptions: {
+          mangle: false,
+          // Reproduce Webpack's defaults
+          // https://webpack.js.org/configuration/optimization/#optimizationminimizer
+          compress: {
+            passes: 2
+          }
+        }
+      })
+    ]
   },
   target: 'web',
   entry: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "del-cli": "^5.1.0",
         "govuk-frontend": "*",
         "rollup": "^4.17.2",
+        "terser-webpack-plugin": "^5.3.10",
         "vite": "^5.2.10",
         "webpack": "^5.91.0"
       }


### PR DESCRIPTION
We were not quite following the right step to optimise the build as it would be in an actual production set up while still retaining the possibility to inspect the content. This PR amends the Webpack build so tree-shaking is set up properly and internal utilities not used by `single-component.mjs` get excluded.

Tree-shaking in Webpack is not only a matter of setting `usedExports` (which still [includes unused code, just doesn't export it](https://webpack.js.org/guides/tree-shaking/#add-a-utility)), but also of having the `TerserPlugin` set up, as it's the one [effectively removing the unused code](https://webpack.js.org/guides/tree-shaking/#minify-the-output).

Instead, tree-shaking is properly set up [by using the `production` mode](https://webpack.js.org/guides/tree-shaking/#minify-the-output). We can then tweak the configuration of TerserPlugin, disabling mangling so we can look at class, function and variable names in the output. 

Closes #4964