### PR TITLE
Build each entry independently when testing Vite

### DIFF
--- a/.github/workflows/bundler-integrations/package.json
+++ b/.github/workflows/bundler-integrations/package.json
@@ -8,13 +8,14 @@
     "rollup:initAll": "npm run rollup:cli -- -o dist/rollup/initAll.js ./src/initAll.mjs",
     "rollup:cli": "rollup -c rollup.config.mjs",
     "webpack": "webpack --mode production -o dist/webpack",
-    "vite": "vite build",
+    "vite": "cross-env ENTRY_NAME=single-component vite build && cross-env ENTRY_NAME=initAll vite build",
     "clean": "del-cli dist",
     "build:all": "concurrently \"npm run rollup\" \"npm run webpack\" \"npm run vite\" --names \"rollup,webpack,vite\" --prefix-colors \"red.dim,blue.dim,yellow.dim\""
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "del-cli": "^5.1.0",
     "govuk-frontend": "*",
     "rollup": "^4.17.2",

--- a/.github/workflows/bundler-integrations/vite.config.mjs
+++ b/.github/workflows/bundler-integrations/vite.config.mjs
@@ -1,6 +1,10 @@
-/** @type {import('vite').UserConfig} */
-// the default vite config used by the different test case configs
+// Allows to run the same configuration against different files
+// as Vite would split shared code in a separate chunk if trying
+// to build an array of entries in `build.rollupOptions.input`
+// or `build.lib.entry`
+const entryName = process.env.ENTRY_NAME ?? 'single-component'
 
+/** @type {import('vite').UserConfig} */
 export default {
   build: {
     // Align output with other bundlers to facilitate testing
@@ -8,8 +12,11 @@ export default {
     assetsDir: '.',
     // Prevent minification so we can see actual class/function names
     minify: false,
+    // Vite will clean the build folder, but we'll have two concurrent builds
+    // (one for each entry) so we want to prevent that
+    emptyOutDir: false,
     rollupOptions: {
-      input: ['./src/single-component.mjs', './src/initAll.mjs'],
+      input: `./src/${entryName}.mjs`,
       output: {
         entryFileNames: '[name].js'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
         "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3",
         "del-cli": "^5.1.0",
         "govuk-frontend": "*",
         "rollup": "^4.17.2",


### PR DESCRIPTION
Builds `initAll.mjs` and `single-component.mjs` independently during Vite integration tests, to work around Vite cleverly optimising a build with multiple entries by splitting shared code in a separate file. [After investigation](https://github.com/alphagov/govuk-frontend/issues/4978#issuecomment-2107863308), it seems we can only make separate builds to circumvent that cleverness.

Simplest option looked to allow to pass the name of the file through environment variable, so we can run the build command multiple times targeting a separate entry. As we want to have the same build folder structure as for Webpack and Rollup, both builds will need to output to the same folder, for which we need to disable Vite automatically cleaning up its build folder.

Closes #4978. 