### PR TITLE
Add `isSupported` to `all.mjs`

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -12,6 +12,7 @@ export { Radios } from './components/radios/radios.mjs'
 export { SkipLink } from './components/skip-link/skip-link.mjs'
 export { Tabs } from './components/tabs/tabs.mjs'
 export { initAll, createAll } from './init.mjs'
+export { isSupported } from './common/index.mjs'
 
 /**
  * @typedef {import('./init.mjs').Config} Config

--- a/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
@@ -41,10 +41,24 @@ describe('GOV.UK Frontend', () => {
       expect(typeofCreateAll).toBe('function')
     })
 
+    it('exports `isSupported` function', async () => {
+      const typeofIsSupported = await page.evaluate(
+        async (importPath, exportName) => {
+          const namespace = await import(importPath)
+          return typeof namespace[exportName]
+        },
+        scriptsPath.href,
+        'isSupported'
+      )
+
+      expect(typeofIsSupported).toBe('function')
+    })
+
     it('exports Components', async () => {
       const components = exported
         .filter(
-          (method) => !['initAll', 'createAll', 'version'].includes(method)
+          (method) =>
+            !['initAll', 'createAll', 'version', 'isSupported'].includes(method)
         )
         .sort()
 

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -194,8 +194,7 @@ export function setFocus($element, options = {}) {
  * Some browsers will load and run our JavaScript but GOV.UK Frontend
  * won't be supported.
  *
- * @internal
- * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
+ * @param {HTMLElement | null} [$scope] - (internal) `<body>` HTML element checked for browser support
  * @returns {boolean} Whether GOV.UK Frontend is supported on this page
  */
 export function isSupported($scope = document.body) {


### PR DESCRIPTION
## What

- adds `isSupported` as an export for import from `govuk-frontend`
- removes `internal` from JSDoc to mark function as public
- adds `exports isSupported function` test
- updates `exports Components` test

## Why

`isSupported` is a method that will be very useful for developers creating their own components that dependent on the `govuk-frontend`. `isSupported` returns a boolean to indicate if the browser is supported by `govuk-frontend` by checking for presence of the `govuk-frontend-supported` on the body of the page.

Fixes https://github.com/alphagov/govuk-frontend/issues/5210