### PR TITLE
Update Breadcrumb component to improve screen reader accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Recommended changes
+
+#### Update Breadcrumbs to use `nav` and `aria-label`
+
+We've made changes to the Breadcrumbs component to improve how it appears to screen readers.
+
+We've changed the wrapping element to use the `nav` tag to expose it as a navigational landmark, and added an `aria-label` attribute to differentiate it as breadcrumb navigation.
+
+This change was introduced in [pull request #4995: Update Breadcrumb component to improve screen reader accessibility](https://github.com/alphagov/govuk-frontend/pull/4995).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -32,6 +32,10 @@ params:
     type: object
     required: false
     description: HTML attributes (for example data attributes) to add to the breadcrumbs container.
+  - name: labelText
+    type: string
+    required: false
+    description: Plain text label identifying the landmark to screen readers. Defaults to "Breadcrumb".
 
 examples:
   - name: default
@@ -108,7 +112,7 @@ examples:
     options:
       attributes:
         id: my-navigation
-        role: navigation
+        'data-foo': 'bar'
       items:
         - text: Home
   - name: item attributes
@@ -134,3 +138,13 @@ examples:
         - html: <em>Section 1</em>
           href: /section-1
         - html: <em>Section 2</em>
+          href: /section-2
+  - name: custom label
+    hidden: true
+    options:
+      labelText: Briwsion bara
+      items:
+        - text: Hafan
+          href: '/'
+        - text: Sefydliadau
+          href: '/organisations'

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.jsdom.test.js
@@ -18,6 +18,14 @@ describe('Breadcrumbs', () => {
       $listItems = document.querySelectorAll('li.govuk-breadcrumbs__list-item')
     })
 
+    it('renders as a nav element', () => {
+      expect($component.tagName.toLowerCase()).toBe('nav')
+    })
+
+    it('renders with default aria-label', () => {
+      expect($component).toHaveAttribute('aria-label', 'Breadcrumb')
+    })
+
     it('includes an ordered list', () => {
       expect($component).toContainElement($list)
     })
@@ -152,7 +160,14 @@ describe('Breadcrumbs', () => {
 
       const $component = document.querySelector('.govuk-breadcrumbs')
       expect($component).toHaveAttribute('id', 'my-navigation')
-      expect($component).toHaveAttribute('role', 'navigation')
+      expect($component).toHaveAttribute('data-foo', 'bar')
+    })
+
+    it('renders with a custom aria-label', () => {
+      document.body.innerHTML = render('breadcrumbs', examples['custom label'])
+
+      const $component = document.querySelector('.govuk-breadcrumbs')
+      expect($component).toHaveAttribute('aria-label', 'Briwsion bara')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
@@ -11,7 +11,7 @@
   {% set classNames = classNames + " govuk-breadcrumbs--collapse-on-mobile" %}
 {% endif -%}
 
-<div class="{{ classNames }}" {{- govukAttributes(params.attributes) }}>
+<nav class="{{ classNames }}" {{- govukAttributes(params.attributes) }} aria-label="{{ params.labelText | default("Breadcrumb") }}">
   <ol class="govuk-breadcrumbs__list">
 {% for item in params.items %}
   {% if item.href %}
@@ -27,4 +27,4 @@
   {% endif %}
 {% endfor %}
   </ol>
-</div>
+</nav>


### PR DESCRIPTION
An accessibility issue raised during development of #4950 was that, when a Breadcrumbs component is placed following a Header or Service Header that contains navigation elements, they are both announced (by screen readers) or displayed (in no CSS/reader modes) as a bulleted lists of links, with little affordance to users that they are two distinct navigational elements. 

This PR aims to resolve the screen reader issue by adding an `aria-label` of "Breadcrumb". It does not solve the display issue. Doing so would require the inclusion of some visible or visually-hidden text, judging by @selfthinker's comment on the GOV.UK Publishing Components version: https://github.com/alphagov/govuk_publishing_components/pull/2045#issuecomment-1803596065, though we could choose to modify this PR to do that as well.

As `aria-label` is only supported in practice by interactive elements and landmarks, the breadcrumb component wrapper has been changed to a `nav` to make it a landmark element. Doing so also resolves a common accessibility audit complaint that this component does not exist within a landmark (e.g. https://github.com/alphagov/govuk-frontend/issues/1604). This is not strictly required to meet WCAG, but may be considered good practice. 

## Background

The breadcrumb navigation was previously contained within a `nav` element, but this was removed in 2013 in an effort to reduce the number of navigation landmarks that appear on the page, as documented [in this blog post](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/) by @tombye. 

However, I think that the Breadcrumbs do not meet the criteria for removing `nav` as given in the post—the individual links do not provide sufficient labelling on their own and the components' role as a navigational aid can only be inferred through visual context which is not available to users who are blind or with low vision, nor assistive technologies they may use, and for which no fallback is provided.

Compare Breadcrumbs with other `nav` elements it's common to find on GOV.UK:
- Primary navigation has an accessible label and can have context inferred by being within the `header` (`banner`) landmark and near the top of the page.
- Links in the page footer have visible headings and can have context inferred by being within the `footer` (`contentinfo`) landmark.
- Most other `nav` elements that appear on GOV.UK have visible headings (e.g. related content lists), accessible labels (e.g. pagination), or can have some context inferred from their parents (e.g. table of contents has a `complementary` role and is one of the first things inside of the `main` landmark). Most provide multiple of these affordances.
- Skip links and back links don't typically exist in groups and can have their contexts largely by their labelling. 

Breadcrumbs currently have none of these: they lack the `nav` element, they lack headings (visible or not), lack accessible labelling, their context cannot be inferred from a parent landmark because they don't have one, and it cannot be inferred from the links themselves as (apart from 'Home') they are disembodied section names.

With these changes, our component is much more in line with the example in the [WAI ARIA Authoring Guide](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/) and the [W3C's design system component](https://design-system.w3.org/components/breadcrumbs.html) (which is heavily inspired by ours, their deviation implying they felt we were in the wrong here). The same approach is also used by our friends at [ONS](https://service-manual.ons.gov.uk/design-system/components/breadcrumbs#example.example-breadcrumbs.html), [Scottish Government Design System](https://designsystem.gov.scot/components/breadcrumbs) and [USWDS](https://designsystem.digital.gov/components/breadcrumb/), really putting us in the minority with our current approach. 

## Changes
- Changes the wrapping element of the Breadcrumbs component from a `div` to a `nav`.
- Adds a required `aria-label` to the Breadcrumb component wrapper.
- Adds a new Nunjucks parameter to set the `aria-label` named `labelText`. This defaults to `"Breadcrumb"`.
- Adds Nunjucks parameter documentation for `labelText`.
- Adds tests to ensure the element is a `nav`, renders the default `aria-label`, and that the Nunjucks parameter can override the `aria-label`. 
- Updates one existing example and test that set `role="navigation"`, as this was being flagged by the HTML linter as redundant role usage.