### PR TITLE
Encapsulate check for components support in method

### DIFF
--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
@@ -1,0 +1,44 @@
+import { SupportError } from './errors/index.mjs'
+import { GOVUKFrontendComponent } from './govuk-frontend-component.mjs'
+
+describe('GOVUKFrontendComponent', () => {
+  describe('isSupported()', () => {
+    beforeEach(() => {
+      // Jest does not tidy the JSDOM document between tests
+      // so we need to take care of that ourselves
+      document.documentElement.innerHTML = ''
+    })
+
+    describe('default implementation', () => {
+      class ServiceComponent extends GOVUKFrontendComponent {
+        static moduleName = 'app-service-component'
+      }
+
+      it('Makes initialisation throw if GOV.UK Frontend is not supported', () => {
+        expect(() => new ServiceComponent(document.body)).toThrow(SupportError)
+      })
+
+      it('Allows initialisation if GOV.UK Frontend is supported', () => {
+        document.body.classList.add('govuk-frontend-supported')
+
+        expect(() => new ServiceComponent(document.body)).not.toThrow()
+      })
+    })
+
+    describe('when overriden', () => {
+      it('Allows child classes to define their own condition for support', () => {
+        class ServiceComponent extends GOVUKFrontendComponent {
+          static moduleName = 'app-service-component'
+
+          isSupported() {
+            return true
+          }
+        }
+
+        expect(() => new ServiceComponent(document.body)).not.toThrow(
+          SupportError
+        )
+      })
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -47,15 +47,25 @@ export class GOVUKFrontendComponent {
   }
 
   /**
-   * Validates whether GOV.UK Frontend is supported
+   * Validates whether components are supported
    *
    * @private
-   * @throws {SupportError} when GOV.UK Frontend is not supported
+   * @throws {SupportError} when the components are not supported
    */
   checkSupport() {
-    if (!isSupported()) {
+    if (!this.isSupported()) {
       throw new SupportError()
     }
+  }
+
+  /**
+   * Defines whether the components are supported
+   *
+   * @protected
+   * @returns {boolean} whether the components are supported
+   */
+  isSupported() {
+    return isSupported()
   }
 }
 


### PR DESCRIPTION
This will allow subclasses of `GOVUKFrontendComponent` to override when components are supported, possibly combining it with when GOV.UK Frontend itself is supported.