### PR TITLE
Refactor `ElementError` to use component's `moduleName` instead of `componentName`

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -281,6 +281,18 @@ function isObject(option) {
 }
 
 /**
+ * Format error message
+ *
+ * @internal
+ * @param {ComponentWithModuleName} Component - Component that threw the error
+ * @param {string} message - Error message
+ * @returns {string} - Formatted error message
+ */
+export function formatErrorMessage(Component, message) {
+  return `${Component.moduleName}: ${message}`
+}
+
+/**
  * Schema for component config
  *
  * @typedef {object} Schema
@@ -308,3 +320,16 @@ function isObject(option) {
  * @typedef {keyof ObjectNested} NestedKey
  * @typedef {{ [key: string]: string | boolean | number | ObjectNested | undefined }} ObjectNested
  */
+
+/* eslint-disable jsdoc/valid-types --
+ * `{new(...args: any[] ): object}` is not recognised as valid
+ * https://github.com/gajus/eslint-plugin-jsdoc/issues/145#issuecomment-1308722878
+ * https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/131
+ **/
+
+/**
+ * @typedef ComponentWithModuleName
+ * @property {string} moduleName - Name of the component
+ */
+
+/* eslint-enable jsdoc/valid-types */

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -118,7 +118,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -137,7 +137,7 @@ export class Accordion extends GOVUKFrontendComponent {
     const $sections = this.$root.querySelectorAll(`.${this.sectionClass}`)
     if (!$sections.length) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Sections (\`<div class="${this.sectionClass}">\`)`
       })
     }
@@ -201,7 +201,7 @@ export class Accordion extends GOVUKFrontendComponent {
       const $header = $section.querySelector(`.${this.sectionHeaderClass}`)
       if (!$header) {
         throw new ElementError({
-          componentName: 'Accordion',
+          component: Accordion,
           identifier: `Section headers (\`<div class="${this.sectionHeaderClass}">\`)`
         })
       }
@@ -233,14 +233,14 @@ export class Accordion extends GOVUKFrontendComponent {
 
     if (!$heading) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Section heading (\`.${this.sectionHeadingClass}\`)`
       })
     }
 
     if (!$span) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Section button placeholder (\`<span class="${this.sectionButtonClass}">\`)`
       })
     }
@@ -411,7 +411,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
     if (!$content) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Section content (\`<div class="${this.sectionContentClass}">\`)`
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -739,7 +739,7 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Accordion: Root element (`$root`) not found'
+              message: 'govuk-accordion: Root element (`$root`) not found'
             }
           })
         })
@@ -756,7 +756,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Root element (`$root`) is not of type HTMLElement'
+                'govuk-accordion: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -777,7 +777,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Sections (`<div class="govuk-accordion__section">`) not found'
+                'govuk-accordion: Sections (`<div class="govuk-accordion__section">`) not found'
             }
           })
         })
@@ -798,7 +798,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section headers (`<div class="govuk-accordion__section-header">`) not found'
+                'govuk-accordion: Section headers (`<div class="govuk-accordion__section-header">`) not found'
             }
           })
         })
@@ -817,7 +817,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section heading (`.govuk-accordion__section-heading`) not found'
+                'govuk-accordion: Section heading (`.govuk-accordion__section-heading`) not found'
             }
           })
         })
@@ -836,7 +836,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section button placeholder (`<span class="govuk-accordion__section-button">`) not found'
+                'govuk-accordion: Section button placeholder (`<span class="govuk-accordion__section-button">`) not found'
             }
           })
         })
@@ -855,7 +855,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section content (`<div class="govuk-accordion__section-content">`) not found'
+                'govuk-accordion: Section content (`<div class="govuk-accordion__section-content">`) not found'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -35,7 +35,7 @@ export class Button extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Button',
+        component: Button,
         element: $root,
         identifier: 'Root element (`$root`)'
       })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -355,7 +355,7 @@ describe('/components/button', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Button: Root element (`$root`) not found'
+            message: 'govuk-button: Root element (`$root`) not found'
           }
         })
       })
@@ -371,7 +371,8 @@ describe('/components/button', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Button: Root element (`$root`) is not of type HTMLElement'
+            message:
+              'govuk-button: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -66,7 +66,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Character count',
+        component: CharacterCount,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -80,7 +80,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
       )
     ) {
       throw new ElementError({
-        componentName: 'Character count',
+        component: CharacterCount,
         element: $textarea,
         expectedType: 'HTMLTextareaElement or HTMLInputElement',
         identifier: 'Form field (`.govuk-js-character-count`)'
@@ -133,7 +133,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     const $textareaDescription = document.getElementById(textareaDescriptionId)
     if (!$textareaDescription) {
       throw new ElementError({
-        componentName: 'Character count',
+        component: CharacterCount,
         element: $textareaDescription,
         identifier: `Count message (\`id="${textareaDescriptionId}"\`)`
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -839,7 +839,7 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Character count: Root element (`$root`) not found'
+            message: 'govuk-character-count: Root element (`$root`) not found'
           }
         })
       })
@@ -856,7 +856,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Root element (`$root`) is not of type HTMLElement'
+              'govuk-character-count: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -875,7 +875,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Form field (`.govuk-js-character-count`) not found'
+              'govuk-character-count: Form field (`.govuk-js-character-count`) not found'
           }
         })
       })
@@ -896,7 +896,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Form field (`.govuk-js-character-count`) is not of type HTMLTextareaElement or HTMLInputElement'
+              'govuk-character-count: Form field (`.govuk-js-character-count`) is not of type HTMLTextareaElement or HTMLInputElement'
           }
         })
       })
@@ -915,7 +915,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Count message (`id="more-detail-info"`) not found'
+              'govuk-character-count: Count message (`id="more-detail-info"`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -32,7 +32,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Checkboxes',
+        component: Checkboxes,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -41,7 +41,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
     const $inputs = $root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError({
-        componentName: 'Checkboxes',
+        component: Checkboxes,
         identifier: 'Form inputs (`<input type="checkbox">`)'
       })
     }
@@ -60,7 +60,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
       // Throw if target conditional element does not exist.
       if (!document.getElementById(targetId)) {
         throw new ElementError({
-          componentName: 'Checkboxes',
+          component: Checkboxes,
           identifier: `Conditional reveal (\`id="${targetId}"\`)`
         })
       }

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -394,7 +394,7 @@ describe('Checkboxes', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Checkboxes: Root element (`$root`) not found'
+              message: 'govuk-checkboxes: Root element (`$root`) not found'
             }
           })
         })
@@ -411,7 +411,7 @@ describe('Checkboxes', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Root element (`$root`) is not of type HTMLElement'
+                'govuk-checkboxes: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -432,7 +432,7 @@ describe('Checkboxes', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Form inputs (`<input type="checkbox">`) not found'
+                'govuk-checkboxes: Form inputs (`<input type="checkbox">`) not found'
             }
           })
         })
@@ -451,7 +451,7 @@ describe('Checkboxes', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Conditional reveal (`id="conditional-how-contacted"`) not found'
+                'govuk-checkboxes: Conditional reveal (`id="conditional-how-contacted"`) not found'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -34,7 +34,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Error summary',
+        component: ErrorSummary,
         element: $root,
         identifier: 'Root element (`$root`)'
       })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -263,7 +263,7 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Error summary: Root element (`$root`) not found'
+          message: 'govuk-error-summary: Root element (`$root`) not found'
         }
       })
     })
@@ -280,7 +280,7 @@ describe('Error Summary', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Error summary: Root element (`$root`) is not of type HTMLElement'
+            'govuk-error-summary: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -83,7 +83,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Exit this page',
+        component: ExitThisPage,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -92,7 +92,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     const $button = $root.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
       throw new ElementError({
-        componentName: 'Exit this page',
+        component: ExitThisPage,
         element: $button,
         expectedType: 'HTMLAnchorElement',
         identifier: 'Button (`.govuk-exit-this-page__button`)'

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -258,7 +258,7 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Exit this page: Root element (`$root`) not found'
+            message: 'govuk-exit-this-page: Root element (`$root`) not found'
           }
         })
       })
@@ -275,7 +275,7 @@ describe('/components/exit-this-page', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Exit this page: Root element (`$root`) is not of type HTMLElement'
+              'govuk-exit-this-page: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -294,7 +294,7 @@ describe('/components/exit-this-page', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Exit this page: Button (`.govuk-exit-this-page__button`) not found'
+              'govuk-exit-this-page: Button (`.govuk-exit-this-page__button`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -47,7 +47,7 @@ export class Header extends GOVUKFrontendComponent {
 
     if (!$root) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -66,7 +66,7 @@ export class Header extends GOVUKFrontendComponent {
     const menuId = $menuButton.getAttribute('aria-controls')
     if (!menuId) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         identifier:
           'Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`)'
       })
@@ -75,7 +75,7 @@ export class Header extends GOVUKFrontendComponent {
     const $menu = document.getElementById(menuId)
     if (!$menu) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         element: $menu,
         identifier: `Navigation (\`<ul id="${menuId}">\`)`
       })
@@ -101,7 +101,7 @@ export class Header extends GOVUKFrontendComponent {
 
     if (!breakpoint.value) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -209,7 +209,7 @@ describe('Header navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Header: Root element (`$root`) not found'
+            message: 'govuk-header: Root element (`$root`) not found'
           }
         })
       })
@@ -228,7 +228,7 @@ describe('Header navigation', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Header: Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`) not found'
+              'govuk-header: Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`) not found'
           }
         })
       })
@@ -247,7 +247,8 @@ describe('Header navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Header: Navigation (`<ul id="navigation">`) not found'
+            message:
+              'govuk-header: Navigation (`<ul id="navigation">`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -27,7 +27,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Notification banner',
+        component: NotificationBanner,
         element: $root,
         identifier: 'Root element (`$root`)'
       })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -263,7 +263,7 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Notification banner: Root element (`$root`) not found'
+          message: 'govuk-notification-banner: Root element (`$root`) not found'
         }
       })
     })
@@ -280,7 +280,7 @@ describe('Notification banner', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Notification banner: Root element (`$root`) is not of type HTMLElement'
+            'govuk-notification-banner: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -47,7 +47,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Password input',
+        component: PasswordInput,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -56,7 +56,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     const $input = $root.querySelector('.govuk-js-password-input-input')
     if (!($input instanceof HTMLInputElement)) {
       throw new ElementError({
-        componentName: 'Password input',
+        component: PasswordInput,
         element: $input,
         expectedType: 'HTMLInputElement',
         identifier: 'Form field (`.govuk-js-password-input-input`)'
@@ -74,7 +74,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     )
     if (!($showHideButton instanceof HTMLButtonElement)) {
       throw new ElementError({
-        componentName: 'Password input',
+        component: PasswordInput,
         element: $showHideButton,
         expectedType: 'HTMLButtonElement',
         identifier: 'Button (`.govuk-js-password-input-toggle`)'

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -212,7 +212,7 @@ describe('/components/password-input', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Password input: Root element (`$root`) not found'
+              message: 'govuk-password-input: Root element (`$root`) not found'
             }
           })
         })
@@ -229,7 +229,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Root element (`$root`) is not of type HTMLElement'
+                'govuk-password-input: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -248,7 +248,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Form field (`.govuk-js-password-input-input`) not found'
+                'govuk-password-input: Form field (`.govuk-js-password-input-input`) not found'
             }
           })
         })
@@ -269,7 +269,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Form field (`.govuk-js-password-input-input`) is not of type HTMLInputElement'
+                'govuk-password-input: Form field (`.govuk-js-password-input-input`) is not of type HTMLInputElement'
             }
           })
         })
@@ -308,7 +308,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Button (`.govuk-js-password-input-toggle`) not found'
+                'govuk-password-input: Button (`.govuk-js-password-input-toggle`) not found'
             }
           })
         })
@@ -329,7 +329,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Button (`.govuk-js-password-input-toggle`) is not of type HTMLButtonElement'
+                'govuk-password-input: Button (`.govuk-js-password-input-toggle`) is not of type HTMLButtonElement'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -32,7 +32,7 @@ export class Radios extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Radios',
+        component: Radios,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -41,7 +41,7 @@ export class Radios extends GOVUKFrontendComponent {
     const $inputs = $root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError({
-        componentName: 'Radios',
+        component: Radios,
         identifier: 'Form inputs (`<input type="radio">`)'
       })
     }
@@ -60,7 +60,7 @@ export class Radios extends GOVUKFrontendComponent {
       // Throw if target conditional element does not exist.
       if (!document.getElementById(targetId)) {
         throw new ElementError({
-          componentName: 'Radios',
+          component: Radios,
           identifier: `Conditional reveal (\`id="${targetId}"\`)`
         })
       }

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -346,7 +346,7 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$root`) not found'
+          message: 'govuk-radios: Root element (`$root`) not found'
         }
       })
     })
@@ -362,7 +362,8 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$root`) is not of type HTMLElement'
+          message:
+            'govuk-radios: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })
@@ -380,7 +381,8 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Form inputs (`<input type="radio">`) not found'
+          message:
+            'govuk-radios: Form inputs (`<input type="radio">`) not found'
         }
       })
     })
@@ -396,7 +398,7 @@ describe('Radios', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Radios: Conditional reveal (`id="conditional-how-contacted"`) not found'
+            'govuk-radios: Conditional reveal (`id="conditional-how-contacted"`) not found'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
@@ -43,7 +43,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
 
     if (!$root) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -65,7 +65,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
     const menuId = $menuButton.getAttribute('aria-controls')
     if (!menuId) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         identifier:
           'Navigation button (`<button class="govuk-js-service-navigation-toggle">`) attribute (`aria-controls`)'
       })
@@ -74,7 +74,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
     const $menu = document.getElementById(menuId)
     if (!$menu) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         element: $menu,
         identifier: `Navigation (\`<ul id="${menuId}">\`)`
       })
@@ -100,7 +100,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
 
     if (!breakpoint.value) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
@@ -86,7 +86,8 @@ describe('/components/service-navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Service Navigation: Root element (`$root`) not found'
+            message:
+              'govuk-service-navigation: Root element (`$root`) not found'
           }
         })
       })
@@ -105,7 +106,7 @@ describe('/components/service-navigation', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Service Navigation: Navigation button (`<button class="govuk-js-service-navigation-toggle">`) attribute (`aria-controls`) not found'
+              'govuk-service-navigation: Navigation button (`<button class="govuk-js-service-navigation-toggle">`) attribute (`aria-controls`) not found'
           }
         })
       })
@@ -125,7 +126,7 @@ describe('/components/service-navigation', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Service Navigation: Navigation (`<ul id="navigation">`) not found'
+              'govuk-service-navigation: Navigation (`<ul id="navigation">`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -22,7 +22,7 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLAnchorElement)) {
       throw new ElementError({
-        componentName: 'Skip link',
+        component: SkipLink,
         element: $root,
         expectedType: 'HTMLAnchorElement',
         identifier: 'Root element (`$root`)'
@@ -74,7 +74,7 @@ export class SkipLink extends GOVUKFrontendComponent {
     // Check for link target element
     if (!$linkedElement) {
       throw new ElementError({
-        componentName: 'Skip link',
+        component: SkipLink,
         element: $linkedElement,
         identifier: `Target content (\`id="${linkedElementId}"\`)`
       })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -154,7 +154,7 @@ describe('Skip Link', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Skip link: Root element (`$root`) not found'
+          message: 'govuk-skip-link: Root element (`$root`) not found'
         }
       })
     })
@@ -171,7 +171,7 @@ describe('Skip Link', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Root element (`$root`) is not of type HTMLAnchorElement'
+            'govuk-skip-link: Root element (`$root`) is not of type HTMLAnchorElement'
         }
       })
     })
@@ -188,7 +188,7 @@ describe('Skip Link', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Target content (`id="this-element-does-not-exist"`) not found'
+            'govuk-skip-link: Target content (`id="this-element-does-not-exist"`) not found'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -49,7 +49,7 @@ export class Tabs extends GOVUKFrontendComponent {
 
     if (!$root) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -58,7 +58,7 @@ export class Tabs extends GOVUKFrontendComponent {
     const $tabs = $root.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: 'Links (`<a class="govuk-tabs__tab">`)'
       })
     }
@@ -78,14 +78,14 @@ export class Tabs extends GOVUKFrontendComponent {
 
     if (!$tabList) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: 'List (`<ul class="govuk-tabs__list">`)'
       })
     }
 
     if (!$tabListItems.length) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: 'List items (`<li class="govuk-tabs__list-item">`)'
       })
     }
@@ -106,7 +106,7 @@ export class Tabs extends GOVUKFrontendComponent {
 
     if (!breakpoint.value) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -295,7 +295,7 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: Root element (`$root`) not found'
+            message: 'govuk-tabs: Root element (`$root`) not found'
           }
         })
       })
@@ -313,7 +313,8 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: Links (`<a class="govuk-tabs__tab">`) not found'
+            message:
+              'govuk-tabs: Links (`<a class="govuk-tabs__tab">`) not found'
           }
         })
       })
@@ -333,7 +334,8 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: List (`<ul class="govuk-tabs__list">`) not found'
+            message:
+              'govuk-tabs: List (`<ul class="govuk-tabs__list">`) not found'
           }
         })
       })
@@ -355,7 +357,7 @@ describe('/components/tabs', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Tabs: List items (`<li class="govuk-tabs__list-item">`) not found'
+              'govuk-tabs: List items (`<li class="govuk-tabs__list-item">`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -1,3 +1,5 @@
+import { Accordion } from 'govuk-frontend'
+
 import {
   ElementError,
   GOVUKFrontendError,
@@ -80,7 +82,7 @@ describe('errors', () => {
     it('is an instance of GOVUKFrontendError', () => {
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
           identifier: 'variableName'
         })
       ).toBeInstanceOf(GOVUKFrontendError)
@@ -88,7 +90,15 @@ describe('errors', () => {
     it('has its own name set', () => {
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
+          identifier: 'variableName'
+        }).name
+      ).toBe('ElementError')
+    })
+    it('has name set by Component', () => {
+      expect(
+        new ElementError({
+          component: Accordion,
           identifier: 'variableName'
         }).name
       ).toBe('ElementError')
@@ -101,22 +111,38 @@ describe('errors', () => {
     it('formats the message when the element is not found', () => {
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
           identifier: 'variableName'
         }).message
-      ).toBe('Component name: variableName not found')
+      ).toBe(`${Accordion.moduleName}: variableName not found`)
     })
     it('formats the message when the element is not the right type', () => {
       const $element = document.createElement('div')
 
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
           element: $element,
           expectedType: 'HTMLAnchorElement',
           identifier: 'variableName'
         }).message
-      ).toBe('Component name: variableName is not of type HTMLAnchorElement')
+      ).toBe(
+        `${Accordion.moduleName}: variableName is not of type HTMLAnchorElement`
+      )
+    })
+    it('formats the message when the element is not the right type and Component in config', () => {
+      const $element = document.createElement('div')
+
+      expect(
+        new ElementError({
+          component: Accordion,
+          element: $element,
+          expectedType: 'HTMLAnchorElement',
+          identifier: 'variableName'
+        }).message
+      ).toBe(
+        `${Accordion.moduleName}: variableName is not of type HTMLAnchorElement`
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -1,3 +1,5 @@
+import { formatErrorMessage } from '../common/index.mjs'
+
 /**
  * GOV.UK Frontend error
  *
@@ -81,16 +83,16 @@ export class ElementError extends GOVUKFrontendError {
 
     // Build message from options
     if (typeof messageOrOptions === 'object') {
-      const { componentName, identifier, element, expectedType } =
-        messageOrOptions
+      const { component, identifier, element, expectedType } = messageOrOptions
 
-      // Add prefix and identifier
-      message = `${componentName}: ${identifier}`
+      message = identifier
 
       // Append reason
       message += element
         ? ` is not of type ${expectedType ?? 'HTMLElement'}`
         : ' not found'
+
+      message = formatErrorMessage(component, message)
     }
 
     super(message)
@@ -124,8 +126,8 @@ export class InitError extends GOVUKFrontendError {
  *
  * @internal
  * @typedef {object} ElementErrorOptions
- * @property {string} componentName - The name of the component throwing the error
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
  * @property {Element | null} [element] - The element in error
  * @property {string} [expectedType] - The type that was expected for the identifier
+ * @property {import('../common/index.mjs').ComponentWithModuleName} component - Component throwing the error
  */


### PR DESCRIPTION
## What

Refactor ElementError to use component's `moduleName` instead of `componentName`. New `formatErrorMessage` helper function implemented. Tests updated.

## Why

To enable further refactoring. This will allow us to move functions that throw `ElementError` into `GOVUKFrontendComponent`. 


Fixes https://github.com/alphagov/govuk-frontend/issues/5324