### PR TITLE
Update various department brand colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5396: Update DCMS, Defra, DSIT and FCDO brand colours](https://github.com/alphagov/govuk-frontend/pull/5396)
+
 ## v5.7.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@5.7.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
-- [#5396: Update DCMS, Defra, DSIT and FCDO brand colours](https://github.com/alphagov/govuk-frontend/pull/5396)
+- [#5396: Update various department brand colours](https://github.com/alphagov/govuk-frontend/pull/5396)
 
 ## v5.7.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -60,7 +60,8 @@ $_govuk-organisation-colours: (
       "`department-for-communities-local-government` became `ministry-of-housing-communities-local-government` in 2018."
   ),
   "department-for-culture-media-sport": (
-    colour: #d6006e
+    colour: #ed1588,
+    contrast-safe: #d6177a
   ),
   "department-for-digital-culture-media-sport": (
     colour: #d40072,
@@ -75,8 +76,8 @@ $_govuk-organisation-colours: (
     contrast-safe: #00852f
   ),
   "department-for-environment-food-rural-affairs": (
-    colour: #00af43,
-    contrast-safe: #008733
+    colour: #00a33b,
+    contrast-safe: #008531
   ),
   "department-for-exiting-the-european-union": (
     colour: #009fe3,
@@ -98,7 +99,7 @@ $_govuk-organisation-colours: (
       "`department-for-levelling-up-housing-communities` was renamed to `ministry-of-housing-communities-local-government` in 2024."
   ),
   "department-for-science-innovation-technology": (
-    colour: #00f9f8,
+    colour: #00f8f8,
     contrast-safe: #008180
   ),
   "department-for-transport": (
@@ -128,7 +129,7 @@ $_govuk-organisation-colours: (
     deprecation-message: "`foreign-commonwealth-office` became `foreign-commonwealth-development-office` in 2018."
   ),
   "foreign-commonwealth-development-office": (
-    colour: #002269
+    colour: #012069
   ),
   "government-equalities-office": (
     colour: #0056b8,

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -169,17 +169,18 @@ $_govuk-organisation-colours: (
     colour: #9c182f
   ),
   "office-of-the-secretary-of-state-for-scotland": (
-    colour: #00205c
+    colour: #00205c,
+    deprecation-message: "`office-of-the-secretary-of-state-for-scotland` was renamed to `scotland-office` in 2024."
   ),
   "office-of-the-secretary-of-state-for-wales": (
-    colour: #a8353a
+    colour: #a8353a,
+    deprecation-message: "`office-of-the-secretary-of-state-for-wales` was renamed to `wales-office` in 2024."
   ),
   "prime-ministers-office-10-downing-street": (
     colour: #0b0c0c
   ),
   "scotland-office": (
-    colour: #002663,
-    deprecation-message: "`scotland-office` became `office-of-the-secretary-of-state-for-scotland` in 2018."
+    colour: #00205c
   ),
   "serious-fraud-office": (
     colour: #82368c
@@ -193,8 +194,7 @@ $_govuk-organisation-colours: (
       "`uk-trade-investment` became `department-for-international-trade` in 2016. As of 2023, it is equivalent to `department-for-business-trade`."
   ),
   "wales-office": (
-    colour: #a33038,
-    deprecation-message: "`wales-office` became `office-of-the-secretary-of-state-for-wales` in 2018."
+    colour: #a33038
   )
 );
 


### PR DESCRIPTION
It has been flagged to us that the following departments brand colours don't align with the freshly updated HMG Identity System guidelines. In all cases, the shade being used is slightly different from what is specified in the guidelines, so the differences are all fairly minor.

## Changes

### Departments 
- Office of the Secretary of State for Scotland (OSSS) has been renamed back to the Scotland Office, the name it had prior to 2018. The old name has been un-deprecated, while OSSS has been deprecated.
- Office of the Secretary of State for Wales (OSSW) has been renamed back to the Wales Office, the name it had prior to 2018. The old name has been un-deprecated, while OSSW has been deprecated.

### Colours

- DCMS: `#d6006e` → `#ed1588`
  - As the new colour no longer has a 4.5:1 minimum contrast ratio, a contrast-safe alternative has been added: `#d6177a`
- Defra: `#00af43` → `#00a33b`
  - Additionally, the contrast-safe colour has been updated: `#008733` → `#008531` 
- DSIT: `#00f9f8` → `#00f8f8`
- FCDO: `#002269` → `#012069`
- Scotland Office: `#002663` → `#00205c`