### PR TITLE
Remove non-operational value parameter from file upload component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ The component is now output as a link if the `href` parameter is set. Otherwise,
 
 This means it's no longer possible to use `input` elements for buttons. Buttons using `input` are less flexible than `button` elements in terms of styling and content allowed within them, so we want to avoid using them.
 
-This change was introduced in [pull request #6383: Remove element parameter from Button component](https://github.com/alphagov/govuk-frontend/pull/6383)
+This change was introduced in [pull request #6383: Remove element parameter from Button component](https://github.com/alphagov/govuk-frontend/pull/6383).
 
 #### Stop using `$govuk-canvas-background-colour`
 
@@ -110,6 +110,12 @@ We've reviewed the design of the tag component in response to changes from the n
 Tags now have a 1px border, with the colour based on the background colour of the tag. This makes tags easier to distinguish against white backgrounds.
 
 This change was introduced in [pull request #6379: Add borders to tags](https://github.com/alphagov/govuk-frontend/pull/6379)
+
+#### Other fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5311 Remove non-operational value parameter from file upload component](https://github.com/alphagov/govuk-frontend/pull/5311)
 
 ## v6.0.0-beta.0 (Beta breaking release)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -7,11 +7,6 @@ params:
     type: string
     required: false
     description: The ID of the input. Defaults to the value of `name`.
-  - name: value
-    type: string
-    required: false
-    description: Optional initial value of the input.
-    deprecated: '5.7.1'
   - name: disabled
     type: boolean
     required: false
@@ -142,7 +137,6 @@ examples:
         text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       errorMessage:
         text: Error message goes here
-
   - name: with label as page heading
     options:
       id: file-upload-1

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -76,7 +76,6 @@
   >
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"
-  {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if params.multiple %} multiple{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -53,13 +53,6 @@ describe('File upload', () => {
       ).toBeTruthy()
     })
 
-    it('renders with value', () => {
-      const $ = render('file-upload', examples['with value'])
-
-      const $component = $('.govuk-file-upload')
-      expect($component.val()).toBe('C:\\fakepath\\myphoto.jpg')
-    })
-
     it('renders with aria-describedby', () => {
       const $ = render('file-upload', examples['with describedBy'])
 


### PR DESCRIPTION
For security reasons, all contemporary web browsers disallow the `value` attribute to be set to anything other than an empty string, be that via HTML or JavaScript, effectively making it a read only attribute. This parameter has thus never actually done anything other than output a non-functioning HTML attribute value. As such, we should probably get rid of it.

Our tests for this functionality appear to have been passing because it was comparing the value of the HTML attribute against what it was set to, without regarding that the underlying API property didn't match either of them.

## Changes
- Removes the `value` parameter and related code from the component.
- Removes the `value` parameter documentation.
- Removes tests relating to the parameter.

## Thoughts
Would we consider this a breaking change? One the one hand, it's a change to the component API that has been in place since 2017. On the other, it's been non-operational that entire time.

There's a possibility that other services or forks have implemented it, on the basis of the same (flawed) test we had and which may have their own tests fail with its removal. I'm not sure if that speculation is reason enough to consider it breaking, however.