### PR TITLE
[WIP] Define default `id` parameter values for various components

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -234,6 +234,15 @@ examples:
               </ul>
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: id
+    hidden: true
+    options:
+      id: custom-id
+      items:
+        - heading:
+            text: Section A
+          content:
+            text: Some content
   - name: classes
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -1,7 +1,7 @@
 params:
   - name: id
     type: string
-    required: true
+    required: false
     description: Must be unique across the domain of your service if `rememberExpanded` is `true` (as the expanded state of individual instances of the component persists across page loads using [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)). Used as an `id` in the HTML for the accordion as a whole, and also as a prefix for the `id`s of the section contents and the buttons that open them, so that those `id`s can be the target of `aria-control` attributes.
   - name: headingLevel
     type: integer
@@ -95,7 +95,6 @@ params:
 examples:
   - name: default
     options:
-      id: default-example
       items:
         - heading:
             text: Section A

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.jsdom.test.js
@@ -44,11 +44,18 @@ describe('Accordion', () => {
     it('renders with id', () => {
       const $component = document.querySelector('.govuk-accordion')
 
-      expect($component).toHaveAttribute('id', 'default-example')
+      expect($component).toHaveAttribute('id', 'accordion')
     })
   })
 
   describe('custom options', () => {
+    it('renders with id', () => {
+      document.body.innerHTML = render('accordion', examples.id)
+      const $component = document.querySelector('.govuk-accordion')
+
+      expect($component).toHaveAttribute('id', 'custom-id')
+    })
+
     it('renders with classes', () => {
       document.body.innerHTML = render('accordion', examples.classes)
       const $component = document.querySelector('.govuk-accordion')

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.njk
@@ -1,22 +1,24 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
 {% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
+{%- set componentId = params.id | default("accordion") -%}
+
 {%- macro _accordionItem(params, item, index) %}
   {%- set headingLevel = params.headingLevel if params.headingLevel else 2 %}
   <div class="govuk-accordion__section {%- if item.expanded %} govuk-accordion__section--expanded{% endif %}">
     <div class="govuk-accordion__section-header">
       <h{{ headingLevel }} class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="{{ params.id }}-heading-{{ index }}">
+        <span class="govuk-accordion__section-button" id="{{ componentId }}-heading-{{ index }}">
           {{ item.heading.html | safe | trim | indent(8) if item.heading.html else item.heading.text }}
         </span>
       </h{{ headingLevel }}>
       {% if item.summary.html or item.summary.text %}
-      <div class="govuk-accordion__section-summary govuk-body" id="{{ params.id }}-summary-{{ index }}">
+      <div class="govuk-accordion__section-summary govuk-body" id="{{ componentId }}-summary-{{ index }}">
         {{ item.summary.html | safe | trim | indent(8) if item.summary.html else item.summary.text }}
       </div>
       {% endif %}
     </div>
-    <div id="{{ params.id }}-content-{{ index }}" class="govuk-accordion__section-content">
+    <div id="{{ componentId }}-content-{{ index }}" class="govuk-accordion__section-content">
     {% if item.content.html %}
       {{ item.content.html | safe | trim | indent(6) }}
     {% elif item.content.text %}
@@ -28,7 +30,7 @@
   </div>
 {% endmacro -%}
 
-<div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-accordion" id="{{ params.id }}"
+<div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-accordion" id="{{ componentId }}"
   {{- govukI18nAttributes({
     key: 'hide-all-sections',
     message: params.hideAllSectionsText

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the textarea.
+    required: false
+    description: The ID of the textarea and also as a prefix for the `id`s of the textarea's hints, so that those `id`s can be the target of `aria-describedby` attributes. Defaults to matching `name`.
   - name: name
     type: string
     required: true
@@ -135,7 +135,6 @@ examples:
   - name: default
     options:
       name: more-detail
-      id: more-detail
       maxlength: 10
       label:
         text: Can you provide more detail?

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -3,6 +3,8 @@
 {% from "../textarea/macro.njk" import govukTextarea %}
 {% from "../hint/macro.njk" import govukHint %}
 
+{%- set componentId = params.id | default(params.name) -%}
+
 {#-
   If the limit is set in JavaScript, we won't be able to interpolate the message
   until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
@@ -16,7 +18,7 @@
 {%- set countMessageHtml %}
 {{ govukHint({
   text: textareaDescriptionTextNoLimit,
-  id: params.id + '-info',
+  id: componentId + '-info',
   classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
 }) | trim }}
 {% if params.formGroup.afterInput %}
@@ -91,9 +93,9 @@
 {% endfor -%}
 
 {{ govukTextarea({
-  id: params.id,
+  id: componentId,
   name: params.name,
-  describedBy: params.id + '-info',
+  describedBy: componentId + '-info',
   rows: params.rows,
   spellcheck: params.spellcheck,
   value: params.value,
@@ -112,7 +114,7 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: componentId
   },
   hint: params.hint,
   errorMessage: params.errorMessage,

--- a/packages/govuk-frontend/src/govuk/components/date-input/__snapshots__/template.test.js.snap
+++ b/packages/govuk-frontend/src/govuk/components/date-input/__snapshots__/template.test.js.snap
@@ -13,17 +13,17 @@ exports[`Date input nested dependant components passes through fieldset params w
 
 exports[`Date input nested dependant components passes through label params without breaking 1`] = `
 <label class="govuk-label govuk-date-input__label"
-       for="dob-day"
+       for="date-input-day"
 >
   Day
 </label>
 <label class="govuk-label govuk-date-input__label"
-       for="dob-month"
+       for="date-input-month"
 >
   Month
 </label>
 <label class="govuk-label govuk-date-input__label"
-       for="dob-year"
+       for="date-input-year"
 >
   Year
 </label>

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: This is used for the main component and to compose the ID attribute for each item.
+    required: false
+    description: This is used for the main component and to compose the ID attribute for each item. Defaults to `namePrefix` if set, otherwise uses `"date-input"`.
   - name: namePrefix
     type: string
     required: false
@@ -109,8 +109,6 @@ params:
 
 examples:
   - name: default
-    options:
-      id: dob
   - name: complete question
     options:
       id: dob

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -4,6 +4,8 @@
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../input/macro.njk" import govukInput %}
 
+{%- set componentId = (params.id if params.id else params.namePrefix) | default("date-input") %}
+
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
@@ -33,7 +35,7 @@
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
-  {% set hintId = params.id + "-hint" %}
+  {% set hintId = componentId + "-hint" %}
   {% set describedBy = describedBy + " " + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -44,7 +46,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + "-error" %}
+  {% set errorId = componentId + "-error" %}
   {% set describedBy = describedBy + " " + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -57,7 +59,7 @@
 {% endif %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {{- govukAttributes(params.attributes) -}}
-    {%- if params.id %} id="{{ params.id }}"{% endif %}>
+    {%- if componentId %} id="{{ componentId }}"{% endif %}>
     {% if params.formGroup.beforeInputs %}
     {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
     {% endif %}
@@ -68,7 +70,7 @@
           text: item.label if item.label else item.name | capitalize,
           classes: "govuk-date-input__label"
         },
-        id: item.id if item.id else (params.id + "-" + item.name),
+        id: item.id if item.id else (componentId + "-" + item.name),
         classes: "govuk-date-input__input " + (item.classes if item.classes),
         name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -17,7 +17,7 @@ describe('Date input', () => {
       const $ = render('date-input', examples.default)
 
       const $component = $('.govuk-date-input')
-      expect($component.attr('id')).toBe('dob')
+      expect($component.attr('id')).toBe('date-input')
     })
 
     it('renders default inputs', () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -5,8 +5,8 @@ params:
     description: The name of the input, which is submitted with the form data.
   - name: id
     type: string
-    required: true
-    description: The ID of the input.
+    required: false
+    description: The ID of the input. Defaults to matching `name`.
   - name: value
     type: string
     required: false
@@ -85,7 +85,6 @@ params:
 examples:
   - name: default
     options:
-      id: file-upload-1
       name: file-upload-1
       label:
         text: Upload a file

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -3,9 +3,12 @@
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
 
+{%- set componentId = params.id | default(params.name) -%}
+
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
   {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
@@ -14,10 +17,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: componentId
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = componentId + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -28,7 +31,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = componentId + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -42,7 +45,7 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ componentId }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -388,6 +388,13 @@ examples:
       value: QQ 12 34 56 C
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: id
+    hidden: true
+    options:
+      id: test-id
+      name: different-name
+      label:
+        text: With custom ID
   - name: classes
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the input.
+    required: false
+    description: The ID of the input. Defaults to matching `name`.
   - name: name
     type: string
     required: true
@@ -166,7 +166,6 @@ examples:
     options:
       label:
         text: National Insurance number
-      id: input-example
       name: test-name
   - name: with hint text
     options:

--- a/packages/govuk-frontend/src/govuk/components/input/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.jsdom.test.js
@@ -17,12 +17,13 @@ describe('Input', () => {
       $label = document.querySelector('.govuk-label')
     })
 
-    it('sets the `id` attribute based on the `id` option', () => {
-      expect($component).toHaveAttribute('id', 'input-example')
-    })
-
     it('sets the `name` attribute based on the `name` option', () => {
       expect($component).toHaveAttribute('name', 'test-name')
+    })
+
+    it('sets the `id` attribute based on the `name` option', () => {
+      const inputName = $component.getAttribute('name')
+      expect($component).toHaveAttribute('id', inputName)
     })
 
     it('sets the `type` attribute to a default value of "text"', () => {
@@ -65,6 +66,13 @@ describe('Input', () => {
   })
 
   describe('custom options', () => {
+    it('sets the `id` attribute based on the `id` option', () => {
+      document.body.innerHTML = render('input', examples.id)
+
+      const $component = document.querySelector('.govuk-input')
+      expect($component).toHaveAttribute('id', 'test-id')
+    })
+
     it('includes additional classes from the `classes` option', () => {
       document.body.innerHTML = render('input', examples.classes)
 

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -3,6 +3,8 @@
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
 
+{%- set componentId = params.id | default(params.name) -%}
+
 {#- Set classes for this component #}
 {%- set classNames = "govuk-input" -%}
 
@@ -27,7 +29,7 @@
   <input
     {{- govukAttributes({
       class: classNames,
-      id: params.id,
+      id: componentId,
       name: params.name,
       type: params.type | default("text", true),
       spellcheck: {
@@ -83,10 +85,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: componentId
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = componentId + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -97,7 +99,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = componentId + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: ID for each select box.
+    required: false
+    description: ID for each select box. Defaults to matching `name`.
   - name: name
     type: string
     required: true
@@ -110,7 +110,6 @@ params:
 examples:
   - name: default
     options:
-      id: select-1
       name: select-1
       label:
         text: Label text goes here

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -3,9 +3,12 @@
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
 
+{%- set componentId = params.id | default(params.name) -%}
+
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
   {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
@@ -14,10 +17,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: componentId
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = componentId + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -28,7 +31,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = componentId + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -43,7 +46,7 @@
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
   <select class="govuk-select
-    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ componentId }}" name="{{ params.name }}"
     {%- if params.disabled %} disabled{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
     {{- govukAttributes(params.attributes) }}>

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
@@ -2,11 +2,11 @@ params:
   - name: id
     type: string
     required: false
-    description: This is used for the main component and to compose the ID attribute for each item.
+    description: This is used for the main component and to compose the ID attribute for each item. Default is `"tabs"`.
   - name: idPrefix
     type: string
     required: false
-    description: Optional prefix. This is used to prefix the `id` attribute for each tab item and panel, separated by `-`.
+    description: Optional prefix. This is used to prefix the `id` attribute for each tab item and panel, separated by `-`. Defaults to matching `id`.
   - name: title
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.njk
@@ -1,10 +1,10 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
 
 {%- set componentId = params.id | default("tabs") -%}
-{%- set prefixId = params.prefixId | default(componentid) -%}
+{%- set idPrefix = params.idPrefix | default(componentid) -%}
 
 {%- macro _tabListItem(params, item, index) %}
-{% set tabPanelId = item.id if item.id else prefixId + "-" + index -%}
+{% set tabPanelId = item.id if item.id else idPrefix + "-" + index -%}
 <li class="govuk-tabs__list-item {%- if index == 1 %} govuk-tabs__list-item--selected{% endif %}">
   <a class="govuk-tabs__tab" href="#{{ tabPanelId }}"
     {{- govukAttributes(item.attributes) }}>
@@ -14,7 +14,7 @@
 {% endmacro -%}
 
 {%- macro _tabPanel(params, item, index) %}
-{% set tabPanelId = item.id if item.id else prefixId + "-" + index -%}
+{% set tabPanelId = item.id if item.id else idPrefix + "-" + index -%}
 <div class="govuk-tabs__panel {%- if index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ tabPanelId }}"
   {{- govukAttributes(item.panel.attributes) }}>
 {% if item.panel.html %}

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.njk
@@ -1,7 +1,10 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
 
+{%- set componentId = params.id | default("tabs") -%}
+{%- set prefixId = params.prefixId | default(componentid) -%}
+
 {%- macro _tabListItem(params, item, index) %}
-{% set tabPanelId = item.id if item.id else idPrefix + "-" + index -%}
+{% set tabPanelId = item.id if item.id else prefixId + "-" + index -%}
 <li class="govuk-tabs__list-item {%- if index == 1 %} govuk-tabs__list-item--selected{% endif %}">
   <a class="govuk-tabs__tab" href="#{{ tabPanelId }}"
     {{- govukAttributes(item.attributes) }}>
@@ -11,7 +14,7 @@
 {% endmacro -%}
 
 {%- macro _tabPanel(params, item, index) %}
-{% set tabPanelId = item.id if item.id else idPrefix + "-" + index -%}
+{% set tabPanelId = item.id if item.id else prefixId + "-" + index -%}
 <div class="govuk-tabs__panel {%- if index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ tabPanelId }}"
   {{- govukAttributes(item.panel.attributes) }}>
 {% if item.panel.html %}
@@ -22,11 +25,7 @@
 </div>
 {% endmacro -%}
 
-{#- If an id 'prefix' is not passed, fall back to using the name attribute
-  instead. We need this for error messages and hints as well -#}
-{% set idPrefix = params.idPrefix if params.idPrefix -%}
-
-<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}"
+<div {%- if componentId %} id="{{ componentId }}"{% endif %} class="govuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }} data-module="govuk-tabs">
   <h2 class="govuk-tabs__title">
     {{ params.title | default ("Contents") }}

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.njk
@@ -3,9 +3,12 @@
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
 
+{%- set componentId = params.id | default(params.name)%}
+
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
   {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
@@ -14,10 +17,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: componentId
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = componentId + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -28,7 +31,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = componentId + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -42,7 +45,7 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
+  <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ componentId }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the textarea.
+    required: false
+    description: The ID of the textarea. Defaults to matching `name`.
   - name: name
     type: string
     required: true
@@ -98,7 +98,6 @@ examples:
   - name: default
     options:
       name: more-detail
-      id: more-detail
       label:
         text: Can you provide more detail?
   - name: with hint


### PR DESCRIPTION
Many components in the Design System have a functional requirement for an `id` to be defined in order to work as expected. As it stands, some components provide a default `id` value if one isn't specified, whereas other components don't. We already do this ourselves for the Checkboxes and Radios components, by having the `idPrefix` to match the `name` parameter by default.

This has led to [instances of developers forgetting to set `id`s](https://github.com/alphagov/govuk-frontend/issues/3497#issuecomment-1697688942) and for some ports of govuk-frontend to implement their own methods of setting default `id`s. The [ASP.NET Core](https://github.com/gunndabad/govuk-frontend-aspnetcore) and [Jinja](https://github.com/LandRegistry/govuk-frontend-jinja) ports both fall back to `name`, and the [Vue port](https://govukvue.org/) automatically generates unique IDs if one isn't specified. 

Related to #3497. 

## Changes
- Everywhere an `id` is required, but lacked a default or fallback value, now has a default or fallback defined.
  - On form controls, this fallback is to the `name` parameter. Otherwise, it is to a hardcoded string (the component name). 
- Update Nunjucks parameter documentation for modified components.
- Update default examples to remove explicitly defined `id` parameters.

### Components changed
Previously, all of these components required an `id` attribute to work as expected and/or to render valid and accessible HTML.

- **Accordion**: ID defaults to string `"accordion"`. Used for the root element and as a prefix for child element IDs. 
- **Character count**: ID falls back to `name` parameter. Used for the `textarea` and for related labels/hint IDs. 
- **Date input**: ID falls back to the `namePrefix` parameter if it's defined, otherwise defaults to the string `"date-input"`. Used for the root element and to prefix the IDs of child inputs.
- **File upload**: ID falls back to `name` parameter. Used for the `input` and for related labels/hint IDs. 
- **Select**: ID falls back to `name` parameter. Used for the `select` and for related labels/hint IDs. 
- **Text input**: ID falls back to `name` parameter. Used for the `input` and for related labels/hint IDs. 
- **Textarea**: ID falls back to `name` parameter. Used for the `textarea` and for related labels/hint IDs. 

**Tabs** is a bit of a weird case in that its `id` and `idPrefix` parameters were completely detached from one another, both needing setting individually even if they were the same value.

This was incongruent with similar components, where the `idPrefix` always falls back to the `id` or `name`. In this case, I've made it so that `idPrefix` falls back to match the `id`, and the `id` defaults to `"tabs"`. 

## Todo
- There are no new or modified tests for this change.
- Changelog entry.

## Thoughts
- There feels like there's greater value to fallbacks existing for form controls (where we can match the `name`) than non-form components like the Accordion and Tabs. I'm open to not setting defaults for non-form components, but having defaults for everything feels more consistent.
- Cases where the fallback is the `name` parameter can introduce a potential issue — `name`s can contain characters that `id`s cannot, such as square brackets. There are no attempts to protect against the creation of invalid `id`s here, though one could potentially be introduced, such as 'slugifying' the `name`.