### PR TITLE
Add missing quotes around `<strong>` tag in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5278: Fix service navigation mobile toggle spacing](https://github.com/alphagov/govuk-frontend/pull/5278)
-- [#5331: Fix Warning Text font weight when <strong> styles are reset](https://github.com/alphagov/govuk-frontend/pull/5331)
+- [#5331: Fix Warning Text font weight when `<strong>` styles are reset](https://github.com/alphagov/govuk-frontend/pull/5331)
 - [#5352: Only apply margin to details summary when open](https://github.com/alphagov/govuk-frontend/pull/5352)
 - [#5089: Fix details expanded state not announced on iOS](https://github.com/alphagov/govuk-frontend/pull/5089)
 


### PR DESCRIPTION
Without it, the tag was treated as HTML and messing the formatting of the content following it.

Thanks @36degrees for spotting this.