### PR TITLE
Improves TypeDoc generated in the review app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,7 +103,11 @@ module.exports = {
       settings: {
         jsdoc: {
           // Allows us to use type declarations that exist in our dependencies
-          mode: 'typescript'
+          mode: 'typescript',
+          tagNamePreference: {
+            // TypeDoc doesn't understand '@abstract' but '@virtual'
+            abstract: 'virtual'
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27751,6 +27751,16 @@
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
       }
     },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.0.0.tgz",
+      "integrity": "sha512-R7D8fYrK34mBFZSlF1EqJxfqiUSlQSmyrCiQgTQD52nNm6+kUtqwiaqaNkuJ2rA2wBgWFecUA8JzHT7x2r7ePg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "0.26.x"
+      }
+    },
     "node_modules/typedoc/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -29756,7 +29766,8 @@
         "rollup": "^4.19.1",
         "sassdoc": "^2.7.4",
         "supertest": "^7.0.0",
-        "typedoc": "^0.26.6"
+        "typedoc": "^0.26.6",
+        "typedoc-plugin-missing-exports": "^3.0.0"
       },
       "engines": {
         "node": "^20.9.0",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -61,7 +61,8 @@
     "rollup": "^4.19.1",
     "sassdoc": "^2.7.4",
     "supertest": "^7.0.0",
-    "typedoc": "^0.26.6"
+    "typedoc": "^0.26.6",
+    "typedoc-plugin-missing-exports": "^3.0.0"
   },
   "optionalDependencies": {
     "nunjucks": "^3.2.4"

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -59,5 +59,10 @@ module.exports = {
     ...typedoc.Configuration.OptionDefaults.modifierTags,
     '@preserve',
     '@constant'
-  ]
+  ],
+
+  // We don't want typedoc to render a 'Preserve' tag
+  // as it's only for controlling which comments get rendered or not
+  // after transpilation
+  excludeTags: ['@preserve']
 }

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -38,6 +38,17 @@ module.exports = {
   // settings menu of the JSDoc page.
   excludePrivate: false,
 
-  // Ignore known undocumented types (@internal, @private etc)
-  intentionallyNotExported: ['I18n', 'TranslationPluralForms']
+  plugin: [
+    // Use typedoc-plugin-missing-exports to ensure that internal symbols which
+    // are not exported are included in the documentation (like the `I18n` class
+    // or the components' config types)
+    'typedoc-plugin-missing-exports'
+  ],
+  // By default, missing-exports will regroup all symbols under an `<internal>`
+  // module whose naming is a bit poor. Instead, we let the symbols be displayed
+  // alongside the others
+  placeInternalsInOwningModule: true,
+  // The missing-exports plugin will include built-in symbols, like the DOM API.
+  // We don't want those in our documentation, so we need to exclude them
+  excludeExternals: true
 }

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -6,6 +6,7 @@ const {
   packageNameToPath
 } = require('@govuk-frontend/lib/names')
 const slash = require('slash')
+const typedoc = require('typedoc')
 
 const basePath = join(packageNameToPath('govuk-frontend'), 'src')
 const workspacePath = slash(relative(paths.root, basePath))
@@ -50,5 +51,13 @@ module.exports = {
   placeInternalsInOwningModule: true,
   // The missing-exports plugin will include built-in symbols, like the DOM API.
   // We don't want those in our documentation, so we need to exclude them
-  excludeExternals: true
+  excludeExternals: true,
+
+  // Make TypeDoc aware of tags we use but it does not parse by default
+  // so it doesn't warn unnecessarily
+  modifierTags: [
+    ...typedoc.Configuration.OptionDefaults.modifierTags,
+    '@preserve',
+    '@constant'
+  ]
 }

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -16,7 +16,7 @@
  *   name = "MissingRootError"
  * }
  * ```
- * @abstract
+ * @virtual
  */
 export class GOVUKFrontendError extends Error {
   name = 'GOVUKFrontendError'

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -7,7 +7,7 @@ import { SupportError } from './errors/index.mjs'
  * Centralises the behaviours shared by our components
  *
  * @internal
- * @abstract
+ * @virtual
  */
 export class GOVUKFrontendComponent {
   /**


### PR DESCRIPTION
Includes in the API reference symbols (classes, interfaces...) that our code was using, but were not exported, like the `I18n` class or the types of the config for the components. This means that the docs can properly create links when these 'internal' symbols are used as types for function arguments, return values, or class properties.

Also fixes warnings displayed during the generation of the JavaScript API reference because some JSDoc tags were not known of TypeDoc (which relies on the list of tags from [TSDoc](https://tsdoc.org/), not the whole list of [JSDoc](https://jsdoc.app/) tags).

For comparison:
- [PR preview](https://govuk-frontend-pr-5238.herokuapp.com/docs/javascript/)
- [main](https://govuk-frontend-review.herokuapp.com/docs/javascript/)

