### PR TITLE
Add `canInitialise` to `GOVUKFrontendComponent`

### DIFF
--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -55,6 +55,13 @@ export class ConfigError extends GOVUKFrontendError {
 }
 
 /**
+ * Indicates that a component encountered a false `canInitialise` function call result
+ */
+export class CanInitError extends GOVUKFrontendError {
+  name = 'CanInitError'
+}
+
+/**
  * Indicates an issue with an element (possibly `null` or `undefined`)
  */
 export class ElementError extends GOVUKFrontendError {

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,5 +1,5 @@
 import { isInitialised, isSupported } from './common/index.mjs'
-import { InitError, SupportError } from './errors/index.mjs'
+import { InitError, SupportError, CanInitError } from './errors/index.mjs'
 
 /**
  * Base Component class
@@ -20,8 +20,18 @@ export class GOVUKFrontendComponent {
     this.checkSupport()
     this.checkInitialised($module)
 
-    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
-      .moduleName
+    const childClassConstructor = /** @type {ChildClassConstructor} */ (
+      this.constructor
+    )
+
+    const moduleName = childClassConstructor.moduleName
+    const canInitialise = childClassConstructor.canInitialise
+
+    if (typeof canInitialise === 'function') {
+      if (!canInitialise()) {
+        throw new CanInitError('`canInitialise` returned `false`')
+      }
+    }
 
     if (typeof moduleName === 'string') {
       moduleName && $module?.setAttribute(`data-${moduleName}-init`, '')
@@ -72,6 +82,7 @@ export class GOVUKFrontendComponent {
 /**
  * @typedef ChildClass
  * @property {string} [moduleName] - The module name that'll be looked for in the DOM when initialising the component
+ * @property {() => boolean} [canInitialise] - The module name that'll be looked for in the DOM when initialising the component
  */
 
 /**


### PR DESCRIPTION
## What

Add `canInitialise` to `GOVUKFrontendComponent` and associated test.

## Why

If user extends `GOVUKFrontendComponent` they can define a function that will be executed before initialisation. If function returns false, then component will not initialise.

Fixes https://github.com/alphagov/govuk-frontend/issues/5225