### PR TITLE
Remove direct links to Polyfill[dot]io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5127: Remove direct links to Polyfill[dot]io](https://github.com/alphagov/govuk-frontend/pull/5127)
+
 ## GOV.UK Frontend v4.8.0 (Feature release)
 
 This release includes the ability to update the crown logo. You must do this between 19 February and 1 March 2024.

--- a/src/govuk/vendor/README.md
+++ b/src/govuk/vendor/README.md
@@ -1,0 +1,7 @@
+# NOTE
+
+These polyfills were generated using polyfill.io, which was reported as compromised on 25th June 2024.
+
+We generated this code well before the compromise, and it is free of malicious code.
+
+However, we recommend checking any polyfills you have generated in a similar way.

--- a/src/govuk/vendor/polyfills/DOMTokenList.mjs
+++ b/src/govuk/vendor/polyfills/DOMTokenList.mjs
@@ -1,7 +1,6 @@
 // @ts-nocheck
 (function (undefined) {
 
-    // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-service/master/packages/polyfill-library/polyfills/DOMTokenList/detect.js
     var detect = (
       'DOMTokenList' in this && (function (x) {
         return 'classList' in x ? !x.classList.toggle('x', false) && !x.className : true;
@@ -10,7 +9,6 @@
 
     if (detect) return
 
-    // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-service/master/packages/polyfill-library/polyfills/DOMTokenList/polyfill.js
     (function (global) {
       var nativeImpl = "DOMTokenList" in global && global.DOMTokenList;
 

--- a/src/govuk/vendor/polyfills/Date/now.mjs
+++ b/src/govuk/vendor/polyfills/Date/now.mjs
@@ -1,12 +1,10 @@
 // @ts-nocheck
 (function (undefined) {
 
-    // Detection from https://github.com/Financial-Times/polyfill-library/blob/v3.111.0/polyfills/Date/now/detect.js
     var detect = ('Date' in self && 'now' in self.Date && 'getTime' in self.Date.prototype)
 
     if (detect) return
 
-    // Polyfill from https://polyfill.io/v3/polyfill.js?version=3.111.0&features=Date.now&flags=always
     Date.now = function () {
         return new Date().getTime();
     };

--- a/src/govuk/vendor/polyfills/Document.mjs
+++ b/src/govuk/vendor/polyfills/Document.mjs
@@ -1,12 +1,10 @@
 // @ts-nocheck
 (function (undefined) {
 
-// Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Document/detect.js
 var detect = ("Document" in this)
 
 if (detect) return
 
-// Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Document&flags=always
 if ((typeof WorkerGlobalScope === "undefined") && (typeof importScripts !== "function")) {
 
 	if (this.HTMLDocument) { // IE8

--- a/src/govuk/vendor/polyfills/Element.mjs
+++ b/src/govuk/vendor/polyfills/Element.mjs
@@ -3,12 +3,10 @@ import './Document.mjs'
 
 (function(undefined) {
 
-// Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Element/detect.js
 var detect = ('Element' in this && 'HTMLElement' in this)
 
 if (detect) return
 
-// Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Element&flags=always
 (function () {
 
 	// IE8

--- a/src/govuk/vendor/polyfills/Element/prototype/classList.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/classList.mjs
@@ -5,7 +5,6 @@ import '../../Element.mjs'
 
 (function(undefined) {
 
-    // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-service/8717a9e04ac7aff99b4980fbedead98036b0929a/packages/polyfill-library/polyfills/Element/prototype/classList/detect.js
     var detect = (
       'document' in this && "classList" in document.documentElement && 'Element' in this && 'classList' in Element.prototype && (function () {
         var e = document.createElement('span');
@@ -16,7 +15,6 @@ import '../../Element.mjs'
 
     if (detect) return
 
-    // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Element.prototype.classList&flags=always
     (function (global) {
       var dpSupport = true;
       var defineGetter = function (object, name, fn, configurable) {

--- a/src/govuk/vendor/polyfills/Element/prototype/closest.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/closest.mjs
@@ -3,14 +3,12 @@ import './matches.mjs'
 
 (function(undefined) {
 
-  // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/closest/detect.js
   var detect = (
     'document' in this && "closest" in document.documentElement
   )
 
   if (detect) return
 
-  // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/closest/polyfill.js
   Element.prototype.closest = function closest(selector) {
     var node = this;
 

--- a/src/govuk/vendor/polyfills/Element/prototype/dataset.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/dataset.mjs
@@ -4,7 +4,6 @@ import '../../Element.mjs'
 
 (function(undefined) {
 
-  // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-library/13cf7c340974d128d557580b5e2dafcd1b1192d1/polyfills/Element/prototype/dataset/detect.js
   var detect = (function(){
     if (!document.documentElement.dataset) {
       return false;
@@ -16,7 +15,6 @@ import '../../Element.mjs'
 
   if (detect) return
 
-  // Polyfill derived from  https://raw.githubusercontent.com/Financial-Times/polyfill-library/13cf7c340974d128d557580b5e2dafcd1b1192d1/polyfills/Element/prototype/dataset/polyfill.js
   Object.defineProperty(Element.prototype, 'dataset', {
     get: function() {
       var element = this;

--- a/src/govuk/vendor/polyfills/Element/prototype/matches.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/matches.mjs
@@ -1,14 +1,12 @@
 // @ts-nocheck
 (function (undefined) {
 
-  // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/matches/detect.js
   var detect = (
     'document' in this && "matches" in document.documentElement
   )
 
   if (detect) return
 
-  // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/matches/polyfill.js
   Element.prototype.matches = Element.prototype.webkitMatchesSelector || Element.prototype.oMatchesSelector || Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || function matches(selector) {
     var element = this;
     var elements = (element.document || element.ownerDocument).querySelectorAll(selector);

--- a/src/govuk/vendor/polyfills/Element/prototype/nextElementSibling.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/nextElementSibling.mjs
@@ -4,14 +4,12 @@ import '../../Element.mjs'
 
 (function(undefined) {
 
-    // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-library/master/polyfills/Element/prototype/nextElementSibling/detect.js
     var detect = (
       'document' in this && "nextElementSibling" in document.documentElement
     )
 
     if (detect) return
 
-    // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-library/master/polyfills/Element/prototype/nextElementSibling/polyfill.js
     Object.defineProperty(Element.prototype, "nextElementSibling", {
       get: function(){
         var el = this.nextSibling;

--- a/src/govuk/vendor/polyfills/Element/prototype/previousElementSibling.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/previousElementSibling.mjs
@@ -4,14 +4,12 @@ import '../../Element.mjs'
 
 (function(undefined) {
 
-    // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-library/master/polyfills/Element/prototype/previousElementSibling/detect.js
     var detect = (
       'document' in this && "previousElementSibling" in document.documentElement
     )
 
     if (detect) return
 
-    // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-library/master/polyfills/Element/prototype/previousElementSibling/polyfill.js
     Object.defineProperty(Element.prototype, 'previousElementSibling', {
       get: function(){
         var el = this.previousSibling;

--- a/src/govuk/vendor/polyfills/Event.mjs
+++ b/src/govuk/vendor/polyfills/Event.mjs
@@ -5,7 +5,6 @@ import './Object/defineProperty.mjs'
 
 (function(undefined) {
 
-// Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
 var detect = (
   (function(global) {
 
@@ -25,7 +24,6 @@ var detect = (
 
 if (detect) return
 
-// Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always
 (function () {
 	var unlistenableWindowEvents = {
 		click: 1,

--- a/src/govuk/vendor/polyfills/Function/prototype/bind.mjs
+++ b/src/govuk/vendor/polyfills/Function/prototype/bind.mjs
@@ -2,12 +2,10 @@
 import '../../Object/defineProperty.mjs'
 
 (function(undefined) {
-  // Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Function/prototype/bind/detect.js
   var detect = 'bind' in Function.prototype
 
   if (detect) return
 
-  // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Function.prototype.bind&flags=always
   Object.defineProperty(Function.prototype, 'bind', {
       value: function bind(that) { // .length is 1
           // add necessary es5-shim utilities

--- a/src/govuk/vendor/polyfills/Object/defineProperty.mjs
+++ b/src/govuk/vendor/polyfills/Object/defineProperty.mjs
@@ -1,7 +1,6 @@
 // @ts-nocheck
 (function (undefined) {
 
-// Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Object/defineProperty/detect.js
 var detect = (
   // In IE8, defineProperty could only act on DOM elements, so full support
   // for the feature requires the ability to set a property on an arbitrary object
@@ -18,7 +17,6 @@ var detect = (
 
 if (detect) return
 
-// Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Object.defineProperty&flags=always
 (function (nativeDefineProperty) {
 
 	var supportsAccessors = Object.prototype.hasOwnProperty('__defineGetter__');

--- a/src/govuk/vendor/polyfills/String/prototype/trim.mjs
+++ b/src/govuk/vendor/polyfills/String/prototype/trim.mjs
@@ -1,12 +1,10 @@
 // @ts-nocheck
 (function (undefined) {
 
-    // Detection from https://github.com/mdn/content/blob/cf607d68522cd35ee7670782d3ee3a361eaef2e4/files/en-us/web/javascript/reference/global_objects/string/trim/index.md#polyfill
     var detect = ('trim' in String.prototype)
 
     if (detect) return
 
-    // Polyfill from https://github.com/mdn/content/blob/cf607d68522cd35ee7670782d3ee3a361eaef2e4/files/en-us/web/javascript/reference/global_objects/string/trim/index.md#polyfill
     String.prototype.trim = function () {
         return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
     };

--- a/src/govuk/vendor/polyfills/Window.mjs
+++ b/src/govuk/vendor/polyfills/Window.mjs
@@ -1,12 +1,10 @@
 // @ts-nocheck
 (function (undefined) {
 
-// Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Window/detect.js
 var detect = ('Window' in this)
 
 if (detect) return
 
-// Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Window&flags=always
 if ((typeof WorkerGlobalScope === "undefined") && (typeof importScripts !== "function")) {
 	(function (global) {
 		if (global.constructor) {


### PR DESCRIPTION
Closes #5105 

The included note bulked out the package code considerably (see [#dcf4810](https://github.com/alphagov/govuk-frontend/commit/dcf481045b4aba63390ad672bea2a368f086e693)), so I've gone with a single README in the polyfill folder.

If we wanted to include the note in the code itself, we could add a version of it to `src/all.mjs`. Then it'd only be included once. But that felt a bit misplaced.

To propagate the changes to the `dist` and `package` folders, we'd need to do a patch release. I considered just manually updating these and skipping the CHANGELOG entry, but this seems more transparent, despite being more hassle.