### PR TITLE
Stop warnings/errors from raw SCSS calculations

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_measurements.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_measurements.scss
@@ -20,19 +20,19 @@ $govuk-page-width: 960px !default;
 
 $govuk-grid-widths: (
   one-quarter: (
-    100% / 4
+    calc(100% / 4)
   ),
   one-third: (
-    100% / 3
+    calc(100% / 3)
   ),
   one-half: (
-    100% / 2
+    calc(100% / 2)
   ),
   two-thirds: (
-    200% / 3
+    calc(200% / 3)
   ),
   three-quarters: (
-    300% / 4
+    calc(300% / 4)
   ),
   full: 100%
 ) !default;
@@ -49,7 +49,7 @@ $govuk-gutter: 30px !default;
 /// @type Number
 /// @access public
 
-$govuk-gutter-half: $govuk-gutter / 2;
+$govuk-gutter-half: calc($govuk-gutter / 2);
 
 // =========================================================
 // Borders


### PR DESCRIPTION
There are a few calculations which are not wrapped in `calc() `and thus generate warnings.

The effect of this change is to stop these errors/warnings being reported in the console