### PR TITLE
Consider JSDoc `@import` for non-exported types

### DIFF
--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -333,7 +333,8 @@ function getReviewAppUrl(prNumber, path = '/') {
  */
 
 /**
- * @typedef {import('@octokit/plugin-rest-endpoint-methods').RestEndpointMethodTypes["issues"]} IssuesEndpoint
+ * @import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
+ * @typedef {RestEndpointMethodTypes["issues"]} IssuesEndpoint
  * @typedef {IssuesEndpoint["listComments"]["parameters"]} IssueCommentsListParams
  * @typedef {IssuesEndpoint["getComment"]["response"]["data"]} IssueCommentData
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jest-dom": "^5.4.0",
-        "eslint-plugin-jsdoc": "^48.2.2",
+        "eslint-plugin-jsdoc": "^50.6.3",
         "eslint-plugin-markdown": "^4.0.1",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
@@ -1979,14 +1979,15 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.42.0.tgz",
-      "integrity": "sha512-R1w57YlVA6+YE01wch3GPYn6bCsrOV3YW/5oGGE2tmX6JcL9Nr+b5IikrjMPF+v9CV3ay+obImEdsDhovhJrzw==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
+      "integrity": "sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "comment-parser": "1.4.1",
-        "esquery": "^1.5.0",
-        "jsdoc-type-pratt-parser": "~4.0.0"
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
       },
       "engines": {
         "node": ">=16"
@@ -4652,6 +4653,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@prettier/sync": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.5.2.tgz",
@@ -6451,10 +6465,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9142,6 +9157,7 @@
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
       "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -11440,10 +11456,11 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
-      "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -12099,20 +12116,23 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "48.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.2.2.tgz",
-      "integrity": "sha512-S0Gk+rpT5w/ephKCncUY7kUsix9uE4B9XI8D/fS1/26d8okE+vZsuG1IvIt4B6sJUdQqsnzi+YXfmh+HJG11CA==",
+      "version": "50.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.3.tgz",
+      "integrity": "sha512-NxbJyt1M5zffPcYZ8Nb53/8nnbIScmiLAMdoe0/FAszwb7lcSiX3iYBTsuF7RV84dZZJC8r3NghomrUXsmWvxQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.42.0",
+        "@es-joy/jsdoccomment": "~0.49.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
-        "debug": "^4.3.4",
+        "debug": "^4.3.6",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.5.0",
-        "is-builtin-module": "^3.2.1",
-        "semver": "^7.6.0",
-        "spdx-expression-parse": "^4.0.0"
+        "espree": "^10.1.0",
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
       },
       "engines": {
         "node": ">=18"
@@ -12131,6 +12151,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
@@ -12598,10 +12649,11 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -18763,10 +18815,11 @@
       "devOptional": true
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -21855,6 +21908,20 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/parse-imports": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "dependencies": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/parse-json": {
@@ -25621,6 +25688,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -27075,6 +27149,23 @@
         "get-port": "^3.1.0"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/systeminformation": {
       "version": "5.25.11",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
@@ -27802,10 +27893,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "devOptional": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-jest-dom": "^5.4.0",
-    "eslint-plugin-jsdoc": "^48.2.2",
+    "eslint-plugin-jsdoc": "^50.6.3",
     "eslint-plugin-markdown": "^4.0.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -13,5 +13,5 @@ export function getHTMLCode(componentName, options) {
 }
 
 /**
- * @typedef {import('@govuk-frontend/lib/components').MacroRenderOptions} MacroRenderOptions
+ * @import {MacroRenderOptions} from '@govuk-frontend/lib/components'
  */

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
@@ -32,5 +32,5 @@ export function getNunjucksCode(componentName, options) {
 }
 
 /**
- * @typedef {import('@govuk-frontend/lib/components').MacroRenderOptions} MacroRenderOptions
+ * @import {MacroRenderOptions} from '@govuk-frontend/lib/components'
  */

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -27,9 +27,12 @@ module.exports = function (api) {
         )
 
         // Flag any JSDoc comments worth keeping
-        const isDocumentation = ['* @param', '* @returns', '* @typedef'].some(
-          (tag) => comment.includes(tag)
-        )
+        const isDocumentation = [
+          '* @param',
+          '* @returns',
+          '* @typedef',
+          '* @import'
+        ].some((tag) => comment.includes(tag))
 
         // Print only public JSDoc comments
         return !isPrivate && isDocumentation

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -3,7 +3,7 @@ import { pkg } from '@govuk-frontend/config'
 import configFn from './govuk-prototype-kit.config.mjs'
 
 describe('GOV.UK Prototype Kit config', () => {
-  /** @type {import('./govuk-prototype-kit.config.mjs').PrototypeKitConfig} */
+  /** @type {PrototypeKitConfig} */
   let config
 
   beforeAll(async () => {
@@ -196,3 +196,7 @@ describe('GOV.UK Prototype Kit config', () => {
     })
   })
 })
+
+/**
+ * @import { PrototypeKitConfig } from './govuk-prototype-kit.config.mjs'
+ */

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -18,6 +18,6 @@ export { GOVUKFrontendComponent as Component } from './govuk-frontend-component.
 export { ConfigurableComponent } from './common/configuration.mjs'
 
 /**
- * @typedef {import('./init.mjs').Config} Config
- * @typedef {import('./init.mjs').ConfigKey} ConfigKey
+ * @typedef {import('./init.mjs').Config} Config for all components via `initAll()`
+ * @typedef {import('./init.mjs').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
  */

--- a/packages/govuk-frontend/src/govuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
@@ -261,5 +261,5 @@ describe('extractConfigByNamespace', () => {
 })
 
 /**
- * @typedef {import('../configuration.mjs').Schema} Schema
+ * @import { Schema } from '../configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/common/configuration/normalise-dataset.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/normalise-dataset.jsdom.test.mjs
@@ -54,5 +54,5 @@ describe('normaliseDataset', () => {
 })
 
 /**
- * @typedef {import('./../configuration.mjs').Schema} Schema
+ * @import { Schema } from './../configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -639,5 +639,5 @@ export class Accordion extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
+ * @import { Schema } from '../../common/configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -122,5 +122,5 @@ export class Button extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
+ * @import { Schema } from '../../common/configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -45,8 +45,8 @@ describe('/components/button', () => {
     /**
      * Sets the number of times a button was clicked
      *
-     * @param {import('puppeteer').ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
-     * @returns {Promise<import('puppeteer').ElementHandle<HTMLButtonElement>>} Puppeteer button element
+     * @param {ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
+     * @returns {Promise<ElementHandle<HTMLButtonElement>>} Puppeteer button element
      */
     async function setButtonTracking($button) {
       const counts = {
@@ -82,7 +82,7 @@ describe('/components/button', () => {
     /**
      * Gets the number of times the button was clicked
      *
-     * @param {import('puppeteer').ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
+     * @param {ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
      * @returns {Promise<{ click: number; debounce: number; }>} Number of times the button was clicked
      */
     function getButtonTracking($button) {
@@ -93,7 +93,7 @@ describe('/components/button', () => {
     }
 
     describe('not enabled', () => {
-      /** @type {import('puppeteer').ElementHandle<HTMLButtonElement>} */
+      /** @type {ElementHandle<HTMLButtonElement>} */
       let $button
 
       beforeEach(async () => {
@@ -113,7 +113,7 @@ describe('/components/button', () => {
     })
 
     describe('using data-attributes', () => {
-      /** @type {import('puppeteer').ElementHandle<HTMLButtonElement>} */
+      /** @type {ElementHandle<HTMLButtonElement>} */
       let $button
 
       beforeEach(async () => {
@@ -167,7 +167,7 @@ describe('/components/button', () => {
     })
 
     describe('using JavaScript configuration', () => {
-      /** @type {import('puppeteer').ElementHandle<HTMLButtonElement>} */
+      /** @type {ElementHandle<HTMLButtonElement>} */
       let $button
 
       beforeEach(async () => {
@@ -226,7 +226,7 @@ describe('/components/button', () => {
     })
 
     describe('using JavaScript configuration, but cancelled by data-attributes', () => {
-      /** @type {import('puppeteer').ElementHandle<HTMLButtonElement>} */
+      /** @type {ElementHandle<HTMLButtonElement>} */
       let $button
 
       beforeEach(async () => {
@@ -250,7 +250,7 @@ describe('/components/button', () => {
     })
 
     describe('using `initAll`', () => {
-      /** @type {import('puppeteer').ElementHandle<HTMLButtonElement>} */
+      /** @type {ElementHandle<HTMLButtonElement>} */
       let $button
 
       beforeEach(async () => {
@@ -379,3 +379,7 @@ describe('/components/button', () => {
     })
   })
 })
+
+/**
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -521,6 +521,6 @@ export class CharacterCount extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
- * @typedef {import('../../i18n.mjs').TranslationPluralForms} TranslationPluralForms
+ * @import { Schema } from '../../common/configuration.mjs'
+ * @import { TranslationPluralForms } from '../../i18n.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -189,5 +189,5 @@ export class ErrorSummary extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
+ * @import { Schema } from '../../common/configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -453,5 +453,5 @@ export class ExitThisPage extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
+ * @import { Schema } from '../../common/configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -74,5 +74,5 @@ export class NotificationBanner extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
+ * @import { Schema } from '../../common/configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -249,6 +249,5 @@ export class PasswordInput extends ConfigurableComponent {
  */
 
 /**
- * @typedef {import('../../common/configuration.mjs').Schema} Schema
- * @typedef {import('../../i18n.mjs').TranslationPluralForms} TranslationPluralForms
+ * @import { Schema } from '../../common/configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -134,5 +134,5 @@ export class InitError extends GOVUKFrontendError {
  */
 
 /**
- * @typedef {import('../common/index.mjs').ComponentWithModuleName} ComponentWithModuleName
+ * @import { ComponentWithModuleName } from '../common/index.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -183,16 +183,13 @@ export { initAll, createAll }
 /**
  * Config for individual components
  *
- * @typedef {import('./components/accordion/accordion.mjs').AccordionConfig} AccordionConfig
- * @typedef {import('./components/accordion/accordion.mjs').AccordionTranslations} AccordionTranslations
- * @typedef {import('./components/button/button.mjs').ButtonConfig} ButtonConfig
- * @typedef {import('./components/character-count/character-count.mjs').CharacterCountConfig} CharacterCountConfig
- * @typedef {import('./components/character-count/character-count.mjs').CharacterCountTranslations} CharacterCountTranslations
- * @typedef {import('./components/error-summary/error-summary.mjs').ErrorSummaryConfig} ErrorSummaryConfig
- * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageConfig} ExitThisPageConfig
- * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageTranslations} ExitThisPageTranslations
- * @typedef {import('./components/notification-banner/notification-banner.mjs').NotificationBannerConfig} NotificationBannerConfig
- * @typedef {import('./components/password-input/password-input.mjs').PasswordInputConfig} PasswordInputConfig
+ * @import { AccordionConfig } from './components/accordion/accordion.mjs'
+ * @import { ButtonConfig } from './components/button/button.mjs'
+ * @import { CharacterCountConfig } from './components/character-count/character-count.mjs'
+ * @import { ErrorSummaryConfig } from './components/error-summary/error-summary.mjs'
+ * @import { ExitThisPageConfig } from './components/exit-this-page/exit-this-page.mjs'
+ * @import { NotificationBannerConfig } from './components/notification-banner/notification-banner.mjs'
+ * @import { PasswordInputConfig } from './components/password-input/password-input.mjs'
  */
 
 /**

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -29,7 +29,5 @@ module.exports = {
 }
 
 /**
- * @typedef {import('@govuk-frontend/lib/components').MacroOptions} MacroOptions
- * @typedef {import('@govuk-frontend/lib/components').MacroRenderOptions} MacroRenderOptions
- * @typedef {import('@govuk-frontend/lib/components').TemplateRenderOptions} TemplateRenderOptions
+ * @import { MacroRenderOptions, TemplateRenderOptions } from '@govuk-frontend/lib/components'
  */

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -11,9 +11,9 @@ const slug = require('slug')
 /**
  * Axe Puppeteer reporter
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
- * @param {import('axe-core').RuleObject} [overrides] - Axe rule overrides
- * @returns {Promise<import('axe-core').AxeResults>} Axe Puppeteer instance
+ * @param {Page} page - Puppeteer page object
+ * @param {RuleObject} [overrides] - Axe rule overrides
+ * @returns {Promise<AxeResults>} Axe Puppeteer instance
  */
 async function axe(page, overrides = {}) {
   const reporter = new AxePuppeteer(page)
@@ -23,7 +23,7 @@ async function axe(page, overrides = {}) {
   /**
    * Shared options for GOV.UK Frontend
    *
-   * @satisfies {import('axe-core').RunOptions}
+   * @satisfies {RunOptions}
    */
   const options = {
     runOnly: {
@@ -101,11 +101,11 @@ async function axe(page, overrides = {}) {
  * functions as nested context values aren't passed into Puppeteer correctly
  *
  * @template {object} HandlerContext
- * @param {import('puppeteer').Page} page - Puppeteer page object
+ * @param {Page} page - Puppeteer page object
  * @param {string} [componentName] - The kebab-cased name of the component
  * @param {MacroRenderOptions} [renderOptions] - Nunjucks macro render options
  * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
- * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
+ * @returns {Promise<Page>} Puppeteer page object
  */
 async function render(page, componentName, renderOptions, browserOptions) {
   await page.setRequestInterception(true)
@@ -225,7 +225,7 @@ async function render(page, componentName, renderOptions, browserOptions) {
  * - Responds to file:// asset requests (web fonts etc)
  * - Skips unknown requests
  *
- * @param {import('puppeteer').HTTPRequest} request - Puppeteer HTTP request
+ * @param {HTTPRequest} request - Puppeteer HTTP request
  * @returns {Promise<void>}
  */
 async function requestHandler(request) {
@@ -250,11 +250,11 @@ async function requestHandler(request) {
 /**
  * Navigate to path
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
+ * @param {Page} page - Puppeteer page object
  * @param {URL | string} path - Path or URL to navigate to
  * @param {object} [options] - Navigation options
  * @param {URL} [options.baseURL] - Base URL to override
- * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
+ * @returns {Promise<Page>} Puppeteer page object
  */
 async function goTo(page, path, options) {
   const { href, pathname } = !(path instanceof URL)
@@ -278,11 +278,11 @@ async function goTo(page, path, options) {
 /**
  * Navigate to example
  *
- * @param {import('puppeteer').Browser} browser - Puppeteer browser object
+ * @param {Browser} browser - Puppeteer browser object
  * @param {string} exampleName - Example name
  * @param {object} [options] - Navigation options
  * @param {URL} [options.baseURL] - Base URL to override
- * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
+ * @returns {Promise<Page>} Puppeteer page object
  */
 async function goToExample(browser, exampleName, options) {
   return goTo(await browser.newPage(), `/examples/${exampleName}`, options)
@@ -291,10 +291,10 @@ async function goToExample(browser, exampleName, options) {
 /**
  * Navigate to component preview page
  *
- * @param {import('puppeteer').Browser} browser - Puppeteer browser object
+ * @param {Browser} browser - Puppeteer browser object
  * @param {string} [componentName] - Component name
  * @param {Parameters<typeof getComponentURL>[1]} [options] - Navigation options
- * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
+ * @returns {Promise<Page>} Puppeteer page object
  */
 async function goToComponent(browser, componentName, options) {
   return goTo(await browser.newPage(), getComponentURL(componentName, options))
@@ -336,7 +336,7 @@ function getComponentURL(componentName, options) {
 /**
  * Get property value for element
  *
- * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @param {ElementHandle} $element - Puppeteer element handle
  * @param {string} propertyName - Property name to return value for
  * @returns {Promise<unknown>} Property value
  */
@@ -348,7 +348,7 @@ async function getProperty($element, propertyName) {
 /**
  * Get attribute value for element
  *
- * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @param {ElementHandle} $element - Puppeteer element handle
  * @param {string} attributeName - Attribute name to return value for
  * @returns {Promise<string | null>} Attribute value
  */
@@ -359,8 +359,8 @@ function getAttribute($element, attributeName) {
 /**
  * Gets the accessible name of the given element, if it exists in the accessibility tree
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
- * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @param {Page} page - Puppeteer page object
+ * @param {ElementHandle} $element - Puppeteer element handle
  * @returns {Promise<string>} The element's accessible name
  * @throws {TypeError} If the element has no corresponding node in the accessibility tree
  */
@@ -377,7 +377,7 @@ async function getAccessibleName(page, $element) {
 /**
  * Check if element is visible
  *
- * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @param {ElementHandle} $element - Puppeteer element handle
  * @returns {Promise<boolean>} Element visibility
  */
 async function isVisible($element) {
@@ -404,19 +404,13 @@ module.exports = {
  * @typedef {object} BrowserRenderOptions - Component render options
  * @property {Config[ConfigKey]} [config] - Component JavaScript config
  * @property {HandlerContext} [context] - Context options for custom functions
- * @property {HandlerFunction<HandlerContext>} [beforeInitialisation] - Custom function to run before initialisation
- * @property {HandlerFunction<HandlerContext>} [afterInitialisation] - Custom function to run after initialisation
+ * @property {EvaluateFuncWith<Element, [HandlerContext]>} [beforeInitialisation] - Custom function to run before initialisation
+ * @property {EvaluateFuncWith<Element, [HandlerContext]>} [afterInitialisation] - Custom function to run after initialisation
  */
 
 /**
- * Browser handler function with context options
- *
- * @template {object} HandlerContext
- * @typedef {import('puppeteer').EvaluateFuncWith<Element, [HandlerContext]>} HandlerFunction
- */
-
-/**
- * @typedef {import('@govuk-frontend/lib/components').MacroRenderOptions} MacroRenderOptions
- * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
- * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
+ * @import { MacroRenderOptions } from '@govuk-frontend/lib/components'
+ * @import { AxeResults, RuleObject, RunOptions } from 'axe-core'
+ * @import { Config, ConfigKey } from 'govuk-frontend'
+ * @import { Browser, ElementHandle, EvaluateFuncWith, HTTPRequest, Page } from 'puppeteer'
  */

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -103,7 +103,10 @@ export async function write(filePath, result) {
  * 2. Terser minified bundle
  * 3. Sass compiler result
  *
- * @typedef {import('rollup').OutputChunk | import('terser').MinifyOutput | import('postcss').Result} AssetOutput
+ * @import {OutputChunk} from 'rollup'
+ * @import {MinifyOutput} from 'terser'
+ * @import {Result} from 'postcss'
+ * @typedef {OutputChunk | MinifyOutput | Result} AssetOutput
  */
 
 /**
@@ -111,5 +114,6 @@ export async function write(filePath, result) {
  *
  * {@link https://github.com/source-map/source-map-spec}
  *
- * @typedef {import('@jridgewell/source-map').DecodedSourceMap | import('@jridgewell/source-map').EncodedSourceMap} SourceMap
+ * @import {DecodedSourceMap, EncodedSourceMap} from '@jridgewell/source-map'
+ * @typedef {DecodedSourceMap | EncodedSourceMap} SourceMap
  */

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -12,7 +12,7 @@ import puppeteer from 'puppeteer'
 /**
  * Puppeteer browser launcher
  *
- * @returns {Promise<import('puppeteer').Browser>} Puppeteer browser object
+ * @returns {Promise<Browser>} Puppeteer browser object
  */
 export async function launch() {
   await download()
@@ -63,7 +63,7 @@ export async function screenshots() {
  * Send single component screenshots to Percy
  * for visual regression testing
  *
- * @param {import('puppeteer').Browser} browser - Puppeteer browser object
+ * @param {Browser} browser - Puppeteer browser object
  * @param {string} componentName - Component name
  * @param {object} [options] - Component options
  * @param {string} options.exampleName - Example name
@@ -100,7 +100,7 @@ export async function screenshotComponent(browser, componentName, options) {
  * Send single example screenshot to Percy
  * for visual regression testing
  *
- * @param {import('puppeteer').Browser} browser - Puppeteer browser object
+ * @param {Browser} browser - Puppeteer browser object
  * @param {string} exampleName - Component name
  * @returns {Promise<void>}
  */
@@ -121,3 +121,7 @@ export async function screenshotExample(browser, exampleName) {
   // Close page
   return page.close()
 }
+
+/**
+ * @import { Browser } from 'puppeteer'
+ */

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -161,10 +161,12 @@ async function generateMacroOption(componentDataPath, options) {
 }
 
 /**
- * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
- * @typedef {import('@govuk-frontend/lib/components').ComponentData} ComponentData
- * @typedef {import('@govuk-frontend/lib/components').ComponentOption} ComponentOption
- * @typedef {import('@govuk-frontend/lib/components').ComponentExample} ComponentExample
- * @typedef {import('@govuk-frontend/lib/components').ComponentFixture} ComponentFixture
- * @typedef {import('@govuk-frontend/lib/components').ComponentFixtures} ComponentFixtures
+ * @import { AssetEntry } from './assets.mjs'
+ * @import {
+ *  ComponentData,
+ *  ComponentOption,
+ *  ComponentExample,
+ *  ComponentFixture,
+ *  ComponentFixtures
+ * } from '@govuk-frontend/lib/components'
  */

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -32,5 +32,5 @@ export async function compile(modulePath, options) {
 }
 
 /**
- * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
+ * @import { AssetEntry } from './assets.mjs'
  */

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -41,5 +41,5 @@ export async function write(assetPath, { destPath, filePath, fileContents }) {
 }
 
 /**
- * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
+ * @import { AssetEntry } from './assets.mjs'
  */

--- a/shared/tasks/index.mjs
+++ b/shared/tasks/index.mjs
@@ -14,6 +14,11 @@ export * as task from './task.mjs'
 /**
  * Types for tasks
  *
- * @typedef {import('./assets.mjs').AssetPathOptions} TaskOptions
- * @typedef {(options: TaskOptions) => import('gulp').TaskFunction} TaskFunction
+ * @typedef {AssetPathOptions} TaskOptions
+ * @typedef {(options: TaskOptions) => TaskFunction} TaskFunction
+ */
+
+/**
+ * @import { TaskFunction } from 'gulp'
+ * @import { AssetPathOptions } from './assets.mjs'
  */

--- a/shared/tasks/npm.mjs
+++ b/shared/tasks/npm.mjs
@@ -60,5 +60,5 @@ export function script(name, args = [], options) {
 }
 
 /**
- * @typedef {import('./index.mjs').TaskOptions} TaskOptions
+ * @import {TaskOptions} from './index.mjs'
  */

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -100,6 +100,5 @@ export async function compileJavaScript([
 }
 
 /**
- * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
- * @typedef {import('./assets.mjs').AssetOutput} AssetOutput
+ * @import { AssetEntry } from './assets.mjs'
  */

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -126,6 +126,5 @@ export async function compileStylesheet([
 }
 
 /**
- * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
- * @typedef {import('./assets.mjs').AssetOutput} AssetOutput
+ * @import { AssetEntry } from './assets.mjs'
  */


### PR DESCRIPTION
Hello 👋

Thought I'd share a little improvement added in [TypeScript 5.5: JSDoc `@import` tag](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-jsdoc-import-tag)

Should prevent `@typedef` re-exporting private/internal definitions in https://github.com/alphagov/govuk-frontend/issues/5157 by using `@import` instead