### PR TITLE
Remove ↑ up and ↓ down arrow key bindings from tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5046: Skip ‘empty’ tasks in the task list](https://github.com/alphagov/govuk-frontend/pull/5046)
 - [#5066: Fix whitespace affecting text alignment in pagination block variant](https://github.com/alphagov/govuk-frontend/pull/5066)
+- [#5158: Remove ↑ up and ↓ down arrow key bindings from tabs](https://github.com/alphagov/govuk-frontend/pull/5158)
 
 ## 5.4.1 (Fix release)
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -365,26 +365,22 @@ export class Tabs extends GOVUKFrontendComponent {
   /**
    * Handle tab keydown event
    *
-   * - Press right/down arrow for next tab
-   * - Press left/up arrow for previous tab
+   * - Press right arrow for next tab
+   * - Press left arrow for previous tab
    *
    * @private
    * @param {KeyboardEvent} event - Keydown event
    */
   onTabKeydown(event) {
     switch (event.key) {
-      // 'Left', 'Right', 'Up' and 'Down' required for Edge 16 support.
+      // 'Left' and 'Right' required for Edge 16 support.
       case 'ArrowLeft':
-      case 'ArrowUp':
       case 'Left':
-      case 'Up':
         this.activatePreviousTab()
         event.preventDefault()
         break
       case 'ArrowRight':
-      case 'ArrowDown':
       case 'Right':
-      case 'Down':
         this.activateNextTab()
         event.preventDefault()
         break


### PR DESCRIPTION
Currently the Tabs component binds the up and down arrow keys to the same functionality as the left and right arrow keys, using them to navigate between the previous and next tabs within a tablist. 

Last week, [we received a comment stating that these bindings were causing problems in NVDA](https://github.com/alphagov/govuk-design-system-backlog/issues/100#issuecomment-2217329666), as the user became 'trapped' within the tablist and could not arrow out of it—up and down arrows being a frequent control mechanism for moving between adjacent elements.

This morning, [we received another comment stating the opposite](https://github.com/alphagov/govuk-design-system-backlog/issues/100#issuecomment-2238652113), and that the up/down bindings weren't necessarily problematic and that a user could 'break out' by switching to NVDA's document mode.

The [example pattern in the WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#keyboardinteraction) explicitly states that only the arrow keys matching the physical direction of the tablist should be bound to tab changes (left/right for a horizontal list, up/down for a vertical list). 

On this basis, I think we should remove the existing key bindings for the up/down arrows.

## Changes

- Removes up and down arrow `keydown` bindings in the Tabs component.

## Todo 

There's an open-ended question about whether this constitutes a breaking change or not. Is it removing functionality or altering it? Or is it just fixing something that's unexpected? I've avoided adding a changelog just yet so we can ponder that. 

## Thoughts

I initially experimented with rebinding the up and down arrows to move focus between the tablist and the tab panel, as suggested [in this issue](https://github.com/alphagov/govuk-frontend/issues/860), however this still felt like it had a high risk of being incongruous with how an assistive technology user expects their tools to behave and it isn't a behaviour suggested by WAI-ARIA, so I backtracked on doing that in this PR. [You can see that work in a separate branch.](https://github.com/alphagov/govuk-frontend/compare/tabs-remove-up-down-keybinding...tabs-down-arrow-focuses-panel?expand=1)

This does not resolve the other recent issue with the Tabs component in NVDA/Firefox. https://github.com/alphagov/govuk-frontend/issues/5154