### PR TITLE
Only apply margin to details summary when open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5278: Fix service navigation mobile toggle spacing](https://github.com/alphagov/govuk-frontend/pull/5278)
 - [#5331: Fix Warning Text font weight when <strong> styles are reset](https://github.com/alphagov/govuk-frontend/pull/5331)
+- [#5352: Only apply margin to details summary when open](https://github.com/alphagov/govuk-frontend/pull/5352)
 
 ## v5.6.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/details/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/details/_index.scss
@@ -10,7 +10,9 @@
   .govuk-details__summary {
     // Make the focus outline shrink-wrap the text content of the summary
     display: inline-block;
+  }
 
+  .govuk-details[open] .govuk-details__summary {
     margin-bottom: govuk-spacing(1);
   }
 


### PR DESCRIPTION
## What
Only applies the 5px bottom margin of the details summary when the details element is open. The details element when closed how has a bottom margin of 30px whereas before it had a calcualted bottom margin of 35px, a combination of the bttom margin of `govuk-details` and `govuk-details__summary`.

## Why
This is an offshoot of https://github.com/alphagov/govuk-frontend/pull/5089

We're confident about removing this space as it allows us to bypass the concerns we had about managing the non-collpasing margin in Safari iOS 12 and below. Additionally, we weren't able to discern the need for the extra spacing other than speculation. This has been verified by a designer.

## Visual changes
### Before
<img width="227" alt="spacing of the details component withh non-collapsed summary spacing" src="https://github.com/user-attachments/assets/34f1169c-7fb8-44e3-a3e7-eb8183e56e14">

### After
<img width="229" alt="spacing of the details component with no summary spacing on closed" src="https://github.com/user-attachments/assets/f524ee60-5a0a-42a4-aba4-8dfce08734ac">
