### PR TITLE
Fix whitespace affecting text alignment in pagination block variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5066: Fix whitespace affecting text alignment in pagination block variant](https://github.com/alphagov/govuk-frontend/pull/5066)
+
 ## 5.4.1 (Fix release)
 
 ### Recommended changes

--- a/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
@@ -151,7 +151,6 @@
     @include govuk-typography-weight-regular;
     @include govuk-link-decoration;
     display: inline-block;
-    padding-left: govuk-spacing(6);
   }
 
   .govuk-pagination__icon {
@@ -175,35 +174,23 @@
   .govuk-pagination--block {
     display: block;
 
-    .govuk-pagination__item {
-      padding: govuk-spacing(3);
-      float: none;
-    }
-
     .govuk-pagination__next,
     .govuk-pagination__prev {
       padding-left: 0;
       float: none;
+
+      .govuk-pagination__link {
+        display: inline-block;
+      }
     }
 
     .govuk-pagination__next {
       padding-right: govuk-spacing(3);
-
-      .govuk-pagination__icon {
-        margin-left: 0;
-      }
     }
 
     // Only apply a border between prev and next if both are present
     .govuk-pagination__prev + .govuk-pagination__next {
       border-top: 1px solid $govuk-border-colour;
-    }
-
-    // Reset both these elements to their inline default, both to ensure that
-    // the focus state for block mode "shrink wraps" text as expected
-    .govuk-pagination__link,
-    .govuk-pagination__link-title {
-      display: inline;
     }
 
     // Set the after pseudo element to a block which makes the title visually
@@ -216,16 +203,8 @@
     }
 
     .govuk-pagination__link {
+      padding-left: govuk-spacing(6);
       text-align: left;
-
-      &:focus {
-        // Apply focus styling to the label within the link as if it were being
-        // focused to get around a display issue with a focusable inline element
-        // containing a mixture of inline and inline-block level elements
-        .govuk-pagination__link-label {
-          @include govuk-focused-text;
-        }
-      }
 
       &:not(:focus) {
         text-decoration: none;
@@ -233,7 +212,15 @@
     }
 
     .govuk-pagination__icon {
-      margin-right: govuk-spacing(2);
+      // This magic number is brought to you by the following equation:
+      // ((lineHeight − arrowHeight) ÷ 2) ÷ fontSize
+      // ((25 − 13) ÷ 2) ÷ 19 = 0.326em
+      //
+      // This could have been done programmatically but we don't have functions
+      // for grabbing the line-height of specific typography sizes just yet.
+      margin-top: 0.326em;
+      margin-left: govuk-spacing(6) * -1;
+      float: left;
     }
   }
 }


### PR DESCRIPTION
An attempt at fixing the issue where whitespace (or the lack of it) changes the alignment of the title text in the Pagination component's 'block' variant, as described in #3554.

## Changes
- Changes block pagination links to be `inline-block`, allowing for the addition of `padding-left` that affects all text within the component.
- Changes the block pagination arrows to be floated and offset using a negative `margin-left`—preventing them from directly influencing text flow calculations.

## Thoughts
### Focus style difference
This PR does slightly change the focus state on these links, with the focus state now stretching to fit the longest line of text, rather than separately 'shrinkwrapping' the title and label lines. 

|Before|After|
|:-:|:-:|
|![Screenshot of some links, with the first one focused. The focused text has a yellow background that follows the length of each line of text and a thick black border under the last line.](https://github.com/alphagov/govuk-frontend/assets/1253214/a17207f4-6fb7-4777-913f-76baf95b7a8e)|![Screenshot of some links, with the first one focused. The top link has a rectangular yellow background that is sized according to the longer second line, with a thick black border underneath it.](https://github.com/alphagov/govuk-frontend/assets/1253214/0454ba00-9456-44e0-845d-ea176ae2729e)|

I was unable to find a simple way around this using only CSS and wanted to avoid a breaking HTML change. 

I considered removing the focus style from the actual link and re-applying it to the two child elements, but doing so introduced more complexity than I'd like, so I'm gonna 🤞 and hope this is okay until we're content with making a breaking change.

### 0.326 is the magic number

This also introduces a magic number, the `margin-top` on the arrows themselves. Being floated means they no longer automatically align with the text baseline, so some manual offsetting was required.

This could potentially be worked out programmatically: it's $(lineHeight-arrowHeight)\div2$, specifically $(25-13)\div2=6px$ with numbers added, which is ≅0.326em in this context.

However, we don't presently have a function for getting just the `line-height` for a specific type size and breakpoint, and I was still trying to avoid adding unnecessary complexity, and the pagination's `line-height` doesn't change per breakpoint anyway, so I've hardcoded it. This value is precise enough to visually match the arrow's previous position on even high zoom levels. 

![A two-frame animation showing before and after screenshots. In the before, the first line of title text is slightly aligned too far to the left and the second line is entirely to the left. In the after, both lines are aligned with the label text below it. Neither the arrow nor label text move between the before/after.](https://github.com/alphagov/govuk-frontend/assets/1253214/0b0c3fd1-ef93-4004-9cab-fd05a98bbbf0)

These comparison screenshots were made in Firefox at 300% zoom on a 72 DPI display.