### PR TITLE
Add missing CHANGELOG entries for public JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
+#### Respond to initialisation errors when using `createAll` and `initAll`
+
+We've added a new `onError` option for `createAll` and `initAll` that lets you respond to initialisation errors.
+The functions will continue catching errors and initialising components further down the page if one component fails to initialise,
+but this option will let you react to a component failing to initialise (for example, reporting to an error monitoring service).
+
+We introduced this change in:
+
+- [pull request #5252: Add `onError` to `createAll`](https://github.com/alphagov/govuk-frontend/pull/5252)
+- [pull request #5276: Add `onError` to `initAll`](https://github.com/alphagov/govuk-frontend/pull/5276)
+
 #### Check if GOV.UK Frontend is supported
 
 We've added the `isSupported` function to let you check if GOV.UK Frontend is supported in the browser where your script is running.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
+#### Check if GOV.UK Frontend is supported
+
+We've added the `isSupported` function to let you check if GOV.UK Frontend is supported in the browser where your script is running.
+GOV.UK Frontend components will check this automatically, but you may want to use the `isSupported` function to avoid running some code when GOV.UK Frontend is not supported.
+
+We introduced this change in [pull request #5250: Add `isSupported` to `all.mjs`](https://github.com/alphagov/govuk-frontend/pull/5250)
+
 #### Use our base component to build your own components
 
 We've added a `Component` class to help you build your own components. It allows you to focus on your components' specific features by handling these shared behaviours across components:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
+#### Components can no longer be initialised twice on the same element
+
+GOV.UK Frontend components now throw an error if they've already been initialised on the DOM Element they're receiving for initialisation.
+This prevents components from being initialised more than once and therefore not working properly.
+
+We introduced this change in [pull request #5272: Prevent multiple initialisations of a single component instance](https://github.com/alphagov/govuk-frontend/pull/5272)
+
 #### Respond to initialisation errors when using `createAll` and `initAll`
 
 We've added a new `onError` option for `createAll` and `initAll` that lets you respond to initialisation errors.


### PR DESCRIPTION
Add missing CHANGELOG entries for the PRs that [were merged on `public-js-api`](https://github.com/alphagov/govuk-frontend/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Amerged+-author%3Aapp%2Fdependabot+base%3Apublic-js-api+merged%3A%3C%3D2024-09-24) and provide public features.

Each commit adds its own entry for easier review:
- #5250
- `onError` callback (#5252 and #5276)
- #5272

Of the other PRs in [the list](https://github.com/alphagov/govuk-frontend/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Amerged+-author%3Aapp%2Fdependabot+base%3Apublic-js-api+merged%3A%3C%3D2024-09-24):
- #5336 will be documented in the Frontend Docs when describing the base class, so thought we'd just link to the Frontend Docs rather than have a specific entry
- #5337, #5328, #5306 are internal changes

Closes #5321 

