### PR TITLE
Add ‘complex header’ example to review app

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
@@ -5,6 +5,7 @@ notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausage
 ---
 {% extends "layouts/full-page-example.njk" %}
 
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
@@ -12,7 +13,8 @@ notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausage
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
-{{ govukHeader({
+{{ govukHeader({}) }}
+{{ govukServiceNavigation({
   navigation: [
     {
       href: "#1",

--- a/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow-slot/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow-slot/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Companies you follow
-name: Companies you follow (service navigation with service name)
+name: Companies you follow (service navigation with slots)
 scenario: |
   You are a user logged into Companies House WebFiling service, looking at a
   list of companies you are following.
@@ -18,14 +18,41 @@ notes: Based on Companies House "Find an update company information" service
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
+{% block head %}
+  {{ super() }}
+  <style>
+    .app-service-navigation .govuk-service-navigation__wrapper {
+      flex-grow: 1;
+    }
+    .app-sign-out {
+      margin-left: auto;
+      padding: 15px 0 10px;
+    }
+    .app-sign-out .govuk-button {
+      margin: 0;
+      width: auto;
+    }
+  </style>
+{% endblock %}
+
+{% set signOutButton %}
+  <li class="govuk-service-navigation__item app-sign-out">
+    {{ govukButton({
+      type: "button",
+      classes: "govuk-button--inverse",
+      text: "Sign out"
+    }) }}
+  </li>
+{% endset %}
+
 {% block header %}
   {{ govukHeader({
-    classes: "govuk-header--full-width-border"
+    classes: "govuk-header--full-width-border",
+    serviceName: "Find and update company information",
+    serviceUrl: "#0"
   }) }}
   {{ govukServiceNavigation({
     classes: "app-service-navigation",
-    serviceName: "Find company information",
-    serviceUrl: "#0",
     navigation: [
       {
         href: '#1',
@@ -44,7 +71,10 @@ notes: Based on Companies House "Find an update company information" service
         text: 'Companies you follow',
         current: true
       }
-    ]
+    ],
+    slots: {
+      navigationEnd: signOutButton
+    }
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow/index.njk
@@ -1,0 +1,101 @@
+---
+title: Companies you follow
+name: Companies you follow (service navigation)
+scenario: |
+  You are a user logged into Companies House WebFiling service, looking at a
+  list of companies you are following.
+notes: Based on Companies House "Find an update company information" service
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block head %}
+  {{ super() }}
+  <style>
+    .app-service-navigation .govuk-service-navigation__wrapper {
+      flex-grow: 1;
+    }
+    .app-sign-out {
+      margin-left: auto;
+      padding: 15px 0 10px;
+    }
+    .app-sign-out .govuk-button {
+      margin: 0;
+      width: auto;
+    }
+  </style>
+{% endblock %}
+
+{% set signOutButton %}
+  <li class="govuk-service-navigation__item app-sign-out">
+    {{ govukButton({
+      type: "button",
+      classes: "govuk-button--inverse",
+      text: "Sign out"
+    }) }}
+  </li>
+{% endset %}
+
+{% block header %}
+  {{ govukHeader({
+    classes: "govuk-header--full-width-border",
+    serviceName: "Find and update company information",
+    serviceUrl: "#0"
+  }) }}
+  {{ govukServiceNavigation({
+    classes: "app-service-navigation",
+    navigation: [
+      {
+        href: '#1',
+        text: 'Search the register'
+      },
+      {
+        href: '#2',
+        text: 'Your details'
+      },
+      {
+        href: '#3',
+        text: 'Your filings'
+      },
+      {
+        href: '#4',
+        text: 'Companies you follow',
+        current: true
+      }
+    ],
+    slots: {
+      navigationEnd: signOutButton
+    }
+  }) }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Alpha"
+    },
+    html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
+  }) }}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "#0"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">Companies you follow</h1>
+  <p class="govuk-body">You are not following any companies.</p>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -25,18 +25,7 @@ scenario: |
 
 {% block header %}
   {{ govukHeader({
-    serviceName: "Apply for a passport",
-    navigation: [
-        {
-            href: "/",
-            text: "Home"
-        },
-        {
-            href: "#upload-a-photo",
-            text: "Upload a photo",
-            active: true
-        }
-    ]
+    serviceName: "Apply for a passport"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
Mulling over a full-page example that shows the Service navigation component in-situ with the GOV.UK header, phase banner, and other elements that usually appear at the top of a page.

## Changes
- Add ['Companies you follow (service navigation with service name)' full-page example](https://govuk-frontend-pr-5275.herokuapp.com/full-page-examples/companies-you-follow), based on part of the Companies House WebFiling service. This example demonstrates:
  - The Service navigation component, with navigation links and service name/URL included.
  - The full-width border variant of the GOV.UK header component.
  - How the GOV.UK header, Service navigation, Phase banner, and Back link/Breadcrumbs components are placed relative to one another.
- Add ['Companies you follow (service navigation with slots)' full-page example](https://govuk-frontend-pr-5275.herokuapp.com/full-page-examples/companies-you-follow-slots). This one additionally demonstrates:
  - The use of slots within the Service navigation component.
  - How the HTML elements and landmarks differ when the service name is not included in the Service navigation component.
- Updates other examples that included navigation within the GOV.UK header component to either remove the navigation, or to move it to within the Service navigation component. 