### PR TITLE
Improve public JavaScript API for code initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ You can safely delete the old image files, named `govuk-crest.png` and `govuk-cr
 
 We introduced this change in [pull request #5376: Update the Royal Arms graphic in footer (v5.x)](https://github.com/alphagov/govuk-frontend/pull/5376).
 
+#### Use our base component to build your own components
+
+We've added a `Component` class to help you build your own components. It allows you to focus on your components' specific features by handling these shared behaviours across components:
+
+- Checking that GOV.UK Frontend is supported
+- Checking that the component is not already initialised on its root element
+
+We introduced this change in [pull request #5350: Export a base `Component` class](https://github.com/alphagov/govuk-frontend/pull/5350).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ You can safely delete the old image files, named `govuk-crest.png` and `govuk-cr
 
 We introduced this change in [pull request #5376: Update the Royal Arms graphic in footer (v5.x)](https://github.com/alphagov/govuk-frontend/pull/5376).
 
+#### Check if GOV.UK Frontend is supported
+
+We've added the `isSupported` function to let you check if GOV.UK Frontend is supported in the browser where your script is running.
+GOV.UK Frontend components will check this automatically, but you may want to use the `isSupported` function to avoid running some code when GOV.UK Frontend is not supported.
+
+We introduced this change in [pull request #5250: Add `isSupported` to `all.mjs`](https://github.com/alphagov/govuk-frontend/pull/5250)
+
 #### Use our base component to build your own components
 
 We've added a `Component` class to help you build your own components. It allows you to focus on your components' specific features by handling these shared behaviours across components:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ You can safely delete the old image files, named `govuk-crest.png` and `govuk-cr
 
 We introduced this change in [pull request #5376: Update the Royal Arms graphic in footer (v5.x)](https://github.com/alphagov/govuk-frontend/pull/5376).
 
+#### Components can no longer be initialised twice on the same element
+
+GOV.UK Frontend components now throw an error if they've already been initialised on the DOM Element they're receiving for initialisation.
+This prevents components from being initialised more than once and therefore not working properly.
+
+We introduced this change in [pull request #5272: Prevent multiple initialisations of a single component instance](https://github.com/alphagov/govuk-frontend/pull/5272)
+
 #### Respond to initialisation errors when using `createAll` and `initAll`
 
 We've added a new `onError` option for `createAll` and `initAll` that lets you respond to initialisation errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ You can safely delete the old image files, named `govuk-crest.png` and `govuk-cr
 
 We introduced this change in [pull request #5376: Update the Royal Arms graphic in footer (v5.x)](https://github.com/alphagov/govuk-frontend/pull/5376).
 
+#### Respond to initialisation errors when using `createAll` and `initAll`
+
+We've added a new `onError` option for `createAll` and `initAll` that lets you respond to initialisation errors.
+The functions will continue catching errors and initialising components further down the page if one component fails to initialise,
+but this option will let you react to a component failing to initialise (for example, reporting to an error monitoring service).
+
+We introduced this change in:
+
+- [pull request #5252: Add `onError` to `createAll`](https://github.com/alphagov/govuk-frontend/pull/5252)
+- [pull request #5276: Add `onError` to `initAll`](https://github.com/alphagov/govuk-frontend/pull/5276)
+
 #### Check if GOV.UK Frontend is supported
 
 We've added the `isSupported` function to let you check if GOV.UK Frontend is supported in the browser where your script is running.

--- a/docs/contributing/coding-standards/component-options.md
+++ b/docs/contributing/coding-standards/component-options.md
@@ -10,7 +10,7 @@ First, make sure the component class has a constructor parameter for passing in 
 
 ```mjs
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     // ...
   }
 }
@@ -36,7 +36,7 @@ There is no guarantee `config` will have any value at all, so we set the default
 import { mergeConfigs } from '../../common/index.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config
@@ -101,26 +101,26 @@ You can find `data-*` attributes in JavaScript by looking at an element's `datas
 
 See ['Naming configuration options'](#naming-configuration-options) for exceptions to how names are transformed.
 
-As we expect configuration-related `data-*` attributes to always be on the component's root element (the same element with the `data-module` attribute), we can access them all using `$module.dataset`.
+As we expect configuration-related `data-*` attributes to always be on the component's root element (the same element with the `data-module` attribute), we can access them all using `$root.dataset`.
 
-Using the `mergeConfigs` call discussed earlier in this document, update it to include `$module.dataset` as the highest priority.
+Using the `mergeConfigs` call discussed earlier in this document, update it to include `$root.dataset` as the highest priority.
 
 ```mjs
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
   }
 }
 ```
 
-Here, we pass the value of `$module.dataset` through our `normaliseDataset` function. This is because attribute values in dataset are always interpreted as strings. `normaliseDataset` looks at the component's configuration schema and converts values into numbers or booleans where needed.
+Here, we pass the value of `$root.dataset` through our `normaliseDataset` function. This is because attribute values in dataset are always interpreted as strings. `normaliseDataset` looks at the component's configuration schema and converts values into numbers or booleans where needed.
 
 Now, in our HTML, we could pass configuration options by using the kebab-case version of the option's name.
 
@@ -164,11 +164,11 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ConfigError } from '../../errors/index.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
 
     // Check that the configuration provided is valid
@@ -248,11 +248,11 @@ import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 
 export class Accordion {
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
 
     this.stateInfo = extractConfigByNamespace(Accordion, this.config, 'stateInfo');

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -20,20 +20,20 @@ component
  */
 export class Example {
   /**
-   * @param {Element | null} $module - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
-  constructor($module) {
+  constructor($root) {
     if (
-      !($module instanceof HTMLElement) ||
+      !($root instanceof HTMLElement) ||
       !document.body.classList.contains('govuk-frontend-supported')
     ) {
       return this
     }
 
-    this.$module = $module
+    this.$root = $root
 
     // Code goes here
-    this.$module.addEventListener('click', () => {
+    this.$root.addEventListener('click', () => {
       // ...
     })
   }

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -13,21 +13,28 @@ component
 ## Skeleton
 
 ```mjs
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+
 /**
  * Component name
  *
  * @preserve
  */
-export class Example {
+export class Example extends GOVUKFrontendComponent {
   /**
    * @param {Element | null} $root - HTML element to use for component
    */
-  constructor($root) {
-    if (
-      !($root instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
-      return this
+  constructor($root){
+    super($root)
+
+    if (!($root instanceof HTMLElement)) {
+      if (!($root instanceof HTMLElement)) {
+        throw new ElementError({
+          componentName: 'Example',
+          element: $root,
+          identifier: 'Root element (`$root`)'
+        })
+      }
     }
 
     this.$root = $root

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -27,18 +27,6 @@ export class Example extends GOVUKFrontendComponent {
   constructor($root){
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      if (!($root instanceof HTMLElement)) {
-        throw new ElementError({
-          componentName: 'Example',
-          element: $root,
-          identifier: 'Root element (`$root`)'
-        })
-      }
-    }
-
-    this.$root = $root
-
     // Code goes here
     this.$root.addEventListener('click', () => {
       // ...

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -14,6 +14,7 @@ export { SkipLink } from './components/skip-link/skip-link.mjs'
 export { Tabs } from './components/tabs/tabs.mjs'
 export { initAll, createAll } from './init.mjs'
 export { isSupported } from './common/index.mjs'
+export { GOVUKFrontendComponent as Component } from './govuk-frontend-component.mjs'
 
 /**
  * @typedef {import('./init.mjs').Config} Config

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -13,6 +13,7 @@ export { ServiceNavigation } from './components/service-navigation/service-navig
 export { SkipLink } from './components/skip-link/skip-link.mjs'
 export { Tabs } from './components/tabs/tabs.mjs'
 export { initAll, createAll } from './init.mjs'
+export { isSupported } from './common/index.mjs'
 
 /**
  * @typedef {import('./init.mjs').Config} Config

--- a/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
@@ -41,10 +41,24 @@ describe('GOV.UK Frontend', () => {
       expect(typeofCreateAll).toBe('function')
     })
 
+    it('exports `isSupported` function', async () => {
+      const typeofIsSupported = await page.evaluate(
+        async (importPath, exportName) => {
+          const namespace = await import(importPath)
+          return typeof namespace[exportName]
+        },
+        scriptsPath.href,
+        'isSupported'
+      )
+
+      expect(typeofIsSupported).toBe('function')
+    })
+
     it('exports Components', async () => {
       const components = exported
         .filter(
-          (method) => !['initAll', 'createAll', 'version'].includes(method)
+          (method) =>
+            !['initAll', 'createAll', 'version', 'isSupported'].includes(method)
         )
         .sort()
 

--- a/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
@@ -68,6 +68,7 @@ describe('GOV.UK Frontend', () => {
         'Button',
         'CharacterCount',
         'Checkboxes',
+        'Component',
         'ErrorSummary',
         'ExitThisPage',
         'Header',

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -192,14 +192,14 @@ export function setFocus($element, options = {}) {
  * Checks if component is already initialised
  *
  * @internal
- * @param {Element} $module - HTML element to be checked
+ * @param {Element} $root - HTML element to be checked
  * @param {string} moduleName - name of component module
  * @returns {boolean} Whether component is already initialised
  */
-export function isInitialised($module, moduleName) {
+export function isInitialised($root, moduleName) {
   return (
-    $module instanceof HTMLElement &&
-    $module.hasAttribute(`data-${moduleName}-init`)
+    $root instanceof HTMLElement &&
+    $root.hasAttribute(`data-${moduleName}-init`)
   )
 }
 

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -194,8 +194,7 @@ export function setFocus($element, options = {}) {
  * Some browsers will load and run our JavaScript but GOV.UK Frontend
  * won't be supported.
  *
- * @internal
- * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
+ * @param {HTMLElement | null} [$scope] - (internal) `<body>` HTML element checked for browser support
  * @returns {boolean} Whether GOV.UK Frontend is supported on this page
  */
 export function isSupported($scope = document.body) {

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -189,6 +189,21 @@ export function setFocus($element, options = {}) {
 }
 
 /**
+ * Checks if component is already initialised
+ *
+ * @internal
+ * @param {Element} $module - HTML element to be checked
+ * @param {string} moduleName - name of component module
+ * @returns {boolean} Whether component is already initialised
+ */
+export function isInitialised($module, moduleName) {
+  return (
+    $module instanceof HTMLElement &&
+    $module.hasAttribute(`data-${moduleName}-init`)
+  )
+}
+
+/**
  * Checks if GOV.UK Frontend is supported on this page
  *
  * Some browsers will load and run our JavaScript but GOV.UK Frontend

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -281,6 +281,18 @@ function isObject(option) {
 }
 
 /**
+ * Format error message
+ *
+ * @internal
+ * @param {ComponentWithModuleName} Component - Component that threw the error
+ * @param {string} message - Error message
+ * @returns {string} - Formatted error message
+ */
+export function formatErrorMessage(Component, message) {
+  return `${Component.moduleName}: ${message}`
+}
+
+/**
  * Schema for component config
  *
  * @typedef {object} Schema
@@ -308,3 +320,16 @@ function isObject(option) {
  * @typedef {keyof ObjectNested} NestedKey
  * @typedef {{ [key: string]: string | boolean | number | ObjectNested | undefined }} ObjectNested
  */
+
+/* eslint-disable jsdoc/valid-types --
+ * `{new(...args: any[] ): object}` is not recognised as valid
+ * https://github.com/gajus/eslint-plugin-jsdoc/issues/145#issuecomment-1308722878
+ * https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/131
+ **/
+
+/**
+ * @typedef ComponentWithModuleName
+ * @property {string} moduleName - Name of the component
+ */
+
+/* eslint-enable jsdoc/valid-types */

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -114,7 +114,7 @@ export class Accordion extends GOVUKFrontendComponent {
    * @param {AccordionConfig} [config] - Accordion config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -118,7 +118,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -137,7 +137,7 @@ export class Accordion extends GOVUKFrontendComponent {
     const $sections = this.$root.querySelectorAll(`.${this.sectionClass}`)
     if (!$sections.length) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Sections (\`<div class="${this.sectionClass}">\`)`
       })
     }
@@ -201,7 +201,7 @@ export class Accordion extends GOVUKFrontendComponent {
       const $header = $section.querySelector(`.${this.sectionHeaderClass}`)
       if (!$header) {
         throw new ElementError({
-          componentName: 'Accordion',
+          component: Accordion,
           identifier: `Section headers (\`<div class="${this.sectionHeaderClass}">\`)`
         })
       }
@@ -233,14 +233,14 @@ export class Accordion extends GOVUKFrontendComponent {
 
     if (!$heading) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Section heading (\`.${this.sectionHeadingClass}\`)`
       })
     }
 
     if (!$span) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Section button placeholder (\`<span class="${this.sectionButtonClass}">\`)`
       })
     }
@@ -411,7 +411,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
     if (!$content) {
       throw new ElementError({
-        componentName: 'Accordion',
+        component: Accordion,
         identifier: `Section content (\`<div class="${this.sectionContentClass}">\`)`
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -20,7 +20,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class Accordion extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -110,31 +110,31 @@ export class Accordion extends GOVUKFrontendComponent {
   $showAllText = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for accordion
+   * @param {Element | null} $root - HTML element to use for accordion
    * @param {AccordionConfig} [config] - Accordion config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Accordion',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $module.dataset)
+      normaliseDataset(Accordion, $root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)
 
-    const $sections = this.$module.querySelectorAll(`.${this.sectionClass}`)
+    const $sections = this.$root.querySelectorAll(`.${this.sectionClass}`)
     if (!$sections.length) {
       throw new ElementError({
         componentName: 'Accordion',
@@ -171,7 +171,7 @@ export class Accordion extends GOVUKFrontendComponent {
     const $accordionControls = document.createElement('div')
     $accordionControls.setAttribute('class', this.controlsClass)
     $accordionControls.appendChild(this.$showAllButton)
-    this.$module.insertBefore($accordionControls, this.$module.firstChild)
+    this.$root.insertBefore($accordionControls, this.$root.firstChild)
 
     // Build additional wrapper for Show all toggle text and place after icon
     this.$showAllText = document.createElement('span')
@@ -251,7 +251,7 @@ export class Accordion extends GOVUKFrontendComponent {
     $button.setAttribute('type', 'button')
     $button.setAttribute(
       'aria-controls',
-      `${this.$module.id}-content-${index + 1}`
+      `${this.$root.id}-content-${index + 1}`
     )
 
     // Copy all attributes from $span to $button (except `id`, which gets added

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -19,9 +19,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class Accordion extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {AccordionConfig}
@@ -116,20 +113,10 @@ export class Accordion extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Accordion,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $root.dataset)
+      normaliseDataset(Accordion, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const {
   goToExample,
   render,
@@ -709,6 +711,21 @@ describe('/components/accordion', () => {
               message:
                 'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
             }
+          })
+        })
+
+        it('throws when initialised twice', async () => {
+          await expect(
+            render(page, 'accordion', examples.default, {
+              async afterInitialisation($module) {
+                const { Accordion } = await import('govuk-frontend')
+                new Accordion($module)
+              }
+            })
+          ).rejects.toMatchObject({
+            name: 'InitError',
+            message:
+              'Root element (`$module`) already initialised (`govuk-accordion`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -739,7 +739,7 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Accordion: Root element (`$root`) not found'
+              message: 'govuk-accordion: Root element (`$root`) not found'
             }
           })
         })
@@ -756,7 +756,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Root element (`$root`) is not of type HTMLElement'
+                'govuk-accordion: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -777,7 +777,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Sections (`<div class="govuk-accordion__section">`) not found'
+                'govuk-accordion: Sections (`<div class="govuk-accordion__section">`) not found'
             }
           })
         })
@@ -798,7 +798,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section headers (`<div class="govuk-accordion__section-header">`) not found'
+                'govuk-accordion: Section headers (`<div class="govuk-accordion__section-header">`) not found'
             }
           })
         })
@@ -817,7 +817,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section heading (`.govuk-accordion__section-heading`) not found'
+                'govuk-accordion: Section heading (`.govuk-accordion__section-heading`) not found'
             }
           })
         })
@@ -836,7 +836,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section button placeholder (`<span class="govuk-accordion__section-button">`) not found'
+                'govuk-accordion: Section button placeholder (`<span class="govuk-accordion__section-button">`) not found'
             }
           })
         })
@@ -855,7 +855,7 @@ describe('/components/accordion', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Section content (`<div class="govuk-accordion__section-content">`) not found'
+                'govuk-accordion: Section content (`<div class="govuk-accordion__section-content">`) not found'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -725,7 +725,7 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             name: 'InitError',
             message:
-              'Root element (`$module`) already initialised (`govuk-accordion`)'
+              'Root element (`$root`) already initialised (`govuk-accordion`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -717,9 +717,9 @@ describe('/components/accordion', () => {
         it('throws when initialised twice', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              async afterInitialisation($module) {
+              async afterInitialisation($root) {
                 const { Accordion } = await import('govuk-frontend')
-                new Accordion($module)
+                new Accordion($root)
               }
             })
           ).rejects.toMatchObject({
@@ -729,34 +729,34 @@ describe('/components/accordion', () => {
           })
         })
 
-        it('throws when $module is not set', async () => {
+        it('throws when $root is not set', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module) {
-                $module.remove()
+              beforeInitialisation($root) {
+                $root.remove()
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Accordion: Root element (`$module`) not found'
+              message: 'Accordion: Root element (`$root`) not found'
             }
           })
         })
 
-        it('throws when receiving the wrong type for $module', async () => {
+        it('throws when receiving the wrong type for $root', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module) {
+              beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-                $module.outerHTML = `<svg data-module="govuk-accordion"></svg>`
+                $root.outerHTML = `<svg data-module="govuk-accordion"></svg>`
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
               message:
-                'Accordion: Root element (`$module`) is not of type HTMLElement'
+                'Accordion: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -764,8 +764,8 @@ describe('/components/accordion', () => {
         it('throws when the accordion sections are missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module
+              beforeInitialisation($root, { selector }) {
+                $root
                   .querySelectorAll(selector)
                   .forEach((item) => item.remove())
               },
@@ -785,8 +785,8 @@ describe('/components/accordion', () => {
         it('throws when section header is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module
+              beforeInitialisation($root, { selector }) {
+                $root
                   .querySelectorAll(selector)
                   .forEach((item) => item.remove())
               },
@@ -806,8 +806,8 @@ describe('/components/accordion', () => {
         it('throws when any section heading is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-accordion__section-heading'
@@ -825,8 +825,8 @@ describe('/components/accordion', () => {
         it('throws when any section button placeholder span is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-accordion__section-button'
@@ -844,8 +844,8 @@ describe('/components/accordion', () => {
         it('throws when any section content is missing', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-accordion__section-content'

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -725,7 +725,7 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             name: 'InitError',
             message:
-              'Root element (`$root`) already initialised (`govuk-accordion`)'
+              'govuk-accordion: Root element (`$root`) already initialised'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -12,7 +12,7 @@ const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
  */
 export class Button extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -27,32 +27,30 @@ export class Button extends GOVUKFrontendComponent {
   debounceFormSubmitTimer = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for button
+   * @param {Element | null} $root - HTML element to use for button
    * @param {ButtonConfig} [config] - Button config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Button',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       Button.defaults,
       config,
-      normaliseDataset(Button, $module.dataset)
+      normaliseDataset(Button, $root.dataset)
     )
 
-    this.$module.addEventListener('keydown', (event) =>
-      this.handleKeyDown(event)
-    )
-    this.$module.addEventListener('click', (event) => this.debounce(event))
+    this.$root.addEventListener('keydown', (event) => this.handleKeyDown(event))
+    this.$root.addEventListener('click', (event) => this.debounce(event))
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -35,7 +35,7 @@ export class Button extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Button',
+        component: Button,
         element: $root,
         identifier: 'Root element (`$root`)'
       })

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -31,7 +31,7 @@ export class Button extends GOVUKFrontendComponent {
    * @param {ButtonConfig} [config] - Button config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -1,6 +1,5 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
@@ -11,9 +10,6 @@ const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
  * @preserve
  */
 export class Button extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {ButtonConfig}
@@ -33,20 +29,10 @@ export class Button extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Button,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       Button.defaults,
       config,
-      normaliseDataset(Button, $root.dataset)
+      normaliseDataset(Button, this.$root.dataset)
     )
 
     this.$root.addEventListener('keydown', (event) => this.handleKeyDown(event))

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -326,6 +328,21 @@ describe('/components/button', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'button', examples.default, {
+            async afterInitialisation($module) {
+              const { Button } = await import('govuk-frontend')
+              new Button($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-button`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -341,8 +341,7 @@ describe('/components/button', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message:
-            'Root element (`$module`) already initialised (`govuk-button`)'
+          message: 'Root element (`$root`) already initialised (`govuk-button`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -355,7 +355,7 @@ describe('/components/button', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Button: Root element (`$root`) not found'
+            message: 'govuk-button: Root element (`$root`) not found'
           }
         })
       })
@@ -371,7 +371,8 @@ describe('/components/button', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Button: Root element (`$root`) is not of type HTMLElement'
+            message:
+              'govuk-button: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -334,9 +334,9 @@ describe('/components/button', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'button', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { Button } = await import('govuk-frontend')
-              new Button($module)
+              new Button($root)
             }
           })
         ).rejects.toMatchObject({
@@ -345,34 +345,33 @@ describe('/components/button', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'button', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Button: Root element (`$module`) not found'
+            message: 'Button: Root element (`$root`) not found'
           }
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
+      it('throws when receiving the wrong type for $root', async () => {
         await expect(
           render(page, 'button', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-button"></svg>`
+              $root.outerHTML = `<svg data-module="govuk-button"></svg>`
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message:
-              'Button: Root element (`$module`) is not of type HTMLElement'
+            message: 'Button: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -341,7 +341,7 @@ describe('/components/button', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message: 'Root element (`$root`) already initialised (`govuk-button`)'
+          message: 'govuk-button: Root element (`$root`) already initialised'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -19,7 +19,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $textarea
@@ -58,21 +58,21 @@ export class CharacterCount extends GOVUKFrontendComponent {
   maxLength
 
   /**
-   * @param {Element | null} $module - HTML element to use for character count
+   * @param {Element | null} $root - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Character count',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $textarea = $module.querySelector('.govuk-js-character-count')
+    const $textarea = $root.querySelector('.govuk-js-character-count')
     if (
       !(
         $textarea instanceof HTMLTextAreaElement ||
@@ -88,7 +88,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     }
 
     // Read config set using dataset ('data-' values)
-    const datasetConfig = normaliseDataset(CharacterCount, $module.dataset)
+    const datasetConfig = normaliseDataset(CharacterCount, $root.dataset)
 
     // To ensure data-attributes take complete precedence, even if they change
     // the type of count, we need to reset the `maxlength` and `maxwords` from
@@ -120,13 +120,13 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($module, 'lang')
+      locale: closestAttributeValue($root, 'lang')
     })
 
     // Determine the limit attribute (characters or words)
     this.maxLength = this.config.maxwords ?? this.config.maxlength ?? Infinity
 
-    this.$module = $module
+    this.$root = $root
     this.$textarea = $textarea
 
     const textareaDescriptionId = `${this.$textarea.id}-info`

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -66,7 +66,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Character count',
+        component: CharacterCount,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -80,7 +80,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
       )
     ) {
       throw new ElementError({
-        componentName: 'Character count',
+        component: CharacterCount,
         element: $textarea,
         expectedType: 'HTMLTextareaElement or HTMLInputElement',
         identifier: 'Form field (`.govuk-js-character-count`)'
@@ -133,7 +133,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     const $textareaDescription = document.getElementById(textareaDescriptionId)
     if (!$textareaDescription) {
       throw new ElementError({
-        componentName: 'Character count',
+        component: CharacterCount,
         element: $textareaDescription,
         identifier: `Count message (\`id="${textareaDescriptionId}"\`)`
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -62,7 +62,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
    * @param {CharacterCountConfig} [config] - Character count config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -1,5 +1,9 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
-import { mergeConfigs, validateConfig } from '../../common/index.mjs'
+import {
+  formatErrorMessage,
+  mergeConfigs,
+  validateConfig
+} from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ConfigError, ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
@@ -115,7 +119,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     // Check for valid config
     const errors = validateConfig(CharacterCount.schema, this.config)
     if (errors[0]) {
-      throw new ConfigError(`Character count: ${errors[0]}`)
+      throw new ConfigError(formatErrorMessage(CharacterCount, errors[0]))
     }
 
     this.i18n = new I18n(this.config.i18n, {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -23,9 +23,6 @@ import { I18n } from '../../i18n.mjs'
  */
 export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $textarea
 
   /** @private */
@@ -68,15 +65,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: CharacterCount,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $textarea = $root.querySelector('.govuk-js-character-count')
+    const $textarea = this.$root.querySelector('.govuk-js-character-count')
     if (
       !(
         $textarea instanceof HTMLTextAreaElement ||
@@ -92,7 +81,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     }
 
     // Read config set using dataset ('data-' values)
-    const datasetConfig = normaliseDataset(CharacterCount, $root.dataset)
+    const datasetConfig = normaliseDataset(CharacterCount, this.$root.dataset)
 
     // To ensure data-attributes take complete precedence, even if they change
     // the type of count, we need to reset the `maxlength` and `maxwords` from
@@ -124,13 +113,12 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($root, 'lang')
+      locale: closestAttributeValue(this.$root, 'lang')
     })
 
     // Determine the limit attribute (characters or words)
     this.maxLength = this.config.maxwords ?? this.config.maxlength ?? Infinity
 
-    this.$root = $root
     this.$textarea = $textarea
 
     const textareaDescriptionId = `${this.$textarea.id}-info`

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { setTimeout } = require('timers/promises')
 
 const { render } = require('@govuk-frontend/helpers/puppeteer')
@@ -809,6 +811,21 @@ describe('Character count', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'character-count', examples.default, {
+            async afterInitialisation($module) {
+              const { CharacterCount } = await import('govuk-frontend')
+              new CharacterCount($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-character-count`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -825,7 +825,7 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           name: 'InitError',
           message:
-            'Root element (`$module`) already initialised (`govuk-character-count`)'
+            'Root element (`$root`) already initialised (`govuk-character-count`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -839,7 +839,7 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Character count: Root element (`$root`) not found'
+            message: 'govuk-character-count: Root element (`$root`) not found'
           }
         })
       })
@@ -856,7 +856,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Root element (`$root`) is not of type HTMLElement'
+              'govuk-character-count: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -875,7 +875,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Form field (`.govuk-js-character-count`) not found'
+              'govuk-character-count: Form field (`.govuk-js-character-count`) not found'
           }
         })
       })
@@ -896,7 +896,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Form field (`.govuk-js-character-count`) is not of type HTMLTextareaElement or HTMLInputElement'
+              'govuk-character-count: Form field (`.govuk-js-character-count`) is not of type HTMLTextareaElement or HTMLInputElement'
           }
         })
       })
@@ -915,7 +915,7 @@ describe('Character count', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Count message (`id="more-detail-info"`) not found'
+              'govuk-character-count: Count message (`id="more-detail-info"`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -817,9 +817,9 @@ describe('Character count', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { CharacterCount } = await import('govuk-frontend')
-              new CharacterCount($module)
+              new CharacterCount($root)
             }
           })
         ).rejects.toMatchObject({
@@ -829,34 +829,34 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Character count: Root element (`$module`) not found'
+            message: 'Character count: Root element (`$root`) not found'
           }
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
+      it('throws when receiving the wrong type for $root', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-character-count"></svg>`
+              $root.outerHTML = `<svg data-module="govuk-character-count"></svg>`
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
             message:
-              'Character count: Root element (`$module`) is not of type HTMLElement'
+              'Character count: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -864,8 +864,8 @@ describe('Character count', () => {
       it('throws when the textarea is missing', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).remove()
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '.govuk-js-character-count'
@@ -883,9 +883,9 @@ describe('Character count', () => {
       it('throws when the textarea is not the right type', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module, { selector }) {
+            beforeInitialisation($root, { selector }) {
               // Replace with a tag that's neither an `<input>` or `<textarea>`
-              $module.querySelector(selector).outerHTML =
+              $root.querySelector(selector).outerHTML =
                 '<div class="govuk-js-character-count"></div>'
             },
             context: {
@@ -904,8 +904,8 @@ describe('Character count', () => {
       it('throws when the textarea description is missing', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).remove()
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '#more-detail-info'
@@ -949,14 +949,14 @@ describe('Character count', () => {
           // Override maxlength to 10
           maxlength: 10
         },
-        beforeInitialisation($module) {
+        beforeInitialisation($root) {
           // Set locale to Welsh, which expects translations for 'one', 'two',
           // 'few' 'many' and 'other' forms – with the default English strings
           // provided we only have translations for 'one' and 'other'.
           //
           // We want to make sure we handle this gracefully in case users have
           // an existing character count inside an incorrect locale.
-          $module.setAttribute('lang', 'cy')
+          $root.setAttribute('lang', 'cy')
         }
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -931,7 +931,7 @@ describe('Character count', () => {
           cause: {
             name: 'ConfigError',
             message:
-              'Character count: Either "maxlength" or "maxwords" must be provided'
+              'govuk-character-count: Either "maxlength" or "maxwords" must be provided'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -825,7 +825,7 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           name: 'InitError',
           message:
-            'Root element (`$root`) already initialised (`govuk-character-count`)'
+            'govuk-character-count: Root element (`$root`) already initialised'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -8,7 +8,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Checkboxes extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $inputs
@@ -25,20 +25,20 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * (for example if the user has navigated back), and set up event handlers to
    * keep the reveal in sync with the checkbox state.
    *
-   * @param {Element | null} $module - HTML element to use for checkboxes
+   * @param {Element | null} $root - HTML element to use for checkboxes
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Checkboxes',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $inputs = $module.querySelectorAll('input[type="checkbox"]')
+    const $inputs = $root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError({
         componentName: 'Checkboxes',
@@ -46,7 +46,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
       })
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {
@@ -82,11 +82,11 @@ export class Checkboxes extends GOVUKFrontendComponent {
     this.syncAllConditionalReveals()
 
     // Handle events
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
+    this.$root.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**
-   * Sync the conditional reveal states for all checkboxes in this $module.
+   * Sync the conditional reveal states for all checkboxes in this component.
    *
    * @private
    */
@@ -174,7 +174,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
   /**
    * Click event handler
    *
-   * Handle a click within the $module – if the click occurred on a checkbox,
+   * Handle a click within the component root – if the click occurred on a checkbox,
    * sync the state of any associated conditional reveal with the checkbox
    * state.
    *

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -32,7 +32,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Checkboxes',
+        component: Checkboxes,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -41,7 +41,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
     const $inputs = $root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError({
-        componentName: 'Checkboxes',
+        component: Checkboxes,
         identifier: 'Form inputs (`<input type="checkbox">`)'
       })
     }
@@ -60,7 +60,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
       // Throw if target conditional element does not exist.
       if (!document.getElementById(targetId)) {
         throw new ElementError({
-          componentName: 'Checkboxes',
+          component: Checkboxes,
           identifier: `Conditional reveal (\`id="${targetId}"\`)`
         })
       }

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -28,7 +28,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for checkboxes
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -8,9 +8,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Checkboxes extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $inputs
 
   /**
@@ -30,15 +27,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Checkboxes,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $inputs = $root.querySelectorAll('input[type="checkbox"]')
+    const $inputs = this.$root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError({
         component: Checkboxes,
@@ -46,7 +35,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
       })
     }
 
-    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -372,9 +372,9 @@ describe('Checkboxes', () => {
         it('throws when initialised twice', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              async afterInitialisation($module) {
+              async afterInitialisation($root) {
                 const { Checkboxes } = await import('govuk-frontend')
-                new Checkboxes($module)
+                new Checkboxes($root)
               }
             })
           ).rejects.toMatchObject({
@@ -384,34 +384,34 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when $module is not set', async () => {
+        it('throws when $root is not set', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              beforeInitialisation($module) {
-                $module.remove()
+              beforeInitialisation($root) {
+                $root.remove()
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Checkboxes: Root element (`$module`) not found'
+              message: 'Checkboxes: Root element (`$root`) not found'
             }
           })
         })
 
-        it('throws when receiving the wrong type for $module', async () => {
+        it('throws when receiving the wrong type for $root', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              beforeInitialisation($module) {
+              beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-                $module.outerHTML = `<svg data-module="govuk-checkboxes"></svg>`
+                $root.outerHTML = `<svg data-module="govuk-checkboxes"></svg>`
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Root element (`$module`) is not of type HTMLElement'
+                'Checkboxes: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -419,8 +419,8 @@ describe('Checkboxes', () => {
         it('throws when the input list is empty', async () => {
           await expect(
             render(page, 'checkboxes', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module
+              beforeInitialisation($root, { selector }) {
+                $root
                   .querySelectorAll(selector)
                   .forEach((item) => item.remove())
               },
@@ -440,8 +440,8 @@ describe('Checkboxes', () => {
         it('throws when a conditional target element is not found', async () => {
           await expect(
             render(page, 'checkboxes', examples['with conditional items'], {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: '.govuk-checkboxes__conditional'

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -380,7 +380,7 @@ describe('Checkboxes', () => {
           ).rejects.toMatchObject({
             name: 'InitError',
             message:
-              'Root element (`$module`) already initialised (`govuk-checkboxes`)'
+              'Root element (`$root`) already initialised (`govuk-checkboxes`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -394,7 +394,7 @@ describe('Checkboxes', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Checkboxes: Root element (`$root`) not found'
+              message: 'govuk-checkboxes: Root element (`$root`) not found'
             }
           })
         })
@@ -411,7 +411,7 @@ describe('Checkboxes', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Root element (`$root`) is not of type HTMLElement'
+                'govuk-checkboxes: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -432,7 +432,7 @@ describe('Checkboxes', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Form inputs (`<input type="checkbox">`) not found'
+                'govuk-checkboxes: Form inputs (`<input type="checkbox">`) not found'
             }
           })
         })
@@ -451,7 +451,7 @@ describe('Checkboxes', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Checkboxes: Conditional reveal (`id="conditional-how-contacted"`) not found'
+                'govuk-checkboxes: Conditional reveal (`id="conditional-how-contacted"`) not found'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const {
   goToExample,
   getAttribute,
@@ -364,6 +366,21 @@ describe('Checkboxes', () => {
               message:
                 'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
             }
+          })
+        })
+
+        it('throws when initialised twice', async () => {
+          await expect(
+            render(page, 'checkboxes', examples.default, {
+              async afterInitialisation($module) {
+                const { Checkboxes } = await import('govuk-frontend')
+                new Checkboxes($module)
+              }
+            })
+          ).rejects.toMatchObject({
+            name: 'InitError',
+            message:
+              'Root element (`$module`) already initialised (`govuk-checkboxes`)'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -380,7 +380,7 @@ describe('Checkboxes', () => {
           ).rejects.toMatchObject({
             name: 'InitError',
             message:
-              'Root element (`$root`) already initialised (`govuk-checkboxes`)'
+              'govuk-checkboxes: Root element (`$root`) already initialised'
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -34,7 +34,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Error summary',
+        component: ErrorSummary,
         element: $root,
         identifier: 'Root element (`$root`)'
       })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -17,7 +17,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class ErrorSummary extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -26,36 +26,36 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   config
 
   /**
-   * @param {Element | null} $module - HTML element to use for error summary
+   * @param {Element | null} $root - HTML element to use for error summary
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Error summary',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       ErrorSummary.defaults,
       config,
-      normaliseDataset(ErrorSummary, $module.dataset)
+      normaliseDataset(ErrorSummary, $root.dataset)
     )
 
     /**
      * Focus the error summary
      */
     if (!this.config.disableAutoFocus) {
-      setFocus(this.$module)
+      setFocus(this.$root)
     }
 
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
+    this.$root.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -30,7 +30,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -4,7 +4,6 @@ import {
   setFocus
 } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -16,9 +15,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  * @preserve
  */
 export class ErrorSummary extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {ErrorSummaryConfig}
@@ -32,20 +28,10 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: ErrorSummary,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       ErrorSummary.defaults,
       config,
-      normaliseDataset(ErrorSummary, $root.dataset)
+      normaliseDataset(ErrorSummary, this.$root.dataset)
     )
 
     /**

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -249,7 +249,7 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$module`) already initialised (`govuk-error-summary`)'
+          'Root element (`$root`) already initialised (`govuk-error-summary`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -241,9 +241,9 @@ describe('Error Summary', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { ErrorSummary } = await import('govuk-frontend')
-            new ErrorSummary($module)
+            new ErrorSummary($root)
           }
         })
       ).rejects.toMatchObject({
@@ -253,34 +253,34 @@ describe('Error Summary', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Error summary: Root element (`$module`) not found'
+          message: 'Error summary: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-error-summary"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-error-summary"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Error summary: Root element (`$module`) is not of type HTMLElement'
+            'Error summary: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -233,6 +235,21 @@ describe('Error Summary', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'error-summary', examples.default, {
+          async afterInitialisation($module) {
+            const { ErrorSummary } = await import('govuk-frontend')
+            new ErrorSummary($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message:
+          'Root element (`$module`) already initialised (`govuk-error-summary`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -263,7 +263,7 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Error summary: Root element (`$root`) not found'
+          message: 'govuk-error-summary: Root element (`$root`) not found'
         }
       })
     })
@@ -280,7 +280,7 @@ describe('Error Summary', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Error summary: Root element (`$root`) is not of type HTMLElement'
+            'govuk-error-summary: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -249,7 +249,7 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$root`) already initialised (`govuk-error-summary`)'
+          'govuk-error-summary: Root element (`$root`) already initialised'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -79,7 +79,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -83,7 +83,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Exit this page',
+        component: ExitThisPage,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -92,7 +92,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     const $button = $root.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
       throw new ElementError({
-        componentName: 'Exit this page',
+        component: ExitThisPage,
         element: $button,
         expectedType: 'HTMLAnchorElement',
         identifier: 'Button (`.govuk-exit-this-page__button`)'

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -11,7 +11,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class ExitThisPage extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -75,21 +75,21 @@ export class ExitThisPage extends GOVUKFrontendComponent {
   timeoutMessageId = null
 
   /**
-   * @param {Element | null} $module - HTML element that wraps the Exit This Page button
+   * @param {Element | null} $root - HTML element that wraps the Exit This Page button
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Exit this page',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $button = $module.querySelector('.govuk-exit-this-page__button')
+    const $button = $root.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
       throw new ElementError({
         componentName: 'Exit this page',
@@ -102,11 +102,11 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.config = mergeConfigs(
       ExitThisPage.defaults,
       config,
-      normaliseDataset(ExitThisPage, $module.dataset)
+      normaliseDataset(ExitThisPage, $root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)
-    this.$module = $module
+    this.$root = $root
     this.$button = $button
 
     const $skiplinkButton = document.querySelector(
@@ -142,7 +142,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.$updateSpan.setAttribute('role', 'status')
     this.$updateSpan.className = 'govuk-visually-hidden'
 
-    this.$module.appendChild(this.$updateSpan)
+    this.$root.appendChild(this.$updateSpan)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -10,9 +10,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class ExitThisPage extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {ExitThisPageConfig}
@@ -81,15 +78,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: ExitThisPage,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $button = $root.querySelector('.govuk-exit-this-page__button')
+    const $button = this.$root.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
       throw new ElementError({
         component: ExitThisPage,
@@ -102,11 +91,10 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.config = mergeConfigs(
       ExitThisPage.defaults,
       config,
-      normaliseDataset(ExitThisPage, $root.dataset)
+      normaliseDataset(ExitThisPage, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)
-    this.$root = $root
     this.$button = $button
 
     const $skiplinkButton = document.querySelector(

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -244,7 +244,7 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           name: 'InitError',
           message:
-            'Root element (`$module`) already initialised (`govuk-exit-this-page`)'
+            'Root element (`$root`) already initialised (`govuk-exit-this-page`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { setTimeout } = require('timers/promises')
 
 const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
@@ -228,6 +230,21 @@ describe('/components/exit-this-page', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'exit-this-page', examples.default, {
+            async afterInitialisation($module) {
+              const { ExitThisPage } = await import('govuk-frontend')
+              new ExitThisPage($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-exit-this-page`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -236,9 +236,9 @@ describe('/components/exit-this-page', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { ExitThisPage } = await import('govuk-frontend')
-              new ExitThisPage($module)
+              new ExitThisPage($root)
             }
           })
         ).rejects.toMatchObject({
@@ -248,34 +248,34 @@ describe('/components/exit-this-page', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Exit this page: Root element (`$module`) not found'
+            message: 'Exit this page: Root element (`$root`) not found'
           }
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
+      it('throws when receiving the wrong type for $root', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-exit-this-page"></svg>`
+              $root.outerHTML = `<svg data-module="govuk-exit-this-page"></svg>`
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
             message:
-              'Exit this page: Root element (`$module`) is not of type HTMLElement'
+              'Exit this page: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -283,8 +283,8 @@ describe('/components/exit-this-page', () => {
       it('throws when the button is missing', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).remove()
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '.govuk-exit-this-page__button'

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -258,7 +258,7 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Exit this page: Root element (`$root`) not found'
+            message: 'govuk-exit-this-page: Root element (`$root`) not found'
           }
         })
       })
@@ -275,7 +275,7 @@ describe('/components/exit-this-page', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Exit this page: Root element (`$root`) is not of type HTMLElement'
+              'govuk-exit-this-page: Root element (`$root`) is not of type HTMLElement'
           }
         })
       })
@@ -294,7 +294,7 @@ describe('/components/exit-this-page', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Exit this page: Button (`.govuk-exit-this-page__button`) not found'
+              'govuk-exit-this-page: Button (`.govuk-exit-this-page__button`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -244,7 +244,7 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           name: 'InitError',
           message:
-            'Root element (`$root`) already initialised (`govuk-exit-this-page`)'
+            'govuk-exit-this-page: Root element (`$root`) already initialised'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -43,7 +43,7 @@ export class Header extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for header
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!$module) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -47,7 +47,7 @@ export class Header extends GOVUKFrontendComponent {
 
     if (!$root) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -66,7 +66,7 @@ export class Header extends GOVUKFrontendComponent {
     const menuId = $menuButton.getAttribute('aria-controls')
     if (!menuId) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         identifier:
           'Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`)'
       })
@@ -75,7 +75,7 @@ export class Header extends GOVUKFrontendComponent {
     const $menu = document.getElementById(menuId)
     if (!$menu) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         element: $menu,
         identifier: `Navigation (\`<ul id="${menuId}">\`)`
       })
@@ -101,7 +101,7 @@ export class Header extends GOVUKFrontendComponent {
 
     if (!breakpoint.value) {
       throw new ElementError({
-        componentName: 'Header',
+        component: Header,
         identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -9,7 +9,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Header extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $menuButton
@@ -40,21 +40,21 @@ export class Header extends GOVUKFrontendComponent {
    * Apply a matchMedia for desktop which will trigger a state sync if the
    * browser viewport moves between states.
    *
-   * @param {Element | null} $module - HTML element to use for header
+   * @param {Element | null} $root - HTML element to use for header
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!$module) {
+    if (!$root) {
       throw new ElementError({
         componentName: 'Header',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
-    const $menuButton = $module.querySelector('.govuk-js-header-toggle')
+    this.$root = $root
+    const $menuButton = $root.querySelector('.govuk-js-header-toggle')
 
     // Headers don't necessarily have a navigation. When they don't, the menu
     // toggle won't be rendered by our macro (or may be omitted when writing

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -9,9 +9,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Header extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $menuButton
 
   /** @private */
@@ -45,16 +42,7 @@ export class Header extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!$root) {
-      throw new ElementError({
-        component: Header,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-    const $menuButton = $root.querySelector('.govuk-js-header-toggle')
+    const $menuButton = this.$root.querySelector('.govuk-js-header-toggle')
 
     // Headers don't necessarily have a navigation. When they don't, the menu
     // toggle won't be rendered by our macro (or may be omitted when writing

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 const { KnownDevices } = require('puppeteer')
@@ -178,6 +180,21 @@ describe('Header navigation', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'header', examples.default, {
+            async afterInitialisation($module) {
+              const { Header } = await import('govuk-frontend')
+              new Header($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message:
+            'Root element (`$module`) already initialised (`govuk-header`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -193,8 +193,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message:
-            'Root element (`$module`) already initialised (`govuk-header`)'
+          message: 'Root element (`$root`) already initialised (`govuk-header`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -186,9 +186,9 @@ describe('Header navigation', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'header', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { Header } = await import('govuk-frontend')
-              new Header($module)
+              new Header($root)
             }
           })
         ).rejects.toMatchObject({
@@ -197,19 +197,19 @@ describe('Header navigation', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'header', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Remove the root of the components as a way
-              // for the constructor to receive the wrong type for `$module`
-              $module.remove()
+              // for the constructor to receive the wrong type for `$root`
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Header: Root element (`$module`) not found'
+            message: 'Header: Root element (`$root`) not found'
           }
         })
       })
@@ -217,8 +217,8 @@ describe('Header navigation', () => {
       it("throws when the toggle's aria-control attribute is missing", async () => {
         await expect(
           render(page, 'header', examples['with navigation'], {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).removeAttribute('aria-controls')
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).removeAttribute('aria-controls')
             },
             context: {
               selector: '.govuk-js-header-toggle'
@@ -236,9 +236,9 @@ describe('Header navigation', () => {
       it('throws when the menu is missing, but a toggle is present', async () => {
         await expect(
           render(page, 'header', examples['with navigation'], {
-            beforeInitialisation($module, { selector }) {
+            beforeInitialisation($root, { selector }) {
               // Remove the menu `<ul>` referenced by $menuButton's `aria-controls`
-              $module.querySelector(selector).remove()
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: '#navigation'

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -209,7 +209,7 @@ describe('Header navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Header: Root element (`$root`) not found'
+            message: 'govuk-header: Root element (`$root`) not found'
           }
         })
       })
@@ -228,7 +228,7 @@ describe('Header navigation', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Header: Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`) not found'
+              'govuk-header: Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`) not found'
           }
         })
       })
@@ -247,7 +247,8 @@ describe('Header navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Header: Navigation (`<ul id="navigation">`) not found'
+            message:
+              'govuk-header: Navigation (`<ul id="navigation">`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -193,7 +193,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message: 'Root element (`$root`) already initialised (`govuk-header`)'
+          message: 'govuk-header: Root element (`$root`) already initialised'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -23,7 +23,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
   constructor($module, config = {}) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -27,7 +27,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Notification banner',
+        component: NotificationBanner,
         element: $root,
         identifier: 'Root element (`$root`)'
       })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -10,7 +10,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class NotificationBanner extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -19,26 +19,26 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   config
 
   /**
-   * @param {Element | null} $module - HTML element to use for notification banner
+   * @param {Element | null} $root - HTML element to use for notification banner
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
-  constructor($module, config = {}) {
-    super($module)
+  constructor($root, config = {}) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Notification banner',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
     this.config = mergeConfigs(
       NotificationBanner.defaults,
       config,
-      normaliseDataset(NotificationBanner, $module.dataset)
+      normaliseDataset(NotificationBanner, $root.dataset)
     )
 
     /**
@@ -53,10 +53,10 @@ export class NotificationBanner extends GOVUKFrontendComponent {
      * element which should be focused when the page loads.
      */
     if (
-      this.$module.getAttribute('role') === 'alert' &&
+      this.$root.getAttribute('role') === 'alert' &&
       !this.config.disableAutoFocus
     ) {
-      setFocus(this.$module)
+      setFocus(this.$root)
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,6 +1,5 @@
 import { mergeConfigs, setFocus } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -9,9 +8,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  * @preserve
  */
 export class NotificationBanner extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {NotificationBannerConfig}
@@ -25,20 +21,10 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: NotificationBanner,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       NotificationBanner.defaults,
       config,
-      normaliseDataset(NotificationBanner, $root.dataset)
+      normaliseDataset(NotificationBanner, this.$root.dataset)
     )
 
     /**

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -249,7 +249,7 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$module`) already initialised (`govuk-notification-banner`)'
+          'Root element (`$root`) already initialised (`govuk-notification-banner`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -241,9 +241,9 @@ describe('Notification banner', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { NotificationBanner } = await import('govuk-frontend')
-            new NotificationBanner($module)
+            new NotificationBanner($root)
           }
         })
       ).rejects.toMatchObject({
@@ -253,34 +253,34 @@ describe('Notification banner', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Notification banner: Root element (`$module`) not found'
+          message: 'Notification banner: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-notification-banner"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-notification-banner"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Notification banner: Root element (`$module`) is not of type HTMLElement'
+            'Notification banner: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -263,7 +263,7 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Notification banner: Root element (`$root`) not found'
+          message: 'govuk-notification-banner: Root element (`$root`) not found'
         }
       })
     })
@@ -280,7 +280,7 @@ describe('Notification banner', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Notification banner: Root element (`$root`) is not of type HTMLElement'
+            'govuk-notification-banner: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -233,6 +235,21 @@ describe('Notification banner', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'notification-banner', examples.default, {
+          async afterInitialisation($module) {
+            const { NotificationBanner } = await import('govuk-frontend')
+            new NotificationBanner($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message:
+          'Root element (`$module`) already initialised (`govuk-notification-banner`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -249,7 +249,7 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$root`) already initialised (`govuk-notification-banner`)'
+          'govuk-notification-banner: Root element (`$root`) already initialised'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -12,7 +12,7 @@ import { I18n } from '../../i18n.mjs'
  */
 export class PasswordInput extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
    * @private
@@ -39,21 +39,21 @@ export class PasswordInput extends GOVUKFrontendComponent {
   $screenReaderStatusMessage
 
   /**
-   * @param {Element | null} $module - HTML element to use for password input
+   * @param {Element | null} $root - HTML element to use for password input
    * @param {PasswordInputConfig} [config] - Password input config
    */
-  constructor($module, config = {}) {
+  constructor($root, config = {}) {
     super()
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Password input',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $input = $module.querySelector('.govuk-js-password-input-input')
+    const $input = $root.querySelector('.govuk-js-password-input-input')
     if (!($input instanceof HTMLInputElement)) {
       throw new ElementError({
         componentName: 'Password input',
@@ -69,7 +69,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    const $showHideButton = $module.querySelector(
+    const $showHideButton = $root.querySelector(
       '.govuk-js-password-input-toggle'
     )
     if (!($showHideButton instanceof HTMLButtonElement)) {
@@ -87,19 +87,19 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$input = $input
     this.$showHideButton = $showHideButton
 
     this.config = mergeConfigs(
       PasswordInput.defaults,
       config,
-      normaliseDataset(PasswordInput, $module.dataset)
+      normaliseDataset(PasswordInput, $root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($module, 'lang')
+      locale: closestAttributeValue($root, 'lang')
     })
 
     // Show the toggle button element

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -47,7 +47,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Password input',
+        component: PasswordInput,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -56,7 +56,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     const $input = $root.querySelector('.govuk-js-password-input-input')
     if (!($input instanceof HTMLInputElement)) {
       throw new ElementError({
-        componentName: 'Password input',
+        component: PasswordInput,
         element: $input,
         expectedType: 'HTMLInputElement',
         identifier: 'Form field (`.govuk-js-password-input-input`)'
@@ -74,7 +74,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
     )
     if (!($showHideButton instanceof HTMLButtonElement)) {
       throw new ElementError({
-        componentName: 'Password input',
+        component: PasswordInput,
         element: $showHideButton,
         expectedType: 'HTMLButtonElement',
         identifier: 'Button (`.govuk-js-password-input-toggle`)'

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -11,9 +11,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class PasswordInput extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {PasswordInputConfig}
@@ -43,17 +40,9 @@ export class PasswordInput extends GOVUKFrontendComponent {
    * @param {PasswordInputConfig} [config] - Password input config
    */
   constructor($root, config = {}) {
-    super()
+    super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: PasswordInput,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $input = $root.querySelector('.govuk-js-password-input-input')
+    const $input = this.$root.querySelector('.govuk-js-password-input-input')
     if (!($input instanceof HTMLInputElement)) {
       throw new ElementError({
         component: PasswordInput,
@@ -69,7 +58,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    const $showHideButton = $root.querySelector(
+    const $showHideButton = this.$root.querySelector(
       '.govuk-js-password-input-toggle'
     )
     if (!($showHideButton instanceof HTMLButtonElement)) {
@@ -87,19 +76,18 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    this.$root = $root
     this.$input = $input
     this.$showHideButton = $showHideButton
 
     this.config = mergeConfigs(
       PasswordInput.defaults,
       config,
-      normaliseDataset(PasswordInput, $root.dataset)
+      normaliseDataset(PasswordInput, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($root, 'lang')
+      locale: closestAttributeValue(this.$root, 'lang')
     })
 
     // Show the toggle button element

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -212,7 +212,7 @@ describe('/components/password-input', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Password input: Root element (`$root`) not found'
+              message: 'govuk-password-input: Root element (`$root`) not found'
             }
           })
         })
@@ -229,7 +229,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Root element (`$root`) is not of type HTMLElement'
+                'govuk-password-input: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -248,7 +248,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Form field (`.govuk-js-password-input-input`) not found'
+                'govuk-password-input: Form field (`.govuk-js-password-input-input`) not found'
             }
           })
         })
@@ -269,7 +269,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Form field (`.govuk-js-password-input-input`) is not of type HTMLInputElement'
+                'govuk-password-input: Form field (`.govuk-js-password-input-input`) is not of type HTMLInputElement'
             }
           })
         })
@@ -308,7 +308,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Button (`.govuk-js-password-input-toggle`) not found'
+                'govuk-password-input: Button (`.govuk-js-password-input-toggle`) not found'
             }
           })
         })
@@ -329,7 +329,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Button (`.govuk-js-password-input-toggle`) is not of type HTMLButtonElement'
+                'govuk-password-input: Button (`.govuk-js-password-input-toggle`) is not of type HTMLButtonElement'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -202,34 +202,34 @@ describe('/components/password-input', () => {
           })
         })
 
-        it('throws when $module is not set', async () => {
+        it('throws when $root is not set', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module) {
-                $module.remove()
+              beforeInitialisation($root) {
+                $root.remove()
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
-              message: 'Password input: Root element (`$module`) not found'
+              message: 'Password input: Root element (`$root`) not found'
             }
           })
         })
 
-        it('throws when receiving the wrong type for $module', async () => {
+        it('throws when receiving the wrong type for $root', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module) {
+              beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-                $module.outerHTML = `<svg data-module="govuk-password-input"></svg>`
+                $root.outerHTML = `<svg data-module="govuk-password-input"></svg>`
               }
             })
           ).rejects.toMatchObject({
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Root element (`$module`) is not of type HTMLElement'
+                'Password input: Root element (`$root`) is not of type HTMLElement'
             }
           })
         })
@@ -237,8 +237,8 @@ describe('/components/password-input', () => {
         it('throws when the input element is missing', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: inputSelector
@@ -256,9 +256,9 @@ describe('/components/password-input', () => {
         it('throws when the input is not an <input> element', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Replace the input with a textarea
-                $module.querySelector(selector).outerHTML =
+                $root.querySelector(selector).outerHTML =
                   '<textarea class="govuk-js-password-input-input"></textarea>'
               },
               context: {
@@ -277,9 +277,9 @@ describe('/components/password-input', () => {
         it('throws when the input is not a `password` type', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Make the input a number input instead
-                $module.querySelector(selector).setAttribute('type', 'number')
+                $root.querySelector(selector).setAttribute('type', 'number')
               },
               context: {
                 selector: inputSelector
@@ -297,8 +297,8 @@ describe('/components/password-input', () => {
         it('throws when the button is missing', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
-                $module.querySelector(selector).remove()
+              beforeInitialisation($root, { selector }) {
+                $root.querySelector(selector).remove()
               },
               context: {
                 selector: buttonSelector
@@ -316,9 +316,9 @@ describe('/components/password-input', () => {
         it('throws when the button is not a <button> element', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Replace the button with a <div>
-                $module.querySelector(selector).outerHTML =
+                $root.querySelector(selector).outerHTML =
                   '<div class="govuk-js-password-input-toggle"></div>'
               },
               context: {
@@ -337,9 +337,9 @@ describe('/components/password-input', () => {
         it('throws when the button is not a `button` type', async () => {
           await expect(
             render(page, 'password-input', examples.default, {
-              beforeInitialisation($module, { selector }) {
+              beforeInitialisation($root, { selector }) {
                 // Make the button a submit button
-                $module.querySelector(selector).setAttribute('type', 'submit')
+                $root.querySelector(selector).setAttribute('type', 'submit')
               },
               context: {
                 selector: buttonSelector

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -32,7 +32,7 @@ export class Radios extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLElement)) {
       throw new ElementError({
-        componentName: 'Radios',
+        component: Radios,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -41,7 +41,7 @@ export class Radios extends GOVUKFrontendComponent {
     const $inputs = $root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError({
-        componentName: 'Radios',
+        component: Radios,
         identifier: 'Form inputs (`<input type="radio">`)'
       })
     }
@@ -60,7 +60,7 @@ export class Radios extends GOVUKFrontendComponent {
       // Throw if target conditional element does not exist.
       if (!document.getElementById(targetId)) {
         throw new ElementError({
-          componentName: 'Radios',
+          component: Radios,
           identifier: `Conditional reveal (\`id="${targetId}"\`)`
         })
       }

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -8,7 +8,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Radios extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $inputs
@@ -25,20 +25,20 @@ export class Radios extends GOVUKFrontendComponent {
    * (for example if the user has navigated back), and set up event handlers to
    * keep the reveal in sync with the radio state.
    *
-   * @param {Element | null} $module - HTML element to use for radios
+   * @param {Element | null} $root - HTML element to use for radios
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!($module instanceof HTMLElement)) {
+    if (!($root instanceof HTMLElement)) {
       throw new ElementError({
         componentName: 'Radios',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $inputs = $module.querySelectorAll('input[type="radio"]')
+    const $inputs = $root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError({
         componentName: 'Radios',
@@ -46,7 +46,7 @@ export class Radios extends GOVUKFrontendComponent {
       })
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {
@@ -82,11 +82,11 @@ export class Radios extends GOVUKFrontendComponent {
     this.syncAllConditionalReveals()
 
     // Handle events
-    this.$module.addEventListener('click', (event) => this.handleClick(event))
+    this.$root.addEventListener('click', (event) => this.handleClick(event))
   }
 
   /**
-   * Sync the conditional reveal states for all radio buttons in this $module.
+   * Sync the conditional reveal states for all radio buttons in this component.
    *
    * @private
    */
@@ -126,10 +126,10 @@ export class Radios extends GOVUKFrontendComponent {
   /**
    * Click event handler
    *
-   * Handle a click within the $module – if the click occurred on a radio, sync
+   * Handle a click within the component root – if the click occurred on a radio, sync
    * the state of the conditional reveal for all radio buttons in the same form
    * with the same name (because checking one radio could have un-checked a
-   * radio in another $module)
+   * radio under the root of another Radio component)
    *
    * @private
    * @param {MouseEvent} event - Click event

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -28,7 +28,7 @@ export class Radios extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for radios
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -8,9 +8,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Radios extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $inputs
 
   /**
@@ -30,15 +27,7 @@ export class Radios extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Radios,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $inputs = $root.querySelectorAll('input[type="radio"]')
+    const $inputs = this.$root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError({
         component: Radios,
@@ -46,7 +35,6 @@ export class Radios extends GOVUKFrontendComponent {
       })
     }
 
-    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -346,7 +346,7 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$root`) not found'
+          message: 'govuk-radios: Root element (`$root`) not found'
         }
       })
     })
@@ -362,7 +362,8 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$root`) is not of type HTMLElement'
+          message:
+            'govuk-radios: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })
@@ -380,7 +381,8 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Form inputs (`<input type="radio">`) not found'
+          message:
+            'govuk-radios: Form inputs (`<input type="radio">`) not found'
         }
       })
     })
@@ -396,7 +398,7 @@ describe('Radios', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Radios: Conditional reveal (`id="conditional-how-contacted"`) not found'
+            'govuk-radios: Conditional reveal (`id="conditional-how-contacted"`) not found'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const {
   goToExample,
   getProperty,
@@ -317,6 +319,20 @@ describe('Radios', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'radios', examples.default, {
+          async afterInitialisation($module) {
+            const { Radios } = await import('govuk-frontend')
+            new Radios($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message: 'Root element (`$module`) already initialised (`govuk-radios`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -325,9 +325,9 @@ describe('Radios', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { Radios } = await import('govuk-frontend')
-            new Radios($module)
+            new Radios($root)
           }
         })
       ).rejects.toMatchObject({
@@ -336,33 +336,33 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$module`) not found'
+          message: 'Radios: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-radios"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-radios"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Radios: Root element (`$module`) is not of type HTMLElement'
+          message: 'Radios: Root element (`$root`) is not of type HTMLElement'
         }
       })
     })
@@ -370,8 +370,8 @@ describe('Radios', () => {
     it('throws when the input list is empty', async () => {
       await expect(
         render(page, 'radios', examples.default, {
-          beforeInitialisation($module, { selector }) {
-            $module.querySelectorAll(selector).forEach((item) => item.remove())
+          beforeInitialisation($root, { selector }) {
+            $root.querySelectorAll(selector).forEach((item) => item.remove())
           },
           context: {
             selector: '.govuk-radios__item'
@@ -388,8 +388,8 @@ describe('Radios', () => {
     it('throws when a conditional target element is not found', async () => {
       await expect(
         render(page, 'radios', examples['with conditional items'], {
-          beforeInitialisation($module) {
-            $module.querySelector('.govuk-radios__conditional').remove()
+          beforeInitialisation($root) {
+            $root.querySelector('.govuk-radios__conditional').remove()
           }
         })
       ).rejects.toMatchObject({

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -332,7 +332,7 @@ describe('Radios', () => {
         })
       ).rejects.toMatchObject({
         name: 'InitError',
-        message: 'Root element (`$module`) already initialised (`govuk-radios`)'
+        message: 'Root element (`$root`) already initialised (`govuk-radios`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -332,7 +332,7 @@ describe('Radios', () => {
         })
       ).rejects.toMatchObject({
         name: 'InitError',
-        message: 'Root element (`$root`) already initialised (`govuk-radios`)'
+        message: 'govuk-radios: Root element (`$root`) already initialised'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
@@ -43,7 +43,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
 
     if (!$root) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -65,7 +65,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
     const menuId = $menuButton.getAttribute('aria-controls')
     if (!menuId) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         identifier:
           'Navigation button (`<button class="govuk-js-service-navigation-toggle">`) attribute (`aria-controls`)'
       })
@@ -74,7 +74,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
     const $menu = document.getElementById(menuId)
     if (!$menu) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         element: $menu,
         identifier: `Navigation (\`<ul id="${menuId}">\`)`
       })
@@ -100,7 +100,7 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
 
     if (!breakpoint.value) {
       throw new ElementError({
-        componentName: 'Service Navigation',
+        component: ServiceNavigation,
         identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
@@ -9,7 +9,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class ServiceNavigation extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $menuButton
@@ -36,22 +36,22 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
   mql = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for header
+   * @param {Element | null} $root - HTML element to use for header
    */
-  constructor($module) {
+  constructor($root) {
     super()
 
-    if (!$module) {
+    if (!$root) {
       throw new ElementError({
         componentName: 'Service Navigation',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
-    const $menuButton = $module.querySelector(
+    const $menuButton = $root.querySelector(
       '.govuk-js-service-navigation-toggle'
     )
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
@@ -9,9 +9,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class ServiceNavigation extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $menuButton
 
   /** @private */
@@ -39,19 +36,9 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
    * @param {Element | null} $root - HTML element to use for header
    */
   constructor($root) {
-    super()
+    super($root)
 
-    if (!$root) {
-      throw new ElementError({
-        component: ServiceNavigation,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
-    const $menuButton = $root.querySelector(
+    const $menuButton = this.$root.querySelector(
       '.govuk-js-service-navigation-toggle'
     )
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
@@ -74,19 +74,19 @@ describe('/components/service-navigation', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'service-navigation', examples.default, {
-            beforeInitialisation($module) {
+            beforeInitialisation($root) {
               // Remove the root of the components as a way
-              // for the constructor to receive the wrong type for `$module`
-              $module.remove()
+              // for the constructor to receive the wrong type for `$root`
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Service Navigation: Root element (`$module`) not found'
+            message: 'Service Navigation: Root element (`$root`) not found'
           }
         })
       })
@@ -94,8 +94,8 @@ describe('/components/service-navigation', () => {
       it("throws when the toggle's aria-control attribute is missing", async () => {
         await expect(
           render(page, 'service-navigation', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module.querySelector(selector).removeAttribute('aria-controls')
+            beforeInitialisation($root, { selector }) {
+              $root.querySelector(selector).removeAttribute('aria-controls')
             },
             context: {
               selector: toggleButtonSelector
@@ -113,9 +113,9 @@ describe('/components/service-navigation', () => {
       it('throws when the menu is missing, but a toggle is present', async () => {
         await expect(
           render(page, 'service-navigation', examples.default, {
-            beforeInitialisation($module, { selector }) {
+            beforeInitialisation($root, { selector }) {
               // Remove the `<ul>` referenced by $menuButton's `aria-controls`
-              $module.querySelector(selector).remove()
+              $root.querySelector(selector).remove()
             },
             context: {
               selector: navigationSelector

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.puppeteer.test.js
@@ -86,7 +86,8 @@ describe('/components/service-navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Service Navigation: Root element (`$root`) not found'
+            message:
+              'govuk-service-navigation: Root element (`$root`) not found'
           }
         })
       })
@@ -105,7 +106,7 @@ describe('/components/service-navigation', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Service Navigation: Navigation button (`<button class="govuk-js-service-navigation-toggle">`) attribute (`aria-controls`) not found'
+              'govuk-service-navigation: Navigation button (`<button class="govuk-js-service-navigation-toggle">`) attribute (`aria-controls`) not found'
           }
         })
       })
@@ -125,7 +126,7 @@ describe('/components/service-navigation', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Service Navigation: Navigation (`<ul id="navigation">`) not found'
+              'govuk-service-navigation: Navigation (`<ul id="navigation">`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -22,7 +22,7 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     if (!($root instanceof HTMLAnchorElement)) {
       throw new ElementError({
-        componentName: 'Skip link',
+        component: SkipLink,
         element: $root,
         expectedType: 'HTMLAnchorElement',
         identifier: 'Root element (`$root`)'
@@ -74,7 +74,7 @@ export class SkipLink extends GOVUKFrontendComponent {
     // Check for link target element
     if (!$linkedElement) {
       throw new ElementError({
-        componentName: 'Skip link',
+        component: SkipLink,
         element: $linkedElement,
         identifier: `Target content (\`id="${linkedElementId}"\`)`
       })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -9,30 +9,30 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class SkipLink extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /**
-   * @param {Element | null} $module - HTML element to use for skip link
-   * @throws {ElementError} when $module is not set or the wrong type
-   * @throws {ElementError} when $module.hash does not contain a hash
+   * @param {Element | null} $root - HTML element to use for skip link
+   * @throws {ElementError} when $root is not set or the wrong type
+   * @throws {ElementError} when $root.hash does not contain a hash
    * @throws {ElementError} when the linked element is missing or the wrong type
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!($module instanceof HTMLAnchorElement)) {
+    if (!($root instanceof HTMLAnchorElement)) {
       throw new ElementError({
         componentName: 'Skip link',
-        element: $module,
+        element: $root,
         expectedType: 'HTMLAnchorElement',
-        identifier: 'Root element (`$module`)'
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    this.$module = $module
+    this.$root = $root
 
-    const hash = this.$module.hash
-    const href = this.$module.getAttribute('href') ?? ''
+    const hash = this.$root.hash
+    const href = this.$root.getAttribute('href') ?? ''
 
     /** @type {URL | undefined} */
     let url
@@ -45,7 +45,7 @@ export class SkipLink extends GOVUKFrontendComponent {
      *
      */
     try {
-      url = new window.URL(this.$module.href)
+      url = new window.URL(this.$root.href)
     } catch (error) {
       throw new ElementError(
         `Skip link: Target link (\`href="${href}"\`) is invalid`
@@ -86,7 +86,7 @@ export class SkipLink extends GOVUKFrontendComponent {
      * Adds a helper CSS class to hide native focus styles,
      * but removes it on blur to restore native focus styles
      */
-    this.$module.addEventListener('click', () =>
+    this.$root.addEventListener('click', () =>
       setFocus($linkedElement, {
         onBeforeFocus() {
           $linkedElement.classList.add('govuk-skip-link-focused-element')

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -18,7 +18,7 @@ export class SkipLink extends GOVUKFrontendComponent {
    * @throws {ElementError} when the linked element is missing or the wrong type
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!($module instanceof HTMLAnchorElement)) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -6,10 +6,10 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  * Skip link component
  *
  * @preserve
+ * @augments GOVUKFrontendComponent<HTMLAnchorElement>
  */
 export class SkipLink extends GOVUKFrontendComponent {
-  /** @private */
-  $root
+  static elementType = HTMLAnchorElement
 
   /**
    * @param {Element | null} $root - HTML element to use for skip link
@@ -19,17 +19,6 @@ export class SkipLink extends GOVUKFrontendComponent {
    */
   constructor($root) {
     super($root)
-
-    if (!($root instanceof HTMLAnchorElement)) {
-      throw new ElementError({
-        component: SkipLink,
-        element: $root,
-        expectedType: 'HTMLAnchorElement',
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
 
     const hash = this.$root.hash
     const href = this.$root.getAttribute('href') ?? ''

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -140,7 +140,7 @@ describe('Skip Link', () => {
       ).rejects.toMatchObject({
         name: 'InitError',
         message:
-          'Root element (`$module`) already initialised (`govuk-skip-link`)'
+          'Root element (`$root`) already initialised (`govuk-skip-link`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -124,6 +126,21 @@ describe('Skip Link', () => {
           message:
             'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
+      })
+    })
+
+    it('throws when initialised twice', async () => {
+      await expect(
+        render(page, 'skip-link', examples.default, {
+          async afterInitialisation($module) {
+            const { SkipLink } = await import('govuk-frontend')
+            new SkipLink($module)
+          }
+        })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message:
+          'Root element (`$module`) already initialised (`govuk-skip-link`)'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -132,9 +132,9 @@ describe('Skip Link', () => {
     it('throws when initialised twice', async () => {
       await expect(
         render(page, 'skip-link', examples.default, {
-          async afterInitialisation($module) {
+          async afterInitialisation($root) {
             const { SkipLink } = await import('govuk-frontend')
-            new SkipLink($module)
+            new SkipLink($root)
           }
         })
       ).rejects.toMatchObject({
@@ -144,34 +144,34 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when $module is not set', async () => {
+    it('throws when $root is not set', async () => {
       return expect(
         render(page, 'skip-link', examples.default, {
-          beforeInitialisation($module) {
-            $module.remove()
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Skip link: Root element (`$module`) not found'
+          message: 'Skip link: Root element (`$root`) not found'
         }
       })
     })
 
-    it('throws when receiving the wrong type for $module', async () => {
+    it('throws when receiving the wrong type for $root', async () => {
       return expect(
         render(page, 'skip-link', examples.default, {
-          beforeInitialisation($module) {
+          beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-            $module.outerHTML = `<svg data-module="govuk-skip-link"></svg>`
+            $root.outerHTML = `<svg data-module="govuk-skip-link"></svg>`
           }
         })
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Root element (`$module`) is not of type HTMLAnchorElement'
+            'Skip link: Root element (`$root`) is not of type HTMLAnchorElement'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -154,7 +154,7 @@ describe('Skip Link', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
-          message: 'Skip link: Root element (`$root`) not found'
+          message: 'govuk-skip-link: Root element (`$root`) not found'
         }
       })
     })
@@ -171,7 +171,7 @@ describe('Skip Link', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Root element (`$root`) is not of type HTMLAnchorElement'
+            'govuk-skip-link: Root element (`$root`) is not of type HTMLAnchorElement'
         }
       })
     })
@@ -188,7 +188,7 @@ describe('Skip Link', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Target content (`id="this-element-does-not-exist"`) not found'
+            'govuk-skip-link: Target content (`id="this-element-does-not-exist"`) not found'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -139,8 +139,7 @@ describe('Skip Link', () => {
         })
       ).rejects.toMatchObject({
         name: 'InitError',
-        message:
-          'Root element (`$root`) already initialised (`govuk-skip-link`)'
+        message: 'govuk-skip-link: Root element (`$root`) already initialised'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -9,7 +9,7 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Tabs extends GOVUKFrontendComponent {
   /** @private */
-  $module
+  $root
 
   /** @private */
   $tabs
@@ -42,20 +42,20 @@ export class Tabs extends GOVUKFrontendComponent {
   mql = null
 
   /**
-   * @param {Element | null} $module - HTML element to use for tabs
+   * @param {Element | null} $root - HTML element to use for tabs
    */
-  constructor($module) {
-    super($module)
+  constructor($root) {
+    super($root)
 
-    if (!$module) {
+    if (!$root) {
       throw new ElementError({
         componentName: 'Tabs',
-        element: $module,
-        identifier: 'Root element (`$module`)'
+        element: $root,
+        identifier: 'Root element (`$root`)'
       })
     }
 
-    const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
+    const $tabs = $root.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError({
         componentName: 'Tabs',
@@ -63,7 +63,7 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
-    this.$module = $module
+    this.$root = $root
     this.$tabs = $tabs
 
     // Save bound functions so we can remove event listeners during teardown
@@ -71,8 +71,8 @@ export class Tabs extends GOVUKFrontendComponent {
     this.boundTabKeydown = this.onTabKeydown.bind(this)
     this.boundOnHashChange = this.onHashChange.bind(this)
 
-    const $tabList = this.$module.querySelector('.govuk-tabs__list')
-    const $tabListItems = this.$module.querySelectorAll(
+    const $tabList = this.$root.querySelector('.govuk-tabs__list')
+    const $tabListItems = this.$root.querySelectorAll(
       'li.govuk-tabs__list-item'
     )
 
@@ -258,7 +258,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @returns {HTMLAnchorElement | null} Tab link
    */
   getTab(hash) {
-    return this.$module.querySelector(`a.govuk-tabs__tab[href="${hash}"]`)
+    return this.$root.querySelector(`a.govuk-tabs__tab[href="${hash}"]`)
   }
 
   /**
@@ -455,7 +455,7 @@ export class Tabs extends GOVUKFrontendComponent {
       return null
     }
 
-    return this.$module.querySelector(`#${panelId}`)
+    return this.$root.querySelector(`#${panelId}`)
   }
 
   /**
@@ -527,7 +527,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @returns {HTMLAnchorElement | null} Tab link
    */
   getCurrentTab() {
-    return this.$module.querySelector(
+    return this.$root.querySelector(
       '.govuk-tabs__list-item--selected a.govuk-tabs__tab'
     )
   }

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -49,7 +49,7 @@ export class Tabs extends GOVUKFrontendComponent {
 
     if (!$root) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         element: $root,
         identifier: 'Root element (`$root`)'
       })
@@ -58,7 +58,7 @@ export class Tabs extends GOVUKFrontendComponent {
     const $tabs = $root.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: 'Links (`<a class="govuk-tabs__tab">`)'
       })
     }
@@ -78,14 +78,14 @@ export class Tabs extends GOVUKFrontendComponent {
 
     if (!$tabList) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: 'List (`<ul class="govuk-tabs__list">`)'
       })
     }
 
     if (!$tabListItems.length) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: 'List items (`<li class="govuk-tabs__list-item">`)'
       })
     }
@@ -106,7 +106,7 @@ export class Tabs extends GOVUKFrontendComponent {
 
     if (!breakpoint.value) {
       throw new ElementError({
-        componentName: 'Tabs',
+        component: Tabs,
         identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
       })
     }

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -45,7 +45,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @param {Element | null} $module - HTML element to use for tabs
    */
   constructor($module) {
-    super()
+    super($module)
 
     if (!$module) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -9,9 +9,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Tabs extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $tabs
 
   /** @private */
@@ -47,15 +44,7 @@ export class Tabs extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!$root) {
-      throw new ElementError({
-        component: Tabs,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $tabs = $root.querySelectorAll('a.govuk-tabs__tab')
+    const $tabs = this.$root.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError({
         component: Tabs,
@@ -63,7 +52,6 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
-    this.$root = $root
     this.$tabs = $tabs
 
     // Save bound functions so we can remove event listeners during teardown

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-new */
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 const { KnownDevices } = require('puppeteer')
@@ -266,6 +268,20 @@ describe('/components/tabs', () => {
             message:
               'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
+        })
+      })
+
+      it('throws when initialised twice', async () => {
+        await expect(
+          render(page, 'tabs', examples.default, {
+            async afterInitialisation($module) {
+              const { Tabs } = await import('govuk-frontend')
+              new Tabs($module)
+            }
+          })
+        ).rejects.toMatchObject({
+          name: 'InitError',
+          message: 'Root element (`$module`) already initialised (`govuk-tabs`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -281,7 +281,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message: 'Root element (`$module`) already initialised (`govuk-tabs`)'
+          message: 'Root element (`$root`) already initialised (`govuk-tabs`)'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -274,9 +274,9 @@ describe('/components/tabs', () => {
       it('throws when initialised twice', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            async afterInitialisation($module) {
+            async afterInitialisation($root) {
               const { Tabs } = await import('govuk-frontend')
-              new Tabs($module)
+              new Tabs($root)
             }
           })
         ).rejects.toMatchObject({
@@ -285,17 +285,17 @@ describe('/components/tabs', () => {
         })
       })
 
-      it('throws when $module is not set', async () => {
+      it('throws when $root is not set', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module) {
-              $module.remove()
+            beforeInitialisation($root) {
+              $root.remove()
             }
           })
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: Root element (`$module`) not found'
+            message: 'Tabs: Root element (`$root`) not found'
           }
         })
       })
@@ -303,10 +303,8 @@ describe('/components/tabs', () => {
       it('throws when there are no tabs', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module
-                .querySelectorAll(selector)
-                .forEach((item) => item.remove())
+            beforeInitialisation($root, { selector }) {
+              $root.querySelectorAll(selector).forEach((item) => item.remove())
             },
             context: {
               selector: 'a.govuk-tabs__tab'
@@ -323,8 +321,8 @@ describe('/components/tabs', () => {
       it('throws when the tab list is missing', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module, { selector }) {
-              $module
+            beforeInitialisation($root, { selector }) {
+              $root
                 .querySelector(selector)
                 .setAttribute('class', 'govuk-tabs__typo')
             },
@@ -343,8 +341,8 @@ describe('/components/tabs', () => {
       it('throws when there the tab list is empty', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
-            beforeInitialisation($module, { selector, className }) {
-              $module
+            beforeInitialisation($root, { selector, className }) {
+              $root
                 .querySelectorAll(selector)
                 .forEach((item) => item.setAttribute('class', className))
             },

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -295,7 +295,7 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: Root element (`$root`) not found'
+            message: 'govuk-tabs: Root element (`$root`) not found'
           }
         })
       })
@@ -313,7 +313,8 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: Links (`<a class="govuk-tabs__tab">`) not found'
+            message:
+              'govuk-tabs: Links (`<a class="govuk-tabs__tab">`) not found'
           }
         })
       })
@@ -333,7 +334,8 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'ElementError',
-            message: 'Tabs: List (`<ul class="govuk-tabs__list">`) not found'
+            message:
+              'govuk-tabs: List (`<ul class="govuk-tabs__list">`) not found'
           }
         })
       })
@@ -355,7 +357,7 @@ describe('/components/tabs', () => {
           cause: {
             name: 'ElementError',
             message:
-              'Tabs: List items (`<li class="govuk-tabs__list-item">`) not found'
+              'govuk-tabs: List items (`<li class="govuk-tabs__list-item">`) not found'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -281,7 +281,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toMatchObject({
           name: 'InitError',
-          message: 'Root element (`$root`) already initialised (`govuk-tabs`)'
+          message: 'govuk-tabs: Root element (`$root`) already initialised'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -72,7 +72,7 @@ describe('errors', () => {
 
     it('provides feedback for modules already initialised', () => {
       expect(new InitError($moduleName).message).toBe(
-        'Root element (`$module`) already initialised (`govuk-accordion`)'
+        'Root element (`$root`) already initialised (`govuk-accordion`)'
       )
     })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -1,3 +1,5 @@
+import { Accordion } from 'govuk-frontend'
+
 import {
   ElementError,
   GOVUKFrontendError,
@@ -80,7 +82,7 @@ describe('errors', () => {
     it('is an instance of GOVUKFrontendError', () => {
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
           identifier: 'variableName'
         })
       ).toBeInstanceOf(GOVUKFrontendError)
@@ -88,7 +90,15 @@ describe('errors', () => {
     it('has its own name set', () => {
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
+          identifier: 'variableName'
+        }).name
+      ).toBe('ElementError')
+    })
+    it('has name set by Component', () => {
+      expect(
+        new ElementError({
+          component: Accordion,
           identifier: 'variableName'
         }).name
       ).toBe('ElementError')
@@ -101,22 +111,38 @@ describe('errors', () => {
     it('formats the message when the element is not found', () => {
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
           identifier: 'variableName'
         }).message
-      ).toBe('Component name: variableName not found')
+      ).toBe(`${Accordion.moduleName}: variableName not found`)
     })
     it('formats the message when the element is not the right type', () => {
       const $element = document.createElement('div')
 
       expect(
         new ElementError({
-          componentName: 'Component name',
+          component: Accordion,
           element: $element,
           expectedType: 'HTMLAnchorElement',
           identifier: 'variableName'
         }).message
-      ).toBe('Component name: variableName is not of type HTMLAnchorElement')
+      ).toBe(
+        `${Accordion.moduleName}: variableName is not of type HTMLAnchorElement`
+      )
+    })
+    it('formats the message when the element is not the right type and Component in config', () => {
+      const $element = document.createElement('div')
+
+      expect(
+        new ElementError({
+          component: Accordion,
+          element: $element,
+          expectedType: 'HTMLAnchorElement',
+          identifier: 'variableName'
+        }).message
+      ).toBe(
+        `${Accordion.moduleName}: variableName is not of type HTMLAnchorElement`
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -1,4 +1,9 @@
-import { ElementError, GOVUKFrontendError, SupportError } from './index.mjs'
+import {
+  ElementError,
+  GOVUKFrontendError,
+  InitError,
+  SupportError
+} from './index.mjs'
 
 describe('errors', () => {
   describe('GOVUKFrontendError', () => {
@@ -43,6 +48,39 @@ describe('errors', () => {
       // will see support checks run when document.body is still `null`
       expect(new SupportError(null).message).toBe(
         'GOV.UK Frontend initialised without `<script type="module">`'
+      )
+    })
+  })
+
+  describe('InitError', () => {
+    let $element
+    let $moduleName
+
+    beforeAll(() => {
+      $element = document.createElement('div')
+      $element.setAttribute('data-module', 'govuk-accordion')
+      $moduleName = 'govuk-accordion'
+    })
+
+    it('is an instance of GOVUKFrontendError', () => {
+      expect(new InitError($moduleName)).toBeInstanceOf(GOVUKFrontendError)
+    })
+
+    it('has its own name set', () => {
+      expect(new InitError($moduleName).name).toBe('InitError')
+    })
+
+    it('provides feedback for modules already initialised', () => {
+      expect(new InitError($moduleName).message).toBe(
+        'Root element (`$module`) already initialised (`govuk-accordion`)'
+      )
+    })
+
+    it('provides feedback for modules already initialised', () => {
+      $moduleName = undefined
+
+      expect(new InitError($moduleName, 'Accordion').message).toBe(
+        'moduleName not defined in component (`Accordion`)'
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -53,33 +53,24 @@ describe('errors', () => {
   })
 
   describe('InitError', () => {
-    let $element
-    let $moduleName
-
-    beforeAll(() => {
-      $element = document.createElement('div')
-      $element.setAttribute('data-module', 'govuk-accordion')
-      $moduleName = 'govuk-accordion'
-    })
-
     it('is an instance of GOVUKFrontendError', () => {
-      expect(new InitError($moduleName)).toBeInstanceOf(GOVUKFrontendError)
+      expect(new InitError('govuk-accordion')).toBeInstanceOf(
+        GOVUKFrontendError
+      )
     })
 
     it('has its own name set', () => {
-      expect(new InitError($moduleName).name).toBe('InitError')
+      expect(new InitError('govuk-accordion').name).toBe('InitError')
     })
 
     it('provides feedback for modules already initialised', () => {
-      expect(new InitError($moduleName).message).toBe(
+      expect(new InitError('govuk-accordion').message).toBe(
         'Root element (`$root`) already initialised (`govuk-accordion`)'
       )
     })
 
-    it('provides feedback for modules already initialised', () => {
-      $moduleName = undefined
-
-      expect(new InitError($moduleName, 'Accordion').message).toBe(
+    it('provides feedback when no module name is provided', () => {
+      expect(new InitError(undefined, 'Accordion').message).toBe(
         'moduleName not defined in component (`Accordion`)'
       )
     })

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -56,25 +56,21 @@ describe('errors', () => {
 
   describe('InitError', () => {
     it('is an instance of GOVUKFrontendError', () => {
-      expect(new InitError('govuk-accordion')).toBeInstanceOf(
-        GOVUKFrontendError
-      )
+      expect(new InitError(Accordion)).toBeInstanceOf(GOVUKFrontendError)
     })
 
     it('has its own name set', () => {
-      expect(new InitError('govuk-accordion').name).toBe('InitError')
+      expect(new InitError(Accordion).name).toBe('InitError')
     })
 
     it('provides feedback for modules already initialised', () => {
-      expect(new InitError('govuk-accordion').message).toBe(
-        'Root element (`$root`) already initialised (`govuk-accordion`)'
+      expect(new InitError(Accordion).message).toBe(
+        'govuk-accordion: Root element (`$root`) already initialised'
       )
     })
 
-    it('provides feedback when no module name is provided', () => {
-      expect(new InitError(undefined, 'Accordion').message).toBe(
-        'moduleName not defined in component (`Accordion`)'
-      )
+    it('allows a custom message to be provided', () => {
+      expect(new InitError('custom message').message).toBe('custom message')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -98,6 +98,28 @@ export class ElementError extends GOVUKFrontendError {
 }
 
 /**
+ * Indicates that a component is already initialised
+ */
+export class InitError extends GOVUKFrontendError {
+  name = 'InitError'
+
+  /**
+   * @internal
+   * @param {string|undefined} moduleName - name of the component module
+   * @param {string} [className] - name of the component module
+   */
+  constructor(moduleName, className) {
+    let errorText = `moduleName not defined in component (\`${className}\`)`
+
+    if (typeof moduleName === 'string') {
+      errorText = `Root element (\`$module\`) already initialised (\`${moduleName}\`)`
+    }
+
+    super(errorText)
+  }
+}
+
+/**
  * Element error options
  *
  * @internal

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -112,7 +112,7 @@ export class InitError extends GOVUKFrontendError {
     let errorText = `moduleName not defined in component (\`${className}\`)`
 
     if (typeof moduleName === 'string') {
-      errorText = `Root element (\`$module\`) already initialised (\`${moduleName}\`)`
+      errorText = `Root element (\`$root\`) already initialised (\`${moduleName}\`)`
     }
 
     super(errorText)

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -1,3 +1,5 @@
+import { formatErrorMessage } from '../common/index.mjs'
+
 /**
  * GOV.UK Frontend error
  *
@@ -81,16 +83,16 @@ export class ElementError extends GOVUKFrontendError {
 
     // Build message from options
     if (typeof messageOrOptions === 'object') {
-      const { componentName, identifier, element, expectedType } =
-        messageOrOptions
+      const { component, identifier, element, expectedType } = messageOrOptions
 
-      // Add prefix and identifier
-      message = `${componentName}: ${identifier}`
+      message = identifier
 
       // Append reason
       message += element
         ? ` is not of type ${expectedType ?? 'HTMLElement'}`
         : ' not found'
+
+      message = formatErrorMessage(component, message)
     }
 
     super(message)
@@ -124,8 +126,8 @@ export class InitError extends GOVUKFrontendError {
  *
  * @internal
  * @typedef {object} ElementErrorOptions
- * @property {string} componentName - The name of the component throwing the error
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
  * @property {Element | null} [element] - The element in error
  * @property {string} [expectedType] - The type that was expected for the identifier
+ * @property {import('../common/index.mjs').ComponentWithModuleName} component - Component throwing the error
  */

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -107,17 +107,18 @@ export class InitError extends GOVUKFrontendError {
 
   /**
    * @internal
-   * @param {string|undefined} moduleName - name of the component module
-   * @param {string} [className] - name of the component module
+   * @param {ComponentWithModuleName | string} componentOrMessage - name of the component module
    */
-  constructor(moduleName, className) {
-    let errorText = `moduleName not defined in component (\`${className}\`)`
+  constructor(componentOrMessage) {
+    const message =
+      typeof componentOrMessage === 'string'
+        ? componentOrMessage
+        : formatErrorMessage(
+            componentOrMessage,
+            `Root element (\`$root\`) already initialised`
+          )
 
-    if (typeof moduleName === 'string') {
-      errorText = `Root element (\`$root\`) already initialised (\`${moduleName}\`)`
-    }
-
-    super(errorText)
+    super(message)
   }
 }
 
@@ -129,5 +130,9 @@ export class InitError extends GOVUKFrontendError {
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
  * @property {Element | null} [element] - The element in error
  * @property {string} [expectedType] - The type that was expected for the identifier
- * @property {import('../common/index.mjs').ComponentWithModuleName} component - Component throwing the error
+ * @property {ComponentWithModuleName} component - Component throwing the error
+ */
+
+/**
+ * @typedef {import('../common/index.mjs').ComponentWithModuleName} ComponentWithModuleName
  */

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
@@ -1,0 +1,44 @@
+import { SupportError } from './errors/index.mjs'
+import { GOVUKFrontendComponent } from './govuk-frontend-component.mjs'
+
+describe('GOVUKFrontendComponent', () => {
+  describe('isSupported()', () => {
+    beforeEach(() => {
+      // Jest does not tidy the JSDOM document between tests
+      // so we need to take care of that ourselves
+      document.documentElement.innerHTML = ''
+    })
+
+    describe('default implementation', () => {
+      class ServiceComponent extends GOVUKFrontendComponent {
+        static moduleName = 'app-service-component'
+      }
+
+      it('Makes initialisation throw if GOV.UK Frontend is not supported', () => {
+        expect(() => new ServiceComponent(document.body)).toThrow(SupportError)
+      })
+
+      it('Allows initialisation if GOV.UK Frontend is supported', () => {
+        document.body.classList.add('govuk-frontend-supported')
+
+        expect(() => new ServiceComponent(document.body)).not.toThrow()
+      })
+    })
+
+    describe('when overriden', () => {
+      it('Allows child classes to define their own condition for support', () => {
+        class ServiceComponent extends GOVUKFrontendComponent {
+          static moduleName = 'app-service-component'
+
+          isSupported() {
+            return true
+          }
+        }
+
+        expect(() => new ServiceComponent(document.body)).not.toThrow(
+          SupportError
+        )
+      })
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
@@ -2,7 +2,7 @@ import { SupportError } from './errors/index.mjs'
 import { GOVUKFrontendComponent } from './govuk-frontend-component.mjs'
 
 describe('GOVUKFrontendComponent', () => {
-  describe('isSupported()', () => {
+  describe('checkSupport()', () => {
     beforeEach(() => {
       // Jest does not tidy the JSDOM document between tests
       // so we need to take care of that ourselves
@@ -30,13 +30,14 @@ describe('GOVUKFrontendComponent', () => {
         class ServiceComponent extends GOVUKFrontendComponent {
           static moduleName = 'app-service-component'
 
-          static isSupported() {
-            return true
+          static checkSupport() {
+            throw new Error('Custom error')
           }
         }
 
-        expect(() => new ServiceComponent(document.body)).not.toThrow(
-          SupportError
+        // Use the message rather than the class as `SupportError` extends `Error`
+        expect(() => new ServiceComponent(document.body)).toThrow(
+          'Custom error'
         )
       })
     })

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.jsdom.test.mjs
@@ -30,7 +30,7 @@ describe('GOVUKFrontendComponent', () => {
         class ServiceComponent extends GOVUKFrontendComponent {
           static moduleName = 'app-service-component'
 
-          isSupported() {
+          static isSupported() {
             return true
           }
         }

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -56,19 +56,9 @@ export class GOVUKFrontendComponent {
    * @throws {SupportError} when the components are not supported
    */
   static checkSupport() {
-    if (!this.isSupported()) {
+    if (!isSupported()) {
       throw new SupportError()
     }
-  }
-
-  /**
-   * Defines whether the components are supported
-   *
-   * @protected
-   * @returns {boolean} whether the components are supported
-   */
-  static isSupported() {
-    return isSupported()
   }
 }
 

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -6,7 +6,6 @@ import { InitError, SupportError } from './errors/index.mjs'
  *
  * Centralises the behaviours shared by our components
  *
- * @internal
  * @virtual
  */
 export class GOVUKFrontendComponent {

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -14,17 +14,17 @@ export class GOVUKFrontendComponent {
    * Constructs a new component, validating that GOV.UK Frontend is supported
    *
    * @internal
-   * @param {Element | null} [$module] - HTML element to use for component
+   * @param {Element | null} [$root] - HTML element to use for component
    */
-  constructor($module) {
+  constructor($root) {
     this.checkSupport()
-    this.checkInitialised($module)
+    this.checkInitialised($root)
 
     const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
       .moduleName
 
     if (typeof moduleName === 'string') {
-      moduleName && $module?.setAttribute(`data-${moduleName}-init`, '')
+      moduleName && $root?.setAttribute(`data-${moduleName}-init`, '')
     } else {
       throw new InitError(moduleName)
     }
@@ -34,14 +34,14 @@ export class GOVUKFrontendComponent {
    * Validates whether component is already initialised
    *
    * @private
-   * @param {Element | null} [$module] - HTML element to be checked
+   * @param {Element | null} [$root] - HTML element to be checked
    * @throws {InitError} when component is already initialised
    */
-  checkInitialised($module) {
+  checkInitialised($root) {
     const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
       .moduleName
 
-    if ($module && moduleName && isInitialised($module, moduleName)) {
+    if ($root && moduleName && isInitialised($root, moduleName)) {
       throw new InitError(moduleName)
     }
   }

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -17,11 +17,15 @@ export class GOVUKFrontendComponent {
    * @param {Element | null} [$root] - HTML element to use for component
    */
   constructor($root) {
-    this.checkSupport()
+    const childConstructor = /** @type {ChildClassConstructor} */ (
+      this.constructor
+    )
+
+    childConstructor.checkSupport()
+
     this.checkInitialised($root)
 
-    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
-      .moduleName
+    const moduleName = childConstructor.moduleName
 
     if (typeof moduleName === 'string') {
       moduleName && $root?.setAttribute(`data-${moduleName}-init`, '')
@@ -49,10 +53,9 @@ export class GOVUKFrontendComponent {
   /**
    * Validates whether components are supported
    *
-   * @private
    * @throws {SupportError} when the components are not supported
    */
-  checkSupport() {
+  static checkSupport() {
     if (!this.isSupported()) {
       throw new SupportError()
     }
@@ -64,7 +67,7 @@ export class GOVUKFrontendComponent {
    * @protected
    * @returns {boolean} whether the components are supported
    */
-  isSupported() {
+  static isSupported() {
     return isSupported()
   }
 }

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -47,15 +47,25 @@ export class GOVUKFrontendComponent {
   }
 
   /**
-   * Validates whether GOV.UK Frontend is supported
+   * Validates whether components are supported
    *
    * @private
-   * @throws {SupportError} when GOV.UK Frontend is not supported
+   * @throws {SupportError} when the components are not supported
    */
   checkSupport() {
-    if (!isSupported()) {
+    if (!this.isSupported()) {
       throw new SupportError()
     }
+  }
+
+  /**
+   * Defines whether the components are supported
+   *
+   * @protected
+   * @returns {boolean} whether the components are supported
+   */
+  isSupported() {
+    return isSupported()
   }
 }
 

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,5 +1,5 @@
-import { isSupported } from './common/index.mjs'
-import { SupportError } from './errors/index.mjs'
+import { isInitialised, isSupported } from './common/index.mjs'
+import { InitError, SupportError } from './errors/index.mjs'
 
 /**
  * Base Component class
@@ -14,9 +14,36 @@ export class GOVUKFrontendComponent {
    * Constructs a new component, validating that GOV.UK Frontend is supported
    *
    * @internal
+   * @param {Element | null} [$module] - HTML element to use for component
    */
-  constructor() {
+  constructor($module) {
     this.checkSupport()
+    this.checkInitialised($module)
+
+    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
+      .moduleName
+
+    if (typeof moduleName === 'string') {
+      moduleName && $module?.setAttribute(`data-${moduleName}-init`, '')
+    } else {
+      throw new InitError(moduleName)
+    }
+  }
+
+  /**
+   * Validates whether component is already initialised
+   *
+   * @private
+   * @param {Element | null} [$module] - HTML element to be checked
+   * @throws {InitError} when component is already initialised
+   */
+  checkInitialised($module) {
+    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
+      .moduleName
+
+    if ($module && moduleName && isInitialised($module, moduleName)) {
+      throw new InitError(moduleName)
+    }
   }
 
   /**
@@ -31,3 +58,12 @@ export class GOVUKFrontendComponent {
     }
   }
 }
+
+/**
+ * @typedef ChildClass
+ * @property {string} [moduleName] - The module name that'll be looked for in the DOM when initialising the component
+ */
+
+/**
+ * @typedef {typeof GOVUKFrontendComponent & ChildClass} ChildClassConstructor
+ */

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -20,17 +20,24 @@ export class GOVUKFrontendComponent {
       this.constructor
     )
 
+    // TypeScript does not enforce that inheriting classes will define a `moduleName`
+    // (even if we add a `@virtual` `static moduleName` property to this class).
+    // While we trust users to do this correctly, we do a little check to provide them
+    // a helpful error message.
+    //
+    // After this, we'll be sure that `childConstructor` has a `moduleName`
+    // as expected of the `ChildClassConstructor` we've cast `this.constructor` to.
+    if (typeof childConstructor.moduleName !== 'string') {
+      throw new InitError(childConstructor.moduleName)
+    }
+
     childConstructor.checkSupport()
 
     this.checkInitialised($root)
 
     const moduleName = childConstructor.moduleName
 
-    if (typeof moduleName === 'string') {
-      moduleName && $root?.setAttribute(`data-${moduleName}-init`, '')
-    } else {
-      throw new InitError(moduleName)
-    }
+    $root?.setAttribute(`data-${moduleName}-init`, '')
   }
 
   /**
@@ -63,7 +70,7 @@ export class GOVUKFrontendComponent {
 
 /**
  * @typedef ChildClass
- * @property {string} [moduleName] - The module name that'll be looked for in the DOM when initialising the component
+ * @property {string} moduleName - The module name that'll be looked for in the DOM when initialising the component
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -15,11 +15,24 @@ export class GOVUKFrontendComponent {
    */
   static elementType = HTMLElement
 
+  // allows Typescript user to work around the lack of types
+  // in GOVUKFrontend package, Typescript is not aware of $root
+  // in components that extend GOVUKFrontendComponent
+  /**
+   * Returns the root element of the component
+   *
+   * @protected
+   * @returns {RootElementType} - the root element of component
+   */
+  get $root() {
+    return this._$root
+  }
+
   /**
    * @protected
    * @type {RootElementType}
    */
-  $root
+  _$root
 
   /**
    * Constructs a new component, validating that GOV.UK Frontend is supported
@@ -51,7 +64,7 @@ export class GOVUKFrontendComponent {
         expectedType: childConstructor.elementType.name
       })
     } else {
-      this.$root = /** @type {RootElementType} */ ($root)
+      this._$root = /** @type {RootElementType} */ ($root)
     }
 
     childConstructor.checkSupport()

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -28,7 +28,7 @@ export class GOVUKFrontendComponent {
     // After this, we'll be sure that `childConstructor` has a `moduleName`
     // as expected of the `ChildClassConstructor` we've cast `this.constructor` to.
     if (typeof childConstructor.moduleName !== 'string') {
-      throw new InitError(childConstructor.moduleName)
+      throw new InitError(`\`moduleName\` not defined in component`)
     }
 
     childConstructor.checkSupport()
@@ -48,11 +48,11 @@ export class GOVUKFrontendComponent {
    * @throws {InitError} when component is already initialised
    */
   checkInitialised($root) {
-    const moduleName = /** @type {ChildClassConstructor} */ (this.constructor)
-      .moduleName
+    const constructor = /** @type {ChildClassConstructor} */ (this.constructor)
+    const moduleName = constructor.moduleName
 
     if ($root && moduleName && isInitialised($root, moduleName)) {
-      throw new InitError(moduleName)
+      throw new InitError(constructor)
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -107,10 +107,7 @@ describe('initAll', () => {
     })
 
     it('executes onError if specified', () => {
-      const errorCallback = jest.fn((error, context) => {
-        console.log(error)
-        console.log(context)
-      })
+      const errorCallback = jest.fn((_error, _context) => {})
 
       initAll({
         accordion: {
@@ -119,14 +116,12 @@ describe('initAll', () => {
         onError: errorCallback
       })
 
-      expect(errorCallback).toHaveBeenCalled()
+      expect(global.console.log).not.toHaveBeenCalled()
 
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(errorCallback).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'GOV.UK Frontend is not supported in this browser'
-        })
-      )
-      expect(global.console.log).toHaveBeenCalledWith(
+        }),
         expect.objectContaining({
           config: {
             accordion: {
@@ -188,17 +183,15 @@ describe('initAll', () => {
     document.body.classList.add('govuk-frontend-supported')
     document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
 
+    const accordionEl = document.querySelector(
+      "[data-module='govuk-accordion']"
+    )
+
     jest.mocked(GOVUKFrontend.Accordion).mockImplementation(() => {
       throw new Error('Error thrown from accordion')
     })
 
-    const errorCallback = jest.fn((error, context) => {
-      console.log(error)
-      console.log(context)
-    })
-
-    // Silence warnings in test output, and allow us to 'expect' them
-    jest.spyOn(global.console, 'log').mockImplementation()
+    const errorCallback = jest.fn((_error, _context) => {})
 
     initAll({
       onError: errorCallback,
@@ -207,15 +200,18 @@ describe('initAll', () => {
       }
     })
 
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(global.console.log).not.toHaveBeenCalled()
+
+    expect(errorCallback).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Error thrown from accordion'
-      })
-    )
-    expect(global.console.log).toHaveBeenCalledWith(
+      }),
       expect.objectContaining({
         component: GOVUKFrontend.Accordion,
-        config: { rememberExpanded: true }
+        config: {
+          rememberExpanded: true
+        },
+        element: accordionEl
       })
     )
   })
@@ -273,13 +269,7 @@ describe('createAll', () => {
   it('executes specified onError callback and returns empty array if not supported', () => {
     document.body.classList.remove('govuk-frontend-supported')
 
-    const errorCallback = jest.fn((error, context) => {
-      console.log(error)
-      console.log(context)
-    })
-
-    // Silence warnings in test output, and allow us to 'expect' them
-    jest.spyOn(global.console, 'log').mockImplementation()
+    const errorCallback = jest.fn((_error, _context) => {})
 
     expect(() => {
       createAll(
@@ -289,14 +279,12 @@ describe('createAll', () => {
       )
     }).not.toThrow()
 
-    expect(errorCallback).toHaveBeenCalled()
+    expect(global.console.log).not.toHaveBeenCalled()
 
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(errorCallback).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'GOV.UK Frontend is not supported in this browser'
-      })
-    )
-    expect(global.console.log).toHaveBeenCalledWith(
+      }),
       expect.objectContaining({
         component: MockComponent,
         config: { attribute: 'random' }

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -202,6 +202,40 @@ describe('createAll', () => {
     expect(result).toStrictEqual([])
   })
 
+  it('executes specified onError callback and returns empty array if not supported', () => {
+    document.body.classList.remove('govuk-frontend-supported')
+
+    const errorCallback = jest.fn((error, context) => {
+      console.log(error)
+      console.log(context)
+    })
+
+    // Silence warnings in test output, and allow us to 'expect' them
+    jest.spyOn(global.console, 'log').mockImplementation()
+
+    expect(() => {
+      createAll(
+        MockComponent,
+        { attribute: 'random' },
+        { onError: errorCallback }
+      )
+    }).not.toThrow()
+
+    expect(errorCallback).toHaveBeenCalled()
+
+    expect(global.console.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'GOV.UK Frontend is not supported in this browser'
+      })
+    )
+    expect(global.console.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: MockComponent,
+        config: { attribute: 'random' }
+      })
+    )
+  })
+
   it('returns an empty array if no matching components exist on the page', () => {
     const componentRoot = document.createElement('div')
     componentRoot.setAttribute(
@@ -298,7 +332,7 @@ describe('createAll', () => {
     })
   })
 
-  describe('when a $scope is passed', () => {
+  describe('when a $scope is passed as third parameter', () => {
     it('only initialises components within that scope', () => {
       document.body.innerHTML = `
         <div data-module="mock-component"></div>
@@ -321,6 +355,28 @@ describe('createAll', () => {
         document.querySelector('.my-scope [data-module="mock-component"]')
       ])
     })
+
+    it('only initialises components within that scope if scope passed as options attribute', () => {
+      document.body.innerHTML = `
+        <div data-module="mock-component"></div>
+        <div class="not-in-scope">
+          <div data-module="mock-component"></div>
+        </div>'
+        <div class="my-scope">
+          <div data-module="mock-component"></div>
+        </div>`
+
+      const result = createAll(MockComponent, undefined, {
+        onError: (e, x) => {},
+        scope: document.querySelector('.my-scope')
+      })
+
+      expect(result).toStrictEqual([expect.any(MockComponent)])
+
+      expect(result[0].args).toStrictEqual([
+        document.querySelector('.my-scope [data-module="mock-component"]')
+      ])
+    })
   })
 
   describe('when components throw errors', () => {
@@ -332,6 +388,68 @@ describe('createAll', () => {
         }
       }
     }
+
+    it('executes callback if specified as part of options object', () => {
+      document.body.innerHTML = `<div data-module="mock-component" data-boom></div>`
+
+      const errorCallback = jest.fn((error, context) => {
+        console.log(error)
+        console.log(context)
+      })
+
+      // Silence warnings in test output, and allow us to 'expect' them
+      jest.spyOn(global.console, 'log').mockImplementation()
+
+      expect(() => {
+        createAll(
+          MockComponentThatErrors,
+          { attribute: 'random' },
+          { onError: errorCallback }
+        )
+      }).not.toThrow()
+
+      expect(errorCallback).toHaveBeenCalled()
+
+      expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(global.console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          component: MockComponentThatErrors,
+          config: { attribute: 'random' },
+          element: document.querySelector('[data-module="mock-component"]')
+        })
+      )
+    })
+
+    it('executes callback if specified as function', () => {
+      document.body.innerHTML = `<div data-module="mock-component" data-boom></div>`
+
+      const errorCallback = jest.fn((error, context) => {
+        console.log(error)
+        console.log(context)
+      })
+
+      // Silence warnings in test output, and allow us to 'expect' them
+      jest.spyOn(global.console, 'log').mockImplementation()
+
+      expect(() => {
+        createAll(
+          MockComponentThatErrors,
+          { attribute: 'random' },
+          errorCallback
+        )
+      }).not.toThrow()
+
+      expect(errorCallback).toHaveBeenCalled()
+
+      expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(global.console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          component: MockComponentThatErrors,
+          config: { attribute: 'random' },
+          element: document.querySelector('[data-module="mock-component"]')
+        })
+      )
+    })
 
     it('catches errors thrown by components and logs them to the console', () => {
       document.body.innerHTML = `<div data-module="mock-component" data-boom></div>`

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -105,6 +105,38 @@ describe('initAll', () => {
         })
       )
     })
+
+    it('executes onError if specified', () => {
+      const errorCallback = jest.fn((error, context) => {
+        console.log(error)
+        console.log(context)
+      })
+
+      initAll({
+        accordion: {
+          rememberExpanded: true
+        },
+        onError: errorCallback
+      })
+
+      expect(errorCallback).toHaveBeenCalled()
+
+      expect(global.console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
+      )
+      expect(global.console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: {
+            accordion: {
+              rememberExpanded: true
+            },
+            onError: errorCallback
+          }
+        })
+      )
+    })
   })
 
   it('only initialises components within a given scope', () => {
@@ -148,6 +180,42 @@ describe('initAll', () => {
     expect(global.console.log).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Error thrown from accordion'
+      })
+    )
+  })
+
+  it('executes onError callback on component create if specified', () => {
+    document.body.classList.add('govuk-frontend-supported')
+    document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
+
+    jest.mocked(GOVUKFrontend.Accordion).mockImplementation(() => {
+      throw new Error('Error thrown from accordion')
+    })
+
+    const errorCallback = jest.fn((error, context) => {
+      console.log(error)
+      console.log(context)
+    })
+
+    // Silence warnings in test output, and allow us to 'expect' them
+    jest.spyOn(global.console, 'log').mockImplementation()
+
+    initAll({
+      onError: errorCallback,
+      accordion: {
+        rememberExpanded: true
+      }
+    })
+
+    expect(global.console.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Error thrown from accordion'
+      })
+    )
+    expect(global.console.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: GOVUKFrontend.Accordion,
+        config: { rememberExpanded: true }
       })
     )
   })

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -154,8 +154,12 @@ describe('initAll', () => {
 })
 
 describe('createAll', () => {
+  beforeEach(() => {
+    document.body.classList.add('govuk-frontend-supported')
+  })
+
   afterEach(() => {
-    document.body.innerHTML = ''
+    document.body.outerHTML = '<body></body>'
   })
 
   class MockComponent {
@@ -180,6 +184,20 @@ describe('createAll', () => {
 
   it('returns an empty array if no components exist on the page', () => {
     const result = createAll(MockComponent)
+
+    expect(result).toStrictEqual([])
+  })
+
+  it('throws error and returns empty array if not supported', () => {
+    document.body.classList.remove('govuk-frontend-supported')
+
+    const result = createAll(MockComponent)
+
+    expect(global.console.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'GOV.UK Frontend is not supported in this browser'
+      })
+    )
 
     expect(result).toStrictEqual([])
   })

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -368,69 +368,23 @@ describe('createAll', () => {
     expect(result[1].args).toStrictEqual([document.getElementById('b')])
   })
 
-  describe('when a component accepts config', () => {
-    class MockComponentWithConfig extends MockComponent {
-      static defaults = {
-        __test: false
-      }
-    }
-
+  describe('when a configuration is passed', () => {
     it('initialises a component, passing the component root and config', () => {
       const componentRoot = document.createElement('div')
       componentRoot.setAttribute('data-module', 'mock-component')
       document.body.appendChild(componentRoot)
 
-      const result = createAll(MockComponentWithConfig, {
+      const result = createAll(MockComponent, {
         __test: true
       })
 
-      expect(result).toStrictEqual([expect.any(MockComponentWithConfig)])
+      expect(result).toStrictEqual([expect.any(MockComponent)])
 
       expect(result[0].args).toStrictEqual([
         componentRoot,
         {
           __test: true
         }
-      ])
-    })
-
-    it('initialises a component, passing the component root even when no config is passed', () => {
-      const componentRoot = document.createElement('div')
-      componentRoot.setAttribute('data-module', 'mock-component')
-      document.body.appendChild(componentRoot)
-
-      const result = createAll(MockComponentWithConfig)
-
-      expect(result).toStrictEqual([expect.any(MockComponentWithConfig)])
-
-      console.log(result[0].args)
-
-      expect(result[0].args).toStrictEqual([componentRoot])
-    })
-
-    it('passes the config to all component objects', () => {
-      document.body.innerHTML = `
-      <div data-module="mock-component" id="a"></div>
-      <div data-module="mock-component" id="b"></div>`
-
-      const config = {
-        __test: true
-      }
-
-      const result = createAll(MockComponentWithConfig, config)
-
-      expect(result).toStrictEqual([
-        expect.any(MockComponentWithConfig),
-        expect.any(MockComponentWithConfig)
-      ])
-
-      expect(result[0].args).toStrictEqual([
-        document.getElementById('a'),
-        config
-      ])
-      expect(result[1].args).toStrictEqual([
-        document.getElementById('b'),
-        config
       ])
     })
   })

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -76,6 +76,12 @@ function createAll(Component, config, $scope = document) {
     `[data-module="${Component.moduleName}"]`
   )
 
+  // Skip initialisation when GOV.UK Frontend is not supported
+  if (!isSupported()) {
+    console.log(new SupportError())
+    return []
+  }
+
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-return --
    * We can't define CompatibleClass as `{new(): CompatibleClass, moduleName: string}`,
    * as when doing `typeof Accordion` (or any component), TypeScript doesn't seem

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -20,14 +20,20 @@ import { SupportError } from './errors/index.mjs'
  * Use the `data-module` attributes to find, instantiate and init all of the
  * components provided as part of GOV.UK Frontend.
  *
- * @param {Config & { scope?: Element }} [config] - Config for all components (with optional scope)
+ * @param {Config & { scope?: Element, onError?: OnErrorCallback<CompatibleClass> }} [config] - Config for all components (with optional scope)
  */
 function initAll(config) {
   config = typeof config !== 'undefined' ? config : {}
 
   // Skip initialisation when GOV.UK Frontend is not supported
   if (!isSupported()) {
-    console.log(new SupportError())
+    if (config.onError) {
+      config.onError(new SupportError(), {
+        config
+      })
+    } else {
+      console.log(new SupportError())
+    }
     return
   }
 
@@ -49,10 +55,15 @@ function initAll(config) {
 
   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
   // Defaults to the entire document if nothing is set.
-  const $scope = config.scope ?? document
+  // const $scope = config.scope ?? document
+
+  const options = {
+    scope: config.scope ?? document,
+    onError: config.onError
+  }
 
   components.forEach(([Component, config]) => {
-    createAll(Component, config, $scope)
+    createAll(Component, config, options)
   })
 }
 
@@ -194,7 +205,7 @@ export { initAll, createAll }
  * @template {CompatibleClass} T
  * @typedef {object} ErrorContext
  * @property {Element} [element] - Element used for component module initialisation
- * @property {T} component - Class of component
+ * @property {T} [component] - Class of component
  * @property {T["defaults"]} config - Config supplied to component
  */
 

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -133,7 +133,7 @@ function createAll(Component, config, createAllOptions) {
       try {
         // Only pass config to components that accept it
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return 'defaults' in Component && typeof config !== 'undefined'
+        return typeof config !== 'undefined'
           ? new Component($element, config)
           : new Component($element)
       } catch (error) {

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -137,7 +137,7 @@ function createAll(Component, config, createAllOptions) {
           ? new Component($element, config)
           : new Component($element)
       } catch (error) {
-        if (onError && error instanceof Error) {
+        if (onError) {
           onError(error, {
             element: $element,
             component: Component,
@@ -212,7 +212,7 @@ export { initAll, createAll }
 /**
  * @template {CompatibleClass} T
  * @callback OnErrorCallback
- * @param {Error} error - Thrown error
+ * @param {unknown} error - Thrown error
  * @param {ErrorContext<T>} context - Object containing the element, component class and configuration
  */
 

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -169,14 +169,14 @@ async function render(page, componentName, renderOptions, browserOptions) {
           return namespace.initAll()
         }
 
-        // Find all matching modules
-        const $modules = document.querySelectorAll(selector)
+        // Find all component roots
+        const $roots = document.querySelectorAll(selector)
 
         try {
-          // Loop and initialise all $modules or use default
+          // Loop and initialise all $roots or use default
           // selector `null` return value when none found
-          ;($modules.length ? $modules : [null]).forEach(
-            ($module) => new namespace[exportName]($module, config)
+          ;($roots.length ? $roots : [null]).forEach(
+            ($root) => new namespace[exportName]($root, config)
           )
         } catch ({ name, message }) {
           return { name, message }


### PR DESCRIPTION
This PR aggregates the work to offer new features in our JavaScript public API around code initialisation:
- adding a `isSupported` function to check if GOV.UK Frontend is supported outside of components
- allowing `createAll` to initialise external components
- offering a `Component` class to extend when building your own components

See [the list of PRs merged on its branch](https://github.com/alphagov/govuk-frontend/pulls?q=sort%3Aupdated-desc+is%3Apr+base%3Apublic-js-api+is%3Aclosed) for more details.