### PR TITLE
Refactor the `root` type check in `GOVUKFrontendComponent`

### DIFF
--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -27,18 +27,6 @@ export class Example extends GOVUKFrontendComponent {
   constructor($root){
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      if (!($root instanceof HTMLElement)) {
-        throw new ElementError({
-          componentName: 'Example',
-          element: $root,
-          identifier: 'Root element (`$root`)'
-        })
-      }
-    }
-
-    this.$root = $root
-
     // Code goes here
     this.$root.addEventListener('click', () => {
       // ...

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -19,9 +19,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class Accordion extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {AccordionConfig}
@@ -116,20 +113,10 @@ export class Accordion extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Accordion,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       Accordion.defaults,
       config,
-      normaliseDataset(Accordion, $root.dataset)
+      normaliseDataset(Accordion, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -1,6 +1,5 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
@@ -11,9 +10,6 @@ const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
  * @preserve
  */
 export class Button extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {ButtonConfig}
@@ -33,20 +29,10 @@ export class Button extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Button,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       Button.defaults,
       config,
-      normaliseDataset(Button, $root.dataset)
+      normaliseDataset(Button, this.$root.dataset)
     )
 
     this.$root.addEventListener('keydown', (event) => this.handleKeyDown(event))

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -23,9 +23,6 @@ import { I18n } from '../../i18n.mjs'
  */
 export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $textarea
 
   /** @private */
@@ -68,15 +65,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: CharacterCount,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $textarea = $root.querySelector('.govuk-js-character-count')
+    const $textarea = this.$root.querySelector('.govuk-js-character-count')
     if (
       !(
         $textarea instanceof HTMLTextAreaElement ||
@@ -92,7 +81,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     }
 
     // Read config set using dataset ('data-' values)
-    const datasetConfig = normaliseDataset(CharacterCount, $root.dataset)
+    const datasetConfig = normaliseDataset(CharacterCount, this.$root.dataset)
 
     // To ensure data-attributes take complete precedence, even if they change
     // the type of count, we need to reset the `maxlength` and `maxwords` from
@@ -124,13 +113,12 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($root, 'lang')
+      locale: closestAttributeValue(this.$root, 'lang')
     })
 
     // Determine the limit attribute (characters or words)
     this.maxLength = this.config.maxwords ?? this.config.maxlength ?? Infinity
 
-    this.$root = $root
     this.$textarea = $textarea
 
     const textareaDescriptionId = `${this.$textarea.id}-info`

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -8,9 +8,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Checkboxes extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $inputs
 
   /**
@@ -30,15 +27,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Checkboxes,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $inputs = $root.querySelectorAll('input[type="checkbox"]')
+    const $inputs = this.$root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError({
         component: Checkboxes,
@@ -46,7 +35,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
       })
     }
 
-    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -4,7 +4,6 @@ import {
   setFocus
 } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -16,9 +15,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  * @preserve
  */
 export class ErrorSummary extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {ErrorSummaryConfig}
@@ -32,20 +28,10 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: ErrorSummary,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       ErrorSummary.defaults,
       config,
-      normaliseDataset(ErrorSummary, $root.dataset)
+      normaliseDataset(ErrorSummary, this.$root.dataset)
     )
 
     /**

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -10,9 +10,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class ExitThisPage extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {ExitThisPageConfig}
@@ -81,15 +78,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: ExitThisPage,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $button = $root.querySelector('.govuk-exit-this-page__button')
+    const $button = this.$root.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
       throw new ElementError({
         component: ExitThisPage,
@@ -102,11 +91,10 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.config = mergeConfigs(
       ExitThisPage.defaults,
       config,
-      normaliseDataset(ExitThisPage, $root.dataset)
+      normaliseDataset(ExitThisPage, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n)
-    this.$root = $root
     this.$button = $button
 
     const $skiplinkButton = document.querySelector(

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -9,9 +9,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Header extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $menuButton
 
   /** @private */
@@ -45,16 +42,7 @@ export class Header extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!$root) {
-      throw new ElementError({
-        component: Header,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-    const $menuButton = $root.querySelector('.govuk-js-header-toggle')
+    const $menuButton = this.$root.querySelector('.govuk-js-header-toggle')
 
     // Headers don't necessarily have a navigation. When they don't, the menu
     // toggle won't be rendered by our macro (or may be omitted when writing

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,6 +1,5 @@
 import { mergeConfigs, setFocus } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -9,9 +8,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  * @preserve
  */
 export class NotificationBanner extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {NotificationBannerConfig}
@@ -25,20 +21,10 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   constructor($root, config = {}) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: NotificationBanner,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
     this.config = mergeConfigs(
       NotificationBanner.defaults,
       config,
-      normaliseDataset(NotificationBanner, $root.dataset)
+      normaliseDataset(NotificationBanner, this.$root.dataset)
     )
 
     /**

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -11,9 +11,6 @@ import { I18n } from '../../i18n.mjs'
  * @preserve
  */
 export class PasswordInput extends GOVUKFrontendComponent {
-  /** @private */
-  $root
-
   /**
    * @private
    * @type {PasswordInputConfig}
@@ -43,17 +40,9 @@ export class PasswordInput extends GOVUKFrontendComponent {
    * @param {PasswordInputConfig} [config] - Password input config
    */
   constructor($root, config = {}) {
-    super()
+    super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: PasswordInput,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $input = $root.querySelector('.govuk-js-password-input-input')
+    const $input = this.$root.querySelector('.govuk-js-password-input-input')
     if (!($input instanceof HTMLInputElement)) {
       throw new ElementError({
         component: PasswordInput,
@@ -69,7 +58,7 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    const $showHideButton = $root.querySelector(
+    const $showHideButton = this.$root.querySelector(
       '.govuk-js-password-input-toggle'
     )
     if (!($showHideButton instanceof HTMLButtonElement)) {
@@ -87,19 +76,18 @@ export class PasswordInput extends GOVUKFrontendComponent {
       )
     }
 
-    this.$root = $root
     this.$input = $input
     this.$showHideButton = $showHideButton
 
     this.config = mergeConfigs(
       PasswordInput.defaults,
       config,
-      normaliseDataset(PasswordInput, $root.dataset)
+      normaliseDataset(PasswordInput, this.$root.dataset)
     )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
-      locale: closestAttributeValue($root, 'lang')
+      locale: closestAttributeValue(this.$root, 'lang')
     })
 
     // Show the toggle button element

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -8,9 +8,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Radios extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $inputs
 
   /**
@@ -30,15 +27,7 @@ export class Radios extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!($root instanceof HTMLElement)) {
-      throw new ElementError({
-        component: Radios,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $inputs = $root.querySelectorAll('input[type="radio"]')
+    const $inputs = this.$root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError({
         component: Radios,
@@ -46,7 +35,6 @@ export class Radios extends GOVUKFrontendComponent {
       })
     }
 
-    this.$root = $root
     this.$inputs = $inputs
 
     this.$inputs.forEach(($input) => {

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.mjs
@@ -9,9 +9,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class ServiceNavigation extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $menuButton
 
   /** @private */
@@ -39,19 +36,9 @@ export class ServiceNavigation extends GOVUKFrontendComponent {
    * @param {Element | null} $root - HTML element to use for header
    */
   constructor($root) {
-    super()
+    super($root)
 
-    if (!$root) {
-      throw new ElementError({
-        component: ServiceNavigation,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
-
-    const $menuButton = $root.querySelector(
+    const $menuButton = this.$root.querySelector(
       '.govuk-js-service-navigation-toggle'
     )
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -6,10 +6,10 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  * Skip link component
  *
  * @preserve
+ * @augments GOVUKFrontendComponent<HTMLAnchorElement>
  */
 export class SkipLink extends GOVUKFrontendComponent {
-  /** @private */
-  $root
+  static elementType = HTMLAnchorElement
 
   /**
    * @param {Element | null} $root - HTML element to use for skip link
@@ -19,17 +19,6 @@ export class SkipLink extends GOVUKFrontendComponent {
    */
   constructor($root) {
     super($root)
-
-    if (!($root instanceof HTMLAnchorElement)) {
-      throw new ElementError({
-        component: SkipLink,
-        element: $root,
-        expectedType: 'HTMLAnchorElement',
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    this.$root = $root
 
     const hash = this.$root.hash
     const href = this.$root.getAttribute('href') ?? ''

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -9,9 +9,6 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
  */
 export class Tabs extends GOVUKFrontendComponent {
   /** @private */
-  $root
-
-  /** @private */
   $tabs
 
   /** @private */
@@ -47,15 +44,7 @@ export class Tabs extends GOVUKFrontendComponent {
   constructor($root) {
     super($root)
 
-    if (!$root) {
-      throw new ElementError({
-        component: Tabs,
-        element: $root,
-        identifier: 'Root element (`$root`)'
-      })
-    }
-
-    const $tabs = $root.querySelectorAll('a.govuk-tabs__tab')
+    const $tabs = this.$root.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError({
         component: Tabs,
@@ -63,7 +52,6 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
-    this.$root = $root
     this.$tabs = $tabs
 
     // Save bound functions so we can remove event listeners during teardown


### PR DESCRIPTION
## What

- Moves the type check of `root` into `GOVUKFrontendComponent` base class which components in the Design System extend
- Moves assignment of `root` into the `GOVUKFrontendComponent` base class which components in the Design System extend
- Adds `elementType` which specifies `type` of `root` to be checked and can be overloaded by child classes
- Add `getGOVUKFrontendExportsNames` to `rollup.release.config.mjs` which ensures that we don't run into an error in which `window.*` is undefined during build
- Updates the `Skeleton` section of Javascript documentation to use new format
- Remove `root` from each component (now defined and assigned in GOVUKFrontendComponent)
- Add `augments` when component requires typing of the `root` to be set

## Why

Follows on from https://github.com/alphagov/govuk-frontend/pull/5334 and fixes https://github.com/alphagov/govuk-frontend/issues/5326
