### PR TITLE
Define additional screenshots in component YAML

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/back-link/back-link.yaml
+++ b/packages/govuk-frontend/src/govuk/components/back-link/back-link.yaml
@@ -29,6 +29,7 @@ examples:
       href: '#'
       text: Back to home
   - name: inverse
+    screenshot: true
     previewLayoutModifiers:
       - inverse
     options:

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -83,6 +83,7 @@ examples:
         - text: Special educational needs and disability (SEND) and high needs
           href: '/education/special-educational-needs-and-disability-send-and-high-needs'
   - name: inverse
+    screenshot: true
     description: Breadcrumbs that appear on dark backgrounds
     previewLayoutModifiers:
       - inverse

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -65,6 +65,7 @@ examples:
       text: Link button
       href: '/'
   - name: start
+    screenshot: true
     options:
       text: Start now button
       isStartButton: true
@@ -144,6 +145,7 @@ examples:
       href: '/'
       classes: govuk-button--warning
   - name: inverse
+    screenshot: true
     description: A button that appears on dark backgrounds
     previewLayoutModifiers:
       - inverse
@@ -169,6 +171,7 @@ examples:
       href: '/'
       classes: govuk-button--inverse
   - name: inverse start
+    screenshot: true
     description: A start button that appears on dark backgrounds
     previewLayoutModifiers:
       - inverse

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -265,6 +265,7 @@ examples:
   - name: with hints on items
     options:
       name: with-hints-on-items
+      screenshot: true
       fieldset:
         legend:
           text: How do you want to sign in?
@@ -578,6 +579,7 @@ examples:
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: small
+    screenshot: true
     options:
       idPrefix: nationality
       name: nationality

--- a/packages/govuk-frontend/src/govuk/components/details/details.yaml
+++ b/packages/govuk-frontend/src/govuk/components/details/details.yaml
@@ -44,6 +44,7 @@ examples:
         you’re entitled to vote in. If you can’t provide your nationality,
         you’ll have to send copies of identity documents through the post.
   - name: expanded
+    screenshot: true
     options:
       id: help-with-nationality
       summaryText: Help with nationality

--- a/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
+++ b/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
@@ -203,12 +203,14 @@ examples:
           href: '/page/3'
           current: true
   - name: with prev and next only
+    screenshot: true
     options:
       previous:
         href: '/previous'
       next:
         href: '/next'
   - name: with prev and next only and labels
+    screenshot: true
     options:
       previous:
         text: 'Previous page'

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -258,6 +258,7 @@ examples:
           text: Create an account
 
   - name: with hints on items
+    screenshot: true
     options:
       idPrefix: gov
       name: gov
@@ -504,6 +505,7 @@ examples:
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: small
+    screenshot: true
     options:
       idPrefix: 'how-contacted-2'
       name: 'how-contacted-2'

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -320,6 +320,7 @@ module.exports = {
  * @property {string} name - Example name
  * @property {string} [description] - Example description
  * @property {boolean} [hidden] - Example hidden from review app
+ * @property {boolean} [screenshot] - Screenshot and include in visual regression tests
  * @property {string[]} [previewLayoutModifiers] - Component preview layout class modifiers
  * @property {MacroOptions} options - Nunjucks macro options (or params)
  */

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -38,27 +38,16 @@ export async function screenshots() {
     // Screenshot "default" example
     await screenshotComponent(browser, componentName)
 
-    // Screenshot "inverse" example
-    if (Object.keys(componentExamples).includes('inverse')) {
+    // Screenshot any other examples with 'screenshot: true'
+    const otherExamples = Object.keys(componentExamples).filter(
+      (key) => componentExamples[key].fixture.screenshot
+    )
+
+    for (const exampleName of otherExamples) {
       await screenshotComponent(browser, componentName, {
-        exampleName: 'inverse'
+        exampleName
       })
     }
-  }
-
-  // Screenshot specific component examples
-  for (const [componentName, options] of /** @type {const} */ ([
-    ['button', { exampleName: 'start' }],
-    ['button', { exampleName: 'inverse-start' }],
-    ['checkboxes', { exampleName: 'with-hints-on-items' }],
-    ['checkboxes', { exampleName: 'small' }],
-    ['details', { exampleName: 'expanded' }],
-    ['pagination', { exampleName: 'with-prev-and-next-only' }],
-    ['pagination', { exampleName: 'with-prev-and-next-only-and-labels' }],
-    ['radios', { exampleName: 'with-hints-on-items' }],
-    ['radios', { exampleName: 'small' }]
-  ])) {
-    await screenshotComponent(browser, componentName, options)
   }
 
   // Screenshot specific example pages

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -127,6 +127,7 @@ async function generateFixture(componentDataPath, options) {
         // Add defaults to optional fields
         description: example.description ?? '',
         previewLayoutModifiers: example.previewLayoutModifiers ?? [],
+        screenshot: example.screenshot ?? false,
 
         // Add rendered Nunjucks example to fixture
         html: html.trim()


### PR DESCRIPTION
Rather than hardcoding the list of additional examples to screenshot in the task, add a new `screenshot` boolean to the component YAML (and generated fixtures.yaml) which determines whether the example should be included in the screenshots or not.

Preserve the existing list of screenshotted examples by setting `screenshot: true` in the YAML for those examples.

Remove special treatment of examples named ‘inverse’ but retain their screenshots by also setting `screenshot: true`.