### PR TITLE
Move service name and navigation into section

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
@@ -51,12 +51,14 @@
     containerClasses: "app-width-container--wide"
   }) }}
 
-  {{ govukPhaseBanner({
-    tag: {
-      text: "Alpha"
-    },
-    html: 'C\'est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l\'améliorer.'
-  }) }}
+  {% set phaseBanner %}
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Alpha"
+      },
+      html: 'C\'est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l\'améliorer.'
+    }) }}
+  {% endset %}
 
   {{ govukServiceHeader({
     serviceName: "Nom du service",
@@ -74,7 +76,10 @@
         href: '#3',
         text: 'Élément de navigation 3'
       }
-    ]
+    ],
+    slots: {
+      end: phaseBanner
+    }
   }) }}
   <!-- endblock:header -->
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/manage-company-information/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/manage-company-information/index.njk
@@ -95,10 +95,12 @@ notes: Based on elements of Companies Houses company information view
 
 {% block header %}
   {{ govukHeader() }}
-  {{ govukPhaseBanner({
-    tag: { text: 'Alpha' },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
+  {% set phaseBanner %}
+    {{ govukPhaseBanner({
+      tag: { text: 'Alpha' },
+      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    }) }}
+  {% endset %}
   {{ govukServiceHeader({
     serviceName: 'Manage company information',
     serviceUrl: '#/',
@@ -108,7 +110,10 @@ notes: Based on elements of Companies Houses company information view
       { href: '#/3', text: 'People', active: true },
       { href: '#/4', text: 'Registers' },
       { href: '#/4', text: 'More' }
-    ]
+    ],
+    slots: {
+      end: phaseBanner
+    }
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -24,14 +24,19 @@ scenario: |
 
 {% block header %}
   {{ super() }}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "Beta"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
+  {% set phaseBanner %}
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Beta"
+      },
+      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    }) }}
+  {% endset %}
   {{ govukServiceHeader({
-    serviceName: "Apply for a passport"
+    serviceName: "Apply for a passport",
+    slots: {
+      end: phaseBanner
+    }
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/confirm.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/full-page-example.njk" %}
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/service-header/macro.njk" import govukServiceHeader %}
 
 {% set pageTitle = "Photo submitted" %}
@@ -8,12 +9,14 @@
 
 {% block header %}
   {{ super() }}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "Beta"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
+  {% set phaseBanner %}
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Beta"
+      },
+      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    }) }}
+  {% endset %}
   {{ govukServiceHeader({
     serviceName: "Apply for a passport",
     navigation: [
@@ -26,7 +29,10 @@
             text: "Upload a photo",
             active: true
         }
-    ]
+    ],
+    slots: {
+      end: phaseBanner
+    }
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -26,12 +26,14 @@ scenario: |
 
 {% block header %}
   {{ super() }}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "Beta"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
+  {% set phaseBanner %}
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Beta"
+      },
+      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    }) }}
+  {% endset %}
   {{ govukServiceHeader({
     serviceName: "Apply for a passport",
     navigation: [
@@ -44,7 +46,10 @@ scenario: |
             text: "Upload a photo",
             active: true
         }
-    ]
+    ],
+    slots: {
+      end: phaseBanner
+    }
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend/src/govuk/components/service-header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-header/_index.scss
@@ -3,14 +3,11 @@
   $govuk-service-header-border-color: $govuk-border-colour;
   $govuk-service-header-active-link-border-width: govuk-spacing(1);
 
-  .govuk-service-header {
-    border-bottom: 1px solid $govuk-service-header-border-color;
-    background-color: $govuk-service-header-background;
-  }
-
   .govuk-service-header__container {
     display: flex;
     padding-top: $govuk-service-header-active-link-border-width;
+    border-bottom: 1px solid $govuk-service-header-border-color;
+    background-color: $govuk-service-header-background;
 
     @include govuk-media-query($until: tablet) {
       flex-direction: column;

--- a/packages/govuk-frontend/src/govuk/components/service-header/service-header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-header/service-header.yaml
@@ -290,3 +290,30 @@ examples:
         end: '<div>[end]</div>'
         navigationStart: '<li>[navigation start]</li>'
         navigationEnd: '<li>[navigation end]</li>'
+  - name: with phase banner
+    hidden: true
+    options:
+      serviceName: Apply for a juggling license
+      serviceUrl: '#/'
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+        - href: '#/2'
+          text: Navigation item 2
+          active: true
+        - href: '#/3'
+          text: Navigation item 3
+        - href: '#/4'
+          text: Navigation item 4
+      slots:
+        end: |
+          <div class="govuk-phase-banner">
+          <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+          Alpha
+          </strong>
+          <span class="govuk-phase-banner__text">
+          This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.
+          </span>
+          </p>
+          </div>

--- a/packages/govuk-frontend/src/govuk/components/service-header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/service-header/template.njk
@@ -5,64 +5,66 @@
 
 {% if params.serviceName or params.navigation | length %}
   <div class="govuk-service-header {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-service-header"
-    {{- govukAttributes(params.attributes) }}>
-    <div class="govuk-service-header__container govuk-width-container">
+    aria-label="Service information and navigation" {{- govukAttributes(params.attributes) }}>
+    <div class="govuk-width-container">
 
         {# Slot: start #}
         {%- if params.slots.start %}{{ params.slots.start | safe }}{% endif -%}
 
-        {# Service name #}
-        {% if params.serviceName %}
-          <span class="govuk-service-header__service-name">
-            {% if params.serviceUrl %}
-            <a href="{{ params.serviceUrl }}" class="govuk-service-header__link govuk-service-header__link--service-name">
-              {{ params.serviceName }}
-            </a>
-            {% else %}
-              {{- params.serviceName -}}
-            {% endif %}
-          </span>
-        {% endif %}
+        <section class="govuk-service-header__container">
+          {# Service name #}
+          {% if params.serviceName %}
+            <span class="govuk-service-header__service-name">
+              {% if params.serviceUrl %}
+              <a href="{{ params.serviceUrl }}" class="govuk-service-header__link govuk-service-header__link--service-name">
+                {{ params.serviceName }}
+              </a>
+              {% else %}
+                {{- params.serviceName -}}
+              {% endif %}
+            </span>
+          {% endif %}
 
-        {# Navigation #}
-        {% if params.navigation | length %}
-          <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-service-header__navigation {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
-            <button type="button" class="govuk-service-header__toggle govuk-js-service-header-toggle" aria-controls="{{ navigationId }}" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
-              {{ menuButtonText }}
-            </button>
+          {# Navigation #}
+          {% if params.navigation | length %}
+            <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-service-header__navigation {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
+              <button type="button" class="govuk-service-header__toggle govuk-js-service-header-toggle" aria-controls="{{ navigationId }}" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
+                {{ menuButtonText }}
+              </button>
 
-            <ul class="govuk-service-header__navigation-list" id="{{ navigationId }}" >
+              <ul class="govuk-service-header__navigation-list" id="{{ navigationId }}" >
 
-              {# Slot: navigationStart #}
-              {%- if params.slots.navigationStart %}{{ params.slots.navigationStart | safe }}{% endif -%}
+                {# Slot: navigationStart #}
+                {%- if params.slots.navigationStart %}{{ params.slots.navigationStart | safe }}{% endif -%}
 
-              {% for item in params.navigation %}
-                <li class="govuk-service-header__navigation-item {%- if item.active or item.current %} govuk-service-header__navigation-item--active{% endif %}">
-                  {% if item.href %}
-                    <a class="govuk-service-header__link" href="{{ item.href }}"
-                      {%- if item.active or item.current %} aria-current="{{ 'page' if item.current else 'true' }}"{% endif %}
-                      {{- govukAttributes(item.attributes) -}}>
-                      {# We wrap active links in strong tags so that users who override colours or
-                      styles will still have some indicator of the current nav item. #}
-                      {% if item.active or item.current %}
-                        <strong class="govuk-service-header__active-fallback">{{- item.html | safe if item.html else item.text -}}</strong>
-                      {% else %}
+                {% for item in params.navigation %}
+                  <li class="govuk-service-header__navigation-item {%- if item.active or item.current %} govuk-service-header__navigation-item--active{% endif %}">
+                    {% if item.href %}
+                      <a class="govuk-service-header__link" href="{{ item.href }}"
+                        {%- if item.active or item.current %} aria-current="{{ 'page' if item.current else 'true' }}"{% endif %}
+                        {{- govukAttributes(item.attributes) -}}>
+                        {# We wrap active links in strong tags so that users who override colours or
+                        styles will still have some indicator of the current nav item. #}
+                        {% if item.active or item.current %}
+                          <strong class="govuk-service-header__active-fallback">{{- item.html | safe if item.html else item.text -}}</strong>
+                        {% else %}
+                          {{- item.html | safe if item.html else item.text -}}
+                        {% endif %}
+                      </a>
+                    {% elif item.html or item.text %}
+                      <span class="govuk-service-header__navigation-text">
                         {{- item.html | safe if item.html else item.text -}}
-                      {% endif %}
-                    </a>
-                  {% elif item.html or item.text %}
-                    <span class="govuk-service-header__navigation-text">
-                      {{- item.html | safe if item.html else item.text -}}
-                    </span>
-                  {% endif %}
-                </li>
-              {% endfor %}
+                      </span>
+                    {% endif %}
+                  </li>
+                {% endfor %}
 
-              {# Slot: navigationEnd #}
-              {%- if params.slots.navigationEnd %}{{ params.slots.navigationEnd | safe }}{% endif -%}
-            </ul>
-          </nav>
-        {% endif %}
+                {# Slot: navigationEnd #}
+                {%- if params.slots.navigationEnd %}{{ params.slots.navigationEnd | safe }}{% endif -%}
+              </ul>
+            </nav>
+          {% endif %}
+        </section>
 
         {# Slot: end #}
         {%- if params.slots.end %}{{ params.slots.end | safe }}{% endif -%}


### PR DESCRIPTION
This is a possible fix for the 'unclear service name' accessibility issue from https://github.com/alphagov/govuk-design-system/issues/3811

## Links
- [Service header component](https://govuk-frontend-pr-5092.herokuapp.com/components/service-header)
- [Example with a header, service header (with service name and navigation) and phase banner](https://govuk-frontend-pr-5092.herokuapp.com/full-page-examples/upload-your-photo)
- [Example page with header and service header (service name only)](https://govuk-frontend-pr-5092.herokuapp.com/full-page-examples/work-history)
- [Example page with header and service header (navigation only)](https://govuk-frontend-pr-5092.herokuapp.com/full-page-examples/announcements)
- [Example page with cookie banner, header, phase banner, service header (with service name and navigation) and breadcrumbs](https://govuk-frontend-pr-5092.herokuapp.com/full-page-examples/manage-company-information), to emulate a potential 'worse case scenario'
- [Preview Branch](https://github.com/alphagov/govuk-frontend/tree/preview-bk-service-information-section). To install, use `npm install --save "alphagov/govuk-frontend#dc8ff97b4"`

## Before:

```html
<div class="govuk-service-header">
  <div class="govuk-service_header__container govuk-width-container">
    <!-- start slot -->
    <span>service name</span>
    <nav>service navigation</nav>
    <!-- end slot ->>
  </div>
</div>
```

![Manage company information before](https://github.com/alphagov/govuk-frontend/assets/22524634/8d1a4b9a-4d4f-4197-a065-e0c7839087fa)

![Slotted content before](https://github.com/alphagov/govuk-frontend/assets/22524634/e6b5f5bd-c98f-4e29-8adb-25970e7453ba)

After:

```html
<div class="govuk-service-header" aria-label="Service information and navigation">
  <div class="govuk-width-container">
    <!-- start slot -->
   <section class="govuk-service_header__container">
      <span>service name</span>
      <nav>service navigation</nav>
    </section>
    <!-- end slot ->>
  </div>
</div>
```

![Manage company information after](https://github.com/alphagov/govuk-frontend/assets/22524634/1825330e-6ed3-4c7a-8368-978ef294455c)

![Slotted content after](https://github.com/alphagov/govuk-frontend/assets/22524634/0712a9ca-7c1d-4024-b088-bb85f3990d3d)

## Potential issues
- I've limited the background colour and bottom border to the service name and navigation section. This means folks would have to do some extra work to make the `start` and `end` slots look of a piece, but there's not really a guarantee they want them to look the same, and it enables a Phase Banner to be inserted without mucking about with that component's styles. I'm not sure it looks great with a border on the grey service header and then a border on the phase banner, though.
- Feels a bit weird not using the main `.govuk-service-header` class for anything. We could probably finagle some positioning and naming of classes.