### PR TITLE
Fix details expanded state not announced on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5278: Fix service navigation mobile toggle spacing](https://github.com/alphagov/govuk-frontend/pull/5278)
 - [#5331: Fix Warning Text font weight when <strong> styles are reset](https://github.com/alphagov/govuk-frontend/pull/5331)
 - [#5352: Only apply margin to details summary when open](https://github.com/alphagov/govuk-frontend/pull/5352)
+- [#5089: Fix details expanded state not announced on iOS](https://github.com/alphagov/govuk-frontend/pull/5089)
 
 ## v5.6.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/details/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/details/_index.scss
@@ -8,8 +8,7 @@
   }
 
   .govuk-details__summary {
-    // Make the focus outline shrink-wrap the text content of the summary
-    display: inline-block;
+    display: block;
   }
 
   .govuk-details[open] .govuk-details__summary {
@@ -73,6 +72,9 @@
     .govuk-details__summary {
       // Absolutely position the marker against this element
       position: relative;
+
+      // Make the focus outline shrink-wrap the text content of the summary
+      width: fit-content;
 
       // Allow for absolutely positioned marker and align with disclosed text
       padding-left: govuk-spacing(4) + $govuk-border-width;


### PR DESCRIPTION
For some reason, setting `display: inline-block` on the summary means that [VoiceOver on iOS no longer announces the expanded state of the `<details>` element][1].

We were using `display: inline-block` so that the interactive area and the focus state (when visible) were constrained to the text within the `<summary>`.

We can achieve the same thing by using `display: block` with `width: fit-content`.

However, now that we’re no longer using `display: inline-block` [^fn1], the the 5px bottom margin on the summary and the 30px bottom margin on the details now collapse when the `<details>` is closed *except* in Chrome which [has been updated to use `content-visibility`][2].

Preserve the existing margin on the component and make the behaviour across browsers consistent by establishing a new block formatting context using `display: flow-root`, preventing the margins from collapsing.

Safari < 13 does not support `display: flow-root` and so the margins will collapse, which means these older versions of Safari will have 5px less margin than when we were still using `display: inline-block`.

**EDIT:** We've dropped the commit that added `display: flow-root` to the root `details` element as we removed the extra spacing in https://github.com/alphagov/govuk-frontend/pull/5352, bypassing this issue. Therefore the previous 3 paragraphs are out of date. I'm preserving Ollie's description if we ever wanted to bring the spacing back in.

Fixes #2349
Fixes #4972 (whilst this PR doesn't address 4972 directly, we did explore this option and it unfortuantely doesn't make a difference. This solution has been our most successful so far)

[1]: https://bugs.webkit.org/show_bug.cgi?id=230408
[2]: https://issues.chromium.org/issues/40815464

[^fn1]: ‘margins of inline-block boxes do not collapse (not even with their in-flow children)’ – https://www.w3.org/TR/CSS21/box.html#collapsing-margins
