### PR TITLE
Fix alignment of content in conditional checkboxes and radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5043: Refactor the accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5043)
 - [#5044: Remove session storage checks from accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5044)
 - [#5060: Reintroduce additional bottom margin to Error Summary content](https://github.com/alphagov/govuk-frontend/pull/5060)
+- [#5070: Fix alignment of content in conditional checkboxes and radio buttons](https://github.com/alphagov/govuk-frontend/pull/5070)
 
 ## 5.4.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -159,7 +159,7 @@
   // to be an even number in order to be centred under the 40px checkbox or radio.
   $conditional-border-width: $govuk-border-width-narrow;
   // Calculate the amount of padding needed to keep the border centered against the checkbox.
-  $conditional-border-padding: ($govuk-checkboxes-size / 2) - ($conditional-border-width / 2);
+  $conditional-border-padding: ($govuk-touch-target-size / 2) - ($conditional-border-width / 2);
   // Move the border centered with the checkbox
   $conditional-margin-left: $conditional-border-padding;
   // Move the contents of the conditional inline with the label

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -520,6 +520,7 @@ examples:
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: with conditional item checked
+    screenshot: true
     options:
       name: how-contacted-checked
       idPrefix: how-contacted-checked

--- a/packages/govuk-frontend/src/govuk/components/radios/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_index.scss
@@ -176,7 +176,7 @@
   // to be an even number in order to be centred under the 40px checkbox or radio.
   $conditional-border-width: $govuk-border-width-narrow;
   // Calculate the amount of padding needed to keep the border centered against the radios.
-  $conditional-border-padding: ($govuk-radios-size / 2) - ($conditional-border-width / 2);
+  $conditional-border-padding: ($govuk-touch-target-size / 2) - ($conditional-border-width / 2);
   // Move the border centered with the radios
   $conditional-margin-left: $conditional-border-padding;
   // Move the contents of the conditional inline with the label

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -396,6 +396,7 @@ examples:
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: with conditional item checked
+    screenshot: true
     options:
       idPrefix: 'how-contacted-checked'
       name: 'how-contacted-checked'


### PR DESCRIPTION
Checkboxes and radio buttons are visually 40 pixels wide, however their actual width on the page is 44 pixels, with an invisible 2 pixel 'border' around the input that the conditional area's margin-left calculation didn't account for.

Fixes #5069.

## Changes
- Amends the `$conditional-border-padding` calculation in both components to use `$govuk-touch-target-size` instead of `$govuk-checkboxes-size` or `$govuk-radios-size`.
- Adds conditional checkboxes and radios with expanded content to the list of things Percy should screenshot, to help avoid future regressions of this kind.