### PR TITLE
Fix divider width for small checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This change was introduced in [pull request #4995: Update Breadcrumb component t
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
+- [#5114: Fix divider width for small checkboxes](https://github.com/alphagov/govuk-frontend/pull/5114) – thanks to [@colinrotherham](https://github.com/colinrotherham)
 - [#5043: Refactor the accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5043)
 - [#5044: Remove session storage checks from accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/5044)
 - [#5060: Reintroduce additional bottom margin to Error Summary content](https://github.com/alphagov/govuk-frontend/pull/5060)

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -255,6 +255,11 @@
       padding-left: ($govuk-touch-target-size - $input-offset) - ($margin-left + $conditional-border-width);
     }
 
+    .govuk-checkboxes__divider {
+      width: $govuk-small-checkboxes-size;
+      margin-bottom: govuk-spacing(1);
+    }
+
     // Hover state for small checkboxes.
     //
     // We use a hover state for small checkboxes because the touch target size

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -700,6 +700,25 @@ examples:
         - value: b
           text: another thing
 
+  - name: small with divider and None
+    options:
+      name: small-with-divider-and-none
+      classes: govuk-checkboxes--small
+      fieldset:
+        legend:
+          text: Which types of waste do you transport regularly?
+      items:
+        - value: animal
+          text: Waste from animal carcasses
+        - value: mines
+          text: Waste from mines or quarries
+        - value: farm
+          text: Farm or agricultural waste
+        - divider: or
+        - value: none
+          text: None of these
+          behaviour: exclusive
+
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with idPrefix
     hidden: true

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -196,6 +196,7 @@ examples:
         - other
 
   - name: with divider and None
+    screenshot: true
     options:
       name: with-divider-and-none
       fieldset:
@@ -701,6 +702,7 @@ examples:
           text: another thing
 
   - name: small with divider and None
+    screenshot: true
     options:
       name: small-with-divider-and-none
       classes: govuk-checkboxes--small

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -242,6 +242,7 @@ examples:
             For properties that are within a geographical area defined by a local council
 
   - name: with a divider
+    screenshot: true
     options:
       idPrefix: example-divider
       name: example
@@ -680,6 +681,7 @@ examples:
           text: funkiness
 
   - name: small with a divider
+    screenshot: true
     options:
       idPrefix: example-small-divider
       name: example

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -249,7 +249,7 @@ examples:
         legend:
           text: How do you want to sign in?
       items:
-        - value: governement-gateway
+        - value: government-gateway
           text: Use Government Gateway
         - value: govuk-verify
           text: Use GOV.UK Verify
@@ -688,7 +688,7 @@ examples:
           text: How do you want to sign in?
       classes: govuk-radios--small
       items:
-        - value: governement-gateway
+        - value: government-gateway
           text: Use Government Gateway
         - value: govuk-verify
           text: Use GOV.UK Verify


### PR DESCRIPTION
Hello 👋

There might be some history behind this, but I noticed small checkboxes use the regular divider width (unlike radios)

This PR ensures checkboxes follow the same convention as radios and adds a new example

## Before

<img width="465" alt="Before, small checkboxes without adjustments to divider width and margin" src="https://github.com/alphagov/govuk-frontend/assets/415517/ae4fd0c1-6be4-4076-9652-d587273b5b92">

## After

<img width="451" alt="After, small checkboxes with adjustments to divider width and margin" src="https://github.com/alphagov/govuk-frontend/assets/415517/9b6571a6-57d1-4496-be06-34a6a865a965">

---

### History

1. Dividers supported for [**Radios** in GOV.UK Elements](https://govuk-elements.herokuapp.com/form-elements/#form-radio-buttons)
2. Dividers added to [**Radios** in GOV.UK Frontend](https://design-system.service.gov.uk/components/radios/) via PR [#849](https://github.com/alphagov/govuk-frontend/pull/849)
3. Smaller Radios and Checkboxes added in PR [#1125](https://github.com/alphagov/govuk-frontend/pull/1125) _with_ narrow divider widths in https://github.com/alphagov/govuk-frontend/pull/1125/commits/b645ac16c5c802e6a3a53125ac588166a8d20872
4. Dividers added to [**Checkboxes** in GOV.UK Frontend](https://design-system.service.gov.uk/components/checkboxes/) via PR [#2151](https://github.com/alphagov/govuk-frontend/pull/2151) _without_ narrow divider widths

Worth mentioning existing comments regarding divider widths:

* https://github.com/alphagov/govuk-design-system-backlog/issues/59#issuecomment-456880349
* https://github.com/alphagov/govuk-frontend/issues/1079#issuecomment-456882027

And a [similar mention of label wrapping](https://github.com/alphagov/govuk-frontend/issues/4873) (which affects dividers too)