### PR TITLE
Relax requirements to receive configuration with `createAll`

### DIFF
--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -368,69 +368,23 @@ describe('createAll', () => {
     expect(result[1].args).toStrictEqual([document.getElementById('b')])
   })
 
-  describe('when a component accepts config', () => {
-    class MockComponentWithConfig extends MockComponent {
-      static defaults = {
-        __test: false
-      }
-    }
-
+  describe('when a configuration is passed', () => {
     it('initialises a component, passing the component root and config', () => {
       const componentRoot = document.createElement('div')
       componentRoot.setAttribute('data-module', 'mock-component')
       document.body.appendChild(componentRoot)
 
-      const result = createAll(MockComponentWithConfig, {
+      const result = createAll(MockComponent, {
         __test: true
       })
 
-      expect(result).toStrictEqual([expect.any(MockComponentWithConfig)])
+      expect(result).toStrictEqual([expect.any(MockComponent)])
 
       expect(result[0].args).toStrictEqual([
         componentRoot,
         {
           __test: true
         }
-      ])
-    })
-
-    it('initialises a component, passing the component root even when no config is passed', () => {
-      const componentRoot = document.createElement('div')
-      componentRoot.setAttribute('data-module', 'mock-component')
-      document.body.appendChild(componentRoot)
-
-      const result = createAll(MockComponentWithConfig)
-
-      expect(result).toStrictEqual([expect.any(MockComponentWithConfig)])
-
-      console.log(result[0].args)
-
-      expect(result[0].args).toStrictEqual([componentRoot])
-    })
-
-    it('passes the config to all component objects', () => {
-      document.body.innerHTML = `
-      <div data-module="mock-component" id="a"></div>
-      <div data-module="mock-component" id="b"></div>`
-
-      const config = {
-        __test: true
-      }
-
-      const result = createAll(MockComponentWithConfig, config)
-
-      expect(result).toStrictEqual([
-        expect.any(MockComponentWithConfig),
-        expect.any(MockComponentWithConfig)
-      ])
-
-      expect(result[0].args).toStrictEqual([
-        document.getElementById('a'),
-        config
-      ])
-      expect(result[1].args).toStrictEqual([
-        document.getElementById('b'),
-        config
       ])
     })
   })

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -133,7 +133,7 @@ function createAll(Component, config, createAllOptions) {
       try {
         // Only pass config to components that accept it
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return 'defaults' in Component && typeof config !== 'undefined'
+        return typeof config !== 'undefined'
           ? new Component($element, config)
           : new Component($element)
       } catch (error) {


### PR DESCRIPTION
Remove the need for components to have a `defaults` static property, as it's an internal convention which is a lot to ask from outside components.

## Thoughts

Looks like that check was there to [help TypeScript follow when the code was inside `initAll`](https://github.com/alphagov/govuk-frontend/pull/4067#discussion_r1294351948). With [the introduction of `CompatibleClass` type](https://github.com/alphagov/govuk-frontend/pull/4975) and its `{new (...args: any[]): any}` constructor for the implementation of `createAll`, we no longer need it as the `CompatibleClass` loosened the requirements for the components' constructors.

An alternative could have been to check the constructor's length with [the `length` property of `Function`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) before passing a config. This would put a hard constraints on constructors not to use [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) (`constructor(...args) { }`), as those are not counted.

If a call to `createAll` receives a `config` and a component that does not expect a second argument, no harm done. The only issue would be if a component would expect something else than a `config` as a second argument but we'll be documenting the shape of constructors in our documentation (not that it prevents people from doing unexpected things, but I think we should have a certain level of trust with people using our API before getting too defensive. If we see too many issues, we can look at educating more or tightening requirements in the future).

Closes #5373