### PR TITLE
Document private fields in dev JSDoc

### DIFF
--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -34,6 +34,10 @@ module.exports = {
     strict: false
   },
 
+  // Document private methods. These are behind a checkbox in the
+  // settings menu of the JSDoc page.
+  excludePrivate: false,
+
   // Ignore known undocumented types (@internal, @private etc)
   intentionallyNotExported: ['I18n', 'TranslationPluralForms']
 }


### PR DESCRIPTION
Enable private fields in our generated documentation by default.

You still need to select the "Private" checkbox in Settings > Member Visibility on the JSDoc page (`/docs/javascript/`).

Since the review app is meant for internal development, it makes sense to expose everything by default.