### PR TITLE
Improve how licence description wraps in the footer

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -67,7 +67,11 @@
   }
 
   .govuk-footer__licence-description {
+    // This makes the license description reflow under the logo when space gets too narrow
     display: inline-block;
+    // This prevents the description from having orphans when space is narrow enough
+    // and makes the text reflow more nicely
+    text-wrap: balance;
   }
 
   .govuk-footer__copyright-logo {


### PR DESCRIPTION
Proposal for fixing the awkward orphan appearing in the licence description when the new typographic scale is enabled by using [`text-wrap: balance`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#balance) to let the browser balance the text of the description.

## Screenshots

<table>
	<tr>
		<th>Before</th>
		<th>After</th>
	</tr>
	<tr>
		<td><img width="1624" alt="Licence description in the footer with 'stated' on its own in a second line" src="https://github.com/user-attachments/assets/3c9dee31-460f-4acf-8042-d8e1226f6ccf"></td>
		<td>
<img width="1624" alt="Licence description wrapping on two balanced lines" src="https://github.com/user-attachments/assets/4fa23800-29e0-412f-a9c8-2735445e6db7">
		</td>
	<tr>
</table>

## Thoughts

This would only work in [browsers that support the feature](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#browser_compatibility), but it feels an efficient way to enhance the footer. As a bonus, it also looks overal more visually more balanced with the crest on the right hand side.

An alternative would be to amend the content, which we could do anyway but:
* there would be a viewport size where an awkward orphan will appear in any case and `text-wrap: balance` will help at that point
* with people able to set custom content for that description, `text-wrap: balance` will add some safety that it will reflow OK

## Questions

* Are we happy with the solution only benefitting only newer browsers. Especially for Safari, supports starts only with 17.5 shipped in May 2024. For Firefox, we're looking at Dec 2023 and Chromium May 2023 (according to [Can I Use](https://caniuse.com/css-text-wrap-balance))? It obviously feels OK to me, based on the scale of the issue it's meant to solve and the fact that we can't control viewport/zoom levels anyway, but would understand if we'd want to look deeper into it.
* Does the design with `text-wrap: balance` look acceptable?
* Does that kind of reflow bring any readability issue due to the whitespace on the right of the content?

Closes #5290.