### PR TITLE
Add `isSupported` to `createAll`

### DIFF
--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -146,8 +146,12 @@ describe('initAll', () => {
 })
 
 describe('createAll', () => {
+  beforeEach(() => {
+    document.body.classList.add('govuk-frontend-supported')
+  })
+
   afterEach(() => {
-    document.body.innerHTML = ''
+    document.body.outerHTML = '<body></body>'
   })
 
   class MockComponent {
@@ -172,6 +176,20 @@ describe('createAll', () => {
 
   it('returns an empty array if no components exist on the page', () => {
     const result = createAll(MockComponent)
+
+    expect(result).toStrictEqual([])
+  })
+
+  it('throws error and returns empty array if not supported', () => {
+    document.body.classList.remove('govuk-frontend-supported')
+
+    const result = createAll(MockComponent)
+
+    expect(global.console.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'GOV.UK Frontend is not supported in this browser'
+      })
+    )
 
     expect(result).toStrictEqual([])
   })

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -74,6 +74,12 @@ function createAll(Component, config, $scope = document) {
     `[data-module="${Component.moduleName}"]`
   )
 
+  // Skip initialisation when GOV.UK Frontend is not supported
+  if (!isSupported()) {
+    console.log(new SupportError())
+    return []
+  }
+
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-return --
    * We can't define CompatibleClass as `{new(): CompatibleClass, moduleName: string}`,
    * as when doing `typeof Accordion` (or any component), TypeScript doesn't seem


### PR DESCRIPTION
## What

- `createAll` returns empty array and throws error is `isSupported` false
- update existing `createAll` tests and add test for `isSupported` false

## Why

Prevents `createAll` running if `govuk-frontend` not supported.


Fixes #5213