### PR TITLE
Remove session storage checks from accordion JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5043: Refactor the accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5043)
+- [##5044: Remove session storage checks from accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5044)
 
 ## 5.4.0 (Feature release)
 


### PR DESCRIPTION
We don’t do anything different if we detect the browser doesn’t support session storage, so we don’t really need to care whether it works or not.

We do need to wrap attempts to set *or get* from sessions storage in try blocks because setItem [can throw `QuotaExceededError` exceptions][1] and some [older browsers will throw other exceptions if session storage isn’t available (disabled, or using private browsing)][3]

However we don’t need to do anything different if exceptions are thrown – we can safely catch those exceptions and swallow them.

[1]: https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem
[2]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#feature-detecting_localstorage
[3]: https://gist.github.com/paulirish/5558557