### PR TITLE
Add `@typescript-eslint` to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,7 @@ updates:
     ignore:
       - dependency-name: 'eslint-*'
       - dependency-name: 'eslint'
+      - dependency-name: '@typescript-eslint/*'
       # iframe-resizer has switched to GPL licence in v5
       # so we need to avoid upgrading to their next major version
       - dependency-name: 'iframe-resizer'


### PR DESCRIPTION
An extension of what we did for https://github.com/alphagov/govuk-frontend/pull/4999

Freezing these versions of eslint at pre-8 is causing problems with `@typescript-eslint` packages which are expecting surrounding packages to be 8+ (see https://github.com/alphagov/govuk-frontend/pull/5258).