### PR TITLE
Remove deprecated Husky setup code

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no-install lint-staged
+npx --no lint-staged


### PR DESCRIPTION
govuk-frontend repo duplicate of this PR: https://github.com/alphagov/govuk-design-system/pull/3970

As this is solely related to internal tooling, it's my understanding that this doesn't require a changelog entry.