### PR TITLE
Add issue template for cycle briefs

### DIFF
--- a/.github/ISSUE_TEMPLATE/cycle-brief.md
+++ b/.github/ISSUE_TEMPLATE/cycle-brief.md
@@ -1,0 +1,28 @@
+---
+name: "Cycle brief template"
+about: For internal use only – issue template for writing briefs at the beginning of each cycle
+title: ""
+labels: "epic"
+assignees: ""
+---
+
+## Brief
+
+<!-- Use this format if it helps: [Action + Outcome/Output + For User Type + To Solve User Problem] e.g. reinstate the Friday call for contributors to provide an opportunity to engage with the team -->
+
+## Epic lead
+
+## Driving role(s)
+
+## Supporting roles
+
+## Needs awareness
+
+## Further detail
+
+<!-- Any extra context that might help – can include things that are out of scope, things to consider, related work, references -->
+
+```[tasklist]
+### Tasks
+- [ ] Add a draft title or issue reference here
+```


### PR DESCRIPTION
Brings in the template from the Design System site (added in alphagov/govuk-design-system#3667).