### PR TITLE
Allow disabling of linting when running the `dev` task

### DIFF
--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -13,6 +13,15 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 - runs `npm run build`
 - starts the review app, restarting when `.mjs`, `.json` or `.yaml` files change
 - compile again when frontend `.mjs` and `.scss` files change
+- lint the JavaScript and Sass files of the project when they change
+
+  The linting can be disabled using the `GOVUK_DS_FRONTEND_NO_LINTING` environment variable.
+  It accepts a comma separated list of values with the types of linting you want to disable (`scss` and/or `js`).
+  For example:
+
+  ```sh
+  GOVUK_DS_FRONTEND_NO_LINTING=scss,js npm start
+  ```
 
 **`npm test` will do the following:**
 

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -20,12 +20,17 @@ import { scripts, styles } from './index.mjs'
  *
  * @type {import('@govuk-frontend/tasks').TaskFunction}
  */
-export const watch = (options) =>
-  gulp.parallel(
-    /**
-     * Stylesheets lint watcher
-     */
-    task.name('lint:scss watch', () =>
+export const watch = (options) => gulp.parallel(...getTasks(options))
+
+/**
+ * Compute the lists of tasks to be run in parallel
+ *
+ * @param {import('@govuk-frontend/tasks').TaskOptions} options
+ * @returns {any[]} The list of tasks to run in parallel
+ */
+function getTasks(options) {
+  const tasks = {
+    'lint:scss watch': () =>
       gulp.watch(
         '**/*.scss',
         { cwd: options.srcPath },
@@ -34,13 +39,8 @@ export const watch = (options) =>
         npm.script('lint:scss:cli', [
           slash(join(options.workspace, '**/*.scss'))
         ])
-      )
-    ),
-
-    /**
-     * Stylesheets build watcher
-     */
-    task.name('compile:scss watch', () =>
+      ),
+    'compile:scss watch': () =>
       gulp.watch(
         ['**/*.scss', join(paths.package, 'dist/govuk/all.scss')],
         {
@@ -54,13 +54,8 @@ export const watch = (options) =>
 
         // Run Sass compile
         styles(options)
-      )
-    ),
-
-    /**
-     * JavaScripts lint watcher
-     */
-    task.name('lint:js watch', () =>
+      ),
+    'lint:js watch': () =>
       gulp.watch(
         '**/*.{cjs,js,mjs}',
         { cwd: options.srcPath, ignored: ['**/*.test.*'] },
@@ -73,13 +68,8 @@ export const watch = (options) =>
             slash(join(options.workspace, '**/*.{cjs,js,mjs}'))
           ])
         )
-      )
-    ),
-
-    /**
-     * JavaScripts build watcher
-     */
-    task.name('compile:js watch', () =>
+      ),
+    'compile:js watch': () =>
       gulp.watch(
         'javascripts/**/*.mjs',
         { cwd: options.srcPath },
@@ -87,5 +77,7 @@ export const watch = (options) =>
         // Run JavaScripts compile
         scripts(options)
       )
-    )
-  )
+  }
+
+  return Object.entries(tasks).map(([taskName, fn]) => task.name(taskName, fn))
+}

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -34,7 +34,7 @@ export const watch = (options) => gulp.parallel(...getTasks(options))
  */
 function getTasks(options) {
   const tasks = {
-    'lint:scss watch': () =>
+    'lint:scss watch': disabledBy('GOVUK_DS_FRONTEND_NO_LINTING', 'scss', () =>
       gulp.watch(
         '**/*.scss',
         { cwd: options.srcPath },
@@ -43,7 +43,8 @@ function getTasks(options) {
         npm.script('lint:scss:cli', [
           slash(join(options.workspace, '**/*.scss'))
         ])
-      ),
+      )
+    ),
     'compile:scss watch': () =>
       gulp.watch(
         '**/*.scss',
@@ -52,7 +53,7 @@ function getTasks(options) {
         // Run Sass compile
         styles(options)
       ),
-    'lint:js watch': () =>
+    'lint:js watch': disabledBy('GOVUK_DS_FRONTEND_NO_LINTING', 'js', () =>
       gulp.watch(
         '**/*.{cjs,js,mjs}',
         { cwd: options.srcPath, ignored: ['**/*.test.*'] },
@@ -65,7 +66,8 @@ function getTasks(options) {
             slash(join(options.workspace, '**/*.{cjs,js,mjs}'))
           ])
         )
-      ),
+      )
+    ),
     'compile:js watch': () =>
       gulp.watch(
         '**/*.{cjs,js,mjs}',
@@ -100,5 +102,19 @@ function getTasks(options) {
       )
   }
 
-  return Object.entries(tasks).map(([taskName, fn]) => task.name(taskName, fn))
+  return Object.entries(tasks)
+    .filter(([taskName, fn]) => !!fn)
+    .map(([taskName, fn]) => task.name(taskName, fn))
+}
+
+function disabledBy(envVariableName, value, fn) {
+  // Split by comma to ensure we'll match full options
+  // avoiding `css` to match `scss` if we were looking in the whole string
+  const disabledValues = process.env[envVariableName]?.split?.(',')
+
+  if (disabledValues?.includes?.(value)) {
+    return null
+  }
+
+  return fn
 }

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -22,12 +22,19 @@ import { assets, fixtures, scripts, styles, templates } from './index.mjs'
  *
  * @type {import('@govuk-frontend/tasks').TaskFunction}
  */
-export const watch = (options) =>
-  gulp.parallel(
-    /**
-     * Stylesheets lint watcher
-     */
-    task.name('lint:scss watch', () =>
+export const watch = (options) => gulp.parallel(...getTasks(options))
+
+/**
+ * Compute the lists of tasks to be run in parallel
+ *
+ * Allows some of the tasks to be disabled by environment variables
+ *
+ * @param {import('@govuk-frontend/tasks').TaskOptions} options
+ * @returns {any[]} The list of tasks to run in parallel
+ */
+function getTasks(options) {
+  const tasks = {
+    'lint:scss watch': () =>
       gulp.watch(
         '**/*.scss',
         { cwd: options.srcPath },
@@ -36,26 +43,16 @@ export const watch = (options) =>
         npm.script('lint:scss:cli', [
           slash(join(options.workspace, '**/*.scss'))
         ])
-      )
-    ),
-
-    /**
-     * Stylesheets build watcher
-     */
-    task.name('compile:scss watch', () =>
+      ),
+    'compile:scss watch': () =>
       gulp.watch(
         '**/*.scss',
         { cwd: options.srcPath },
 
         // Run Sass compile
         styles(options)
-      )
-    ),
-
-    /**
-     * JavaScripts lint watcher
-     */
-    task.name('lint:js watch', () =>
+      ),
+    'lint:js watch': () =>
       gulp.watch(
         '**/*.{cjs,js,mjs}',
         { cwd: options.srcPath, ignored: ['**/*.test.*'] },
@@ -68,50 +65,32 @@ export const watch = (options) =>
             slash(join(options.workspace, '**/*.{cjs,js,mjs}'))
           ])
         )
-      )
-    ),
-
-    /**
-     * JavaScripts build watcher
-     */
-    task.name('compile:js watch', () =>
+      ),
+    'compile:js watch': () =>
       gulp.watch(
         '**/*.{cjs,js,mjs}',
         { cwd: options.srcPath, ignored: ['**/*.test.*'] },
 
         // Run JavaScripts compile
         scripts(options)
-      )
-    ),
-
-    /**
-     * Component fixtures watcher
-     */
-    task.name('compile:fixtures watch', () =>
+      ),
+    'compile:fixtures watch': () =>
       gulp.watch(
         'govuk/components/*/*.yaml',
         { cwd: options.srcPath },
 
         // Run fixtures compile
         fixtures(options)
-      )
-    ),
-
-    /**
-     * Component template watcher
-     */
-    task.name('copy:templates watch', () =>
+      ),
+    'copy:templates watch': () =>
       gulp.watch(
         'govuk/**/*.{md,njk}',
         { cwd: options.srcPath },
 
         // Run templates copy
         templates(options)
-      )
-    ),
-
-    // Copy GOV.UK Frontend static assets
-    task.name('copy:assets watch', () =>
+      ),
+    'copy:assets watch': () =>
       gulp.watch(
         'govuk/assets/**',
         { cwd: options.srcPath },
@@ -119,5 +98,7 @@ export const watch = (options) =>
         // Run assets copy
         assets(options)
       )
-    )
-  )
+  }
+
+  return Object.entries(tasks).map(([taskName, fn]) => task.name(taskName, fn))
+}


### PR DESCRIPTION
Adds a way to disable CSS and JavaScript linting when running the `dev` task by setting the `GOVUK_DS_FRONTEND_NO_LINTING` env variable. It accepts a comma separated list of the kinds of linting you want to disable (for now `scss` and `js`). For example:

```sh
GOVUK_DS_FRONTEND_NO_LINTING=scss,js npm start
```

## Why

Linting is great for production code, but gets in the way when building experimental code for a spike. Furthermore, when the linting errors, the whole gulp process exits, making the development experience tedious.

## Thoughts

### Name of the environment variable

The name of the environment variable is quite long, but I prefered to err on the side of caution with collisions, especially as some of us may want to set this at OS level so it applies at all time. The general scheme is:
- a prefix for our org (`GOVUK`) and team (`DS`)
- a prefix for the project (`FRONTEND`) - The variable is used both by `govuk-frontend` and the review app, but figured we didn't need that distinction yet.
- the name of the variable (`NO_LINTING`) where we just need to avoid collision within that project

### Code duplication

There's a little code duplication between the two `watch.mjs` files for computing whether the task receives a function and computing the list of Gulp tasks. I prefered erring towards having everything available in these files rather than having us jump through more files. 

## Potential future work

* Some refactoring of the duplicated code in `@govuk-frontend/tasks` if we want to regroup those
* If we need some further granularity (eg. only disable for one of the projects) or less (eg. just set `GOVUK_DS_FRONTEND_NO_LINTING=true` rather than list each language), we can expand the feature at that point
* If we need a similar kind of feature for the Design System site, we could look at duplicating it there (and possibly sharing an env variable to disable linting during dev)