### PR TITLE
Suppress deprecated organisation warnings when testing contrast

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -4,6 +4,7 @@ describe('Organisation colours', () => {
   it('should define contrast-safe colours that meet contrast requirements', async () => {
     const sass = `
       $govuk-new-organisation-colours: true;
+      $govuk-suppressed-warnings: ("organisation-colours");
 
       @import "settings/colours-palette";
       @import "settings/colours-organisations";


### PR DESCRIPTION
We noticed during the 5.5.0 release that this test was returning warnings about deprecated organisations, which was generating unnecessary noise in this context. Here we want to test for WCAG-compliant contrast ratios regardless of the organisation's status.

## Changes
- Updates the test to suppress warnings about deprecated organisations.