### PR TITLE
Update review app examples

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
@@ -70,10 +70,7 @@ scenario: |
 {% endblock %}
 
 {% block content %}
-  {{ govukExitThisPage({
-    text: "Exit this page",
-    redirectUrl: "https://bbc.co.uk/weather/"
-  }) }}
+  {{ govukExitThisPage() }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.mjs
@@ -7,6 +7,7 @@ export { default as cookieBannerServerSide } from './cookie-banner-server-side/i
 export { default as haveYouChangedYourName } from './have-you-changed-your-name/index.mjs'
 export { default as feedback } from './feedback/index.mjs'
 export { default as howDoYouWantToSignIn } from './how-do-you-want-to-sign-in/index.mjs'
+export { default as makeAPayment } from './make-a-payment/index.mjs'
 export { default as search } from './search/index.mjs'
 export { default as signIn } from './sign-in/index.mjs'
 export { default as passportDetails } from './passport-details/index.mjs'

--- a/packages/govuk-frontend-review/src/views/full-page-examples/make-a-payment/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/make-a-payment/confirm.njk
@@ -1,0 +1,19 @@
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set pageTitle = "Payment accepted" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        titleText: pageTitle
+      }) }}
+      <p class="govuk-body">We have sent you an email confirming receipt of the payment.</p>
+      <p class="govuk-body">It may take up to 3 working days for the payment to process and for the money to leave your bank account.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/make-a-payment/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/make-a-payment/index.mjs
@@ -1,0 +1,37 @@
+import express from 'express'
+import { body, matchedData, validationResult } from 'express-validator'
+
+import { formatValidationErrors } from '../../../utils.mjs'
+
+const router = express.Router()
+
+router.post(
+  '/make-a-payment',
+
+  body('amount')
+    .notEmpty()
+    .withMessage('Enter an amount')
+    .isNumeric()
+    .withMessage('Enter a number')
+    .isFloat({ gt: 0 })
+    .withMessage('Enter an amount greater than 0'),
+
+  (req, res) => {
+    const { example } = res.locals
+
+    const viewPath = `./full-page-examples/${example.path}`
+    const errors = formatValidationErrors(validationResult(req))
+
+    if (!errors) {
+      return res.redirect(303, `./${example.path}/confirm`)
+    }
+
+    res.render(`${viewPath}/index`, {
+      errors,
+      errorSummary: Object.values(errors),
+      values: matchedData(req, { onlyValidData: false }) // In production this should sanitized.
+    })
+  }
+)
+
+export default router

--- a/packages/govuk-frontend-review/src/views/full-page-examples/make-a-payment/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/make-a-payment/index.njk
@@ -1,0 +1,63 @@
+---
+title: Make a payment
+scenario: |
+  As part of an online service, you make a variable value payment to the service.
+
+  Things to try:
+
+  1. Don't enter an amount before continuing to the next page.
+  2. Enter a non-number value for an amount.
+  3. Enter a negative number for an amount.
+---
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ "Error: " if errorSummary | length }}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary | length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary
+        }) }}
+      {% endif %}
+
+      <form method="post" novalidate>
+
+        {{ govukInput({
+          label: {
+            text: "How much do you want to pay?",
+            classes: "govuk-label--xl",
+            isPageHeading: true
+          },
+          type: "text",
+          inputmode: "numeric",
+          id: "amount",
+          name: "amount",
+          value: values["amount"],
+          errorMessage: errors["amount"],
+          classes: "govuk-input--width-5",
+          prefix: { text: "£" }
+        }) }}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
@@ -185,12 +185,15 @@ notes: |
       </ul>
 
       {{ govukPagination({
+        previous: {
+          href: "#"
+        },
         next: {
           href: "#"
         },
         items: [
-          { href: "#", number: 1, current: true },
-          { href: "#", number: 2 },
+          { href: "#", number: 1 },
+          { href: "#", number: 2, current: true },
           { href: "#", number: 3 },
           { ellipsis: true },
           { href: "#", number: 2939 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
@@ -54,6 +54,8 @@ notes: The buttons and links on this page are not functional.
       }) }}
 
       {% set moreInformationHTML %}
+        <h2 class="govuk-heading-l">More information</h2>
+
         <p class="govuk-body">You’ll need a debit or credit card to use this service.</p>
 
         <p class="govuk-body"><a class="govuk-link" href="#">It’s £9.50 cheaper</a> to apply for a passport online than by post.</p>
@@ -66,6 +68,8 @@ notes: The buttons and links on this page are not functional.
       {% endset %}
 
       {% set otherWaysToApplyHTML %}
+      <h2 class="govuk-heading-l">Other ways to apply</h2>
+
         <p class="govuk-body">You can pick up passport application forms from your <a class="govuk-link" rel="external" href="http://www.postoffice.co.uk/branch-finder">local Post Office</a> and apply by post, or use the <a class="govuk-link" href="#">Post Office Check and Send service</a>.</p>
       {% endset %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -9,6 +9,7 @@ router.post(
   '/update-your-account-details',
 
   body('email')
+    .trim()
     .notEmpty()
     .withMessage('Enter your email address')
     .isEmail()
@@ -16,7 +17,13 @@ router.post(
       'Enter an email address in the correct format, like name@example.com'
     ),
 
-  body('password').notEmpty().withMessage('Enter a password'),
+  body('password').notEmpty().withMessage('Enter a new password'),
+
+  body('confirm-password')
+    .notEmpty()
+    .withMessage('Enter your new password again')
+    .custom((value, { req }) => req.body.password === value)
+    .withMessage('Enter the same password again'),
 
   (req, res) => {
     const { example } = res.locals

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
@@ -14,6 +14,7 @@ scenario: |
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/password-input/macro.njk" import govukPasswordInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = example.title %}
@@ -53,17 +54,44 @@ scenario: |
           spellcheck: false
         }) }}
 
-        {{ govukPasswordInput({
-          label: {
-            text: "New password",
-            classes: "govuk-label--m"
-          },
-          id: "password",
-          name: "password",
-          value: values["password"],
-          errorMessage: errors["password"],
-          autocomplete: "new-password"
-        }) }}
+        {% call govukFieldset({
+          legend: {
+            text: "Change your password",
+            classes: "govuk-fieldset__legend govuk-fieldset__legend--m"
+          }
+        }) %}
+
+          {{ govukPasswordInput({
+            label: {
+              text: "Choose new password"
+            },
+            id: "password",
+            name: "password",
+            value: values["password"],
+            errorMessage: errors["password"],
+            autocomplete: "new-password",
+            showPasswordAriaLabelText: "Show new password",
+            hidePasswordAriaLabelText: "Hide new password",
+            passwordShownAnnouncementText: "New password is visible",
+            passwordHiddenAnnouncementText: "New password is hidden"
+          }) }}
+
+          {{ govukPasswordInput({
+            label: {
+              text: "Type new password again"
+            },
+            id: "confirm-password",
+            name: "confirm-password",
+            value: values["confirm-password"],
+            errorMessage: errors["confirm-password"],
+            autocomplete: "new-password",
+            showPasswordAriaLabelText: "Show confirmed password",
+            hidePasswordAriaLabelText: "Hide confirmed password",
+            passwordShownAnnouncementText: "Confirmed password is visible",
+            passwordHiddenAnnouncementText: "Confirmed password is hidden"
+          }) }}
+
+        {% endcall %}
 
         {{ govukButton({
           text: "Save account details"


### PR DESCRIPTION
We want to merge these changes into our main branch so that we can use them for ongoing testing and future audits, without having to reproduce them anew.

For https://github.com/alphagov/govuk-frontend/issues/5085.

## Changes
- Adds headings to the Tabs panels in 'Start page' example.
- Adds a second Password input to the 'Update your account details' example.
  - Each has customised ARIA labels and screen reader text unique to each input.
  - Adds validation that checks that both inputs have the same value.
- Adds 'Make a payment' example for testing Text inputs with prefixes and related validation styles.
- Modify the 'Search' example to make it appear to be the second page of results, so that the previous link is visible in Pagination. 
- Remove Exit This Page component configuration from Child Maintenance example, as these were repeating the default values.