### PR TITLE
Selectively silence deprecations and fix missed warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25631,9 +25631,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.72.0.tgz",
-      "integrity": "sha512-MVdnYEEFVVkmsaAaEa9nWoIhCyezG6afJl2a7OF/WKl4PTGtCjgM9+yJBGUtAF9aJ36Us5hwNV8yqffnCJruyg==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.2.tgz",
+      "integrity": "sha512-luiDeWNZ0tKs1jCiSFbuz8wFVQxYqN+vh+yfm9v7kW42yPtwEF8+z2ROaDJluSUZ7vhFmsXuqoKg9qBxc7SCnw==",
       "dev": true,
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
@@ -25647,28 +25647,29 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.72.0",
-        "sass-embedded-android-arm64": "1.72.0",
-        "sass-embedded-android-ia32": "1.72.0",
-        "sass-embedded-android-x64": "1.72.0",
-        "sass-embedded-darwin-arm64": "1.72.0",
-        "sass-embedded-darwin-x64": "1.72.0",
-        "sass-embedded-linux-arm": "1.72.0",
-        "sass-embedded-linux-arm64": "1.72.0",
-        "sass-embedded-linux-ia32": "1.72.0",
-        "sass-embedded-linux-musl-arm": "1.72.0",
-        "sass-embedded-linux-musl-arm64": "1.72.0",
-        "sass-embedded-linux-musl-ia32": "1.72.0",
-        "sass-embedded-linux-musl-x64": "1.72.0",
-        "sass-embedded-linux-x64": "1.72.0",
-        "sass-embedded-win32-ia32": "1.72.0",
-        "sass-embedded-win32-x64": "1.72.0"
+        "sass-embedded-android-arm": "1.77.2",
+        "sass-embedded-android-arm64": "1.77.2",
+        "sass-embedded-android-ia32": "1.77.2",
+        "sass-embedded-android-x64": "1.77.2",
+        "sass-embedded-darwin-arm64": "1.77.2",
+        "sass-embedded-darwin-x64": "1.77.2",
+        "sass-embedded-linux-arm": "1.77.2",
+        "sass-embedded-linux-arm64": "1.77.2",
+        "sass-embedded-linux-ia32": "1.77.2",
+        "sass-embedded-linux-musl-arm": "1.77.2",
+        "sass-embedded-linux-musl-arm64": "1.77.2",
+        "sass-embedded-linux-musl-ia32": "1.77.2",
+        "sass-embedded-linux-musl-x64": "1.77.2",
+        "sass-embedded-linux-x64": "1.77.2",
+        "sass-embedded-win32-arm64": "1.77.2",
+        "sass-embedded-win32-ia32": "1.77.2",
+        "sass-embedded-win32-x64": "1.77.2"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.72.0.tgz",
-      "integrity": "sha512-FararyDR8TdsXQ1LWuooNlPhJD4CcOZAFyPO4GSxwystMYNfXOlrusyHBZ8pqwDxLwLME5XXRSERulCb62CE9Q==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.2.tgz",
+      "integrity": "sha512-rMuIMZ/FstMrT9Y23LDgQGpCyfe3i10dJnmW+DVJ9Gqz4dR7qpysEBIQXU35mHVq8ppNZ0yGiFlFZTSiiVMdzQ==",
       "cpu": [
         "arm"
       ],
@@ -25685,9 +25686,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.72.0.tgz",
-      "integrity": "sha512-8a1T9nrWQocWBK0oWuI8h1t5X1lWIcgzL6QUvYCR4jjEvfiLKwojZB4Rpv87ObjXknw0MOU0jizCjQvz4j8/BQ==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.2.tgz",
+      "integrity": "sha512-7DiFMros5iRYrkPlNqUBfzZ/DCgsI199pRF8xuBsPf9yuB8SLDOqvNk3QOnUCMAbpjW5VW1JgdfGFFlHTCnJQA==",
       "cpu": [
         "arm64"
       ],
@@ -25704,9 +25705,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.72.0.tgz",
-      "integrity": "sha512-5NNgv9WJkp/nM0/N09epN0mMHFJjYZnZCPxs2uc8X+lEw8M07AgXfqwam2uwiZqBF81mwdwMOivcOTll5w1Ciw==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.2.tgz",
+      "integrity": "sha512-qN0laKrAjuvBLFdUogGz8jQlbHs6tgH91tKQeE7ZE4AO9zzDRlXtaEJP1x6B6AGVc8UOEkvQyR3Nej4qwWprhA==",
       "cpu": [
         "ia32"
       ],
@@ -25723,9 +25724,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.72.0.tgz",
-      "integrity": "sha512-lxVfKyhFv73lZ/fTawSBfdFPnj4/UHPv/mzq1wez0178NvdHixsotX4fFrEGcqt0gXruBWLx5w26vXAHeaFCVg==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.2.tgz",
+      "integrity": "sha512-HByqtC5g5hOaJenWs4Klx6gFEIZYx+IEFh5K56U+wB+jd6EU32Lrnbdxy1+i/p/kZrd+23HrVHQPv8zpmxucaw==",
       "cpu": [
         "x64"
       ],
@@ -25742,9 +25743,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.72.0.tgz",
-      "integrity": "sha512-wqiWD4KlhoKTpZkCtpZVxuM7HtsvYdR+sDLu772x3hvTRS1E2pWjb+grR7+9CVCENV/akVSjC9cQIwkT+utygQ==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.2.tgz",
+      "integrity": "sha512-0jkL/FwbAStqqxFSjHfhElEAWrKRRvFz2JeXOxskUdzMehDMv5LaewqSRCijyeKBO3KgurvndmSfrOizdU6WAw==",
       "cpu": [
         "arm64"
       ],
@@ -25761,9 +25762,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.72.0.tgz",
-      "integrity": "sha512-n1zLBOixeIEGx85WdDbPoYFXqsb4Ct0NL8P5EuA5hFZ7RJYUdiI98AfgH0PdS+tNsJRE6bZp/SIZQSSl5FiRxA==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.2.tgz",
+      "integrity": "sha512-8Sy36IxOOFPWA5TdhC87SvOkrXUSis51CGKlIsM8yZISQiY9y8b+wrNJM1f3oHvs641xZBaeIuwibJXaY6hNBg==",
       "cpu": [
         "x64"
       ],
@@ -25780,9 +25781,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.72.0.tgz",
-      "integrity": "sha512-N4oNMQno5/7qOZZb00KV+dq+QMcjf3YyKqZPWNcuQ1xvH61ro8UXvHkqS1s3hmba/1mrDo+7RTaNDDcQ4UMlZw==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.2.tgz",
+      "integrity": "sha512-/gtCseBkGCBw61p6MG2BqeYy8rblffw2KXUzMKjo9Hlqj/KajWDk7j1B+mVnqrHOPB/KBbm8Ym/2ooCYpnMIkQ==",
       "cpu": [
         "arm"
       ],
@@ -25799,9 +25800,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.72.0.tgz",
-      "integrity": "sha512-bsflO/WjtPaAArmSe/IeUEST8Pd7CjbdocfRHZ+49DfrNj5BVNKeHj9JlSy4GwvLyprRM9/I7pkHnJ+Yb3AwjA==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.2.tgz",
+      "integrity": "sha512-hlfNFu1IWHI0cOsbpFWPrJlx7IFZfXuI3iEhwa4oljM21y72E6tETUFmTr4f9Ka9qDLXkUxUoYaTH2SqGU9dDA==",
       "cpu": [
         "arm64"
       ],
@@ -25818,9 +25819,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.72.0.tgz",
-      "integrity": "sha512-SBe28KAn47l/C92dweQBSv0BqXMLUROd6Lpfc0hSrI/ZJ0p+ZPFcX4X4tyN06eG0dBtLRCLD0H+xv/KZ8ut0og==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.2.tgz",
+      "integrity": "sha512-JSIqGIeAKlrMw/oMFFFxZ10F3QUJVdjeGVI83h6mwNHTYgrX6PuOngcAYleIpYR5XicQgfueC5pPVPbP5CArBQ==",
       "cpu": [
         "ia32"
       ],
@@ -25837,9 +25838,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.72.0.tgz",
-      "integrity": "sha512-KUU4nuoxCDWQGpzTcB4/3dlQDlQvJVQpzRo2wOyfJi+8JdJHbx5NxGfuCCqcZ3QTBCgpYtRdL0y4htMygwBARA==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.2.tgz",
+      "integrity": "sha512-LZTSnfHPlfvkdQ8orpnEUCEx40qhKpMjxN3Ggi8kgQqv5jvtqn0ECdWl0n4WI5CrlkmtdS3VeFcsf078bt/f8Q==",
       "cpu": [
         "arm"
       ],
@@ -25853,9 +25854,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.72.0.tgz",
-      "integrity": "sha512-zOWLXWNHL9Dm9ME8MMWw4AfhG4AyJeE+Q5hhayyDdSs1h5/UXbAolp1N0rDZtFLGz289a201nQ3fr7RzHvaXnA==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.2.tgz",
+      "integrity": "sha512-JQZuONuhIurKjc/qE9cTiJXSLixL8hGkalWN3LJHasYHVAU92QA/t8rv0T51vIzf/I2F59He3bapkPme60dwSw==",
       "cpu": [
         "arm64"
       ],
@@ -25869,9 +25870,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.72.0.tgz",
-      "integrity": "sha512-QdYd39yOXPS7uYMcgtZh4sXKmwB+2b3u6rTt0nw7y3rAHpn5nrWQqHJbuIFz0JFmiA+8HB33HMRDcuGdUOmYoQ==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.2.tgz",
+      "integrity": "sha512-6F1GHBgPkcTXtfM0MK3PofozagNF8IawdfIG4RNzGeSZRhGBRgZLOS+vdre4xubTLSaa6xjbI47YfaD43z8URQ==",
       "cpu": [
         "ia32"
       ],
@@ -25885,9 +25886,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.72.0.tgz",
-      "integrity": "sha512-YkqG0/9fUubuK1veHATHhz5mEACVVmzCDiyjgYX5qx8VTOowt/OO3+NAwnZOr4UcjfIfemJNRdSpDFGUwOd01A==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.2.tgz",
+      "integrity": "sha512-8BiqLA1NJeN3rCaX6t747GWMMdH5YUFYuytXU8waDC/u+FSGoOHRxfrsB8BEWHVgSPDxhwZklanPCXXzbzB2lw==",
       "cpu": [
         "x64"
       ],
@@ -25901,9 +25902,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.72.0.tgz",
-      "integrity": "sha512-9CCHTm5iUjJ4zeOKH04jyQH4yxxtaigo3APwXfYQ64xLJHuhazk0qyx8RV1heD44j0YpnSa5ybhWwm8gLKG7/A==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.2.tgz",
+      "integrity": "sha512-czQOxGOX4U47jW9k+cbFBgSt/6FVx2WGLPqPvrgDiEToLJdZyvzUqrkpqQYfJ6hN1koqatCPEpDrUZBcTPGUGg==",
       "cpu": [
         "x64"
       ],
@@ -25919,10 +25920,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.2.tgz",
+      "integrity": "sha512-NA+4Y5PO04YQGtKNCyLrUjQU2nijskVA3Er/UYGtx66BBlWZ/ttbnlk+dU05SF5Jhjb3HtThGGH1meb7pKA+OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.72.0.tgz",
-      "integrity": "sha512-6H+qrmg8i9tlOkBuM0H2XaqDAe1Lja8Uca+NQJO6auzgqCdurZT5cnT/wWlnxYmno4wBq1Ahw0v53ybJVOXhfA==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.2.tgz",
+      "integrity": "sha512-/3hGz4GefhVuuUu2gSOdsxBYym5Di0co0tZbtiokCU/8VhYhcAQ3v2Lni49VV6OnsyJLb1nUx+rbpd8cKO1U4w==",
       "cpu": [
         "ia32"
       ],
@@ -25939,11 +25959,10 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.72.0.tgz",
-      "integrity": "sha512-lboSqBzKyAkDdr9b37babqK5FeLan5GDMwir4URGybHiLJ41PhBCOwLKN722GTnT/A68+axwsE9Xd/ju/aC3dQ==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.2.tgz",
+      "integrity": "sha512-joHLDICWmnR9Ca+LT9B+Fp85sCvV9F3gdtHtXLSuQAEulG5Ip1Z9euB3FUw+Z0s0Vz4MjNea+JD+TwO9eMrpyw==",
       "cpu": [
-        "arm64",
         "x64"
       ],
       "dev": true,

--- a/packages/govuk-frontend/src/govuk/components/components.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.puppeteer.test.js
@@ -16,7 +16,7 @@ describe('Components', () => {
 
   describe('Sass render', () => {
     it('renders CSS for all components', () => {
-      const file = join(paths.package, 'src/govuk/components/_all.scss')
+      const file = join(paths.package, 'src/govuk/components/_index.scss')
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),

--- a/packages/govuk-frontend/src/govuk/helpers/helpers.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/helpers.unit.test.js
@@ -11,12 +11,12 @@ describe('The helpers layer', () => {
   beforeAll(async () => {
     sassFiles = await getListing('**/src/govuk/helpers/**/*.scss', {
       cwd: paths.package,
-      ignore: ['**/_all.scss']
+      ignore: ['**/_all.scss', '**/_index.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const file = join(paths.package, 'src/govuk/helpers/_all.scss')
+    const file = join(paths.package, 'src/govuk/helpers/_index.scss')
     await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -60,8 +60,8 @@ const sassBootstrap = `
 describe('@mixin govuk-typography-common', () => {
   it('should output a @font-face declaration by default', async () => {
     const sass = `
-      @import "settings/all";
-      @import "helpers/all";
+      @import "settings";
+      @import "helpers";
 
       :root {
         @include govuk-typography-common;
@@ -86,8 +86,8 @@ describe('@mixin govuk-typography-common', () => {
     const sass = `
       $govuk-font-family: Helvetica, Arial, sans-serif;
       $govuk-font-family-tabular: monospace;
-      @import "settings/all";
-      @import "helpers/all";
+      @import "settings";
+      @import "helpers";
 
       :root {
         @include govuk-typography-common;
@@ -111,8 +111,8 @@ describe('@mixin govuk-typography-common', () => {
   it('should not output a @font-face declaration when the user has turned off this feature', async () => {
     const sass = `
       $govuk-include-default-font-face: false;
-      @import "settings/all";
-      @import "helpers/all";
+      @import "settings";
+      @import "helpers";
 
       :root {
         @include govuk-typography-common;

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -636,7 +636,7 @@ describe('@mixin govuk-font-size', () => {
         }
       `
 
-      await expect(compileSassString(sass)).resolves.toMatchObject({
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
         css: (await compileSassString(expectedSass)).css
       })
     })

--- a/packages/govuk-frontend/src/govuk/objects/objects.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/objects/objects.unit.test.js
@@ -11,7 +11,7 @@ describe('The objects layer', () => {
   beforeAll(async () => {
     sassFiles = await getListing('**/src/govuk/objects/**/*.scss', {
       cwd: paths.package,
-      ignore: ['**/_all.scss']
+      ignore: ['**/_all.scss', '**/_index.scss']
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/settings/settings.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/settings.unit.test.js
@@ -11,12 +11,12 @@ describe('The settings layer', () => {
   beforeAll(async () => {
     sassFiles = await getListing('**/src/govuk/settings/**/*.scss', {
       cwd: paths.package,
-      ignore: ['**/_all.scss']
+      ignore: ['**/_all.scss', '**/_index.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const file = join(paths.package, 'src/govuk/settings/_all.scss')
+    const file = join(paths.package, 'src/govuk/settings/_index.scss')
     await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 

--- a/packages/govuk-frontend/src/govuk/tools/tools.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/tools.unit.test.js
@@ -11,12 +11,12 @@ describe('The tools layer', () => {
   beforeAll(async () => {
     sassFiles = await getListing('**/src/govuk/tools/**/*.scss', {
       cwd: paths.package,
-      ignore: ['**/_all.scss']
+      ignore: ['**/_all.scss', '**/_index.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const file = join(paths.package, 'src/govuk/tools/_all.scss')
+    const file = join(paths.package, 'src/govuk/tools/_index.scss')
     await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 

--- a/shared/helpers/tests.js
+++ b/shared/helpers/tests.js
@@ -1,7 +1,7 @@
 const { join } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
-const { compileAsync, compileStringAsync, Logger } = require('sass-embedded')
+const { compileAsync, compileStringAsync } = require('sass-embedded')
 
 const sassPaths = [
   join(paths.package, 'src/govuk'),
@@ -18,7 +18,7 @@ const sassPaths = [
 async function compileSassFile(path, options = {}) {
   return compileAsync(path, {
     loadPaths: sassPaths,
-    logger: Logger.silent,
+    silenceDeprecations: ['slash-div'],
     quietDeps: true,
     ...options
   })
@@ -34,7 +34,7 @@ async function compileSassFile(path, options = {}) {
 async function compileSassString(source, options = {}) {
   return compileStringAsync(source, {
     loadPaths: sassPaths,
-    logger: Logger.silent,
+    silenceDeprecations: ['slash-div'],
     quietDeps: true,
     ...options
   })


### PR DESCRIPTION
Silencing all logs means that we may miss:

- any deprecations from Sass that we can fix now without breaking support for LibSass and Ruby Sass
- tests that need updating because of our own deprecations (like the recent deprecation of importing using the `all` entrypoints!)

Instead we can use the new [`silenceDeprecations` option](https://sass-lang.com/documentation/js-api/interfaces/options/#silenceDeprecations) introduced in Sass 1.74.0 and silence just the deprecations we know we can’t do anything about.

Fix the deprecation warnings that we can now see 🎉 