### PR TITLE
Fix Warning Text font weight when `<strong>` styles are reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5278: Fix service navigation mobile toggle spacing](https://github.com/alphagov/govuk-frontend/pull/5278)
+- [#5331: Fix Warning Text font weight when <strong> styles are reset](https://github.com/alphagov/govuk-frontend/pull/5331)
 
 ## v5.6.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
@@ -2,14 +2,12 @@
   .govuk-warning-text {
     @include govuk-font($size: 19);
     @include govuk-responsive-margin(6, "bottom");
+    @include govuk-typography-weight-bold;
     position: relative;
     padding: govuk-spacing(2) 0;
   }
 
   .govuk-warning-text__icon {
-    // We apply this here and not at the parent level because the actual text is
-    // a <strong> and so will always be bold
-    @include govuk-typography-weight-bold;
     box-sizing: border-box;
 
     display: inline-block;
@@ -57,5 +55,8 @@
     @include govuk-text-colour;
     display: block;
     padding-left: 45px;
+    // While `<strong>` is styled `bold` or `bolder` by user-agents
+    // this can be reset by the app's stylesheet
+    font-weight: inherit;
   }
 }


### PR DESCRIPTION
There's no guarantee browser defaults of `bold` or `bolder` have not been overriden so we need to set the font-weight explicitely.

## Thoughts

Rather than reverting to having both the `.govuk-warning-text__icon` and `.govuk-warning-text__text` each have a `font-weight` (as [they used to before v5.0.0](https://github.com/alphagov/govuk-frontend/commit/18caff508c0cb45207f63312c03cf92f77f7e276#diff-245553285fc1127f05c68705df40d7fdf95abebef3173eab71ea6b4d8bf89546)), I took the opportunity to regroup the font configuration in `.govuk-warning-text` and explicitely solve the problem that `strong` may not have the right font-weight set. 

I think this clarifies intentions that 'we want this component to be in 19px bold' but `<strong>` gets in the way so we solve that particular issue.

Closes #5279