### PR TITLE
`checkSupport` made `static`

### DIFF
--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
@@ -2,7 +2,7 @@ import { SupportError } from './errors/index.mjs'
 import { GOVUKFrontendComponent } from './govuk-frontend-component.mjs'
 
 describe('GOVUKFrontendComponent', () => {
-  describe('isSupported()', () => {
+  describe('checkSupport()', () => {
     beforeEach(() => {
       // Jest does not tidy the JSDOM document between tests
       // so we need to take care of that ourselves
@@ -30,13 +30,14 @@ describe('GOVUKFrontendComponent', () => {
         class ServiceComponent extends GOVUKFrontendComponent {
           static moduleName = 'app-service-component'
 
-          static isSupported() {
-            return true
+          static checkSupport() {
+            throw new Error('Custom error')
           }
         }
 
-        expect(() => new ServiceComponent(document.body)).not.toThrow(
-          SupportError
+        // Use the message rather than the class as `SupportError` extends `Error`
+        expect(() => new ServiceComponent(document.body)).toThrow(
+          'Custom error'
         )
       })
     })

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
@@ -30,7 +30,7 @@ describe('GOVUKFrontendComponent', () => {
         class ServiceComponent extends GOVUKFrontendComponent {
           static moduleName = 'app-service-component'
 
-          isSupported() {
+          static isSupported() {
             return true
           }
         }

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -56,19 +56,9 @@ export class GOVUKFrontendComponent {
    * @throws {SupportError} when the components are not supported
    */
   static checkSupport() {
-    if (!this.isSupported()) {
+    if (!isSupported()) {
       throw new SupportError()
     }
-  }
-
-  /**
-   * Defines whether the components are supported
-   *
-   * @protected
-   * @returns {boolean} whether the components are supported
-   */
-  static isSupported() {
-    return isSupported()
   }
 }
 

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -17,11 +17,15 @@ export class GOVUKFrontendComponent {
    * @param {Element | null} [$root] - HTML element to use for component
    */
   constructor($root) {
-    this.checkSupport()
+    const childConstructor = /** @type {ChildClassConstructor} */ (
+      this.constructor
+    )
+
+    childConstructor.checkSupport()
+
     this.checkInitialised($root)
 
-    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
-      .moduleName
+    const moduleName = childConstructor.moduleName
 
     if (typeof moduleName === 'string') {
       moduleName && $root?.setAttribute(`data-${moduleName}-init`, '')
@@ -49,10 +53,9 @@ export class GOVUKFrontendComponent {
   /**
    * Validates whether components are supported
    *
-   * @private
    * @throws {SupportError} when the components are not supported
    */
-  checkSupport() {
+  static checkSupport() {
     if (!this.isSupported()) {
       throw new SupportError()
     }
@@ -64,7 +67,7 @@ export class GOVUKFrontendComponent {
    * @protected
    * @returns {boolean} whether the components are supported
    */
-  isSupported() {
+  static isSupported() {
     return isSupported()
   }
 }


### PR DESCRIPTION
## What

Specify that `checkSupport` of `GOVUKFrontendComponent` is `static` instead of `private`.

## Why

[Change in approach to how we allow people to run their own function to check if a component is supported.](https://github.com/alphagov/govuk-frontend/issues/5225#issuecomment-2360526691) This change means now components that extend `GOVUKFrontendComponent` can overload `checkSupport` (as can be seen in the tests).

Fixes https://github.com/alphagov/govuk-frontend/issues/5225#issuecomment-2360526691 