### PR TITLE
Update _grid.scss to fix typo

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_grid.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_grid.scss
@@ -37,7 +37,7 @@
 ///   }
 ///
 /// @example scss - Customising the breakpoint where width percentage is applied
-///   .govuk-grid-column-one-half-at-desktop {
+///   .govuk-grid-column-one-half-from-desktop {
 ///     @include govuk-grid-column(one-half, $at: desktop);
 ///   }
 ///


### PR DESCRIPTION
From reading [_grid.scss](https://github.com/alphagov/govuk-frontend/blob/520f2345aed725b2c29f14af2cdffcd75a5e130a/packages/govuk-frontend/src/govuk/objects/_grid.scss#L20), I think the generated class name is 'from', not 'at'.