### PR TITLE
Export a base `Component` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### New features
+
+#### Use our base component to build your own components
+
+We've added a `Component` class to help you build your own components. It allows you to focus on your components' specific features by handling these shared behaviours across components:
+
+- Checking that GOV.UK Frontend is supported
+- Checking that the component is not already initialised on its root element
+
+We introduced this change in [pull request #5350: Export a base `Component` class](https://github.com/alphagov/govuk-frontend/pull/5350).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -14,6 +14,7 @@ export { SkipLink } from './components/skip-link/skip-link.mjs'
 export { Tabs } from './components/tabs/tabs.mjs'
 export { initAll, createAll } from './init.mjs'
 export { isSupported } from './common/index.mjs'
+export { GOVUKFrontendComponent as Component } from './govuk-frontend-component.mjs'
 
 /**
  * @typedef {import('./init.mjs').Config} Config

--- a/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/all.puppeteer.test.js
@@ -68,6 +68,7 @@ describe('GOV.UK Frontend', () => {
         'Button',
         'CharacterCount',
         'Checkboxes',
+        'Component',
         'ErrorSummary',
         'ExitThisPage',
         'Header',

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -6,7 +6,6 @@ import { InitError, SupportError } from './errors/index.mjs'
  *
  * Centralises the behaviours shared by our components
  *
- * @internal
  * @virtual
  */
 export class GOVUKFrontendComponent {


### PR DESCRIPTION
Exports the `GOVUKFrontendComponent` class as `Component`, making it available to use as base for components outside of GOV.UK Frontend.

Updates tests and JSDoc to reflect.

Closes #5327 