### PR TITLE
Add progressively enhanced File Upload component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
+#### Use our improved File upload component
+
+We've added a [JavaScript enhancement to the File upload component](https://design-system.service.gov.uk/components/file-upload/#using-the-improved-file-upload-component) which:
+
+- makes the component easier to use for drag and drop
+- allows the text of the component to be translated
+- fixes accessibility issues for users of Dragon, a speech recognition software
+
+This improvement is opt-in, as it's a substantial visual change which risks shifting other content on the page.
+
+To enable this improvement for your users, you'll first need to update the markup of your File upload component:
+
+- if you use our Nunjucks macro, using the new `javascript` option of `govukFileUpload`
+
+  ```njk
+  {{ govukFileUpload({
+  id: "file-upload",
+  name: "photo",
+  label: {
+  	text: "Upload your photo"
+  },
+  javascript: true
+  }) }}
+  ```
+
+- if you're using HTML, wrapping the `<input type="file">` of the File upload markup in a `<div class="govuk-drop-zone" data-module="govuk-file-upload">`
+
+  ```html
+  <div class="govuk-form-group">
+  <label class="govuk-label" for="file-upload-1">
+  	Upload your photo
+  </label>
+  <div class="govuk-drop-zone" data-module="govuk-file-upload">
+  	<input class="govuk-file-upload" id="file-upload" name="photo" type="file">
+  </div>
+  </div>
+  ```
+
+If you're importing components individually in your JavaScript, which we recommend for better performance, you'll then need to import and initialise the new `FileUpload` component.
+
+```js
+import {FileUpload} from 'govuk-frontend'
+
+createAll(FileUpload)
+```
+
+This change was introduced in [pull request #5305: Add progressively enhanced File Upload component](https://github.com/alphagov/govuk-frontend/pull/5305)
+
 #### Form control components now have default `id` attributes
 
 If you're using the included Nunjucks macros, the Text input, Textarea, Password input, Character count, File upload, and Select components now automatically use the value of the `name` parameter for the `id` parameter.

--- a/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
@@ -50,6 +50,10 @@
         "href": "#file"
       },
       {
+        "text": "Problem with file (enhanced)",
+        "href": "#file-enhanced"
+      },
+      {
         "text": "Problem with radios",
         "href": "#radios"
       },
@@ -190,6 +194,18 @@
     errorMessage: {
       "text": "Problem with file"
     }
+  }) }}
+
+  {{ govukFileUpload({
+    label: {
+      "text": 'Label for enhanced file upload'
+    },
+    id: "file-enhanced",
+    name: "file-enhanced",
+    errorMessage: {
+      "text": "Problem with file"
+    },
+    javascript: true
   }) }}
 
   {{ govukRadios({

--- a/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
@@ -28,6 +28,7 @@
     <li><a href="#date" class="govuk-link">Date pattern</a></li>
     <li><a href="#select" class="govuk-link">Select box</a></li>
     <li><a href="#file" class="govuk-link">File upload</a></li>
+    <li><a href="#file-enhanced" class="govuk-link">File upload (enhanced)</a></li>
   </ul>
 
   <form action="/" method="post">
@@ -171,6 +172,18 @@
         label: {
           text: 'Upload a file'
         }
+      }) -}}
+    {% endcall %}
+
+    {% call govukFieldset() %}
+      <span id="file-enhanced"></span>
+      {{- govukFileUpload({
+        id: 'file-upload-2',
+        name: 'file-upload-2',
+        label: {
+          text: 'Upload a file'
+        },
+        javascript: true
       }) -}}
     {% endcall %}
 

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -340,6 +340,21 @@
     }
   }) }}
 
+  {{ govukFileUpload({
+    id: "file-upload-1",
+    name: "file-upload-1",
+    label: {
+      text: "Llwythwch ffeil i fyny"
+    },
+    javascript: true,
+    selectFilesButtonText: "Dewiswch ffeil",
+    filesSelectedDefaultText: "Dim ffeiliau wedi'u dewis",
+    filesSelectedText: {
+        other: "%{count} ffeil wedi'u dewis",
+        one: "%{count} ffeil wedi'i dewis"
+    }
+  }) }}
+
   {{ govukFooter({
     classes: "govuk-!-margin-bottom-4",
     navigation: [

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -69,7 +69,8 @@ scenario: |
                 hint: {
                     text: "Your photo must be at least 50KB and no more than 10MB"
                 },
-                errorMessage: errors["photo"]
+                errorMessage: errors["photo"],
+                javascript: true
             }) }}
 
             {{ govukCheckboxes({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -71,7 +71,8 @@ scenario: |
                 hint: {
                     text: "Your photo must be at least 50KB and no more than 10MB"
                 },
-                errorMessage: errors["photo"]
+                errorMessage: errors["photo"],
+                javascript: true
             }) }}
 
             {{ govukCheckboxes({

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -5,6 +5,7 @@ export { CharacterCount } from './components/character-count/character-count.mjs
 export { Checkboxes } from './components/checkboxes/checkboxes.mjs'
 export { ErrorSummary } from './components/error-summary/error-summary.mjs'
 export { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs'
+export { FileUpload } from './components/file-upload/file-upload.mjs'
 export { Header } from './components/header/header.mjs'
 export { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
 export { PasswordInput } from './components/password-input/password-input.mjs'

--- a/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
@@ -72,6 +72,7 @@ describe('GOV.UK Frontend', () => {
         'ConfigurableComponent',
         'ErrorSummary',
         'ExitThisPage',
+        'FileUpload',
         'Header',
         'NotificationBanner',
         'PasswordInput',

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -3,6 +3,7 @@
 @import "../label/index";
 
 @include govuk-exports("govuk/component/file-upload") {
+  $file-upload-border-width: 2px;
   $component-padding: govuk-spacing(1);
 
   .govuk-file-upload {
@@ -48,34 +49,17 @@
   }
 
   .govuk-file-upload-wrapper {
-    display: inline-flex;
-    align-items: baseline;
+    display: block;
     position: relative;
-  }
-
-  .govuk-file-upload-wrapper--show-dropzone {
-    $dropzone-padding: govuk-spacing(2);
-    $dropzone-offset: $dropzone-padding + $govuk-border-width-form-element;
-
-    // Add negative margins to all sides so that content doesn't jump due to
-    // the addition of the padding and border.
-    margin: -$dropzone-offset;
-    padding: $dropzone-padding;
-    border: $govuk-border-width-form-element dashed $govuk-input-border-colour;
+    z-index: 0;
     background-color: $govuk-body-background-colour;
-
-    .govuk-file-upload__pseudo-button,
-    .govuk-file-upload__status {
-      // When the dropzone is hovered over, make these aspects not accept
-      // mouse events, so dropped files fall through to the input beneath them
-      pointer-events: none;
-    }
   }
 
   .govuk-file-upload-wrapper .govuk-file-upload {
+    position: absolute;
     // Make the native control take up the entire space of the element, but
     // invisible and behind the other elements until we need it
-    position: absolute;
+    z-index: -1;
     top: 0;
     left: 0;
     width: 100%;
@@ -85,62 +69,108 @@
     opacity: 0;
   }
 
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload {
+    z-index: 1;
+  }
+
   .govuk-file-upload__pseudo-button {
     width: auto;
-    margin-bottom: 0;
-    flex-grow: 0;
+    margin-right: govuk-spacing(2);
+    margin-bottom: $govuk-border-width-form-element + 1;
     flex-shrink: 0;
   }
 
-  .govuk-file-upload__status {
+  .govuk-file-upload__instruction {
+    margin-top: govuk-spacing(2) - ($govuk-border-width-form-element + 1);
     margin-bottom: 0;
-    margin-left: govuk-spacing(2);
+    text-align: left;
   }
-}
 
-.govuk-file-upload__button:focus {
-  outline: none;
-}
+  .govuk-file-upload__status {
+    display: block;
+    margin-bottom: govuk-spacing(2);
+    padding: govuk-spacing(3) govuk-spacing(2);
+    text-align: left;
+  }
 
-.govuk-file-upload__button:focus .govuk-file-upload__pseudo-button {
-  outline: 3px solid transparent;
-  background-color: $govuk-focus-colour;
-  box-shadow: 0 2px 0 govuk-colour("black");
-}
+  .govuk-file-upload__status--empty {
+    color: govuk-shade(govuk-colour("blue"), 60%);
+    background-color: govuk-tint(govuk-colour("blue"), 70%);
+  }
 
-.govuk-file-upload__button:focus .govuk-file-upload__pseudo-button:hover {
-  border-color: $govuk-focus-colour;
-  outline: 3px solid transparent;
-  background-color: govuk-colour("light-grey");
-  box-shadow: inset 0 0 0 1px $govuk-focus-colour;
-}
+  // bugs documented with button using flex
+  // https://github.com/philipwalton/flexbugs#flexbug-9
+  // so we need a container here
+  .govuk-file-upload__pseudo-button-container {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+  }
 
-.govuk-file-upload__button:active .govuk-file-upload__pseudo-button:hover {
-  background-color: govuk-shade(govuk-colour("light-grey"), 20%);
-}
+  .govuk-file-upload__button {
+    width: 100%;
+    // align the padding to be same as notification banner and error summary accounting for the thicker borders
+    padding: govuk-spacing(3) (govuk-spacing(3) + $govuk-border-width - $file-upload-border-width);
+    border: $file-upload-border-width govuk-colour("mid-grey") dashed;
+    background-color: govuk-colour("white");
+    cursor: pointer;
 
-.govuk-file-upload__button {
-  align-items: center;
-  display: flex;
-  padding: 0;
-  border: 0;
-  background-color: transparent;
-}
+    @include govuk-media-query($from: tablet) {
+      padding: govuk-spacing(3) (govuk-spacing(4) + $govuk-border-width - $file-upload-border-width);
+    }
+  }
 
-.govuk-file-upload:disabled + .govuk-file-upload__button {
-  pointer-events: none;
-}
+  .govuk-file-upload-wrapper:hover .govuk-file-upload__button {
+    border-color: govuk-shade(govuk-colour("mid-grey"), 20%);
+  }
 
-.govuk-file-upload:disabled + .govuk-file-upload__button .govuk-file-upload__pseudo-button {
-  opacity: (0.5);
+  .govuk-file-upload-wrapper:hover .govuk-file-upload__pseudo-button {
+    background-color: govuk-shade(govuk-colour("light-grey"), 10%);
+  }
 
-  &:hover {
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button,
+  .govuk-file-upload-wrapper:hover .govuk-file-upload__button {
     background-color: govuk-colour("light-grey");
-    cursor: not-allowed;
   }
 
-  &:active {
-    top: 0;
-    box-shadow: 0 $govuk-border-width-form-element 0 govuk-shade(govuk-colour("white"), 60%); // s0
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__status--empty,
+  .govuk-file-upload-wrapper:hover .govuk-file-upload__status--empty,
+  .govuk-file-upload__button:focus .govuk-file-upload__status--empty {
+    background-color: govuk-tint(govuk-colour("blue"), 80%);
+  }
+
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button {
+    border: $file-upload-border-width solid govuk-colour("black");
+  }
+
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__pseudo-button {
+    background-color: govuk-colour("white");
+  }
+
+  .govuk-file-upload__button:active,
+  .govuk-file-upload__button:focus {
+    border: 2px solid govuk-colour("black");
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+    background-color: govuk-colour("light-grey");
+    // Double the border by adding its width again. Use `box-shadow` for this
+    // instead of changing `border-width` - this is for consistency with
+    // components such as textarea where we avoid changing `border-width` as
+    // it will change the element size. Also, `outline` cannot be utilised
+    // here as it is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  }
+
+  .govuk-file-upload__button:focus .govuk-file-upload__pseudo-button {
+    background-color: $govuk-focus-colour;
+    box-shadow: 0 2px 0 govuk-colour("black");
+  }
+
+  .govuk-file-upload-wrapper:hover .govuk-file-upload__button:focus .govuk-file-upload__pseudo-button {
+    border-color: $govuk-focus-colour;
+    outline: 3px solid transparent;
+    background-color: govuk-colour("light-grey");
+    box-shadow: inset 0 0 0 1px $govuk-focus-colour;
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -46,4 +46,52 @@
       cursor: not-allowed;
     }
   }
+
+  .govuk-file-upload-wrapper {
+    display: inline-flex;
+    align-items: baseline;
+    position: relative;
+  }
+
+  .govuk-file-upload-wrapper--show-dropzone {
+    $dropzone-padding: govuk-spacing(2);
+
+    margin-top: -$dropzone-padding;
+    margin-left: -$dropzone-padding;
+    padding: $dropzone-padding;
+    outline: 2px dotted govuk-colour("mid-grey");
+    background-color: govuk-colour("light-grey");
+
+    .govuk-file-upload__button,
+    .govuk-file-upload__status {
+      // When the dropzone is hovered over, make these aspects not accept
+      // mouse events, so dropped files fall through to the input beneath them
+      pointer-events: none;
+    }
+  }
+
+  .govuk-file-upload-wrapper .govuk-file-upload {
+    // Make the native control take up the entire space of the element, but
+    // invisible and behind the other elements until we need it
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    opacity: 0;
+  }
+
+  .govuk-file-upload__button {
+    width: auto;
+    margin-bottom: 0;
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
+
+  .govuk-file-upload__status {
+    margin-bottom: 0;
+    margin-left: govuk-spacing(2);
+  }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -55,12 +55,14 @@
 
   .govuk-file-upload-wrapper--show-dropzone {
     $dropzone-padding: govuk-spacing(2);
+    $dropzone-offset: $dropzone-padding + $govuk-border-width-form-element;
 
-    margin-top: -$dropzone-padding;
-    margin-left: -$dropzone-padding;
+    // Add negative margins to all sides so that content doesn't jump due to
+    // the addition of the padding and border.
+    margin: -$dropzone-offset;
     padding: $dropzone-padding;
-    outline: 2px dotted govuk-colour("mid-grey");
-    background-color: govuk-colour("light-grey");
+    border: $govuk-border-width-form-element dashed $govuk-input-border-colour;
+    background-color: $govuk-body-background-colour;
 
     .govuk-file-upload__button,
     .govuk-file-upload__status {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -55,7 +55,7 @@
     background-color: $govuk-body-background-colour;
   }
 
-  .govuk-file-upload-wrapper .govuk-file-upload {
+  .govuk-frontend-supported .govuk-file-upload-wrapper .govuk-file-upload {
     position: absolute;
     // Make the native control take up the entire space of the element, but
     // invisible and behind the other elements until we need it

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -64,7 +64,7 @@
     border: $govuk-border-width-form-element dashed $govuk-input-border-colour;
     background-color: $govuk-body-background-colour;
 
-    .govuk-file-upload__button,
+    .govuk-file-upload__pseudo-button,
     .govuk-file-upload__status {
       // When the dropzone is hovered over, make these aspects not accept
       // mouse events, so dropped files fall through to the input beneath them
@@ -85,7 +85,7 @@
     opacity: 0;
   }
 
-  .govuk-file-upload__button {
+  .govuk-file-upload__pseudo-button {
     width: auto;
     margin-bottom: 0;
     flex-grow: 0;
@@ -95,5 +95,52 @@
   .govuk-file-upload__status {
     margin-bottom: 0;
     margin-left: govuk-spacing(2);
+  }
+}
+
+.govuk-file-upload__button:focus {
+  outline: none;
+}
+
+.govuk-file-upload__button:focus .govuk-file-upload__pseudo-button {
+  outline: 3px solid transparent;
+  background-color: $govuk-focus-colour;
+  box-shadow: 0 2px 0 govuk-colour("black");
+}
+
+.govuk-file-upload__button:focus .govuk-file-upload__pseudo-button:hover {
+  border-color: $govuk-focus-colour;
+  outline: 3px solid transparent;
+  background-color: govuk-colour("light-grey");
+  box-shadow: inset 0 0 0 1px $govuk-focus-colour;
+}
+
+.govuk-file-upload__button:active .govuk-file-upload__pseudo-button:hover {
+  background-color: govuk-shade(govuk-colour("light-grey"), 20%);
+}
+
+.govuk-file-upload__button {
+  align-items: center;
+  display: flex;
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+}
+
+.govuk-file-upload:disabled + .govuk-file-upload__button {
+  pointer-events: none;
+}
+
+.govuk-file-upload:disabled + .govuk-file-upload__button .govuk-file-upload__pseudo-button {
+  opacity: (0.5);
+
+  &:hover {
+    background-color: govuk-colour("light-grey");
+    cursor: not-allowed;
+  }
+
+  &:active {
+    top: 0;
+    box-shadow: 0 $govuk-border-width-form-element 0 govuk-shade(govuk-colour("white"), 60%); // s0
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
@@ -7,9 +7,37 @@ describe('/components/file-upload', () => {
       const examples = await getExamples('file-upload')
 
       for (const exampleName in examples) {
-        await render(page, 'file-upload', examples[exampleName])
+        // JavaScript enhancements being optional, some examples will not have
+        // any element with `data-module="govuk-file-upload"`. This causes an error
+        // as `render` assumes that if a component is exported by GOV.UK Frontend
+        // its rendered markup will have a `data-module` and tried to initialise
+        // the JavaScript component, even if no element with the right `data-module`
+        // is on the page.
+        //
+        // Because of this, we need to filter `ElementError` thrown by the JavaScript
+        // component to examples that actually run the JavaScript enhancements
+        try {
+          await render(page, 'file-upload', examples[exampleName])
+        } catch (e) {
+          const macroOptions = /** @type {MacroOptions} */ (
+            examples[exampleName].context
+          )
+
+          const exampleUsesJavaScript = macroOptions.javascript
+          const exampleLackedRoot = e.message.includes(
+            'govuk-file-upload: Root element'
+          )
+
+          if (!exampleLackedRoot || exampleUsesJavaScript) {
+            throw e
+          }
+        }
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })
 })
+
+/**
+ * @typedef {import('@govuk-frontend/lib/components').MacroOptions} MacroOptions
+ */

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,15 +1,15 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
-import { mergeConfigs, normaliseDataset } from '../../common/configuration.mjs'
+import { ConfigurableComponent } from '../../common/configuration.mjs'
 import { ElementError } from '../../errors/index.mjs'
-import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
  * File upload component
  *
  * @preserve
+ * @augments ConfigurableComponent<FileUploadConfig,HTMLInputElement>
  */
-export class FileUpload extends GOVUKFrontendComponent {
+export class FileUpload extends ConfigurableComponent {
   /**
    * @private
    */
@@ -25,14 +25,6 @@ export class FileUpload extends GOVUKFrontendComponent {
    */
   $status
 
-  /**
-   * @private
-   * @type {FileUploadConfig}
-   */
-  // eslint-disable-next-line
-  // @ts-ignore
-  config
-
   /** @private */
   i18n
 
@@ -41,23 +33,13 @@ export class FileUpload extends GOVUKFrontendComponent {
    * @param {FileUploadConfig} [config] - File Upload config
    */
   constructor($root, config = {}) {
-    super($root)
-
-    if (!(this.$root instanceof HTMLInputElement)) {
-      return
-    }
+    super($root, config)
 
     if (this.$root.type !== 'file') {
       throw new ElementError(
         'File upload: Form field must be an input of type `file`.'
       )
     }
-
-    this.config = mergeConfigs(
-      FileUpload.defaults,
-      config,
-      normaliseDataset(FileUpload, this.$root.dataset)
-    )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
@@ -139,11 +121,6 @@ export class FileUpload extends GOVUKFrontendComponent {
     // eslint-disable-next-line
     // @ts-ignore
     const fileCount = this.$root.files.length // eslint-disable-line
-
-    // trying to appease typescript
-    if (!this.$status || !this.i18n) {
-      return
-    }
 
     if (fileCount === 0) {
       // If there are no files, show the default selection text

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -8,7 +8,7 @@ import { I18n } from '../../i18n.mjs'
  * File upload component
  *
  * @preserve
- * @augments ConfigurableComponent<FileUploadConfig,HTMLInputElement>
+ * @augments ConfigurableComponent<FileUploadConfig,HTMLFileInputElement>
  */
 export class FileUpload extends ConfigurableComponent {
   /**
@@ -107,10 +107,6 @@ export class FileUpload extends ConfigurableComponent {
    * Check if the value of the underlying input has changed
    */
   onChange() {
-    if (!this.$root.files) {
-      return
-    }
-
     const fileCount = this.$root.files.length
 
     if (fileCount === 0) {
@@ -244,6 +240,10 @@ export class FileUpload extends ConfigurableComponent {
     }
   })
 }
+
+/**
+ * @typedef {HTMLInputElement & {files: FileList}} HTMLFileInputElement
+ */
 
 /**
  * File upload config

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -98,6 +98,7 @@ export class FileUpload extends ConfigurableComponent {
     // Handle drop zone visibility
     // A live region to announce when users enter or leave the drop zone
     this.$announcements = document.createElement('span')
+    this.$announcements.classList.add('govuk-file-upload-announcements')
     this.$announcements.classList.add('govuk-visually-hidden')
     this.$announcements.setAttribute('aria-live', 'assertive')
     this.$wrapper.insertAdjacentElement('afterend', this.$announcements)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -61,7 +61,13 @@ export class FileUpload extends ConfigurableComponent {
       locale: closestAttributeValue(this.$root, 'lang')
     })
 
-    this.$label = this.findLabel()
+    const $label = this.findLabel()
+    $label.setAttribute('for', `${this.id}-input`)
+    // Add an ID to the label if it doesn't have one already
+    // so it can be referenced by `aria-labelledby`
+    if (!$label.id) {
+      $label.id = `${this.id}-label`
+    }
 
     // we need to copy the 'id' of the root element
     // to the new button replacement element
@@ -71,10 +77,6 @@ export class FileUpload extends ConfigurableComponent {
     // Wrapping element. This defines the boundaries of our drag and drop area.
     const $wrapper = document.createElement('div')
     $wrapper.className = 'govuk-file-upload-wrapper'
-
-    const commaSpan = document.createElement('span')
-    commaSpan.className = 'govuk-visually-hidden'
-    commaSpan.innerText = ', '
 
     // Create the file selection button
     const $button = document.createElement('button')
@@ -93,11 +95,16 @@ export class FileUpload extends ConfigurableComponent {
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload__status'
     $status.innerText = this.i18n.t('filesSelectedDefault')
-    $status.setAttribute('aria-hidden', 'true')
     $status.classList.add('govuk-file-upload__status--empty')
 
     $button.appendChild($status)
-    $button.appendChild(commaSpan.cloneNode(true))
+
+    const commaSpan = document.createElement('span')
+    commaSpan.className = 'govuk-visually-hidden'
+    commaSpan.innerText = ', '
+    commaSpan.id = `${this.id}-comma`
+
+    $button.appendChild(commaSpan)
 
     const containerSpan = document.createElement('span')
     containerSpan.className = 'govuk-file-upload__pseudo-button-container'
@@ -106,10 +113,12 @@ export class FileUpload extends ConfigurableComponent {
     buttonSpan.className =
       'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'
     buttonSpan.innerText = this.i18n.t('selectFilesButton')
-    buttonSpan.setAttribute('aria-hidden', 'true')
 
     containerSpan.appendChild(buttonSpan)
-    containerSpan.appendChild(commaSpan.cloneNode(true))
+
+    // Add a space so the button and instruction read correctly
+    // when CSS is disabled
+    containerSpan.insertAdjacentText('beforeend', ' ')
 
     const instructionSpan = document.createElement('span')
     instructionSpan.className = 'govuk-body govuk-file-upload__instruction'
@@ -119,8 +128,8 @@ export class FileUpload extends ConfigurableComponent {
 
     $button.appendChild(containerSpan)
     $button.setAttribute(
-      'aria-label',
-      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')} ${this.i18n.t('instruction')}, ${$status.innerText}`
+      'aria-labelledby',
+      `${$label.id} ${commaSpan.id} ${$button.id}`
     )
     $button.addEventListener('click', this.onClick.bind(this))
 
@@ -144,7 +153,7 @@ export class FileUpload extends ConfigurableComponent {
     // Bind change event to the underlying input
     this.$root.addEventListener('change', this.onChange.bind(this))
 
-    // Syncronise the `disabled` state between the button and underlying input
+    // Synchronise the `disabled` state between the button and underlying input
     this.updateDisabledState()
     this.observeDisabledState()
 
@@ -271,11 +280,6 @@ export class FileUpload extends ConfigurableComponent {
 
       this.$status.classList.remove('govuk-file-upload__status--empty')
     }
-
-    this.$button.setAttribute(
-      'aria-label',
-      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')} ${this.i18n.t('instruction')}, ${this.$status.innerText}`
-    )
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -109,6 +109,10 @@ export class FileUpload extends GOVUKFrontendComponent {
     // Prevent the hidden input being tabbed to by keyboard users
     this.$root.setAttribute('tabindex', '-1')
 
+    // Syncronise the `disabled` state between the button and underlying input
+    this.updateDisabledState()
+    this.observeDisabledState()
+
     // Bind change event to the underlying input
     this.$root.addEventListener('change', this.onChange.bind(this))
     this.$wrapper.addEventListener('dragover', this.onDragOver.bind(this))
@@ -185,6 +189,41 @@ export class FileUpload extends GOVUKFrontendComponent {
     // eslint-disable-next-line
     // @ts-ignore
     this.$wrapper.classList.remove('govuk-file-upload-wrapper--show-dropzone')
+  }
+
+  /**
+   * Create a mutation observer to check if the input's attributes altered.
+   */
+  observeDisabledState() {
+    const observer = new MutationObserver((mutationList) => {
+      for (const mutation of mutationList) {
+        console.log('mutation', mutation)
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'disabled'
+        ) {
+          this.updateDisabledState()
+        }
+      }
+    })
+
+    observer.observe(this.$root, {
+      attributes: true
+    })
+  }
+
+  /**
+   * Synchronise the `disabled` state between the input and replacement button.
+   */
+  updateDisabledState() {
+    if (
+      !(this.$root instanceof HTMLInputElement) ||
+      !(this.$button instanceof HTMLButtonElement)
+    ) {
+      return
+    }
+
+    this.$button.disabled = this.$root.disabled
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -12,25 +12,16 @@ import { I18n } from '../../i18n.mjs'
 export class FileUpload extends GOVUKFrontendComponent {
   /**
    * @private
-   * @type {HTMLInputElement}
-   */
-  $input
-
-  /**
-   * @private
-   * @type {HTMLElement}
    */
   $wrapper
 
   /**
    * @private
-   * @type {HTMLButtonElement}
    */
   $button
 
   /**
    * @private
-   * @type {HTMLElement}
    */
   $status
 
@@ -38,60 +29,53 @@ export class FileUpload extends GOVUKFrontendComponent {
    * @private
    * @type {FileUploadConfig}
    */
+  // eslint-disable-next-line
+  // @ts-ignore
   config
 
   /** @private */
   i18n
 
   /**
-   * @param {Element | null} $input - File input element
+   * @param {Element | null} $root - File input element
    * @param {FileUploadConfig} [config] - File Upload config
    */
-  constructor($input, config = {}) {
-    super($input)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($input instanceof HTMLInputElement)) {
-      throw new ElementError({
-        component: FileUpload,
-        element: $input,
-        expectedType: 'HTMLInputElement',
-        identifier: 'Root element (`$module`)'
-      })
+    if (!(this.$root instanceof HTMLInputElement)) {
+      return
     }
 
-    if ($input.type !== 'file') {
-      throw new ElementError('File upload: Form field must be of type `file`.')
+    if (this.$root.type !== 'file') {
+      throw new ElementError(
+        'File upload: Form field must be an input of type `file`.'
+      )
     }
 
     this.config = mergeConfigs(
       FileUpload.defaults,
       config,
-      normaliseDataset(FileUpload, $input.dataset)
+      normaliseDataset(FileUpload, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($input, 'lang')
+      locale: closestAttributeValue(this.$root, 'lang')
     })
 
-    this.$label = document.querySelector(`[for="${$input.id}"]`)
+    this.$label = document.querySelector(`[for="${this.$root.id}"]`)
 
     if (!this.$label) {
       throw new ElementError({
-        componentName: 'File upload',
+        component: FileUpload,
         identifier: 'No label'
       })
     }
 
-    $input.addEventListener('change', this.onChange.bind(this))
-    this.$input = $input
-
     // Wrapping element. This defines the boundaries of our drag and drop area.
     const $wrapper = document.createElement('div')
     $wrapper.className = 'govuk-file-upload-wrapper'
-    $wrapper.addEventListener('dragover', this.onDragOver.bind(this))
-    $wrapper.addEventListener('dragleave', this.onDragLeaveOrDrop.bind(this))
-    $wrapper.addEventListener('drop', this.onDragLeaveOrDrop.bind(this))
 
     // Create the file selection button
     const $button = document.createElement('button')
@@ -112,29 +96,50 @@ export class FileUpload extends GOVUKFrontendComponent {
     $wrapper.insertAdjacentElement('beforeend', $status)
 
     // Inject all this *after* the native file input
-    this.$input.insertAdjacentElement('afterend', $wrapper)
+    this.$root.insertAdjacentElement('afterend', $wrapper)
 
     // Move the native file input to inside of the wrapper
-    $wrapper.insertAdjacentElement('afterbegin', this.$input)
+    $wrapper.insertAdjacentElement('afterbegin', this.$root)
 
     // Make all these new variables available to the module
     this.$wrapper = $wrapper
     this.$button = $button
     this.$status = $status
 
+    // with everything set up, apply attributes to programmatically hide the input
+    this.$root.setAttribute('aria-hidden', 'true')
+    this.$root.setAttribute('tabindex', '-1')
+
     // Bind change event to the underlying input
-    this.$input.addEventListener('change', this.onChange.bind(this))
+    this.$root.addEventListener('change', this.onChange.bind(this))
+    this.$wrapper.addEventListener('dragover', this.onDragOver.bind(this))
+    this.$wrapper.addEventListener(
+      'dragleave',
+      this.onDragLeaveOrDrop.bind(this)
+    )
+    this.$wrapper.addEventListener('drop', this.onDragLeaveOrDrop.bind(this))
   }
 
   /**
    * Check if the value of the underlying input has changed
    */
   onChange() {
-    if (!this.$input.files) {
+    if (!('files' in this.$root)) {
       return
     }
 
-    const fileCount = this.$input.files.length
+    if (!this.$root.files) {
+      return
+    }
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    const fileCount = this.$root.files.length // eslint-disable-line
+
+    // trying to appease typescript
+    if (!this.$status || !this.i18n) {
+      return
+    }
 
     if (fileCount === 0) {
       // If there are no files, show the default selection text
@@ -143,7 +148,9 @@ export class FileUpload extends GOVUKFrontendComponent {
       // If there is 1 file, just show the file name
       fileCount === 1
     ) {
-      this.$status.innerText = this.$input.files[0].name
+      // eslint-disable-next-line
+      // @ts-ignore
+      this.$status.innerText = this.$root.files[0].name // eslint-disable-line
     } else {
       // Otherwise, tell the user how many files are selected
       this.$status.innerText = this.i18n.t('filesSelected', {
@@ -166,6 +173,8 @@ export class FileUpload extends GOVUKFrontendComponent {
    * file can be dropped here.
    */
   onDragOver() {
+    // eslint-disable-next-line
+    // @ts-ignore
     this.$wrapper.classList.add('govuk-file-upload-wrapper--show-dropzone')
   }
 
@@ -174,6 +183,8 @@ export class FileUpload extends GOVUKFrontendComponent {
    * remove the visual indicator.
    */
   onDragLeaveOrDrop() {
+    // eslint-disable-next-line
+    // @ts-ignore
     this.$wrapper.classList.remove('govuk-file-upload-wrapper--show-dropzone')
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -72,6 +72,10 @@ export class FileUpload extends ConfigurableComponent {
     const $wrapper = document.createElement('div')
     $wrapper.className = 'govuk-file-upload-wrapper'
 
+    const commaSpan = document.createElement('span')
+    commaSpan.className = 'govuk-visually-hidden'
+    commaSpan.innerText = ', '
+
     // Create the file selection button
     const $button = document.createElement('button')
     $button.classList.add('govuk-file-upload__button')
@@ -85,26 +89,40 @@ export class FileUpload extends ConfigurableComponent {
       $button.setAttribute('aria-describedby', ariaDescribedBy)
     }
 
+    // Create status element that shows what/how many files are selected
+    const $status = document.createElement('span')
+    $status.className = 'govuk-body govuk-file-upload__status'
+    $status.innerText = this.i18n.t('filesSelectedDefault')
+    $status.setAttribute('aria-hidden', 'true')
+    $status.classList.add('govuk-file-upload__status--empty')
+
+    $button.appendChild($status)
+    $button.appendChild(commaSpan.cloneNode(true))
+
+    const containerSpan = document.createElement('span')
+    containerSpan.className = 'govuk-file-upload__pseudo-button-container'
+
     const buttonSpan = document.createElement('span')
     buttonSpan.className =
       'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'
     buttonSpan.innerText = this.i18n.t('selectFilesButton')
     buttonSpan.setAttribute('aria-hidden', 'true')
 
-    $button.appendChild(buttonSpan)
-    $button.addEventListener('click', this.onClick.bind(this))
+    containerSpan.appendChild(buttonSpan)
+    containerSpan.appendChild(commaSpan.cloneNode(true))
 
-    // Create status element that shows what/how many files are selected
-    const $status = document.createElement('span')
-    $status.className = 'govuk-body govuk-file-upload__status'
-    $status.innerText = this.i18n.t('filesSelectedDefault')
-    $status.setAttribute('aria-hidden', 'true')
+    const instructionSpan = document.createElement('span')
+    instructionSpan.className = 'govuk-body govuk-file-upload__instruction'
+    instructionSpan.innerText = this.i18n.t('instruction')
 
-    $button.appendChild($status)
+    containerSpan.appendChild(instructionSpan)
+
+    $button.appendChild(containerSpan)
     $button.setAttribute(
       'aria-label',
-      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')}, ${this.i18n.t('filesSelectedDefault')}`
+      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')} ${this.i18n.t('instruction')}, ${$status.innerText}`
     )
+    $button.addEventListener('click', this.onClick.bind(this))
 
     // Assemble these all together
     $wrapper.insertAdjacentElement('beforeend', $button)
@@ -129,9 +147,6 @@ export class FileUpload extends ConfigurableComponent {
     // Syncronise the `disabled` state between the button and underlying input
     this.updateDisabledState()
     this.observeDisabledState()
-
-    // Bind change event to the underlying input
-    this.$root.addEventListener('change', this.onChange.bind(this))
 
     // Handle drop zone visibility
     // A live region to announce when users enter or leave the drop zone
@@ -240,21 +255,26 @@ export class FileUpload extends ConfigurableComponent {
     if (fileCount === 0) {
       // If there are no files, show the default selection text
       this.$status.innerText = this.i18n.t('filesSelectedDefault')
-    } else if (
-      // If there is 1 file, just show the file name
-      fileCount === 1
-    ) {
-      this.$status.innerText = this.$root.files[0].name
+      this.$status.classList.add('govuk-file-upload__status--empty')
     } else {
-      // Otherwise, tell the user how many files are selected
-      this.$status.innerText = this.i18n.t('filesSelected', {
-        count: fileCount
-      })
+      if (
+        // If there is 1 file, just show the file name
+        fileCount === 1
+      ) {
+        this.$status.innerText = this.$root.files[0].name
+      } else {
+        // Otherwise, tell the user how many files are selected
+        this.$status.innerText = this.i18n.t('filesSelected', {
+          count: fileCount
+        })
+      }
+
+      this.$status.classList.remove('govuk-file-upload__status--empty')
     }
 
     this.$button.setAttribute(
       'aria-label',
-      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')}, ${this.$status.innerText}`
+      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')} ${this.i18n.t('instruction')}, ${this.$status.innerText}`
     )
   }
 
@@ -337,7 +357,8 @@ export class FileUpload extends ConfigurableComponent {
         other: '%{count} files chosen'
       },
       dropZoneEntered: 'Entered drop zone',
-      dropZoneLeft: 'Left drop zone'
+      dropZoneLeft: 'Left drop zone',
+      instruction: 'or drop file'
     }
   })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -120,7 +120,7 @@ export class FileUpload extends GOVUKFrontendComponent {
     this.$wrapper.addEventListener('drop', this.onDragLeaveOrDrop.bind(this))
 
     // When a file is dragged over the page (or dragged off the page)
-    document.addEventListener('dragover', this.onDragOver.bind(this))
+    document.addEventListener('dragenter', this.onDragEnter.bind(this))
     document.addEventListener('dragleave', this.onDragLeaveOrDrop.bind(this))
   }
 
@@ -175,8 +175,14 @@ export class FileUpload extends GOVUKFrontendComponent {
   /**
    * When a file is dragged over the container, show a visual indicator that a
    * file can be dropped here.
+   *
+   * @param {DragEvent} event - the drag event
    */
-  onDragOver() {
+  onDragEnter(event) {
+    // Check if the thing being dragged is a file (and not text or something
+    // else), we only want to indicate files.
+    console.log(event)
+
     // eslint-disable-next-line
     // @ts-ignore
     this.$wrapper.classList.add('govuk-file-upload-wrapper--show-dropzone')

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -122,9 +122,7 @@ export class FileUpload extends ConfigurableComponent {
       return
     }
 
-    // eslint-disable-next-line
-    // @ts-ignore
-    const fileCount = this.$root.files.length // eslint-disable-line
+    const fileCount = this.$root.files.length
 
     if (fileCount === 0) {
       // If there are no files, show the default selection text
@@ -133,9 +131,7 @@ export class FileUpload extends ConfigurableComponent {
       // If there is 1 file, just show the file name
       fileCount === 1
     ) {
-      // eslint-disable-next-line
-      // @ts-ignore
-      this.$status.innerText = this.$root.files[0].name // eslint-disable-line
+      this.$status.innerText = this.$root.files[0].name
     } else {
       // Otherwise, tell the user how many files are selected
       this.$status.innerText = this.i18n.t('filesSelected', {
@@ -164,8 +160,6 @@ export class FileUpload extends ConfigurableComponent {
     // else), we only want to indicate files.
     console.log(event)
 
-    // eslint-disable-next-line
-    // @ts-ignore
     this.$wrapper.classList.add('govuk-file-upload-wrapper--show-dropzone')
   }
 
@@ -174,8 +168,6 @@ export class FileUpload extends ConfigurableComponent {
    * remove the visual indicator.
    */
   onDragLeaveOrDrop() {
-    // eslint-disable-next-line
-    // @ts-ignore
     this.$wrapper.classList.remove('govuk-file-upload-wrapper--show-dropzone')
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -243,6 +243,8 @@ export class FileUpload extends GOVUKFrontendComponent {
       selectFilesButton: 'Choose file',
       filesSelectedDefault: 'No file chosen',
       filesSelected: {
+        // the 'one' string isn't used as the component displays the filename
+        // instead, however it's here for coverage's sake
         one: '%{count} file chosen',
         other: '%{count} files chosen'
       }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -98,46 +98,34 @@ export class FileUpload extends ConfigurableComponent {
     // Handle drag'n'drop events
     this.$wrapper.addEventListener('drop', this.onDrop.bind(this))
 
-    this.$wrapper.addEventListener('dragenter', this.onDragEnter.bind(this))
-    this.$wrapper.addEventListener('dragleave', this.onDragLeave.bind(this))
+    document.addEventListener('dragenter', this.onDragEnter.bind(this))
   }
 
   /**
-   * Handles the users entering the area where they can drop their files
+   * Handles the users entering elements on the page
    *
-   * Reveals the drop zone if the user components accepts what the user
-   * is dragging
+   * Because of Safari's lack of support for `relatedTarget` on `dragleave`,
+   * we need to use this both to reveal the drop zone when user's cursor enter it,
+   * and hide it when leaving (ie. entering another element).
+   * https://bugs.webkit.org/show_bug.cgi?id=66547
    *
    * @param {DragEvent} event - The `dragenter` event
    */
   onDragEnter(event) {
-    // TypeScript anticipates that `event.dataTransfer` may be `null`
-    // so we need to check for falsiness first
-    if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
-      this.$wrapper.classList.add('govuk-file-upload-wrapper--show-dropzone')
-    }
-  }
-
-  /**
-   * Hides the drop zone visually when users mouse leave it
-   *
-   * `dragleave` events will fire for each element that the user moves
-   * their move out of. We only want to remove the styling when
-   * they either leave the wrapper or the window altogether
-   *
-   * @param {DragEvent} event - The `dragleave` event
-   */
-  onDragLeave(event) {
-    // `relatedTarget` is only an `EventTarget` so we need to check if it's :
-    // - it's a `Node` in which case we'd still be on the page
-    // - something else in which case user has left the page
-    const relatedTarget =
-      event.relatedTarget instanceof Node ? event.relatedTarget : null
-
-    const leavesWindow = !relatedTarget
-    const leavesDropZone = !this.$wrapper.contains(relatedTarget)
-    if (leavesWindow || leavesDropZone) {
-      this.$wrapper.classList.remove('govuk-file-upload-wrapper--show-dropzone')
+    // DOM interfaces only type `event.target` as `EventTarget`
+    // so we first need to make sure it's a `Node`
+    if (event.target instanceof Node) {
+      if (this.$wrapper.contains(event.target)) {
+        if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
+          this.$wrapper.classList.add(
+            'govuk-file-upload-wrapper--show-dropzone'
+          )
+        }
+      } else {
+        this.$wrapper.classList.remove(
+          'govuk-file-upload-wrapper--show-dropzone'
+        )
+      }
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -29,6 +29,9 @@ export class FileUpload extends ConfigurableComponent {
   /** @private */
   i18n
 
+  /** @private */
+  id
+
   /**
    * @param {Element | null} $root - File input element
    * @param {FileUploadConfig} [config] - File Upload config
@@ -59,7 +62,11 @@ export class FileUpload extends ConfigurableComponent {
     })
 
     this.$label = this.findLabel()
-    this.$label.setAttribute('id', `${this.$root.getAttribute('id')}-label`)
+
+    // we need to copy the 'id' of the root element
+    // to the new button replacement element
+    // so that focus will work in the error summary
+    this.$root.id = `${this.id}-input`
 
     // Wrapping element. This defines the boundaries of our drag and drop area.
     const $wrapper = document.createElement('div')
@@ -69,6 +76,7 @@ export class FileUpload extends ConfigurableComponent {
     const $button = document.createElement('button')
     $button.classList.add('govuk-file-upload__button')
     $button.type = 'button'
+    $button.id = this.id
 
     const buttonSpan = document.createElement('span')
     buttonSpan.className =
@@ -268,7 +276,7 @@ export class FileUpload extends ConfigurableComponent {
    * When the button is clicked, emulate clicking the actual, hidden file input
    */
   onClick() {
-    this.$label.click()
+    this.$root.click()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -114,10 +114,6 @@ export class FileUpload extends ConfigurableComponent {
    * Check if the value of the underlying input has changed
    */
   onChange() {
-    if (!('files' in this.$root)) {
-      return
-    }
-
     if (!this.$root.files) {
       return
     }
@@ -196,13 +192,6 @@ export class FileUpload extends ConfigurableComponent {
    * Synchronise the `disabled` state between the input and replacement button.
    */
   updateDisabledState() {
-    if (
-      !(this.$root instanceof HTMLInputElement) ||
-      !(this.$button instanceof HTMLButtonElement)
-    ) {
-      return
-    }
-
     this.$button.disabled = this.$root.disabled
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -106,8 +106,7 @@ export class FileUpload extends GOVUKFrontendComponent {
     this.$button = $button
     this.$status = $status
 
-    // with everything set up, apply attributes to programmatically hide the input
-    this.$root.setAttribute('aria-hidden', 'true')
+    // Prevent the hidden input being tabbed to by keyboard users
     this.$root.setAttribute('tabindex', '-1')
 
     // Bind change event to the underlying input

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -50,14 +50,7 @@ export class FileUpload extends ConfigurableComponent {
       locale: closestAttributeValue(this.$root, 'lang')
     })
 
-    this.$label = document.querySelector(`[for="${this.$root.id}"]`)
-
-    if (!this.$label) {
-      throw new ElementError({
-        component: FileUpload,
-        identifier: 'No label'
-      })
-    }
+    this.$label = this.findLabel()
 
     // Wrapping element. This defines the boundaries of our drag and drop area.
     const $wrapper = document.createElement('div')
@@ -137,12 +130,31 @@ export class FileUpload extends ConfigurableComponent {
   }
 
   /**
+   * Looks up the `<label>` element associated to the field
+   *
+   * @private
+   * @returns {HTMLElement} The `<label>` element associated to the field
+   * @throws {ElementError} If the `<label>` cannot be found
+   */
+  findLabel() {
+    // Use `label` in the selector so TypeScript knows the type fo `HTMLElement`
+    const $label = document.querySelector(`label[for="${this.$root.id}"]`)
+
+    if (!$label) {
+      throw new ElementError({
+        component: FileUpload,
+        identifier: 'No label'
+      })
+    }
+
+    return $label
+  }
+
+  /**
    * When the button is clicked, emulate clicking the actual, hidden file input
    */
   onClick() {
-    if (this.$label instanceof HTMLElement) {
-      this.$label.click()
-    }
+    this.$label.click()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,5 +1,6 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { ConfigurableComponent } from '../../common/configuration.mjs'
+import { formatErrorMessage } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -37,7 +38,10 @@ export class FileUpload extends ConfigurableComponent {
 
     if (this.$root.type !== 'file') {
       throw new ElementError(
-        'File upload: Form field must be an input of type `file`.'
+        formatErrorMessage(
+          FileUpload,
+          'Form field must be an input of type `file`.'
+        )
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,0 +1,228 @@
+import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
+import { mergeConfigs, normaliseDataset } from '../../common/configuration.mjs'
+import { ElementError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+import { I18n } from '../../i18n.mjs'
+
+/**
+ * File upload component
+ *
+ * @preserve
+ */
+export class FileUpload extends GOVUKFrontendComponent {
+  /**
+   * @private
+   * @type {HTMLInputElement}
+   */
+  $input
+
+  /**
+   * @private
+   * @type {HTMLElement}
+   */
+  $wrapper
+
+  /**
+   * @private
+   * @type {HTMLButtonElement}
+   */
+  $button
+
+  /**
+   * @private
+   * @type {HTMLElement}
+   */
+  $status
+
+  /**
+   * @private
+   * @type {FileUploadConfig}
+   */
+  config
+
+  /** @private */
+  i18n
+
+  /**
+   * @param {Element | null} $input - File input element
+   * @param {FileUploadConfig} [config] - File Upload config
+   */
+  constructor($input, config = {}) {
+    super($input)
+
+    if (!($input instanceof HTMLInputElement)) {
+      throw new ElementError({
+        component: FileUpload,
+        element: $input,
+        expectedType: 'HTMLInputElement',
+        identifier: 'Root element (`$module`)'
+      })
+    }
+
+    if ($input.type !== 'file') {
+      throw new ElementError('File upload: Form field must be of type `file`.')
+    }
+
+    this.config = mergeConfigs(
+      FileUpload.defaults,
+      config,
+      normaliseDataset(FileUpload, $input.dataset)
+    )
+
+    this.i18n = new I18n(this.config.i18n, {
+      // Read the fallback if necessary rather than have it set in the defaults
+      locale: closestAttributeValue($input, 'lang')
+    })
+
+    $input.addEventListener('change', this.onChange.bind(this))
+    this.$input = $input
+
+    // Wrapping element. This defines the boundaries of our drag and drop area.
+    const $wrapper = document.createElement('div')
+    $wrapper.className = 'govuk-file-upload-wrapper'
+    $wrapper.addEventListener('dragover', this.onDragOver.bind(this))
+    $wrapper.addEventListener('dragleave', this.onDragLeaveOrDrop.bind(this))
+    $wrapper.addEventListener('drop', this.onDragLeaveOrDrop.bind(this))
+
+    // Create the file selection button
+    const $button = document.createElement('button')
+    $button.className =
+      'govuk-button govuk-button--secondary govuk-file-upload__button'
+    $button.type = 'button'
+    $button.innerText = this.i18n.t('selectFilesButton')
+    $button.addEventListener('click', this.onClick.bind(this))
+
+    // Create status element that shows what/how many files are selected
+    const $status = document.createElement('span')
+    $status.className = 'govuk-body govuk-file-upload__status'
+    $status.innerText = this.i18n.t('filesSelectedDefault')
+    $status.setAttribute('role', 'status')
+
+    // Assemble these all together
+    $wrapper.insertAdjacentElement('beforeend', $button)
+    $wrapper.insertAdjacentElement('beforeend', $status)
+
+    // Inject all this *after* the native file input
+    this.$input.insertAdjacentElement('afterend', $wrapper)
+
+    // Move the native file input to inside of the wrapper
+    $wrapper.insertAdjacentElement('afterbegin', this.$input)
+
+    // Make all these new variables available to the module
+    this.$wrapper = $wrapper
+    this.$button = $button
+    this.$status = $status
+
+    // Bind change event to the underlying input
+    this.$input.addEventListener('change', this.onChange.bind(this))
+  }
+
+  /**
+   * Check if the value of the underlying input has changed
+   */
+  onChange() {
+    if (!this.$input.files) {
+      return
+    }
+
+    const fileCount = this.$input.files.length
+
+    if (fileCount === 0) {
+      // If there are no files, show the default selection text
+      this.$status.innerText = this.i18n.t('filesSelectedDefault')
+    } else if (
+      // If there is 1 file, just show the file name
+      fileCount === 1
+    ) {
+      this.$status.innerText = this.$input.files[0].name
+    } else {
+      // Otherwise, tell the user how many files are selected
+      this.$status.innerText = this.i18n.t('filesSelected', {
+        count: fileCount
+      })
+    }
+  }
+
+  /**
+   * When the button is clicked, emulate clicking the actual, hidden file input
+   */
+  onClick() {
+    this.$input.click()
+  }
+
+  /**
+   * When a file is dragged over the container, show a visual indicator that a
+   * file can be dropped here.
+   */
+  onDragOver() {
+    this.$wrapper.classList.add('govuk-file-upload-wrapper--show-dropzone')
+  }
+
+  /**
+   * When a dragged file leaves the container, or the file is dropped,
+   * remove the visual indicator.
+   */
+  onDragLeaveOrDrop() {
+    this.$wrapper.classList.remove('govuk-file-upload-wrapper--show-dropzone')
+  }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-file-upload'
+
+  /**
+   * File upload default config
+   *
+   * @see {@link FileUploadConfig}
+   * @constant
+   * @type {FileUploadConfig}
+   */
+  static defaults = Object.freeze({
+    i18n: {
+      selectFilesButton: 'Choose file',
+      filesSelectedDefault: 'No file chosen',
+      filesSelected: {
+        one: '%{count} file chosen',
+        other: '%{count} files chosen'
+      }
+    }
+  })
+
+  /**
+   * File upload config schema
+   *
+   * @constant
+   * @satisfies {Schema<FileUploadConfig>}
+   */
+  static schema = Object.freeze({
+    properties: {
+      i18n: { type: 'object' }
+    }
+  })
+}
+
+/**
+ * File upload config
+ *
+ * @see {@link FileUpload.defaults}
+ * @typedef {object} FileUploadConfig
+ * @property {FileUploadTranslations} [i18n=FileUpload.defaults.i18n] - File upload translations
+ */
+
+/**
+ * File upload translations
+ *
+ * @see {@link FileUpload.defaults.i18n}
+ * @typedef {object} FileUploadTranslations
+ *
+ * Messages used by the component
+ * @property {string} [selectFiles] - Text of button that opens file browser
+ * @property {TranslationPluralForms} [filesSelected] - Text indicating how
+ *   many files have been selected
+ */
+
+/**
+ * @import { Schema } from '../../common/configuration.mjs'
+ * @import { TranslationPluralForms } from '../../i18n.mjs'
+ */

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -115,12 +115,13 @@ export class FileUpload extends GOVUKFrontendComponent {
 
     // Bind change event to the underlying input
     this.$root.addEventListener('change', this.onChange.bind(this))
-    this.$wrapper.addEventListener('dragover', this.onDragOver.bind(this))
-    this.$wrapper.addEventListener(
-      'dragleave',
-      this.onDragLeaveOrDrop.bind(this)
-    )
+
+    // When a file is dropped on the input
     this.$wrapper.addEventListener('drop', this.onDragLeaveOrDrop.bind(this))
+
+    // When a file is dragged over the page (or dragged off the page)
+    document.addEventListener('dragover', this.onDragOver.bind(this))
+    document.addEventListener('dragleave', this.onDragLeaveOrDrop.bind(this))
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -78,6 +78,13 @@ export class FileUpload extends ConfigurableComponent {
     $button.type = 'button'
     $button.id = this.id
 
+    // Copy `aria-describedby` if present so hints and errors
+    // are associated to the `<button>`
+    const ariaDescribedBy = this.$root.getAttribute('aria-describedby')
+    if (ariaDescribedBy) {
+      $button.setAttribute('aria-describedby', ariaDescribedBy)
+    }
+
     const buttonSpan = document.createElement('span')
     buttonSpan.className =
       'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -59,6 +59,7 @@ export class FileUpload extends ConfigurableComponent {
     })
 
     this.$label = this.findLabel()
+    this.$label.setAttribute('id', `${this.$root.getAttribute('id')}-label`)
 
     // Wrapping element. This defines the boundaries of our drag and drop area.
     const $wrapper = document.createElement('div')
@@ -73,6 +74,7 @@ export class FileUpload extends ConfigurableComponent {
     buttonSpan.className =
       'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'
     buttonSpan.innerText = this.i18n.t('selectFilesButton')
+    buttonSpan.setAttribute('aria-hidden', 'true')
 
     $button.appendChild(buttonSpan)
     $button.addEventListener('click', this.onClick.bind(this))
@@ -81,13 +83,16 @@ export class FileUpload extends ConfigurableComponent {
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload__status'
     $status.innerText = this.i18n.t('filesSelectedDefault')
-    // $status.setAttribute('aria-hidden', 'true')
+    $status.setAttribute('aria-hidden', 'true')
 
     $button.appendChild($status)
+    $button.setAttribute(
+      'aria-label',
+      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')}, ${this.i18n.t('filesSelectedDefault')}`
+    )
 
     // Assemble these all together
     $wrapper.insertAdjacentElement('beforeend', $button)
-    // $wrapper.insertAdjacentElement('beforeend', $status)
 
     // Inject all this *after* the native file input
     this.$root.insertAdjacentElement('afterend', $wrapper)
@@ -231,6 +236,11 @@ export class FileUpload extends ConfigurableComponent {
         count: fileCount
       })
     }
+
+    this.$button.setAttribute(
+      'aria-label',
+      `${this.$label.innerText}, ${this.i18n.t('selectFilesButton')}, ${this.$status.innerText}`
+    )
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -45,6 +45,14 @@ export class FileUpload extends ConfigurableComponent {
       )
     }
 
+    if (!this.$root.id.length) {
+      throw new ElementError(
+        formatErrorMessage(FileUpload, 'Form field must specify an `id`.')
+      )
+    }
+
+    this.id = this.$root.id
+
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
       locale: closestAttributeValue(this.$root, 'lang')
@@ -58,24 +66,34 @@ export class FileUpload extends ConfigurableComponent {
 
     // Create the file selection button
     const $button = document.createElement('button')
-    $button.className =
-      'govuk-button govuk-button--secondary govuk-file-upload__button'
+    $button.classList.add('govuk-file-upload__button')
     $button.type = 'button'
-    $button.innerText = this.i18n.t('selectFilesButton')
+
+    const buttonSpan = document.createElement('span')
+    buttonSpan.className =
+      'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'
+    buttonSpan.innerText = this.i18n.t('selectFilesButton')
+
+    $button.appendChild(buttonSpan)
     $button.addEventListener('click', this.onClick.bind(this))
 
     // Create status element that shows what/how many files are selected
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload__status'
     $status.innerText = this.i18n.t('filesSelectedDefault')
-    $status.setAttribute('role', 'status')
+    // $status.setAttribute('aria-hidden', 'true')
+
+    $button.appendChild($status)
 
     // Assemble these all together
     $wrapper.insertAdjacentElement('beforeend', $button)
-    $wrapper.insertAdjacentElement('beforeend', $status)
+    // $wrapper.insertAdjacentElement('beforeend', $status)
 
     // Inject all this *after* the native file input
     this.$root.insertAdjacentElement('afterend', $wrapper)
+
+    this.$root.setAttribute('tabindex', '-1')
+    this.$root.setAttribute('aria-hidden', 'true')
 
     // Move the native file input to inside of the wrapper
     $wrapper.insertAdjacentElement('afterbegin', this.$root)
@@ -85,8 +103,8 @@ export class FileUpload extends ConfigurableComponent {
     this.$button = $button
     this.$status = $status
 
-    // Prevent the hidden input being tabbed to by keyboard users
-    this.$root.setAttribute('tabindex', '-1')
+    // Bind change event to the underlying input
+    this.$root.addEventListener('change', this.onChange.bind(this))
 
     // Syncronise the `disabled` state between the button and underlying input
     this.updateDisabledState()

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -74,6 +74,15 @@ export class FileUpload extends GOVUKFrontendComponent {
       locale: closestAttributeValue($input, 'lang')
     })
 
+    this.$label = document.querySelector(`[for="${$input.id}"]`)
+
+    if (!this.$label) {
+      throw new ElementError({
+        componentName: 'File upload',
+        identifier: 'No label'
+      })
+    }
+
     $input.addEventListener('change', this.onChange.bind(this))
     this.$input = $input
 
@@ -147,7 +156,9 @@ export class FileUpload extends GOVUKFrontendComponent {
    * When the button is clicked, emulate clicking the actual, hidden file input
    */
   onClick() {
-    this.$input.click()
+    if (this.$label instanceof HTMLElement) {
+      this.$label.click()
+    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -438,6 +438,34 @@ describe('/components/file-upload', () => {
         })
       })
 
+      describe('aria-describedby', () => {
+        it('copies the `aria-describedby` attribute from the `<input>` to the `<button>`', async () => {
+          await render(
+            page,
+            'file-upload',
+            examples['with error message and hint']
+          )
+
+          const $button = await page.$(buttonSelector)
+          const ariaDescribedBy = await $button.evaluate((el) =>
+            el.getAttribute('aria-describedby')
+          )
+
+          expect(ariaDescribedBy).toBe('file-upload-3-hint file-upload-3-error')
+        })
+
+        it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
+          await render(page, 'file-upload', examples.default)
+
+          const $button = await page.$(buttonSelector)
+          const ariaDescribedBy = await $button.evaluate((el) =>
+            el.getAttribute('aria-describedby')
+          )
+
+          expect(ariaDescribedBy).toBeNull()
+        })
+      })
+
       describe('errors at instantiation', () => {
         let examples
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -288,7 +288,7 @@ describe('/components/file-upload', () => {
           ).resolves.toBe('Entered drop zone')
         })
 
-        it('gets hidden when dropping on the field', async () => {
+        xit('gets hidden when dropping on the field', async () => {
           // Add a little pixel to make sure we're effectively within the element
           await page.mouse.drop(
             { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -413,7 +413,7 @@ describe('/components/file-upload', () => {
               cause: {
                 name: 'ElementError',
                 message:
-                  'File upload: Form field must be an input of type `file`.'
+                  'govuk-file-upload: Form field must be an input of type `file`.'
               }
             })
           })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -1,0 +1,286 @@
+const { render } = require('@govuk-frontend/helpers/puppeteer')
+const { getExamples } = require('@govuk-frontend/lib/components')
+
+const inputSelector = '.govuk-file-upload'
+const wrapperSelector = '.govuk-file-upload-wrapper'
+const buttonSelector = '.govuk-file-upload__button'
+const statusSelector = '.govuk-file-upload__status'
+
+describe('/components/file-upload', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('file-upload')
+  })
+
+  describe('/components/file-upload/preview', () => {
+    describe('when JavaScript is unavailable or fails', () => {
+      beforeAll(async () => {
+        await page.setJavaScriptEnabled(false)
+      })
+
+      afterAll(async () => {
+        await page.setJavaScriptEnabled(true)
+      })
+
+      it('renders an unmodified file input', async () => {
+        await render(page, 'file-upload', examples.default)
+
+        const inputType = await page.$eval(inputSelector, (el) =>
+          el.getAttribute('type')
+        )
+        expect(inputType).toBe('file')
+      })
+
+      it('does not inject additional elements', async () => {
+        await render(page, 'file-upload', examples.default)
+
+        const $wrapperElement = await page.$(wrapperSelector)
+        const $buttonElement = await page.$(buttonSelector)
+        const $statusElement = await page.$(statusSelector)
+
+        expect($wrapperElement).toBeNull()
+        expect($buttonElement).toBeNull()
+        expect($statusElement).toBeNull()
+      })
+    })
+
+    describe('when JavaScript is available', () => {
+      describe('on page load', () => {
+        beforeAll(async () => {
+          await render(page, 'file-upload', examples.default)
+        })
+
+        describe('wrapper element', () => {
+          it('renders the wrapper element', async () => {
+            const wrapperElement = await page.$eval(wrapperSelector, (el) => el)
+
+            expect(wrapperElement).toBeDefined()
+          })
+
+          it('moves the file input inside of the wrapper element', async () => {
+            const inputElementParent = await page.$eval(
+              inputSelector,
+              (el) => el.parentNode
+            )
+            const wrapperElement = await page.$eval(wrapperSelector, (el) => el)
+
+            expect(inputElementParent).toStrictEqual(wrapperElement)
+          })
+        })
+
+        describe('file input', () => {
+          it('sets tabindex to -1', async () => {
+            const inputElementTabindex = await page.$eval(inputSelector, (el) =>
+              el.getAttribute('tabindex')
+            )
+
+            expect(inputElementTabindex).toBe('-1')
+          })
+        })
+
+        describe('choose file button', () => {
+          it('renders the button element', async () => {
+            const buttonElement = await page.$eval(buttonSelector, (el) => el)
+            const buttonElementType = await page.$eval(buttonSelector, (el) =>
+              el.getAttribute('type')
+            )
+
+            expect(buttonElement).toBeDefined()
+            expect(buttonElementType).toBe('button')
+          })
+
+          it('renders the button with default text', async () => {
+            const buttonElementText = await page.$eval(buttonSelector, (el) =>
+              el.innerHTML.trim()
+            )
+
+            expect(buttonElementText).toBe('Choose file')
+          })
+        })
+
+        describe('status element', () => {
+          it('renders the status element', async () => {
+            const statusElement = await page.$eval(statusSelector, (el) => el)
+
+            expect(statusElement).toBeDefined()
+          })
+
+          it('renders the status element with role', async () => {
+            const statusElementRole = await page.$eval(statusSelector, (el) =>
+              el.getAttribute('role')
+            )
+
+            expect(statusElementRole).toBe('status')
+          })
+
+          it('renders the status element with default text', async () => {
+            const statusElementText = await page.$eval(statusSelector, (el) =>
+              el.innerHTML.trim()
+            )
+
+            expect(statusElementText).toBe('No file chosen')
+          })
+        })
+      })
+
+      describe('when clicking the choose file button', () => {
+        it('opens the file picker', async () => {
+          // It doesn't seem to be possible to check if the file picker dialog
+          // opens as an isolated test, so this test clicks the button, tries to
+          // set a value in the file chooser, then checks if that value was set
+          // on the input as expected.
+          const testFilename = 'test.gif'
+          await render(page, 'file-upload', examples.default)
+
+          const [fileChooser] = await Promise.all([
+            page.waitForFileChooser(),
+            page.click(buttonSelector)
+          ])
+
+          await fileChooser.accept([testFilename])
+
+          const inputElementValue = await page.$eval(
+            inputSelector,
+            (el) =>
+              // @ts-ignore
+              el.value
+          )
+
+          // For Windows and backward compatibility, the values of file inputs
+          // are always formatted starting with `C:\\fakepath\\`
+          expect(inputElementValue).toBe(`C:\\fakepath\\${testFilename}`)
+        })
+      })
+
+      describe('when selecting a file', () => {
+        const testFilename = 'fakefile.txt'
+
+        beforeEach(async () => {
+          await render(page, 'file-upload', examples.default)
+
+          const [fileChooser] = await Promise.all([
+            page.waitForFileChooser(),
+            page.click(inputSelector)
+          ])
+          await fileChooser.accept([testFilename])
+        })
+
+        it('updates the file input value', async () => {
+          const inputElementValue = await page.$eval(
+            inputSelector,
+            (el) =>
+              // @ts-ignore
+              el.value
+          )
+
+          const inputElementFiles = await page.$eval(
+            inputSelector,
+            (el) =>
+              // @ts-ignore
+              el.files
+          )
+
+          // For Windows and backward compatibility, the values of file inputs
+          // are always formatted starting with `C:\\fakepath\\`
+          expect(inputElementValue).toBe(`C:\\fakepath\\${testFilename}`)
+
+          // Also check the files object
+          expect(inputElementFiles[0]).toBeDefined()
+        })
+
+        it('updates the filename in the status element', async () => {
+          const statusElementText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
+          )
+
+          expect(statusElementText).toBe(testFilename)
+        })
+      })
+
+      describe('when selecting multiple files', () => {
+        beforeEach(async () => {
+          await render(page, 'file-upload', examples['allows multiple files'])
+
+          const [fileChooser] = await Promise.all([
+            page.waitForFileChooser(),
+            page.click(inputSelector)
+          ])
+          await fileChooser.accept(['testfile1.txt', 'testfile2.pdf'])
+        })
+
+        it('updates the file input value', async () => {
+          const inputElementValue = await page.$eval(
+            inputSelector,
+            (el) =>
+              // @ts-ignore
+              el.value
+          )
+
+          const inputElementFiles = await page.$eval(
+            inputSelector,
+            (el) =>
+              // @ts-ignore
+              el.files
+          )
+
+          // For Windows and backward compatibility, the values of file inputs
+          // are always formatted starting with `C:\\fakepath\\`
+          //
+          // Additionally, `value` will only ever return the first file selected
+          expect(inputElementValue).toBe(`C:\\fakepath\\testfile1.txt`)
+
+          // Also check the files object
+          expect(inputElementFiles[0]).toBeDefined()
+          expect(inputElementFiles[1]).toBeDefined()
+        })
+
+        it('shows the number of files selected in the status element', async () => {
+          const statusElementText = await page.$eval(statusSelector, (el) =>
+            el.innerHTML.trim()
+          )
+
+          expect(statusElementText).toBe('2 files chosen')
+        })
+      })
+
+      describe('i18n', () => {
+        beforeEach(async () => {
+          await render(page, 'file-upload', examples.translated)
+        })
+
+        it('uses the correct translation for the choose file button', async () => {
+          const buttonText = await page.$eval(buttonSelector, (el) =>
+            el.innerHTML.trim()
+          )
+
+          expect(buttonText).toBe('Dewiswch ffeil')
+        })
+
+        describe('status element', () => {
+          it('uses the correct translation when no files are selected', async () => {
+            const statusText = await page.$eval(statusSelector, (el) =>
+              el.innerHTML.trim()
+            )
+
+            expect(statusText).toBe("Dim ffeiliau wedi'u dewis")
+          })
+
+          it('uses the correct translation when multiple files are selected', async () => {
+            const [fileChooser] = await Promise.all([
+              page.waitForFileChooser(),
+              page.click(inputSelector)
+            ])
+            await fileChooser.accept(['testfile1.txt', 'testfile2.pdf'])
+
+            const statusText = await page.$eval(statusSelector, (el) =>
+              el.innerHTML.trim()
+            )
+
+            expect(statusText).toBe("2 ffeil wedi'u dewis")
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -51,7 +51,7 @@ describe('/components/file-upload', () => {
     describe('when JavaScript is available', () => {
       describe('on page load', () => {
         beforeAll(async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
         })
 
         describe('wrapper element', () => {
@@ -126,7 +126,7 @@ describe('/components/file-upload', () => {
             // set a value in the file chooser, then checks if that value was set
             // on the input as expected.
             const testFilename = 'test.gif'
-            await render(page, 'file-upload', examples.default)
+            await render(page, 'file-upload', examples.javascript)
 
             const [fileChooser] = await Promise.all([
               page.waitForFileChooser(),
@@ -153,7 +153,7 @@ describe('/components/file-upload', () => {
         const testFilename = 'fakefile.txt'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
@@ -196,7 +196,13 @@ describe('/components/file-upload', () => {
 
       describe('when selecting multiple files', () => {
         beforeEach(async () => {
-          await render(page, 'file-upload', examples['allows multiple files'])
+          await render(page, 'file-upload', examples.javascript, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('multiple', '')
+            }
+          })
 
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
@@ -258,7 +264,7 @@ describe('/components/file-upload', () => {
           '.govuk-file-upload-wrapper:not(.govuk-file-upload-wrapper--show-dropzone)'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           $wrapper = await page.$('.govuk-file-upload-wrapper')
           wrapperBoundingBox = await $wrapper.boundingBox()
@@ -395,7 +401,13 @@ describe('/components/file-upload', () => {
 
       describe('disabled state syncing', () => {
         it('disables the button if the input is disabled on page load', async () => {
-          await render(page, 'file-upload', examples.disabled)
+          await render(page, 'file-upload', examples.javascript, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('disabled', '')
+            }
+          })
 
           const buttonDisabled = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
@@ -405,7 +417,7 @@ describe('/components/file-upload', () => {
         })
 
         it('disables the button if the input is disabled programatically', async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           await page.$eval(inputSelector, (el) =>
             el.setAttribute('disabled', '')
@@ -419,7 +431,13 @@ describe('/components/file-upload', () => {
         })
 
         it('enables the button if the input is enabled programatically', async () => {
-          await render(page, 'file-upload', examples.disabled)
+          await render(page, 'file-upload', examples.javascript, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('disabled', '')
+            }
+          })
 
           const buttonDisabledBefore = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
@@ -443,7 +461,7 @@ describe('/components/file-upload', () => {
           await render(
             page,
             'file-upload',
-            examples['with error message and hint']
+            examples['javascript, with error message and hint']
           )
 
           const $button = await page.$(buttonSelector)
@@ -455,7 +473,7 @@ describe('/components/file-upload', () => {
         })
 
         it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           const $button = await page.$(buttonSelector)
           const ariaDescribedBy = await $button.evaluate((el) =>
@@ -475,7 +493,7 @@ describe('/components/file-upload', () => {
 
         it('can throw a SupportError if appropriate', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               beforeInitialisation() {
                 document.body.classList.remove('govuk-frontend-supported')
               }
@@ -491,7 +509,7 @@ describe('/components/file-upload', () => {
 
         it('throws when initialised twice', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               async afterInitialisation($root) {
                 const { FileUpload } = await import('govuk-frontend')
                 new FileUpload($root)
@@ -506,7 +524,7 @@ describe('/components/file-upload', () => {
 
         it('throws when $root is not set', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               beforeInitialisation($root) {
                 $root.remove()
               }
@@ -521,7 +539,7 @@ describe('/components/file-upload', () => {
 
         it('throws when receiving the wrong type for $root', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
                 $root.outerHTML = `<svg data-module="govuk-file-upload"></svg>`
@@ -539,7 +557,7 @@ describe('/components/file-upload', () => {
         describe('missing or misconfigured elements', () => {
           it('throws if the input type is not "file"', async () => {
             await expect(
-              render(page, 'file-upload', examples.default, {
+              render(page, 'file-upload', examples.javascript, {
                 beforeInitialisation() {
                   document
                     .querySelector('[type="file"]')
@@ -557,7 +575,7 @@ describe('/components/file-upload', () => {
 
           it('throws if no label is present', async () => {
             await expect(
-              render(page, 'file-upload', examples.default, {
+              render(page, 'file-upload', examples.javascript, {
                 beforeInitialisation() {
                   document.querySelector('label').remove()
                 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -51,7 +51,7 @@ describe('/components/file-upload', () => {
     describe('when JavaScript is available', () => {
       describe('on page load', () => {
         beforeAll(async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
         })
 
         describe('wrapper element', () => {
@@ -126,7 +126,7 @@ describe('/components/file-upload', () => {
             // set a value in the file chooser, then checks if that value was set
             // on the input as expected.
             const testFilename = 'test.gif'
-            await render(page, 'file-upload', examples.javascript)
+            await render(page, 'file-upload', examples.enhanced)
 
             const [fileChooser] = await Promise.all([
               page.waitForFileChooser(),
@@ -153,7 +153,7 @@ describe('/components/file-upload', () => {
         const testFilename = 'fakefile.txt'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
@@ -196,7 +196,7 @@ describe('/components/file-upload', () => {
 
       describe('when selecting multiple files', () => {
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.javascript, {
+          await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
                 .querySelector('[type="file"]')
@@ -264,7 +264,7 @@ describe('/components/file-upload', () => {
           '.govuk-file-upload-wrapper:not(.govuk-file-upload-wrapper--show-dropzone)'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           $wrapper = await page.$('.govuk-file-upload-wrapper')
           wrapperBoundingBox = await $wrapper.boundingBox()
@@ -401,7 +401,7 @@ describe('/components/file-upload', () => {
 
       describe('disabled state syncing', () => {
         it('disables the button if the input is disabled on page load', async () => {
-          await render(page, 'file-upload', examples.javascript, {
+          await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
                 .querySelector('[type="file"]')
@@ -417,7 +417,7 @@ describe('/components/file-upload', () => {
         })
 
         it('disables the button if the input is disabled programatically', async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           await page.$eval(inputSelector, (el) =>
             el.setAttribute('disabled', '')
@@ -431,7 +431,7 @@ describe('/components/file-upload', () => {
         })
 
         it('enables the button if the input is enabled programatically', async () => {
-          await render(page, 'file-upload', examples.javascript, {
+          await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
                 .querySelector('[type="file"]')
@@ -461,7 +461,7 @@ describe('/components/file-upload', () => {
           await render(
             page,
             'file-upload',
-            examples['javascript, with error message and hint']
+            examples['enhanced, with error message and hint']
           )
 
           const $button = await page.$(buttonSelector)
@@ -473,7 +473,7 @@ describe('/components/file-upload', () => {
         })
 
         it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           const $button = await page.$(buttonSelector)
           const ariaDescribedBy = await $button.evaluate((el) =>
@@ -493,7 +493,7 @@ describe('/components/file-upload', () => {
 
         it('can throw a SupportError if appropriate', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               beforeInitialisation() {
                 document.body.classList.remove('govuk-frontend-supported')
               }
@@ -509,7 +509,7 @@ describe('/components/file-upload', () => {
 
         it('throws when initialised twice', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               async afterInitialisation($root) {
                 const { FileUpload } = await import('govuk-frontend')
                 new FileUpload($root)
@@ -524,7 +524,7 @@ describe('/components/file-upload', () => {
 
         it('throws when $root is not set', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               beforeInitialisation($root) {
                 $root.remove()
               }
@@ -539,7 +539,7 @@ describe('/components/file-upload', () => {
 
         it('throws when receiving the wrong type for $root', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
                 $root.outerHTML = `<svg data-module="govuk-file-upload"></svg>`
@@ -557,7 +557,7 @@ describe('/components/file-upload', () => {
         describe('missing or misconfigured elements', () => {
           it('throws if the input type is not "file"', async () => {
             await expect(
-              render(page, 'file-upload', examples.javascript, {
+              render(page, 'file-upload', examples.enhanced, {
                 beforeInitialisation() {
                   document
                     .querySelector('[type="file"]')
@@ -575,7 +575,7 @@ describe('/components/file-upload', () => {
 
           it('throws if no label is present', async () => {
             await expect(
-              render(page, 'file-upload', examples.javascript, {
+              render(page, 'file-upload', examples.enhanced, {
                 beforeInitialisation() {
                   document.querySelector('label').remove()
                 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -111,7 +111,7 @@ describe('/components/file-upload', () => {
             expect(buttonElementText).toBe('Choose file')
             expect(statusElementText).toBe('No file chosen')
             expect(buttonAriaText).toBe(
-              'Upload a file, Choose file, No file chosen'
+              'Upload a file, Choose file or drop file, No file chosen'
             )
           })
         })
@@ -370,7 +370,7 @@ describe('/components/file-upload', () => {
           expect(buttonElementText).toBe('Dewiswch ffeil')
           expect(statusElementText).toBe("Dim ffeiliau wedi'u dewis")
           expect(buttonAriaText).toBe(
-            "Llwythwch ffeil i fyny, Dewiswch ffeil, Dim ffeiliau wedi'u dewis"
+            "Llwythwch ffeil i fyny, Dewiswch ffeil neu ollwng ffeil, Dim ffeiliau wedi'u dewis"
           )
         })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -281,6 +281,51 @@ describe('/components/file-upload', () => {
           })
         })
       })
+
+      describe('disabled state syncing', () => {
+        it('disables the button if the input is disabled on page load', async () => {
+          await render(page, 'file-upload', examples.disabled)
+
+          const buttonDisabled = await page.$eval(buttonSelector, (el) =>
+            el.hasAttribute('disabled')
+          )
+
+          expect(buttonDisabled).toBeTruthy()
+        })
+
+        it('disables the button if the input is disabled programatically', async () => {
+          await render(page, 'file-upload', examples.default)
+
+          await page.$eval(inputSelector, (el) =>
+            el.setAttribute('disabled', '')
+          )
+
+          const buttonDisabledAfter = await page.$eval(buttonSelector, (el) =>
+            el.hasAttribute('disabled')
+          )
+
+          expect(buttonDisabledAfter).toBeTruthy()
+        })
+
+        it('enables the button if the input is enabled programatically', async () => {
+          await render(page, 'file-upload', examples.disabled)
+
+          const buttonDisabledBefore = await page.$eval(buttonSelector, (el) =>
+            el.hasAttribute('disabled')
+          )
+
+          await page.$eval(inputSelector, (el) =>
+            el.removeAttribute('disabled')
+          )
+
+          const buttonDisabledAfter = await page.$eval(buttonSelector, (el) =>
+            el.hasAttribute('disabled')
+          )
+
+          expect(buttonDisabledBefore).toBeTruthy()
+          expect(buttonDisabledAfter).toBeFalsy()
+        })
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -326,6 +326,49 @@ describe('/components/file-upload', () => {
           expect(buttonDisabledAfter).toBeFalsy()
         })
       })
+
+      describe('errors at instantiation', () => {
+        let examples
+
+        beforeAll(async () => {
+          examples = await getExamples('file-upload')
+        })
+
+        describe('missing or misconfigured elements', () => {
+          it('throws if the input type is not "file"', async () => {
+            await expect(
+              render(page, 'file-upload', examples.default, {
+                beforeInitialisation() {
+                  document
+                    .querySelector('[type="file"]')
+                    .setAttribute('type', 'text')
+                }
+              })
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message:
+                  'File upload: Form field must be an input of type `file`.'
+              }
+            })
+          })
+
+          it('throws if no label is present', async () => {
+            await expect(
+              render(page, 'file-upload', examples.default, {
+                beforeInitialisation() {
+                  document.querySelector('label').remove()
+                }
+              })
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message: 'govuk-file-upload: No label not found'
+              }
+            })
+          })
+        })
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -157,6 +157,17 @@ examples:
         text: Upload a file
       formGroup:
         classes: extra-class
+  - name: translated
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Llwythwch ffeil i fyny
+      selectFilesButtonText: Dewiswch ffeil
+      filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
+      filesSelectedText:
+        one: "%{count} ffeil wedi'i dewis"
+        other: "%{count} ffeil wedi'u dewis"
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -174,6 +174,7 @@ examples:
       formGroup:
         classes: extra-class
   - name: javascript
+    screenshot: true
     options:
       id: file-upload-1
       name: file-upload-1

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -116,6 +116,13 @@ examples:
         text: Upload a file
       attributes:
         capture: 'user'
+  - name: is disabled
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      disabled: true
   - name: with hint text
     options:
       id: file-upload-2

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -85,6 +85,10 @@ params:
     type: string
     required: false
     description: The text of the button that opens the file picker. JavaScript enhanced version of the component only. Default is "Choose file".
+  - name: instructionText
+    type: string
+    required: false
+    description: The text of the instruction text that follows the button that opens the file picker. JavaScript enhanced version of the component only. Default is "or drop file".
   - name: filesSelected
     type: object
     required: false
@@ -201,6 +205,7 @@ examples:
       multiple: true
       javascript: true
       selectFilesButtonText: Dewiswch ffeil
+      instructionText: neu ollwng ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
         other: "%{count} ffeil wedi'u dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -163,11 +163,12 @@ examples:
       name: file-upload-1
       label:
         text: Llwythwch ffeil i fyny
+      multiple: true
       selectFilesButtonText: Dewiswch ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
-        one: "%{count} ffeil wedi'i dewis"
         other: "%{count} ffeil wedi'u dewis"
+        one: "%{count} ffeil wedi'i dewis"
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -15,6 +15,10 @@ params:
     type: boolean
     required: false
     description: If `true`, file input will be disabled.
+  - name: multiple
+    type: boolean
+    required: false
+    description: If `true`, a user may select multiple files at the same time. The exact mechanism to do this differs depending on operating system.
   - name: describedBy
     type: string
     required: false
@@ -94,8 +98,7 @@ examples:
       name: file-upload-1
       label:
         text: Upload a file
-      attributes:
-        multiple: true
+      multiple: true
   - name: allows image files only
     options:
       id: file-upload-1

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -77,6 +77,18 @@ params:
             type: string
             required: true
             description: HTML to add after the input. If `html` is provided, the `text` option will be ignored.
+  - name: selectFilesButtonText
+    type: string
+    required: false
+    description: The text of the button that opens the file picker. JavaScript enhanced version of the component only. Default is "Choose file".
+  - name: filesSelected
+    type: object
+    required: false
+    description: The text to display when multiple files has been chosen by the user. JavaScript enhanced version of the component only. The component will replace the `%{count}` placeholder with the number of files selected. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+  - name: filesSelectedDefault
+    type: string
+    required: false
+    description: The text to display when no file has been chosen by the user. JavaScript enhanced version of the component only. Default is "No file chosen".
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -77,6 +77,10 @@ params:
             type: string
             required: true
             description: HTML to add after the input. If `html` is provided, the `text` option will be ignored.
+  - name: javascript
+    type: boolean
+    required: false
+    description: Whether to enable JavaScript enhancements for the component
   - name: selectFilesButtonText
     type: string
     required: false
@@ -169,6 +173,14 @@ examples:
         text: Upload a file
       formGroup:
         classes: extra-class
+  - name: javascript
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      javascript: true
+      multiple: true
   - name: translated
     options:
       id: file-upload-1
@@ -176,6 +188,7 @@ examples:
       label:
         text: Llwythwch ffeil i fyny
       multiple: true
+      javascript: true
       selectFilesButtonText: Dewiswch ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
@@ -264,3 +277,16 @@ examples:
         text: Error message
       hint:
         text: hint
+  - name: translated, no javascript enhancement
+    hidden: true
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Llwythwch ffeil i fyny
+      multiple: true
+      selectFilesButtonText: Dewiswch ffeil
+      filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
+      filesSelectedText:
+        other: "%{count} ffeil wedi'u dewis"
+        one: "%{count} ffeil wedi'i dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -88,6 +88,31 @@ examples:
       name: file-upload-1
       label:
         text: Upload a file
+  - name: allows multiple files
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      attributes:
+        multiple: true
+  - name: allows image files only
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      attributes:
+        accept: 'image/*'
+  - name: allows direct media capture
+    description: Currently only works on mobile devices.
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      attributes:
+        capture: 'user'
   - name: with hint text
     options:
       id: file-upload-2
@@ -106,13 +131,6 @@ examples:
         text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       errorMessage:
         text: Error message goes here
-  - name: with value
-    options:
-      id: file-upload-4
-      name: file-upload-4
-      value: C:\fakepath\myphoto.jpg
-      label:
-        text: Upload a photo
   - name: with label as page heading
     options:
       id: file-upload-1
@@ -131,6 +149,14 @@ examples:
         classes: extra-class
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: with value
+    hidden: true
+    options:
+      id: file-upload-4
+      name: file-upload-4
+      value: C:\fakepath\myphoto.jpg
+      label:
+        text: Upload a photo
   - name: attributes
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -173,7 +173,7 @@ examples:
         text: Upload a file
       formGroup:
         classes: extra-class
-  - name: javascript
+  - name: enhanced
     screenshot: true
     options:
       id: file-upload-1
@@ -181,6 +181,17 @@ examples:
       label:
         text: Upload a file
       javascript: true
+  - name: enhanced, with error message and hint
+    options:
+      javascript: true
+      id: file-upload-3
+      name: file-upload-3
+      label:
+        text: Upload a file
+      hint:
+        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+      errorMessage:
+        text: Error message goes here
   - name: translated
     options:
       id: file-upload-1
@@ -277,18 +288,6 @@ examples:
         text: Error message
       hint:
         text: hint
-  - name: javascript, with error message and hint
-    hidden: true
-    options:
-      javascript: true
-      id: file-upload-3
-      name: file-upload-3
-      label:
-        text: Upload a file
-      hint:
-        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
-      errorMessage:
-        text: Error message goes here
   - name: translated, no javascript enhancement
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -180,7 +180,6 @@ examples:
       label:
         text: Upload a file
       javascript: true
-      multiple: true
   - name: translated
     options:
       id: file-upload-1
@@ -277,6 +276,18 @@ examples:
         text: Error message
       hint:
         text: hint
+  - name: javascript, with error message and hint
+    hidden: true
+    options:
+      javascript: true
+      id: file-upload-3
+      name: file-upload-3
+      label:
+        text: Upload a file
+      hint:
+        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+      errorMessage:
+        text: Error message goes here
   - name: translated, no javascript enhancement
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -128,7 +128,7 @@ examples:
         text: Upload a file
       attributes:
         capture: 'user'
-  - name: is disabled
+  - name: disabled
     options:
       id: file-upload-1
       name: file-upload-1

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -60,7 +60,7 @@
   }) -}}
   {{- govukI18nAttributes({
     key: 'files-selected',
-    message: params.filesSelectedText
+    messages: params.filesSelectedText
   }) -}}
   {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -45,23 +45,27 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file" data-module="govuk-file-upload"
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if params.multiple %} multiple{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {{- govukI18nAttributes({
-    key: 'select-files-button',
-    message: params.selectFilesButtonText
-  }) -}}
-  {{- govukI18nAttributes({
-    key: 'files-selected-default',
-    message: params.filesSelectedDefaultText
-  }) -}}
-  {{- govukI18nAttributes({
-    key: 'files-selected',
-    messages: params.filesSelectedText
-  }) -}}
+  {%- if params.javascript %}
+    data-module="govuk-file-upload"
+
+    {{- govukI18nAttributes({
+      key: 'select-files-button',
+      message: params.selectFilesButtonText
+    }) -}}
+    {{- govukI18nAttributes({
+      key: 'files-selected-default',
+      message: params.filesSelectedDefaultText
+    }) -}}
+    {{- govukI18nAttributes({
+      key: 'files-selected',
+      messages: params.filesSelectedText
+    }) -}}
+  {%- endif %}
   {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -44,7 +44,7 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file" data-module="govuk-file-upload"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -1,4 +1,5 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
+{% from "../../macros/i18n.njk" import govukI18nAttributes %}
 {% from "../error-message/macro.njk" import govukErrorMessage %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
@@ -49,6 +50,18 @@
   {%- if params.disabled %} disabled{% endif %}
   {%- if params.multiple %} multiple{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {{- govukI18nAttributes({
+    key: 'select-files-button',
+    message: params.selectFilesButtonText
+  }) -}}
+  {{- govukI18nAttributes({
+    key: 'files-selected-default',
+    message: params.filesSelectedDefaultText
+  }) -}}
+  {{- govukI18nAttributes({
+    key: 'files-selected',
+    message: params.filesSelectedText
+  }) -}}
   {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -65,6 +65,10 @@
       key: 'files-selected',
       messages: params.filesSelectedText
     }) -}}
+    {{- govukI18nAttributes({
+      key: 'instruction',
+      message: params.instructionText
+    }) -}}    
   {%- endif %}
   {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -47,6 +47,7 @@
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file" data-module="govuk-file-upload"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
+  {%- if params.multiple %} multiple{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -45,14 +45,10 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"
-  {%- if params.value %} value="{{ params.value }}"{% endif %}
-  {%- if params.disabled %} disabled{% endif %}
-  {%- if params.multiple %} multiple{% endif %}
-  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {%- if params.javascript %}
+{% if params.javascript %}
+  <div
+    class="govuk-file-upload-wrapper"
     data-module="govuk-file-upload"
-
     {{- govukI18nAttributes({
       key: 'select-files-button',
       message: params.selectFilesButtonText
@@ -68,9 +64,18 @@
     {{- govukI18nAttributes({
       key: 'instruction',
       message: params.instructionText
-    }) -}}    
-  {%- endif %}
+    }) -}}
+  >
+{% endif %}
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"
+  {%- if params.value %} value="{{ params.value }}"{% endif %}
+  {%- if params.disabled %} disabled{% endif %}
+  {%- if params.multiple %} multiple{% endif %}
+  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {{- govukAttributes(params.attributes) }}>
+{% if params.javascript %}
+  </div>
+{% endif %}
 {% if params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -74,6 +74,13 @@ describe('File upload', () => {
       expect($component.attr('multiple')).toBeTruthy()
     })
 
+    it('renders with multiple', () => {
+      const $ = render('file-upload', examples['is disabled'])
+
+      const $component = $('.govuk-file-upload')
+      expect($component.attr('disabled')).toBeTruthy()
+    })
+
     it('renders with attributes', () => {
       const $ = render('file-upload', examples.attributes)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -224,37 +224,37 @@ describe('File upload', () => {
       expect($input.attr('data-module')).toBeUndefined()
     })
 
-    it('adds the data-module attribute to the input when `true`', () => {
+    it('adds the data-module attribute to the wrapper when `true`', () => {
       const $ = render('file-upload', examples.enhanced)
 
-      const $input = $('.govuk-form-group > .govuk-file-upload')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
-      expect($input.attr('data-module')).toBe('govuk-file-upload')
+      expect($wrapper.attr('data-module')).toBe('govuk-file-upload')
     })
 
     it('adds the data-module attribute when receiving an object', () => {
       const $ = render('file-upload', examples.translated)
 
-      const $input = $('.govuk-form-group > .govuk-file-upload')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
-      expect($input.attr('data-module')).toBe('govuk-file-upload')
+      expect($wrapper.attr('data-module')).toBe('govuk-file-upload')
     })
 
     it('enables the rendering of translation messages when true', () => {
       const $ = render('file-upload', examples.translated)
 
-      const $input = $('.govuk-form-group > .govuk-file-upload')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
-      expect($input.attr('data-i18n.select-files-button')).toBe(
+      expect($wrapper.attr('data-i18n.select-files-button')).toBe(
         'Dewiswch ffeil'
       )
-      expect($input.attr('data-i18n.files-selected-default')).toBe(
+      expect($wrapper.attr('data-i18n.files-selected-default')).toBe(
         "Dim ffeiliau wedi'u dewis"
       )
-      expect($input.attr('data-i18n.files-selected.one')).toBe(
+      expect($wrapper.attr('data-i18n.files-selected.one')).toBe(
         "%{count} ffeil wedi'i dewis"
       )
-      expect($input.attr('data-i18n.files-selected.other')).toBe(
+      expect($wrapper.attr('data-i18n.files-selected.other')).toBe(
         "%{count} ffeil wedi'u dewis"
       )
     })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -216,6 +216,64 @@ describe('File upload', () => {
     })
   })
 
+  describe('`javascript` option', () => {
+    it('is falsy by default', () => {
+      const $ = render('file-upload', examples.javascript)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload input')
+      expect($input.attr('data-module')).toBeUndefined()
+    })
+
+    it('adds the data-module attribute to the input when `true`', () => {
+      const $ = render('file-upload', examples.javascript)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-module')).toBe('govuk-file-upload')
+    })
+
+    it('adds the data-module attribute when receiving an object', () => {
+      const $ = render('file-upload', examples.translated)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-module')).toBe('govuk-file-upload')
+    })
+
+    it('enables the rendering of translation messages when true', () => {
+      const $ = render('file-upload', examples.translated)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-i18n.select-files-button')).toBe(
+        'Dewiswch ffeil'
+      )
+      expect($input.attr('data-i18n.files-selected-default')).toBe(
+        "Dim ffeiliau wedi'u dewis"
+      )
+      expect($input.attr('data-i18n.files-selected.one')).toBe(
+        "%{count} ffeil wedi'i dewis"
+      )
+      expect($input.attr('data-i18n.files-selected.other')).toBe(
+        "%{count} ffeil wedi'u dewis"
+      )
+    })
+
+    it('prevents the rendering of translation messages when false', () => {
+      const $ = render(
+        'file-upload',
+        examples['translated, no javascript enhancement']
+      )
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-i18n.select-files-button')).toBeUndefined()
+      expect($input.attr('data-i18n.files-selected-default')).toBeUndefined()
+      expect($input.attr('data-i18n.files-selected.one')).toBeUndefined()
+      expect($input.attr('data-i18n.files-selected.other')).toBeUndefined()
+    })
+  })
+
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('file-upload', examples.error)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -74,8 +74,8 @@ describe('File upload', () => {
       expect($component.attr('multiple')).toBeTruthy()
     })
 
-    it('renders with multiple', () => {
-      const $ = render('file-upload', examples['is disabled'])
+    it('renders with disabled', () => {
+      const $ = render('file-upload', examples.disabled)
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('disabled')).toBeTruthy()

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -67,6 +67,13 @@ describe('File upload', () => {
       expect($component.attr('aria-describedby')).toMatch('test-target-element')
     })
 
+    it('renders with multiple', () => {
+      const $ = render('file-upload', examples['allows multiple files'])
+
+      const $component = $('.govuk-file-upload')
+      expect($component.attr('multiple')).toBeTruthy()
+    })
+
     it('renders with attributes', () => {
       const $ = render('file-upload', examples.attributes)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -225,7 +225,7 @@ describe('File upload', () => {
     })
 
     it('adds the data-module attribute to the input when `true`', () => {
-      const $ = render('file-upload', examples.javascript)
+      const $ = render('file-upload', examples.enhanced)
 
       const $input = $('.govuk-form-group > .govuk-file-upload')
 

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -14,6 +14,7 @@ jest.mock(`./components/character-count/character-count.mjs`)
 jest.mock(`./components/checkboxes/checkboxes.mjs`)
 jest.mock(`./components/error-summary/error-summary.mjs`)
 jest.mock(`./components/exit-this-page/exit-this-page.mjs`)
+jest.mock(`./components/file-upload/file-upload.mjs`)
 jest.mock(`./components/header/header.mjs`)
 jest.mock(`./components/notification-banner/notification-banner.mjs`)
 jest.mock(`./components/password-input/password-input.mjs`)
@@ -38,6 +39,7 @@ describe('initAll', () => {
     'character-count',
     'error-summary',
     'exit-this-page',
+    'file-upload',
     'notification-banner',
     'password-input'
   ]

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -5,6 +5,7 @@ import { CharacterCount } from './components/character-count/character-count.mjs
 import { Checkboxes } from './components/checkboxes/checkboxes.mjs'
 import { ErrorSummary } from './components/error-summary/error-summary.mjs'
 import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs'
+import { FileUpload } from './components/file-upload/file-upload.mjs'
 import { Header } from './components/header/header.mjs'
 import { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
 import { PasswordInput } from './components/password-input/password-input.mjs'
@@ -44,6 +45,7 @@ function initAll(config) {
     [Checkboxes],
     [ErrorSummary, config.errorSummary],
     [ExitThisPage, config.exitThisPage],
+    [FileUpload, config.fileUpload],
     [Header],
     [NotificationBanner, config.notificationBanner],
     [PasswordInput, config.passwordInput],
@@ -176,6 +178,7 @@ export { initAll, createAll }
  * @property {CharacterCountConfig} [characterCount] - Character Count config
  * @property {ErrorSummaryConfig} [errorSummary] - Error Summary config
  * @property {ExitThisPageConfig} [exitThisPage] - Exit This Page config
+ * @property {FileUploadConfig} [fileUpload] - File Upload config
  * @property {NotificationBannerConfig} [notificationBanner] - Notification Banner config
  * @property {PasswordInputConfig} [passwordInput] - Password input config
  */
@@ -190,6 +193,7 @@ export { initAll, createAll }
  * @import { ExitThisPageConfig } from './components/exit-this-page/exit-this-page.mjs'
  * @import { NotificationBannerConfig } from './components/notification-banner/notification-banner.mjs'
  * @import { PasswordInputConfig } from './components/password-input/password-input.mjs'
+ * @import { FileUploadConfig } from './components/file-upload/file-upload.mjs'
  */
 
 /**

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -196,6 +196,7 @@ describe('packages/govuk-frontend/dist/', () => {
           export { Checkboxes } from './components/checkboxes/checkboxes.mjs';
           export { ErrorSummary } from './components/error-summary/error-summary.mjs';
           export { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs';
+          export { FileUpload } from './components/file-upload/file-upload.mjs';
           export { Header } from './components/header/header.mjs';
           export { NotificationBanner } from './components/notification-banner/notification-banner.mjs';
           export { PasswordInput } from './components/password-input/password-input.mjs';


### PR DESCRIPTION
Adds a [JavaScript enhancement to the File upload component](https://design-system.service.gov.uk/components/file-upload/#using-the-improved-file-upload-component) which:

- makes the component easier to use for drag and drop
- allows the text of the component to be translated
- fixes [accessibility issues for users of Dragon](https://github.com/alphagov/govuk-frontend/issues/3686), a speech recognition software

![Screenshot of the enhanced file upload component, showing a dash-bordered area fencing a 'No file chosen' message over a blue background, full width above a 'Chose file' secondary button and 'or drop file' instructions](https://github.com/user-attachments/assets/a0c8e902-590b-457a-807f-1bee6098eeac)

## Changes

- A new `FileUpload` component is available in JavaScript, which replaces the native file `<input>` with a drop-zone providing a visible area for people to drop their files and a button they can activate via keyboard, mouse or touch to open a file picker
- Accompanying updates to the Sass file for the File upload component so that the drop-zone and button are presented correctly when CSS has loaded. 
- A new `javascript` option for the Nunjucks macro to enable the enhancement, allowing us to ship this as a non-breaking change. The feature will be enabled by default in the next major release.
- New translation options for the Nunjucks macro to allow users to customise all the texts of the enhanced File upload (whether for translation or to adapt the texts to their specific situation).


This work was initiated as a spike in this PR and completed by merging the work from #5626.