### PR TITLE
Replace custom Sass logger w/ silenceDeprecations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31590,7 +31590,6 @@
         "@govuk-frontend/lib": "*",
         "@npmcli/run-script": "^7.0.4",
         "@percy/puppeteer": "^2.0.2",
-        "chalk": "^5.3.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^3.0.0",
         "nunjucks": "^3.2.4",
@@ -31607,18 +31606,6 @@
       "engines": {
         "node": "^20.9.0",
         "npm": "^10.1.0"
-      }
-    },
-    "shared/tasks/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     }
   }

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -14,7 +14,6 @@
     "@govuk-frontend/lib": "*",
     "@npmcli/run-script": "^7.0.4",
     "@percy/puppeteer": "^2.0.2",
-    "chalk": "^5.3.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^3.0.0",
     "nunjucks": "^3.2.4",


### PR DESCRIPTION
Use the new `silenceDeprecations` feature introduced in Sass 1.74.0 and remove the custom logger that was implemented to filter them out.

The logger was introduced in 81f59d9 and ec547be as part of #3164.

As mentioned in the first commit message, the output otherwise exactly matches the log output from Dart Sass. I’ve also manually verified this by comparing the output from the custom logger with an empty array for `supressed` and using the default logged with an empty array for `silenceDeprecations`.

There’s nothing else using `chalk` which was introduced as a dependency in 81f59d9 so uninstall that too.

Closes #4993 