### PR TITLE
Rename `$module` to `$root` across the codebase

### DIFF
--- a/docs/contributing/coding-standards/component-options.md
+++ b/docs/contributing/coding-standards/component-options.md
@@ -10,7 +10,7 @@ First, make sure the component class has a constructor parameter for passing in 
 
 ```mjs
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     // ...
   }
 }
@@ -36,7 +36,7 @@ There is no guarantee `config` will have any value at all, so we set the default
 import { mergeConfigs } from '../../common/index.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config
@@ -101,26 +101,26 @@ You can find `data-*` attributes in JavaScript by looking at an element's `datas
 
 See ['Naming configuration options'](#naming-configuration-options) for exceptions to how names are transformed.
 
-As we expect configuration-related `data-*` attributes to always be on the component's root element (the same element with the `data-module` attribute), we can access them all using `$module.dataset`.
+As we expect configuration-related `data-*` attributes to always be on the component's root element (the same element with the `data-module` attribute), we can access them all using `$root.dataset`.
 
-Using the `mergeConfigs` call discussed earlier in this document, update it to include `$module.dataset` as the highest priority.
+Using the `mergeConfigs` call discussed earlier in this document, update it to include `$root.dataset` as the highest priority.
 
 ```mjs
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
   }
 }
 ```
 
-Here, we pass the value of `$module.dataset` through our `normaliseDataset` function. This is because attribute values in dataset are always interpreted as strings. `normaliseDataset` looks at the component's configuration schema and converts values into numbers or booleans where needed.
+Here, we pass the value of `$root.dataset` through our `normaliseDataset` function. This is because attribute values in dataset are always interpreted as strings. `normaliseDataset` looks at the component's configuration schema and converts values into numbers or booleans where needed.
 
 Now, in our HTML, we could pass configuration options by using the kebab-case version of the option's name.
 
@@ -164,11 +164,11 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ConfigError } from '../../errors/index.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
 
     // Check that the configuration provided is valid
@@ -248,11 +248,11 @@ import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
 
     this.stateInfo = extractConfigByNamespace(Accordion, this.config, 'stateInfo');

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -20,20 +20,20 @@ component
  */
 export class Example {
   /**
-   * @param {Element | null} $module - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
-  constructor($module) {
+  constructor($root) {
     if (
-      !($module instanceof HTMLElement) ||
+      !($root instanceof HTMLElement) ||
       !document.body.classList.contains('govuk-frontend-supported')
     ) {
       return this
     }
 
-    this.$module = $module
+    this.$root = $root
 
     // Code goes here
-    this.$module.addEventListener('click', () => {
+    this.$root.addEventListener('click', () => {
       // ...
     })
   }

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -13,21 +13,28 @@ component
 ## Skeleton
 
 ```mjs
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+
 /**
  * Component name
  *
  * @preserve
  */
-export class Example {
+export class Example extends GOVUKFrontendComponent {
   /**
    * @param {Element | null} $root - HTML element to use for component
    */
-  constructor($root) {
-    if (
-      !($root instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
-      return this
+  constructor($root){
+    super($root)
+
+    if (!($root instanceof HTMLElement)) {
+      if (!($root instanceof HTMLElement)) {
+        throw new ElementError({
+          componentName: 'Example',
+          element: $root,
+          identifier: 'Root element (`$root`)'
+        })
+      }
     }
 
     this.$root = $root

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -192,14 +192,14 @@ export function setFocus($element, options = {}) {
  * Checks if component is already initialised
  *
  * @internal
- * @param {Element} $module - HTML element to be checked
+ * @param {Element} $root - HTML element to be checked
  * @param {string} moduleName - name of component module
  * @returns {boolean} Whether component is already initialised
  */
-export function isInitialised($module, moduleName) {
+export function isInitialised($root, moduleName) {
   return (
-    $module instanceof HTMLElement &&
-    $module.hasAttribute(`data-${moduleName}-init`)
+    $root instanceof HTMLElement &&
+    $root.hasAttribute(`data-${moduleName}-init`)
   )
 }
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -20,7 +20,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class Accordion extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -110,31 +110,31 @@ export class Accordion extends GOVUKFrontendComponent {
   $showAllText = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for accordion
+   * @param {Element | null} $root - HTML element to use for accordion
    * @param {AccordionConfig} [config] - Accordion config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Accordion',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)
 
-    const $sections = this.$module.querySelectorAll(`.${this.sectionClass}`)
+    const $sections = this.$root.querySelectorAll(`.${this.sectionClass}`)
     if (!$sections.length) {
       throw new ElementError({
         componentName: 'Accordion',
@@ -171,7 +171,7 @@ export class Accordion extends GOVUKFrontendComponent {
     const $accordionControls = document.createElement('div')
     $accordionControls.setAttribute('class', this.controlsClass)
     $accordionControls.appendChild(this.$showAllButton)
-    this.$module.insertBefore($accordionControls, this.$module.firstChild)
+    this.$root.insertBefore($accordionControls, this.$root.firstChild)
 
     // Build additional wrapper for Show all toggle text and place after icon
     this.$showAllText = document.createElement('span')
@@ -251,7 +251,7 @@ export class Accordion extends GOVUKFrontendComponent {
     $button.setAttribute('type', 'button')
     $button.setAttribute(
       'aria-controls',
-      `${this.$module.id}-content-${index + 1}`
+      `${this.$root.id}-content-${index + 1}`
     )
 
     // Copy all attributes from $span to $button (except `id`, which gets added

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -725,7 +725,7 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             name: 'InitError',
             message:
-              'Root element (`$module`) already initialised (`govuk-accordion`)'
+              'Root element (`$root`) already initialised (`govuk-accordion`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -717,9 +717,9 @@ describe('/components/accordion', () => {
         it('throws when initialised twice', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              async afterInitialisation($module) {
+              async afterInitialisation($root) {
                 const { Accordion } = await import('govuk-frontend')
-                new Accordion($module)
+                new Accordion($root)
               }
             })
           ).rejects.toMatchObject({
@@ -729,34 +729,34 @@ describe('/components/accordion', () => {
           })
         })
 
-        it('throws when $module is not set', async () => {
+        it('throws when $root is not set', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module) {
-                $module.remove()
+              beforeInitialisation($root) {
+                $root.remove()
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Accordion: Root element (`$module`) not found'
+              message: 'Accordion: Root element (`$root`) not found'
             }
           })
         })
 
-        it('throws when receiving the wrong type for $module', async () => {
+        it('throws when receiving the wrong type for $root', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module) {
+              beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-                $module.outerHTML = `<svg data-module="govuk-accordion"></svg>`
+                $root.outerHTML = `<svg data-module="govuk-accordion"></svg>`
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Root element (`$module`) is not of type HTMLElement'
+                'Accordion: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -764,8 +764,8 @@ describe('/components/accordion', () => {
         it('throws when the accordion sections are missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module
+              beforeInitialisation($root, { selector }) {
+                $root
                   .querySelectorAll(selector)
                   .forEach((item) => item.remove())
               },
@@ -785,8 +785,8 @@ describe('/components/accordion', () => {
         it('throws when section header is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module
+              beforeInitialisation($root, { selector }) {
+                $root
                   .querySelectorAll(selector)
                   .forEach((item) => item.remove())
               },
@@ -806,8 +806,8 @@ describe('/components/accordion', () => {
         it('throws when any section heading is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-accordion__section-heading'
@@ -825,8 +825,8 @@ describe('/components/accordion', () => {
         it('throws when any section button placeholder span is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-accordion__section-button'
@@ -844,8 +844,8 @@ describe('/components/accordion', () => {
         it('throws when any section content is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-accordion__section-content'

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -12,7 +12,7 @@ const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
  */
 export class Button extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -27,32 +27,30 @@ export class Button extends GOVUKFrontendComponent {
   debounceFormSubmitTimer = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for button
+   * @param {Element | null} $root - HTML element to use for button
    * @param {ButtonConfig} [config] - Button config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Button',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       Button.defaults,
       config,
-      normaliseDataset(Button, $module.dataset)
+      normaliseDataset(Button, $root.dataset)
     )
 
-    this.$module.addEventListener('keydown', (event) =>
-      this.handleKeyDown(event)
-    )
-    this.$module.addEventListener('click', (event) => this.debounce(event))
+    this.$root.addEventListener('keydown', (event) => this.handleKeyDown(event))
+    this.$root.addEventListener('click', (event) => this.debounce(event))
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -341,8 +341,7 @@ describe('/components/button', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message:
-            'Root element (`$module`) already initialised (`govuk-button`)'
+          message: 'Root element (`$root`) already initialised (`govuk-button`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -334,9 +334,9 @@ describe('/components/button', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'button', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { Button } = await import('govuk-frontend')
-              new Button($module)
+              new Button($root)
             }
           })
         ).rejects.toMatchObject({
@@ -345,34 +345,33 @@ describe('/components/button', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'button', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Button: Root element (`$module`) not found'
+            message: 'Button: Root element (`$root`) not found'
           }
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
+      it('throws when receiving the wrong type for $root', async () => {
         await expect(
           render(page, 'button', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-button"></svg>`
+              $root.outerHTML = `<svg data-module="govuk-button"></svg>`
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message:
-              'Button: Root element (`$module`) is not of type HTMLElement'
+            message: 'Button: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -19,7 +19,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $textarea
@@ -58,21 +58,21 @@ export class CharacterCount extends GOVUKFrontendComponent {
   maxLength
 
   /**
-   * @param {Element | null} $module - HTML element to use for character count
+   * @param {Element | null} $root - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Character count',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $textarea = $module.querySelector('.govuk-js-character-count')
+    const $textarea = $root.querySelector('.govuk-js-character-count')
     if (
       !(
         $textarea instanceof HTMLTextAreaElement ||
@@ -88,7 +88,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     }
 
     // Read config set using dataset ('data-' values)
-    const datasetConfig = normaliseDataset(CharacterCount, $module.dataset)
+    const datasetConfig = normaliseDataset(CharacterCount, $root.dataset)
 
     // To ensure data-attributes take complete precedence, even if they change
     // the type of count, we need to reset the `maxlength` and `maxwords` from
@@ -120,13 +120,13 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($module, 'lang')
+      locale: closestAttributeValue($root, 'lang')
     })
 
     // Determine the limit attribute (characters or words)
     this.maxLength = this.config.maxwords ?? this.config.maxlength ?? Infinity
 
-    this.$module = $module
+    this.$root = $root
     this.$textarea = $textarea
 
     const textareaDescriptionId = `${this.$textarea.id}-info`

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -825,7 +825,7 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           name: 'InitError',
           message:
-            'Root element (`$module`) already initialised (`govuk-character-count`)'
+            'Root element (`$root`) already initialised (`govuk-character-count`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -817,9 +817,9 @@ describe('Character count', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { CharacterCount } = await import('govuk-frontend')
-              new CharacterCount($module)
+              new CharacterCount($root)
             }
           })
         ).rejects.toMatchObject({
@@ -829,34 +829,34 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Character count: Root element (`$module`) not found'
+            message: 'Character count: Root element (`$root`) not found'
           }
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
+      it('throws when receiving the wrong type for $root', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-character-count"></svg>`
+              $root.outerHTML = `<svg data-module="govuk-character-count"></svg>`
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Root element (`$module`) is not of type HTMLElement'
+              'Character count: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -864,8 +864,8 @@ describe('Character count', () => {
       it('throws when the textarea is missing', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).remove()
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '.govuk-js-character-count'
@@ -883,9 +883,9 @@ describe('Character count', () => {
       it('throws when the textarea is not the right type', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module, { selector }) {
+            beforeInitialisation($root, { selector }) {
               // Replace with a tag that's neither an `<input>` or `<textarea>`
-              $module.querySelector(selector).outerHTML =
+              $root.querySelector(selector).outerHTML =
                 '<div class="govuk-js-character-count"></div>'
             },
             context: {
@@ -904,8 +904,8 @@ describe('Character count', () => {
       it('throws when the textarea description is missing', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).remove()
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '#more-detail-info'
@@ -949,14 +949,14 @@ describe('Character count', () => {
           // Override maxlength to 10
           maxlength: 10
         },
-        beforeInitialisation($module) {
+        beforeInitialisation($root) {
           // Set locale to Welsh, which expects translations for 'one', 'two',
           // 'few' 'many' and 'other' forms – with the default English strings
           // provided we only have translations for 'one' and 'other'.
           //
           // We want to make sure we handle this gracefully in case users have
           // an existing character count inside an incorrect locale.
-          $module.setAttribute('lang', 'cy')
+          $root.setAttribute('lang', 'cy')
         }
       })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -8,7 +8,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Checkboxes extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $inputs
@@ -25,20 +25,20 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * (for example if the user has navigated back), and set up event handlers to
    * keep the reveal in sync with the checkbox state.
    *
-   * @param {Element | null} $module - HTML element to use for checkboxes
+   * @param {Element | null} $root - HTML element to use for checkboxes
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Checkboxes',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $inputs = $module.querySelectorAll('input[type="checkbox"]')
+    const $inputs = $root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError({
         componentName: 'Checkboxes',
@@ -46,7 +46,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
       })
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {
@@ -82,11 +82,11 @@ export class Checkboxes extends GOVUKFrontendComponent {
     this.syncAllConditionalReveals()
 
     // Handle events
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
+    this.$root.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**
-   * Sync the conditional reveal states for all checkboxes in this $module.
+   * Sync the conditional reveal states for all checkboxes in this component.
    *
    * @private
    */
@@ -174,7 +174,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
   /**
    * Click event handler
    *
-   * Handle a click within the $module – if the click occurred on a checkbox,
+   * Handle a click within the component root – if the click occurred on a checkbox,
    * sync the state of any associated conditional reveal with the checkbox
    * state.
    *

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -372,9 +372,9 @@ describe('Checkboxes', () => {
         it('throws when initialised twice', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              async afterInitialisation($module) {
+              async afterInitialisation($root) {
                 const { Checkboxes } = await import('govuk-frontend')
-                new Checkboxes($module)
+                new Checkboxes($root)
               }
             })
           ).rejects.toMatchObject({
@@ -384,34 +384,34 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when $module is not set', async () => {
+        it('throws when $root is not set', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              beforeInitialisation($module) {
-                $module.remove()
+              beforeInitialisation($root) {
+                $root.remove()
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Checkboxes: Root element (`$module`) not found'
+              message: 'Checkboxes: Root element (`$root`) not found'
             }
           })
         })
 
-        it('throws when receiving the wrong type for $module', async () => {
+        it('throws when receiving the wrong type for $root', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              beforeInitialisation($module) {
+              beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-                $module.outerHTML = `<svg data-module="govuk-checkboxes"></svg>`
+                $root.outerHTML = `<svg data-module="govuk-checkboxes"></svg>`
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Root element (`$module`) is not of type HTMLElement'
+                'Checkboxes: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -419,8 +419,8 @@ describe('Checkboxes', () => {
         it('throws when the input list is empty', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module
+              beforeInitialisation($root, { selector }) {
+                $root
                   .querySelectorAll(selector)
                   .forEach((item) => item.remove())
               },
@@ -440,8 +440,8 @@ describe('Checkboxes', () => {
         it('throws when a conditional target element is not found', async () => {
           await expect(
             render(page, 'checkboxes', examples['with conditional items'], {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-checkboxes__conditional'

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -380,7 +380,7 @@ describe('Checkboxes', () => {
           ).rejects.toMatchObject({
             name: 'InitError',
             message:
-              'Root element (`$module`) already initialised (`govuk-checkboxes`)'
+              'Root element (`$root`) already initialised (`govuk-checkboxes`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -17,7 +17,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class ErrorSummary extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -26,36 +26,36 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   config
 
   /**
-   * @param {Element | null} $module - HTML element to use for error summary
+   * @param {Element | null} $root - HTML element to use for error summary
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Error summary',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       ErrorSummary.defaults,
       config,
-      normaliseDataset(ErrorSummary, $module.dataset)
+      normaliseDataset(ErrorSummary, $root.dataset)
     )
 
     /**
      * Focus the error summary
      */
     if (!this.config.disableAutoFocus) {
-      setFocus(this.$module)
+      setFocus(this.$root)
     }
 
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
+    this.$root.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -249,7 +249,7 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$module`) already initialised (`govuk-error-summary`)'
+          'Root element (`$root`) already initialised (`govuk-error-summary`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -241,9 +241,9 @@ describe('Error Summary', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { ErrorSummary } = await import('govuk-frontend')
-            new ErrorSummary($module)
+            new ErrorSummary($root)
           }
         })
       ).rejects.toMatchObject({
@@ -253,34 +253,34 @@ describe('Error Summary', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Error summary: Root element (`$module`) not found'
+          message: 'Error summary: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-error-summary"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-error-summary"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Error summary: Root element (`$module`) is not of type HTMLElement'
+            'Error summary: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -11,7 +11,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class ExitThisPage extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -75,21 +75,21 @@ export class ExitThisPage extends GOVUKFrontendComponent {
   timeoutMessageId = null
 
   /**
-   * @param {Element | null} $module - HTML element that wraps the Exit This Page button
+   * @param {Element | null} $root - HTML element that wraps the Exit This Page button
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Exit this page',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $button = $module.querySelector('.govuk-exit-this-page__button')
+    const $button = $root.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
       throw new ElementError({
         componentName: 'Exit this page',
@@ -102,11 +102,11 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.config = mergeConfigs(
       ExitThisPage.defaults,
       config,
-      normaliseDataset(ExitThisPage, $module.dataset)
+      normaliseDataset(ExitThisPage, $root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)
-    this.$module = $module
+    this.$root = $root
     this.$button = $button
 
     const $skiplinkButton = document.querySelector(
@@ -142,7 +142,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.$updateSpan.setAttribute('role', 'status')
     this.$updateSpan.className = 'govuk-visually-hidden'
 
-    this.$module.appendChild(this.$updateSpan)
+    this.$root.appendChild(this.$updateSpan)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -244,7 +244,7 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           name: 'InitError',
           message:
-            'Root element (`$module`) already initialised (`govuk-exit-this-page`)'
+            'Root element (`$root`) already initialised (`govuk-exit-this-page`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -236,9 +236,9 @@ describe('/components/exit-this-page', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { ExitThisPage } = await import('govuk-frontend')
-              new ExitThisPage($module)
+              new ExitThisPage($root)
             }
           })
         ).rejects.toMatchObject({
@@ -248,34 +248,34 @@ describe('/components/exit-this-page', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Exit this page: Root element (`$module`) not found'
+            message: 'Exit this page: Root element (`$root`) not found'
           }
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
+      it('throws when receiving the wrong type for $root', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-exit-this-page"></svg>`
+              $root.outerHTML = `<svg data-module="govuk-exit-this-page"></svg>`
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
             message:
-              'Exit this page: Root element (`$module`) is not of type HTMLElement'
+              'Exit this page: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -283,8 +283,8 @@ describe('/components/exit-this-page', () => {
       it('throws when the button is missing', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).remove()
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '.govuk-exit-this-page__button'

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -9,7 +9,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Header extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $menuButton
@@ -40,21 +40,21 @@ export class Header extends GOVUKFrontendComponent {
    * Apply a matchMedia for desktop which will trigger a state sync if the
    * browser viewport moves between states.
    *
-   * @param {Element | null} $module - HTML element to use for header
+   * @param {Element | null} $root - HTML element to use for header
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!$module) {
+    if (!$root) {
       throw new ElementError({
         componentName: 'Header',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
-    const $menuButton = $module.querySelector('.govuk-js-header-toggle')
+    this.$root = $root
+    const $menuButton = $root.querySelector('.govuk-js-header-toggle')
 
     // Headers don't necessarily have a navigation. When they don't, the menu
     // toggle won't be rendered by our macro (or may be omitted when writing

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -193,8 +193,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message:
-            'Root element (`$module`) already initialised (`govuk-header`)'
+          message: 'Root element (`$root`) already initialised (`govuk-header`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -186,9 +186,9 @@ describe('Header navigation', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'header', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { Header } = await import('govuk-frontend')
-              new Header($module)
+              new Header($root)
             }
           })
         ).rejects.toMatchObject({
@@ -197,19 +197,19 @@ describe('Header navigation', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'header', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Remove the root of the components as a way
-              // for the constructor to receive the wrong type for `$module`
-              $module.remove()
+              // for the constructor to receive the wrong type for `$root`
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Header: Root element (`$module`) not found'
+            message: 'Header: Root element (`$root`) not found'
           }
         })
       })
@@ -217,8 +217,8 @@ describe('Header navigation', () => {
       it("throws when the toggle's aria-control attribute is missing", async () => {
         await expect(
           render(page, 'header', examples['with navigation'], {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).removeAttribute('aria-controls')
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).removeAttribute('aria-controls')
             },
             context: {
               selector: '.govuk-js-header-toggle'
@@ -236,9 +236,9 @@ describe('Header navigation', () => {
       it('throws when the menu is missing, but a toggle is present', async () => {
         await expect(
           render(page, 'header', examples['with navigation'], {
-            beforeInitialisation($module, { selector }) {
+            beforeInitialisation($root, { selector }) {
               // Remove the menu `<ul>` referenced by $menuButton's `aria-controls`
-              $module.querySelector(selector).remove()
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '#navigation'

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -10,7 +10,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class NotificationBanner extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -19,26 +19,26 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   config
 
   /**
-   * @param {Element | null} $module - HTML element to use for notification banner
+   * @param {Element | null} $root - HTML element to use for notification banner
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Notification banner',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       NotificationBanner.defaults,
       config,
-      normaliseDataset(NotificationBanner, $module.dataset)
+      normaliseDataset(NotificationBanner, $root.dataset)
     )
 
     /**
@@ -53,10 +53,10 @@ export class NotificationBanner extends GOVUKFrontendComponent {
      * element which should be focused when the page loads.
      */
     if (
-      this.$module.getAttribute('role') === 'alert' &&
+      this.$root.getAttribute('role') === 'alert' &&
       !this.config.disableAutoFocus
     ) {
-      setFocus(this.$module)
+      setFocus(this.$root)
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -249,7 +249,7 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$module`) already initialised (`govuk-notification-banner`)'
+          'Root element (`$root`) already initialised (`govuk-notification-banner`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -241,9 +241,9 @@ describe('Notification banner', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { NotificationBanner } = await import('govuk-frontend')
-            new NotificationBanner($module)
+            new NotificationBanner($root)
           }
         })
       ).rejects.toMatchObject({
@@ -253,34 +253,34 @@ describe('Notification banner', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Notification banner: Root element (`$module`) not found'
+          message: 'Notification banner: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-notification-banner"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-notification-banner"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Notification banner: Root element (`$module`) is not of type HTMLElement'
+            'Notification banner: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -12,7 +12,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class PasswordInput extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -39,21 +39,21 @@ export class PasswordInput extends GOVUKFrontendComponent {
   $screenReaderStatusMessage
 
   /**
-   * @param {Element | null} $module - HTML element to use for password input
+   * @param {Element | null} $root - HTML element to use for password input
    * @param {PasswordInputConfig} [config] - Password input config
    */
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     super()
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Password input',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $input = $module.querySelector('.govuk-js-password-input-input')
+    const $input = $root.querySelector('.govuk-js-password-input-input')
     if (!($input instanceof HTMLInputElement)) {
       throw new ElementError({
         componentName: 'Password input',
@@ -69,7 +69,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    const $showHideButton = $module.querySelector(
+    const $showHideButton = $root.querySelector(
       '.govuk-js-password-input-toggle'
     )
     if (!($showHideButton instanceof HTMLButtonElement)) {
@@ -87,19 +87,19 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$input = $input
     this.$showHideButton = $showHideButton
 
     this.config = mergeConfigs(
       PasswordInput.defaults,
       config,
-      normaliseDataset(PasswordInput, $module.dataset)
+      normaliseDataset(PasswordInput, $root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($module, 'lang')
+      locale: closestAttributeValue($root, 'lang')
     })
 
     // Show the toggle button element

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -202,34 +202,34 @@ describe('/components/password-input', () => {
           })
         })
 
-        it('throws when $module is not set', async () => {
+        it('throws when $root is not set', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module) {
-                $module.remove()
+              beforeInitialisation($root) {
+                $root.remove()
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Password input: Root element (`$module`) not found'
+              message: 'Password input: Root element (`$root`) not found'
             }
           })
         })
 
-        it('throws when receiving the wrong type for $module', async () => {
+        it('throws when receiving the wrong type for $root', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module) {
+              beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-                $module.outerHTML = `<svg data-module="govuk-password-input"></svg>`
+                $root.outerHTML = `<svg data-module="govuk-password-input"></svg>`
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Root element (`$module`) is not of type HTMLElement'
+                'Password input: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -237,8 +237,8 @@ describe('/components/password-input', () => {
         it('throws when the input element is missing', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: inputSelector
@@ -256,9 +256,9 @@ describe('/components/password-input', () => {
         it('throws when the input is not an <input> element', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Replace the input with a textarea
-                $module.querySelector(selector).outerHTML =
+                $root.querySelector(selector).outerHTML =
                   '<textarea class="govuk-js-password-input-input"></textarea>'
               },
               context: {
@@ -277,9 +277,9 @@ describe('/components/password-input', () => {
         it('throws when the input is not a `password` type', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Make the input a number input instead
-                $module.querySelector(selector).setAttribute('type', 'number')
+                $root.querySelector(selector).setAttribute('type', 'number')
               },
               context: {
                 selector: inputSelector
@@ -297,8 +297,8 @@ describe('/components/password-input', () => {
         it('throws when the button is missing', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: buttonSelector
@@ -316,9 +316,9 @@ describe('/components/password-input', () => {
         it('throws when the button is not a <button> element', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Replace the button with a <div>
-                $module.querySelector(selector).outerHTML =
+                $root.querySelector(selector).outerHTML =
                   '<div class="govuk-js-password-input-toggle"></div>'
               },
               context: {
@@ -337,9 +337,9 @@ describe('/components/password-input', () => {
         it('throws when the button is not a `button` type', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Make the button a submit button
-                $module.querySelector(selector).setAttribute('type', 'submit')
+                $root.querySelector(selector).setAttribute('type', 'submit')
               },
               context: {
                 selector: buttonSelector

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -8,7 +8,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Radios extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $inputs
@@ -25,20 +25,20 @@ export class Radios extends GOVUKFrontendComponent {
    * (for example if the user has navigated back), and set up event handlers to
    * keep the reveal in sync with the radio state.
    *
-   * @param {Element | null} $module - HTML element to use for radios
+   * @param {Element | null} $root - HTML element to use for radios
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Radios',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $inputs = $module.querySelectorAll('input[type="radio"]')
+    const $inputs = $root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError({
         componentName: 'Radios',
@@ -46,7 +46,7 @@ export class Radios extends GOVUKFrontendComponent {
       })
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {
@@ -82,11 +82,11 @@ export class Radios extends GOVUKFrontendComponent {
     this.syncAllConditionalReveals()
 
     // Handle events
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
+    this.$root.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**
-   * Sync the conditional reveal states for all radio buttons in this $module.
+   * Sync the conditional reveal states for all radio buttons in this component.
    *
    * @private
    */
@@ -126,10 +126,10 @@ export class Radios extends GOVUKFrontendComponent {
   /**
    * Click event handler
    *
-   * Handle a click within the $module – if the click occurred on a radio, sync
+   * Handle a click within the component root – if the click occurred on a radio, sync
    * the state of the conditional reveal for all radio buttons in the same form
    * with the same name (because checking one radio could have un-checked a
-   * radio in another $module)
+   * radio under the root of another Radio component)
    *
    * @private
    * @param {MouseEvent} event - Click event

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -325,9 +325,9 @@ describe('Radios', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { Radios } = await import('govuk-frontend')
-            new Radios($module)
+            new Radios($root)
           }
         })
       ).rejects.toMatchObject({
@@ -336,33 +336,33 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$module`) not found'
+          message: 'Radios: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-radios"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-radios"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$module`) is not of type HTMLElement'
+          message: 'Radios: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })
@@ -370,8 +370,8 @@ describe('Radios', () => {
     it('throws when the input list is empty', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          beforeInitialisation($module, { selector }) {
-            $module.querySelectorAll(selector).forEach((item) => item.remove())
+          beforeInitialisation($root, { selector }) {
+            $root.querySelectorAll(selector).forEach((item) => item.remove())
           },
           context: {
             selector: '.govuk-radios__item'
@@ -388,8 +388,8 @@ describe('Radios', () => {
     it('throws when a conditional target element is not found', async () => {
       await expect(
         render(page, 'radios', examples['with conditional items'], {
-          beforeInitialisation($module) {
-            $module.querySelector('.govuk-radios__conditional').remove()
+          beforeInitialisation($root) {
+            $root.querySelector('.govuk-radios__conditional').remove()
           }
         })
       ).rejects.toMatchObject({

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -332,7 +332,7 @@ describe('Radios', () => {
         })
       ).rejects.toMatchObject({
         name: 'InitError',
-        message: 'Root element (`$module`) already initialised (`govuk-radios`)'
+        message: 'Root element (`$root`) already initialised (`govuk-radios`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
@@ -9,7 +9,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class ServiceNavigation extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $menuButton
@@ -36,22 +36,22 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
   mql = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for header
+   * @param {Element | null} $root - HTML element to use for header
    */
-  constructor($module) {
+  constructor($root) {
     super()
 
-    if (!$module) {
+    if (!$root) {
       throw new ElementError({
         componentName: 'Service Navigation',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
-    const $menuButton = $module.querySelector(
+    const $menuButton = $root.querySelector(
       '.govuk-js-service-navigation-toggle'
     )
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
@@ -74,19 +74,19 @@ describe('/components/service-navigation', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'service-navigation', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Remove the root of the components as a way
-              // for the constructor to receive the wrong type for `$module`
-              $module.remove()
+              // for the constructor to receive the wrong type for `$root`
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Service Navigation: Root element (`$module`) not found'
+            message: 'Service Navigation: Root element (`$root`) not found'
           }
         })
       })
@@ -94,8 +94,8 @@ describe('/components/service-navigation', () => {
       it("throws when the toggle's aria-control attribute is missing", async () => {
         await expect(
           render(page, 'service-navigation', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).removeAttribute('aria-controls')
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).removeAttribute('aria-controls')
             },
             context: {
               selector: toggleButtonSelector
@@ -113,9 +113,9 @@ describe('/components/service-navigation', () => {
       it('throws when the menu is missing, but a toggle is present', async () => {
         await expect(
           render(page, 'service-navigation', examples.default, {
-            beforeInitialisation($module, { selector }) {
+            beforeInitialisation($root, { selector }) {
               // Remove the `<ul>` referenced by $menuButton's `aria-controls`
-              $module.querySelector(selector).remove()
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: navigationSelector

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -9,30 +9,30 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class SkipLink extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
-   * @param {Element | null} $module - HTML element to use for skip link
-   * @throws {ElementError} when $module is not set or the wrong type
-   * @throws {ElementError} when $module.hash does not contain a hash
+   * @param {Element | null} $root - HTML element to use for skip link
+   * @throws {ElementError} when $root is not set or the wrong type
+   * @throws {ElementError} when $root.hash does not contain a hash
    * @throws {ElementError} when the linked element is missing or the wrong type
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!($module instanceof HTMLAnchorElement)) {
+    if (!($root instanceof HTMLAnchorElement)) {
       throw new ElementError({
         componentName: 'Skip link',
-        element: $module,
+        element: $root,
         expectedType: 'HTMLAnchorElement',
-        identifier: 'Root element (`$module`)'
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
-    const hash = this.$module.hash
-    const href = this.$module.getAttribute('href') ?? ''
+    const hash = this.$root.hash
+    const href = this.$root.getAttribute('href') ?? ''
 
     /** @type {URL | undefined} */
     let url
@@ -45,7 +45,7 @@ export class SkipLink extends GOVUKFrontendComponent {
      *
      */
     try {
-      url = new window.URL(this.$module.href)
+      url = new window.URL(this.$root.href)
     } catch (error) {
       throw new ElementError(
         `Skip link: Target link (\`href="${href}"\`) is invalid`
@@ -86,7 +86,7 @@ export class SkipLink extends GOVUKFrontendComponent {
      * Adds a helper CSS class to hide native focus styles,
      * but removes it on blur to restore native focus styles
      */
-    this.$module.addEventListener('click', () =>
+    this.$root.addEventListener('click', () =>
       setFocus($linkedElement, {
         onBeforeFocus() {
           $linkedElement.classList.add('govuk-skip-link-focused-element')

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -140,7 +140,7 @@ describe('Skip Link', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$module`) already initialised (`govuk-skip-link`)'
+          'Root element (`$root`) already initialised (`govuk-skip-link`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -132,9 +132,9 @@ describe('Skip Link', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'skip-link', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { SkipLink } = await import('govuk-frontend')
-            new SkipLink($module)
+            new SkipLink($root)
           }
         })
       ).rejects.toMatchObject({
@@ -144,34 +144,34 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       return expect(
         render(page, 'skip-link', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Skip link: Root element (`$module`) not found'
+          message: 'Skip link: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       return expect(
         render(page, 'skip-link', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-skip-link"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-skip-link"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Root element (`$module`) is not of type HTMLAnchorElement'
+            'Skip link: Root element (`$root`) is not of type HTMLAnchorElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -9,7 +9,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Tabs extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $tabs
@@ -42,20 +42,20 @@ export class Tabs extends GOVUKFrontendComponent {
   mql = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for tabs
+   * @param {Element | null} $root - HTML element to use for tabs
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!$module) {
+    if (!$root) {
       throw new ElementError({
         componentName: 'Tabs',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
+    const $tabs = $root.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError({
         componentName: 'Tabs',
@@ -63,7 +63,7 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$tabs = $tabs
 
     // Save bound functions so we can remove event listeners during teardown
@@ -71,8 +71,8 @@ export class Tabs extends GOVUKFrontendComponent {
     this.boundTabKeydown = this.onTabKeydown.bind(this)
     this.boundOnHashChange = this.onHashChange.bind(this)
 
-    const $tabList = this.$module.querySelector('.govuk-tabs__list')
-    const $tabListItems = this.$module.querySelectorAll(
+    const $tabList = this.$root.querySelector('.govuk-tabs__list')
+    const $tabListItems = this.$root.querySelectorAll(
       'li.govuk-tabs__list-item'
     )
 
@@ -258,7 +258,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @returns {HTMLAnchorElement | null} Tab link
    */
   getTab(hash) {
-    return this.$module.querySelector(`a.govuk-tabs__tab[href="${hash}"]`)
+    return this.$root.querySelector(`a.govuk-tabs__tab[href="${hash}"]`)
   }
 
   /**
@@ -455,7 +455,7 @@ export class Tabs extends GOVUKFrontendComponent {
       return null
     }
 
-    return this.$module.querySelector(`#${panelId}`)
+    return this.$root.querySelector(`#${panelId}`)
   }
 
   /**
@@ -527,7 +527,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @returns {HTMLAnchorElement | null} Tab link
    */
   getCurrentTab() {
-    return this.$module.querySelector(
+    return this.$root.querySelector(
       '.govuk-tabs__list-item--selected a.govuk-tabs__tab'
     )
   }

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -281,7 +281,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message: 'Root element (`$module`) already initialised (`govuk-tabs`)'
+          message: 'Root element (`$root`) already initialised (`govuk-tabs`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -274,9 +274,9 @@ describe('/components/tabs', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { Tabs } = await import('govuk-frontend')
-              new Tabs($module)
+              new Tabs($root)
             }
           })
         ).rejects.toMatchObject({
@@ -285,17 +285,17 @@ describe('/components/tabs', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: Root element (`$module`) not found'
+            message: 'Tabs: Root element (`$root`) not found'
           }
         })
       })
@@ -303,10 +303,8 @@ describe('/components/tabs', () => {
       it('throws when there are no tabs', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module
-                .querySelectorAll(selector)
-                .forEach((item) => item.remove())
+            beforeInitialisation($root, { selector }) {
+              $root.querySelectorAll(selector).forEach((item) => item.remove())
             },
             context: {
               selector: 'a.govuk-tabs__tab'
@@ -323,8 +321,8 @@ describe('/components/tabs', () => {
       it('throws when the tab list is missing', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module
+            beforeInitialisation($root, { selector }) {
+              $root
                 .querySelector(selector)
                 .setAttribute('class', 'govuk-tabs__typo')
             },
@@ -343,8 +341,8 @@ describe('/components/tabs', () => {
       it('throws when there the tab list is empty', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module, { selector, className }) {
-              $module
+            beforeInitialisation($root, { selector, className }) {
+              $root
                 .querySelectorAll(selector)
                 .forEach((item) => item.setAttribute('class', className))
             },

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -72,7 +72,7 @@ describe('errors', () => {
 
     it('provides feedback for modules already initialised', () => {
       expect(new InitError($moduleName).message).toBe(
-        'Root element (`$module`) already initialised (`govuk-accordion`)'
+        'Root element (`$root`) already initialised (`govuk-accordion`)'
       )
     })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -53,33 +53,24 @@ describe('errors', () => {
   })
 
   describe('InitError', () => {
-    let $element
-    let $moduleName
-
-    beforeAll(() => {
-      $element = document.createElement('div')
-      $element.setAttribute('data-module', 'govuk-accordion')
-      $moduleName = 'govuk-accordion'
-    })
-
     it('is an instance of GOVUKFrontendError', () => {
-      expect(new InitError($moduleName)).toBeInstanceOf(GOVUKFrontendError)
+      expect(new InitError('govuk-accordion')).toBeInstanceOf(
+        GOVUKFrontendError
+      )
     })
 
     it('has its own name set', () => {
-      expect(new InitError($moduleName).name).toBe('InitError')
+      expect(new InitError('govuk-accordion').name).toBe('InitError')
     })
 
     it('provides feedback for modules already initialised', () => {
-      expect(new InitError($moduleName).message).toBe(
+      expect(new InitError('govuk-accordion').message).toBe(
         'Root element (`$root`) already initialised (`govuk-accordion`)'
       )
     })
 
-    it('provides feedback for modules already initialised', () => {
-      $moduleName = undefined
-
-      expect(new InitError($moduleName, 'Accordion').message).toBe(
+    it('provides feedback when no module name is provided', () => {
+      expect(new InitError(undefined, 'Accordion').message).toBe(
         'moduleName not defined in component (`Accordion`)'
       )
     })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -112,7 +112,7 @@ export class InitError extends GOVUKFrontendError {
     let errorText = `moduleName not defined in component (\`${className}\`)`
 
     if (typeof moduleName === 'string') {
-      errorText = `Root element (\`$module\`) already initialised (\`${moduleName}\`)`
+      errorText = `Root element (\`$root\`) already initialised (\`${moduleName}\`)`
     }
 
     super(errorText)

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -14,17 +14,17 @@ export class GOVUKFrontendComponent {
    * Constructs a new component, validating that GOV.UK Frontend is supported
    *
    * @internal
-   * @param {Element | null} [$module] - HTML element to use for component
+   * @param {Element | null} [$root] - HTML element to use for component
    */
-  constructor($module) {
+  constructor($root) {
     this.checkSupport()
-    this.checkInitialised($module)
+    this.checkInitialised($root)
 
     const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
       .moduleName
 
     if (typeof moduleName === 'string') {
-      moduleName && $module?.setAttribute(`data-${moduleName}-init`, '')
+      moduleName && $root?.setAttribute(`data-${moduleName}-init`, '')
     } else {
       throw new InitError(moduleName)
     }
@@ -34,14 +34,14 @@ export class GOVUKFrontendComponent {
    * Validates whether component is already initialised
    *
    * @private
-   * @param {Element | null} [$module] - HTML element to be checked
+   * @param {Element | null} [$root] - HTML element to be checked
    * @throws {InitError} when component is already initialised
    */
-  checkInitialised($module) {
+  checkInitialised($root) {
     const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
       .moduleName
 
-    if ($module && moduleName && isInitialised($module, moduleName)) {
+    if ($root && moduleName && isInitialised($root, moduleName)) {
       throw new InitError(moduleName)
     }
   }

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -169,14 +169,14 @@ async function render(page, componentName, renderOptions, browserOptions) {
           return namespace.initAll()
         }
 
-        // Find all matching modules
-        const $modules = document.querySelectorAll(selector)
+        // Find all component roots
+        const $roots = document.querySelectorAll(selector)
 
         try {
-          // Loop and initialise all $modules or use default
+          // Loop and initialise all $roots or use default
           // selector `null` return value when none found
-          ;($modules.length ? $modules : [null]).forEach(
-            ($module) => new namespace[exportName]($module, config)
+          ;($roots.length ? $roots : [null]).forEach(
+            ($root) => new namespace[exportName]($root, config)
           )
         } catch ({ name, message }) {
           return { name, message }


### PR DESCRIPTION
Internal refactoring to rename `$module` to `$root` across the codebase: components, tests, helpers and documentation.

This change is not breaking and won't even affect the component behaviours as:
- `$module` was the name of positional arguments which are in the same position
- `this.$module` was `@private`, so not to be used by external code

The PR splits the renaming component by component for easier review.

Closes #5322 