### PR TITLE
Refactor `govuk-visually-hidden` Sass

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_visually-hidden.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_visually-hidden.scss
@@ -2,7 +2,7 @@
 /// @group helpers/accessibility
 ////
 
-/// Hide an element visually, but have it available for screen readers
+/// Helper function containing the common code for the following two mixins
 ///
 /// @link https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
 ///   - Hiding Content for Accessibility, Jonathan Snook, February 2011
@@ -11,22 +11,10 @@
 ///
 /// @param {Boolean} $important [true] - Whether to mark as `!important`
 ///
-/// @access public
+/// @access private
 
-@mixin govuk-visually-hidden($important: true) {
+@mixin _govuk-visually-hide-content($important: true) {
   position: absolute if($important, !important, null);
-
-  // Absolute positioning has the unintended consequence of removing any
-  // whitespace surrounding visually hidden text from the accessibility tree.
-  // Insert a space character before and after visually hidden text to separate
-  // it from any visible text surrounding it.
-  &::before {
-    content: "\00a0";
-  }
-
-  &::after {
-    content: "\00a0";
-  }
 
   width: 1px if($important, !important, null);
   height: 1px if($important, !important, null);
@@ -36,6 +24,8 @@
   padding: 0 if($important, !important, null);
 
   overflow: hidden if($important, !important, null);
+
+  // `clip` is needed for IE11 support
   clip: rect(0 0 0 0) if($important, !important, null);
   clip-path: inset(50%) if($important, !important, null);
 
@@ -52,55 +42,39 @@
   user-select: none;
 }
 
+/// Hide an element visually, but have it available for screen readers
+///
+/// @param {Boolean} $important [true] - Whether to mark as `!important`
+///
+/// @access public
+
+@mixin govuk-visually-hidden($important: true) {
+  @include _govuk-visually-hide-content($important: $important);
+
+  // Absolute positioning has the unintended consequence of removing any
+  // whitespace surrounding visually hidden text from the accessibility tree.
+  // Insert a space character before and after visually hidden text to separate
+  // it from any visible text surrounding it.
+  &::before {
+    content: "\00a0";
+  }
+
+  &::after {
+    content: "\00a0";
+  }
+}
+
 /// Hide an element visually, but have it available for screen readers whilst
 /// allowing the element to be focused when navigated to via the keyboard (e.g.
 /// for the skip link)
-///
-/// This is slightly less opinionated about borders and padding to make it
-/// easier to style the focussed element.
 ///
 /// @param {Boolean} $important [true] - Whether to mark as `!important`
 ///
 /// @access public
 
 @mixin govuk-visually-hidden-focusable($important: true) {
-  position: absolute if($important, !important, null);
-
-  width: 1px if($important, !important, null);
-  height: 1px if($important, !important, null);
-  // If margin is set to a negative value it can cause text to be announced in
-  // the wrong order in VoiceOver for OSX
-  margin: 0 if($important, !important, null);
-
-  overflow: hidden if($important, !important, null);
-  clip: rect(0 0 0 0) if($important, !important, null);
-  clip-path: inset(50%) if($important, !important, null);
-
-  // For long content, line feeds are not interpreted as spaces and small width
-  // causes content to wrap 1 word per line:
-  // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-  white-space: nowrap if($important, !important, null);
-
-  // Prevent users from selecting or copying visually-hidden text. This prevents
-  // a user unintentionally copying more text than they intended and needing to
-  // manually trim it down again.
-  user-select: none;
-
-  &:active,
-  &:focus {
-    position: static if($important, !important, null);
-
-    width: auto if($important, !important, null);
-    height: auto if($important, !important, null);
-    margin: inherit if($important, !important, null);
-
-    overflow: visible if($important, !important, null);
-    clip: auto if($important, !important, null);
-    clip-path: none if($important, !important, null);
-
-    white-space: inherit if($important, !important, null);
-
-    // Allow the text to be selectable now it's visible
-    user-select: text;
+  // IE 11 doesn't support the combined `:not(:active, :focus)` syntax.
+  &:not(:active):not(:focus) {
+    @include _govuk-visually-hide-content($important: $important);
   }
 }


### PR DESCRIPTION
Review app: https://govuk-frontend-pr-5063.herokuapp.com/

A neat little optimisation that we can probably make now that we've dropped support for older IE versions.

Currently, we have two mixins that share mostly identical styles: `govuk-visually-hidden` and `govuk-visually-hidden-focusable`, with a few of differences: 

1. `govuk-visually-hidden` uses pseudo-elements to add spaces before and after the visually-hidden content.
2. `govuk-visually-hidden-focusable` applies the visually-hidden styles by default, but then attempts to undo these styles when the element receives keyboard focus or is in the active state.
3. `govuk-visually-hidden-focusable` additionally omits a couple of the visually-hidden styles on the basis of not wanting to undo them upon focus or active states.

Having two almost-identical mixins isn't ideal when it comes to code duplication. Trying to manually revert styles upon a particular state is also quite untidy and evidently is something we've had problems doing before, given we've needed to explicitly omit some styles to not unintentionally revert the styles we _do_ want. 

Now that we've dropped support for Internet Explorer 8 and 9, we have the option of using the `:not` selector to only apply the visually-hidden styles when the element is not focused or active, allowing both mixins to use the same set of core styles and allowing for the complete removal of the manual revert code. 🛹

This would close #1597. 

## Changes
* Moves styles common to both mixins into an internal helper mixin.
* Changes `govuk-visually-hidden-focusable` to only apply the visually-hidden styles when the target element is `:not` focused or active, rather than setting the styles by default and then overriding them.

## Thoughts
This uses two chained `:not` selectors to achieve the desired result: `:not(:active):not(:focus)`. This could be just one selector, `:not(:active, :focus)`, but IE 11 doesn't support this syntax and PostCSS doesn't appear to be converting it to the syntax that IE 11 understands. 

I've named the internal mixin `_govuk-visually-hidden-text`. This is technically a misnomer as it could hide any element or set of elements, but simply calling it `_govuk-visually-hidden` seemed too likely to cause confusion. Alternative naming suggestions welcome. 