### PR TITLE
Make root `all.scss` a proxy for `index.scss`

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.scss
+++ b/packages/govuk-frontend/src/govuk/all.scss
@@ -1,9 +1,1 @@
-@import "base";
-
-@import "core/index";
-@import "objects/index";
-
-@import "components/index";
-
-@import "utilities/index";
-@import "overrides/index";
+@import "index";


### PR DESCRIPTION
In #4955 we renamed all of the entrypoints within the individual layers from `all.scss` to `index.scss`, leaving `all.scss` in place as an alias that outputs a deprecation warning.

We also inadvertently [introduced an `index.scss` in the root ‘govuk’ folder but with identical contents to `all.scss`][1]. 

We ultimately intend to rename this root entrypoint to `index.scss` to be consistent with the other changes, but this requires further changes to our documentation, entrypoints in package.json etc.

In order to get the next release out, we’re just going to make `all.scss` a proxy for `index.scss`, without adding a deprecation warning.

We’ll make those changes and introduce a deprecation warning in a future release.

[1]: https://github.com/alphagov/govuk-frontend/pull/4955/files#diff-ec46cef55fb94c8061eaf2fd3f241998f9a13d56fdad7018fe1712e00d5ae3aa