### PR TITLE
Match argument type for `onError` to what `catch` provides

### DIFF
--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -137,7 +137,7 @@ function createAll(Component, config, createAllOptions) {
           ? new Component($element, config)
           : new Component($element)
       } catch (error) {
-        if (onError && error instanceof Error) {
+        if (onError) {
           onError(error, {
             element: $element,
             component: Component,
@@ -212,7 +212,7 @@ export { initAll, createAll }
 /**
  * @template {CompatibleClass} T
  * @callback OnErrorCallback
- * @param {Error} error - Thrown error
+ * @param {unknown} error - Thrown error
  * @param {ErrorContext<T>} context - Object containing the element, component class and configuration
  */
 


### PR DESCRIPTION
This ensures the `onError` callback doesn't miss errors which wouldn't be `Error`.

## Thoughts

While it's best practice to throw an instance of `Error` (or a subclass of `Error`), there's no guarantees on that, so we can't anticipate the type of the variable in the `catch` block.