### PR TITLE
Deprecate File upload component's `value` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Recommended changes
+
+#### Stop setting a `value` for File upload components
+
+The File upload component currently supports a `value` parameter, which populates the `value` HTML attribute of the input.
+
+However, since no modern browser supports passing a `value` to a file input, we've made the decision to remove this parameter. It has been deprecated and will be removed in a future version of GOV.UK Frontend.
+
+We introduced this change in [pull request #5330: Deprecate File upload component's `value` parameter](https://github.com/alphagov/govuk-frontend/pull/5330).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -10,7 +10,7 @@ params:
   - name: value
     type: string
     required: false
-    description: Optional initial value of the input.
+    description: Deprecated. Optional initial value of the input.
   - name: disabled
     type: boolean
     required: false


### PR DESCRIPTION
Deprecates the `value` parameter on the File upload component's Nunjucks macro, as a precursor to removing it with https://github.com/alphagov/govuk-frontend/pull/5311. 

Although it is likely to be safe to remove the parameter immediately, as it's already non-functional in all modern browsers, we're playing it safe and putting it through the normal deprecation and removal process just in case any implementations or ports expect the parameter to exist.

## Changes
- Marks the parameter as deprecated in Nunjucks macro documentation.
- Adds a changelog entry recommending that users remove it, if it's being used.