### PR TITLE
Prevent multiple initialisations of a single component instance

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -189,6 +189,21 @@ export function setFocus($element, options = {}) {
 }
 
 /**
+ * Checks if component is already initialised
+ *
+ * @internal
+ * @param {Element} $module - HTML element to be checked
+ * @param {string} moduleName - name of component module
+ * @returns {boolean} Whether component is already initialised
+ */
+export function isInitialised($module, moduleName) {
+  return (
+    $module instanceof HTMLElement &&
+    $module.hasAttribute(`data-${moduleName}-init`)
+  )
+}
+
+/**
  * Checks if GOV.UK Frontend is supported on this page
  *
  * Some browsers will load and run our JavaScript but GOV.UK Frontend

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -114,7 +114,7 @@ export class Accordion extends GOVUKFrontendComponent {
    * @param {AccordionConfig} [config] - Accordion config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const {
   goToExample,
   render,
@@ -709,6 +711,21 @@ describe('/components/accordion', () => {
               message:
                 'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
             }
+          })
+        })
+
+        it('throws when initialised twice', async () => {
+          await expect(
+            render(page, 'accordion', examples.default, {
+              async afterInitialisation($module) {
+                const { Accordion } = await import('govuk-frontend')
+                new Accordion($module)
+              }
+            })
+          ).rejects.toMatchObject({
+            name: 'InitError',
+            message:
+              'Root element (`$module`) already initialised (`govuk-accordion`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -31,7 +31,7 @@ export class Button extends GOVUKFrontendComponent {
    * @param {ButtonConfig} [config] - Button config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -326,6 +328,21 @@ describe('/components/button', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'button', examples.default, {
+            async afterInitialisation($module) {
+              const { Button } = await import('govuk-frontend')
+              new Button($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-button`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -62,7 +62,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
    * @param {CharacterCountConfig} [config] - Character count config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { setTimeout } = require('timers/promises')
 
 const { render } = require('@govuk-frontend/helpers/puppeteer')
@@ -809,6 +811,21 @@ describe('Character count', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'character-count', examples.default, {
+            async afterInitialisation($module) {
+              const { CharacterCount } = await import('govuk-frontend')
+              new CharacterCount($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-character-count`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -28,7 +28,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for checkboxes
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const {
   goToExample,
   getAttribute,
@@ -364,6 +366,21 @@ describe('Checkboxes', () => {
               message:
                 'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
             }
+          })
+        })
+
+        it('throws when initialised twice', async () => {
+          await expect(
+            render(page, 'checkboxes', examples.default, {
+              async afterInitialisation($module) {
+                const { Checkboxes } = await import('govuk-frontend')
+                new Checkboxes($module)
+              }
+            })
+          ).rejects.toMatchObject({
+            name: 'InitError',
+            message:
+              'Root element (`$module`) already initialised (`govuk-checkboxes`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -30,7 +30,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -233,6 +235,21 @@ describe('Error Summary', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'error-summary', examples.default, {
+          async afterInitialisation($module) {
+            const { ErrorSummary } = await import('govuk-frontend')
+            new ErrorSummary($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message:
+          'Root element (`$module`) already initialised (`govuk-error-summary`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -79,7 +79,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { setTimeout } = require('timers/promises')
 
 const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
@@ -228,6 +230,21 @@ describe('/components/exit-this-page', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'exit-this-page', examples.default, {
+            async afterInitialisation($module) {
+              const { ExitThisPage } = await import('govuk-frontend')
+              new ExitThisPage($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-exit-this-page`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -43,7 +43,7 @@ export class Header extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for header
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!$module) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 const { KnownDevices } = require('puppeteer')
@@ -178,6 +180,21 @@ describe('Header navigation', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'header', examples.default, {
+            async afterInitialisation($module) {
+              const { Header } = await import('govuk-frontend')
+              new Header($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-header`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -23,7 +23,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -233,6 +235,21 @@ describe('Notification banner', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'notification-banner', examples.default, {
+          async afterInitialisation($module) {
+            const { NotificationBanner } = await import('govuk-frontend')
+            new NotificationBanner($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message:
+          'Root element (`$module`) already initialised (`govuk-notification-banner`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -28,7 +28,7 @@ export class Radios extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for radios
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const {
   goToExample,
   getProperty,
@@ -317,6 +319,20 @@ describe('Radios', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'radios', examples.default, {
+          async afterInitialisation($module) {
+            const { Radios } = await import('govuk-frontend')
+            new Radios($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message: 'Root element (`$module`) already initialised (`govuk-radios`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -18,7 +18,7 @@ export class SkipLink extends GOVUKFrontendComponent {
    * @throws {ElementError} when the linked element is missing or the wrong type
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLAnchorElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -124,6 +126,21 @@ describe('Skip Link', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'skip-link', examples.default, {
+          async afterInitialisation($module) {
+            const { SkipLink } = await import('govuk-frontend')
+            new SkipLink($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message:
+          'Root element (`$module`) already initialised (`govuk-skip-link`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -45,7 +45,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for tabs
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!$module) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 const { KnownDevices } = require('puppeteer')
@@ -266,6 +268,20 @@ describe('/components/tabs', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'tabs', examples.default, {
+            async afterInitialisation($module) {
+              const { Tabs } = await import('govuk-frontend')
+              new Tabs($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message: 'Root element (`$module`) already initialised (`govuk-tabs`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -1,4 +1,9 @@
-import { ElementError, GOVUKFrontendError, SupportError } from './index.mjs'
+import {
+  ElementError,
+  GOVUKFrontendError,
+  InitError,
+  SupportError
+} from './index.mjs'
 
 describe('errors', () => {
   describe('GOVUKFrontendError', () => {
@@ -43,6 +48,39 @@ describe('errors', () => {
       // will see support checks run when document.body is still `null`
       expect(new SupportError(null).message).toBe(
         'GOV.UK Frontend initialised without `<script type="module">`'
+      )
+    })
+  })
+
+  describe('InitError', () => {
+    let $element
+    let $moduleName
+
+    beforeAll(() => {
+      $element = document.createElement('div')
+      $element.setAttribute('data-module', 'govuk-accordion')
+      $moduleName = 'govuk-accordion'
+    })
+
+    it('is an instance of GOVUKFrontendError', () => {
+      expect(new InitError($moduleName)).toBeInstanceOf(GOVUKFrontendError)
+    })
+
+    it('has its own name set', () => {
+      expect(new InitError($moduleName).name).toBe('InitError')
+    })
+
+    it('provides feedback for modules already initialised', () => {
+      expect(new InitError($moduleName).message).toBe(
+        'Root element (`$module`) already initialised (`govuk-accordion`)'
+      )
+    })
+
+    it('provides feedback for modules already initialised', () => {
+      $moduleName = undefined
+
+      expect(new InitError($moduleName, 'Accordion').message).toBe(
+        'moduleName not defined in component (`Accordion`)'
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -98,6 +98,28 @@ export class ElementError extends GOVUKFrontendError {
 }
 
 /**
+ * Indicates that a component is already initialised
+ */
+export class InitError extends GOVUKFrontendError {
+  name = 'InitError'
+
+  /**
+   * @internal
+   * @param {string|undefined} moduleName - name of the component module
+   * @param {string} [className] - name of the component module
+   */
+  constructor(moduleName, className) {
+    let errorText = `moduleName not defined in component (\`${className}\`)`
+
+    if (typeof moduleName === 'string') {
+      errorText = `Root element (\`$module\`) already initialised (\`${moduleName}\`)`
+    }
+
+    super(errorText)
+  }
+}
+
+/**
  * Element error options
  *
  * @internal

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,5 +1,5 @@
-import { isSupported } from './common/index.mjs'
-import { SupportError } from './errors/index.mjs'
+import { isInitialised, isSupported } from './common/index.mjs'
+import { InitError, SupportError } from './errors/index.mjs'
 
 /**
  * Base Component class
@@ -14,9 +14,36 @@ export class GOVUKFrontendComponent {
    * Constructs a new component, validating that GOV.UK Frontend is supported
    *
    * @internal
+   * @param {Element | null} [$module] - HTML element to use for component
    */
-  constructor() {
+  constructor($module) {
     this.checkSupport()
+    this.checkInitialised($module)
+
+    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
+      .moduleName
+
+    if (typeof moduleName === 'string') {
+      moduleName && $module?.setAttribute(`data-${moduleName}-init`, '')
+    } else {
+      throw new InitError(moduleName)
+    }
+  }
+
+  /**
+   * Validates whether component is already initialised
+   *
+   * @private
+   * @param {Element | null} [$module] - HTML element to be checked
+   * @throws {InitError} when component is already initialised
+   */
+  checkInitialised($module) {
+    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
+      .moduleName
+
+    if ($module && moduleName && isInitialised($module, moduleName)) {
+      throw new InitError(moduleName)
+    }
   }
 
   /**
@@ -31,3 +58,12 @@ export class GOVUKFrontendComponent {
     }
   }
 }
+
+/**
+ * @typedef ChildClass
+ * @property {string} [moduleName] - The module name that'll be looked for in the DOM when initialising the component
+ */
+
+/**
+ * @typedef {typeof GOVUKFrontendComponent & ChildClass} ChildClassConstructor
+ */


### PR DESCRIPTION
## What

New method for checking if component has already been initialised based on the value of a data attribute on the `module` of the component instance.

Based on the previous work of @colinrotherham (https://github.com/alphagov/govuk-frontend/pull/4561) and https://github.com/alphagov/govuk_publishing_components/ approach to initialising multiple different modules on a single DOM element.

## Why

Prevent multiple initialisations of a single component on single element. 

Closes: https://github.com/alphagov/govuk-frontend/issues/1127