### PR TITLE
Remove redundant tag CSS from phase banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5044: Remove session storage checks from accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5044)
 - [#5060: Reintroduce additional bottom margin to Error Summary content](https://github.com/alphagov/govuk-frontend/pull/5060)
 - [#5070: Fix alignment of content in conditional checkboxes and radio buttons](https://github.com/alphagov/govuk-frontend/pull/5070)
+- [#5090: Remove redundant tag CSS from phase banner](https://github.com/alphagov/govuk-frontend/pull/5090)
 
 ## 5.4.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
@@ -25,14 +25,6 @@
         margin-right: govuk-spacing(2);
       }
     }
-
-    // When forced colour mode is active, for example to provide high contrast,
-    // the background colour of the tag is the same as the rest of the page. To ensure
-    // that the tag is perceived as separate to the rest of the text in the phase banner,
-    // it is made bold.
-    @media screen and (forced-colors: active) {
-      font-weight: bold;
-    }
   }
 
   .govuk-phase-banner__text {


### PR DESCRIPTION
The phase banner uses the tag component, which takes care of doing this for us since 976535e (part of #3502):

https://github.com/alphagov/govuk-frontend/blob/3822ac1bd000d0f965d3cece2716df91641b82cd/packages/govuk-frontend/src/govuk/components/tag/_index.scss#L32-L40