### PR TITLE
Skip ‘empty’ tasks in the task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
+- [#5046: Skip ‘empty’ tasks in the task list](https://github.com/alphagov/govuk-frontend/pull/5046)
 - [#5066: Fix whitespace affecting text alignment in pagination block variant](https://github.com/alphagov/govuk-frontend/pull/5066)
 
 ## 5.4.1 (Fix release)

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -376,3 +376,21 @@ examples:
           status:
             tag:
               html: <strong>Tag</strong>
+
+  - name: with empty values
+    options:
+      items:
+        -
+        - null
+        - title:
+            text: Task A
+          href: '#'
+          status:
+            text: Completed
+        - false
+        - ''
+        - title:
+            text: Task B
+          href: '#'
+          status:
+            text: Completed

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.jsdom.test.js
@@ -281,4 +281,10 @@ describe('Task List', () => {
       expect($link).toHaveAttribute('aria-describedby')
     })
   })
+
+  it('omits empty items from the task list', () => {
+    document.body.innerHTML = render('task-list', examples['with empty values'])
+
+    expect(document.querySelectorAll('.govuk-task-list__item')).toHaveLength(2)
+  })
 })

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -36,6 +36,6 @@
 <ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   {% for item in params.items %}
-    {{- _taskListItem(params, item, loop.index) }}
+    {{- _taskListItem(params, item, loop.index) if item }}
   {% endfor %}
 </ul>


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of #5045 which must be merged first.

This allows users to e.g. guard individual tasks with an `if` statement without empty rows displaying.

Closes #4968