### PR TITLE
Standardise spelling to "falsy"

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -275,10 +275,10 @@ examples:
             html: <span class="myClass">Section A</span>
           content:
             text: Some content
-  - name: with falsey values
+  - name: with falsy values
     hidden: true
     options:
-      id: accordion-falsey
+      id: accordion-falsy
       items:
         - heading:
             text: Section A

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.jsdom.test.js
@@ -112,10 +112,10 @@ describe('Accordion', () => {
       expect($componentSummary).toHaveTextContent('Additional description')
     })
 
-    it('renders list without falsely values', () => {
+    it('renders list without falsy values', () => {
       document.body.innerHTML = render(
         'accordion',
-        examples['with falsey values']
+        examples['with falsy values']
       )
       const $sections = document.querySelectorAll('.govuk-accordion__section')
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -710,7 +710,7 @@ examples:
           text: Option 1
         - value: 2
           text: Option 2
-  - name: with falsey values
+  - name: with falsy values
     hidden: true
     options:
       name: example-name

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -38,8 +38,8 @@ describe('Checkboxes', () => {
     expect($lastLabel.text()).toContain('Citizen of another country')
   })
 
-  it('render example without falsely values', () => {
-    const $ = render('checkboxes', examples['with falsey values'])
+  it('render example without falsy values', () => {
+    const $ = render('checkboxes', examples['with falsy values'])
 
     const $component = $('.govuk-checkboxes')
     const $items = $component.find('.govuk-checkboxes__item')

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -714,7 +714,7 @@ examples:
           text: Yes
         - value: no
           text: No
-  - name: with falsey items
+  - name: with falsy items
     hidden: true
     options:
       name: example-name

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -30,8 +30,8 @@ describe('Radios', () => {
     expect($lastLabel.text()).toContain('No')
   })
 
-  it('renders without falsely items', () => {
-    const $ = render('radios', examples['with falsey items'])
+  it('renders without falsy items', () => {
+    const $ = render('radios', examples['with falsy items'])
 
     const $component = $('.govuk-radios')
     const $items = $component.find('.govuk-radios__item input')

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -261,11 +261,11 @@ examples:
           attributes:
             data-attribute: GHI
             data-second-attribute: JKL
-  - name: with falsey items
+  - name: with falsy items
     hidden: true
     options:
-      id: with-falsey-items
-      name: with-falsey-items
+      id: with-falsy-items
+      name: with-falsy-items
       label:
         text: Label text goes here
       items:
@@ -355,11 +355,11 @@ examples:
         - text: Blue
       value: Green
 
-  - name: with falsey values
+  - name: with falsy values
     hidden: true
     options:
-      name: falsey-values
-      id: falsey-values
+      name: falsy-values
+      id: falsy-values
       label:
         text: Label text goes here
       items:

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -41,21 +41,21 @@ describe('Select', () => {
     })
 
     it('includes the value attribute when the value option is an empty string', () => {
-      const $ = render('select', examples['with falsey values'])
+      const $ = render('select', examples['with falsy values'])
 
       const $firstItem = $('.govuk-select option:nth(0)')
       expect($firstItem.attr('value')).toBe('')
     })
 
     it('includes the value attribute when the value option is false', () => {
-      const $ = render('select', examples['with falsey values'])
+      const $ = render('select', examples['with falsy values'])
 
       const $secondItem = $('.govuk-select option:nth(1)')
       expect($secondItem.attr('value')).toBe('false')
     })
 
     it('includes the value attribute when the value option is 0', () => {
-      const $ = render('select', examples['with falsey values'])
+      const $ = render('select', examples['with falsy values'])
 
       const $thirdItem = $('.govuk-select option:nth(2)')
       expect($thirdItem.attr('value')).toBe('0')
@@ -126,8 +126,8 @@ describe('Select', () => {
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
     })
 
-    it('renders without falsely items', () => {
-      const $ = render('select', examples['with falsey items'])
+    it('renders without falsy items', () => {
+      const $ = render('select', examples['with falsy items'])
 
       const $items = $('.govuk-select option')
       expect($items).toHaveLength(2)

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -834,7 +834,7 @@ examples:
       attributes:
         data-attribute-1: value-1
         data-attribute-2: value-2
-  - name: with falsey values
+  - name: with falsy values
     hidden: true
     options:
       rows:

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
@@ -26,8 +26,8 @@ describe('Summary list', () => {
   })
 
   describe('rows', () => {
-    it('renders list without falsely values', async () => {
-      const $ = render('summary-list', examples['with falsey values'])
+    it('renders list without falsy values', async () => {
+      const $ = render('summary-list', examples['with falsy values'])
 
       const $component = $('.govuk-summary-list')
       const $row = $component.find('.govuk-summary-list__row')

--- a/packages/govuk-frontend/src/govuk/components/table/table.yaml
+++ b/packages/govuk-frontend/src/govuk/components/table/table.yaml
@@ -289,7 +289,7 @@ examples:
         - - text: Foo
             attributes:
               data-fizz: buzz
-  - name: with falsey items
+  - name: with falsy items
     hidden: true
     options:
       rows:

--- a/packages/govuk-frontend/src/govuk/components/table/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/table/template.test.js
@@ -264,8 +264,8 @@ describe('Table', () => {
       ])
     })
 
-    it('can be skipped when falsely', () => {
-      const $ = render('table', examples['with falsey items'])
+    it('can be skipped when falsy', () => {
+      const $ = render('table', examples['with falsy items'])
 
       const cells = $('.govuk-table')
         .find('tbody tr')

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
@@ -243,7 +243,7 @@ examples:
     hidden: true
     options:
       items: []
-  - name: with falsey values
+  - name: with falsy values
     hidden: true
     options:
       items:

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
@@ -85,8 +85,8 @@ describe('Tabs', () => {
       expect($firstPanel.attr('id')).toBe('past-day')
     })
 
-    it('render without falsey values', () => {
-      const $ = render('tabs', examples['with falsey values'])
+    it('render without falsy values', () => {
+      const $ = render('tabs', examples['with falsy values'])
 
       const $component = $('.govuk-tabs')
 

--- a/packages/govuk-frontend/src/govuk/helpers/links.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/links.unit.test.js
@@ -31,7 +31,7 @@ describe('@mixin govuk-link-decoration', () => {
     })
   })
 
-  describe('when $govuk-link-underline-thickness is falsey', () => {
+  describe('when $govuk-link-underline-thickness is falsy', () => {
     it('does not set text-decoration-thickness', async () => {
       const sass = `
         $govuk-link-underline-thickness: false;
@@ -48,7 +48,7 @@ describe('@mixin govuk-link-decoration', () => {
     })
   })
 
-  describe('when $govuk-link-underline-offset is falsey', () => {
+  describe('when $govuk-link-underline-offset is falsy', () => {
     it('does not set text-decoration-offset', async () => {
       const sass = `
       $govuk-link-underline-offset: false;
@@ -81,7 +81,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
     })
   })
 
-  describe('when $govuk-link-hover-underline-thickness is falsey', () => {
+  describe('when $govuk-link-hover-underline-thickness is falsy', () => {
     it('does not set a hover state', async () => {
       const sass = `
       $govuk-link-hover-underline-thickness: false;

--- a/packages/govuk-frontend/src/govuk/i18n.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.jsdom.test.mjs
@@ -111,7 +111,7 @@ describe('I18n', () => {
         expect(i18n.t('nameString', { name: 'John' })).toBe('My name is John')
       })
 
-      it('can replace a placeholder with a falsey value', () => {
+      it('can replace a placeholder with a falsy value', () => {
         const i18n = new I18n({
           nameString: 'My name is %{name}',
           stock: 'Stock level: %{quantity}'


### PR DESCRIPTION
I noticed a typo in some of our tests using `falsely` instead of `falsey`. Then I noticed we use both falsy and falsey across the codebase.

There were more examples of `falsy`, and we have methods using this spelling. It also seems to be [generally preferred](https://developer.mozilla.org/en-US/docs/Glossary/Falsy).

