### PR TITLE
Revert "Merge pull request #5442 from alphagov/dependabot/npm_and_yarn/sass-embedded-1.80.4"

### DIFF
--- a/docs/examples/webpack/package.json
+++ b/docs/examples/webpack/package.json
@@ -20,7 +20,7 @@
     "css-loader": "^7.1.2",
     "mini-css-extract-plugin": "^2.9.1",
     "postcss-loader": "^8.1.1",
-    "sass-embedded": "^1.80.4",
+    "sass-embedded": "^1.79.4",
     "sass-loader": "^16.0.2",
     "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.93.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "css-loader": "^7.1.2",
         "mini-css-extract-plugin": "^2.9.1",
         "postcss-loader": "^8.1.1",
-        "sass-embedded": "^1.80.4",
+        "sass-embedded": "^1.79.4",
         "sass-loader": "^16.0.2",
         "terser-webpack-plugin": "^5.3.10",
         "webpack": "^5.93.0",
@@ -24304,9 +24304,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.80.4.tgz",
-      "integrity": "sha512-lPzKX5g79ZxohlPxh0pXTPFseWj9RfgYI0cPm14CH5ok77Ujuheq/DCp7RStvNDWS8RCQ8Ii6gJC/5WTkGyrhA==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.79.4.tgz",
+      "integrity": "sha512-3AATrtStMgxYjkit02/Ix8vx/P7qderYG6DHjmehfk5jiw53OaWVScmcGJSwp/d77kAkxDQ+Y0r+79VynGmrkw==",
       "dev": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
@@ -24324,32 +24324,32 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.80.4",
-        "sass-embedded-android-arm64": "1.80.4",
-        "sass-embedded-android-ia32": "1.80.4",
-        "sass-embedded-android-riscv64": "1.80.4",
-        "sass-embedded-android-x64": "1.80.4",
-        "sass-embedded-darwin-arm64": "1.80.4",
-        "sass-embedded-darwin-x64": "1.80.4",
-        "sass-embedded-linux-arm": "1.80.4",
-        "sass-embedded-linux-arm64": "1.80.4",
-        "sass-embedded-linux-ia32": "1.80.4",
-        "sass-embedded-linux-musl-arm": "1.80.4",
-        "sass-embedded-linux-musl-arm64": "1.80.4",
-        "sass-embedded-linux-musl-ia32": "1.80.4",
-        "sass-embedded-linux-musl-riscv64": "1.80.4",
-        "sass-embedded-linux-musl-x64": "1.80.4",
-        "sass-embedded-linux-riscv64": "1.80.4",
-        "sass-embedded-linux-x64": "1.80.4",
-        "sass-embedded-win32-arm64": "1.80.4",
-        "sass-embedded-win32-ia32": "1.80.4",
-        "sass-embedded-win32-x64": "1.80.4"
+        "sass-embedded-android-arm": "1.79.4",
+        "sass-embedded-android-arm64": "1.79.4",
+        "sass-embedded-android-ia32": "1.79.4",
+        "sass-embedded-android-riscv64": "1.79.4",
+        "sass-embedded-android-x64": "1.79.4",
+        "sass-embedded-darwin-arm64": "1.79.4",
+        "sass-embedded-darwin-x64": "1.79.4",
+        "sass-embedded-linux-arm": "1.79.4",
+        "sass-embedded-linux-arm64": "1.79.4",
+        "sass-embedded-linux-ia32": "1.79.4",
+        "sass-embedded-linux-musl-arm": "1.79.4",
+        "sass-embedded-linux-musl-arm64": "1.79.4",
+        "sass-embedded-linux-musl-ia32": "1.79.4",
+        "sass-embedded-linux-musl-riscv64": "1.79.4",
+        "sass-embedded-linux-musl-x64": "1.79.4",
+        "sass-embedded-linux-riscv64": "1.79.4",
+        "sass-embedded-linux-x64": "1.79.4",
+        "sass-embedded-win32-arm64": "1.79.4",
+        "sass-embedded-win32-ia32": "1.79.4",
+        "sass-embedded-win32-x64": "1.79.4"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.80.4.tgz",
-      "integrity": "sha512-iAZ7AiKTLGxQGTkZ37c2/7YC4lkbP1o3eP/K74YaF8O+qhKTLyLOwV7OcmzIywac7dqLcNuGqhFCmFqTYpewZw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.79.4.tgz",
+      "integrity": "sha512-YOVpDGDcwWUQvktpJhYo4zOkknDpdX6ALpaeHDTX6GBUvnZfx+Widh76v+QFUhiJQ/I/hndXg1jv/PKilOHRrw==",
       "cpu": [
         "arm"
       ],
@@ -24363,9 +24363,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.80.4.tgz",
-      "integrity": "sha512-htAuBmRvvN2d4smrqxZ6WBw4+OOURaoHzq5oZKqS/E35zYl5FHmrJzp4S5e26a0tEBcjca014tfb/uu9cQgnqA==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.79.4.tgz",
+      "integrity": "sha512-0JAZ8TtXYv9yI3Yasaq03xvo7DLJOmD+Exb30oJKxXcWTAV9TB0ZWKoIRsFxbCyPxyn7ouxkaCEXQtaTRKrmfw==",
       "cpu": [
         "arm64"
       ],
@@ -24379,9 +24379,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.80.4.tgz",
-      "integrity": "sha512-IIee89Jco8/ad2s/oRJTFqpLhBMzg0UXteJyZ5waZPZmkeSR/t9l67Ef1lLQVh9t9/fJ1ViTTiGYm/g/zu6UGw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.79.4.tgz",
+      "integrity": "sha512-IjO3RoyvNN84ZyfAR5s/a8TIdNPfClb7CLGrswB3BN/NElYIJUJMVHD6+Y8W9QwBIZ8DrK1IdLFSTV8nn82xMA==",
       "cpu": [
         "ia32"
       ],
@@ -24395,9 +24395,9 @@
       }
     },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.80.4.tgz",
-      "integrity": "sha512-iJM2kqmWrOeE1aUyTp3uMAG86hyAqbpbOEV7tv828fUsMRDM4uHsHtmyp2n8P2Y0Y2FnLzJpvIm3SwDXGDzT1Q==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.79.4.tgz",
+      "integrity": "sha512-uOT8nXmKxSwuIdcqvElVWBFcm/+YcIvmwfoKbpuuSOSxUe9eqFzxo+fk7ILhynzf6FBlvRUH5DcjGj+sXtCc3w==",
       "cpu": [
         "riscv64"
       ],
@@ -24411,9 +24411,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.80.4.tgz",
-      "integrity": "sha512-vd8VrLvUoHeTcsDoIJesXLbQYZH26a8lAzXy6u4+vEuAwikF4WiXBDFrpqiv38QeD3faLeoPtksRsFbAdQqJAA==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.79.4.tgz",
+      "integrity": "sha512-W2FQoj3Z2J2DirNs3xSBVvrhMuqLnsqvOPulxOkhL/074+faKOZZnPx2tZ5zsHbY97SonciiU0SV0mm98xI42w==",
       "cpu": [
         "x64"
       ],
@@ -24427,9 +24427,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.80.4.tgz",
-      "integrity": "sha512-SJz7EM1i4NXa7CT/njIWMNYJ6CvbHljDIzUAZEe3V3u1KWl/eNO3pbWAnnDN62tBppwgWx/UdDUbAKowsT6Z8w==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.79.4.tgz",
+      "integrity": "sha512-pcYtbN1VUAAcfgyHeX8ySndDWGjIvcq6rldduktPbGGuAlEWFDfnwjTbv0hS945ggdzZ6TFnaFlLEDr0SjKzBA==",
       "cpu": [
         "arm64"
       ],
@@ -24443,9 +24443,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.80.4.tgz",
-      "integrity": "sha512-J/QlBVO66DLtgALgCmM8rZ5zG0dBCIYW1eXIAnnDwC7vGkbAXMtO60M0O/2WNrAfmFfJz1hvKDLjlsxB2XGBLg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.79.4.tgz",
+      "integrity": "sha512-ir8CFTfc4JLx/qCP8LK1/3pWv35nRyAQkUK7lBIKM6hWzztt64gcno9rZIk4SpHr7Z/Bp1IYWWRS4ZT+4HmsbA==",
       "cpu": [
         "x64"
       ],
@@ -24459,9 +24459,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.80.4.tgz",
-      "integrity": "sha512-vuaWhc4ebnaY1AgIWNvFv1snxmkWfvlCU7vnQf4qkn3R2Yyd2J+sjkO8o0NgMX8n5XRUSkAaYUJFCH+Nim6KgQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.79.4.tgz",
+      "integrity": "sha512-H/XEE3rY7c+tY0qDaELjPjC6VheAhBo1tPJQ6UHoBEf8xrbT/RT3dWiIS8grp9Vk54RCn05BEB/+POaljvvKGA==",
       "cpu": [
         "arm"
       ],
@@ -24475,9 +24475,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.80.4.tgz",
-      "integrity": "sha512-hI6zQyrR6qJbvyEHfj8UGXNB8VyUa72jel46406AuxUnViA0RyZDSqXUF8vwVw/Hjv1LkA5ihK9dBmWNbLz1zQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.79.4.tgz",
+      "integrity": "sha512-XIVn2mCuA422SR2kmKjF6jhjMs1Vrt1DbZ/ktSp+eR0sU4ugu2htg45GajiUFSKKRj7Sc+cBdThq1zPPsDLf1w==",
       "cpu": [
         "arm64"
       ],
@@ -24491,9 +24491,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.80.4.tgz",
-      "integrity": "sha512-wcPExI8UbYrrJvGvo4v2Q+RktbCp44i3qZQ18hglPcVZOC1IzT9NPqZn0XmrqD4hmNbgsYR+picODkvqGw7iDA==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.79.4.tgz",
+      "integrity": "sha512-3nqZxV4nuUTb1ahLexVl4hsnx1KKwiGdHEf1xHWTZai6fYFMcwyNPrHySCQzFHqb5xiqSpPzzrKjuDhF6+guuQ==",
       "cpu": [
         "ia32"
       ],
@@ -24507,9 +24507,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.80.4.tgz",
-      "integrity": "sha512-HWo0G/9tuhj/uSEwte9KiDK2Xezrfh7nhdEH69ZIfOAqP5byTXL7o08TYagbvMAoljR43Vfna6MelV7NUX4WCw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.79.4.tgz",
+      "integrity": "sha512-HnbU1DEiQdUayioNzxh2WlbTEgQRBPTgIIvof8J63QLmVItUqE7EkWYkSUy4RhO+8NsuN9wzGmGTzFBvTImU7g==",
       "cpu": [
         "arm"
       ],
@@ -24523,9 +24523,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.80.4.tgz",
-      "integrity": "sha512-y8slzQ8Jjkl+53mUDkp3zxcDrTXVVxzpa+6nKh5Ue8l1YU2KdVZG1v2PoDXxE6o99B5I2TVBG8i02IsdYoL8jQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.79.4.tgz",
+      "integrity": "sha512-C6qX06waPEfDgOHR8jXoYxl0EtIXOyBDyyonrLO3StRjWjGx7XMQj2hA/KXSsV+Hr71fBOsaViosqWXPzTbEiQ==",
       "cpu": [
         "arm64"
       ],
@@ -24539,9 +24539,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.80.4.tgz",
-      "integrity": "sha512-A2WSwnomho491iCeHh3c0YRympfAoJOKr+IyxalTcRH/pjENOWZWZUt00WE2q0tTpEd2V+goWvgS5pmUGewgmg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.79.4.tgz",
+      "integrity": "sha512-y5b0fdOPWyhj4c+mc88GvQiC5onRH1V0iNaWNjsiZ+L4hHje6T98nDLrCJn0fz5GQnXjyLCLZduMWbfV0QjHGg==",
       "cpu": [
         "ia32"
       ],
@@ -24555,9 +24555,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.80.4.tgz",
-      "integrity": "sha512-tYQsAHZLr2mnlJQBJ8Z/n/ySIFJ9JWpsUsoLe9fYgGDaBUfItdzUnj15CChRWld8vFe/I84hb7fbCtYXrI60Jg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.79.4.tgz",
+      "integrity": "sha512-G2M5ADMV9SqnkwpM0S+UzDz7xR2njCOhofku/sDMZABzAjQQWTsAykKoGmzlT98fTw2HbNhb6u74umf2WLhCfw==",
       "cpu": [
         "riscv64"
       ],
@@ -24571,9 +24571,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.80.4.tgz",
-      "integrity": "sha512-NZnr+SYbWlmXx0IaSQ8oF0jYkOULp9qKWMmmZQ1mxuGQ3z7tJqFhpH3M+hYkrFNeOq+GaH+nhHGOD4ZNBxeRkg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.79.4.tgz",
+      "integrity": "sha512-kQm8dCU3DXf7DtUGWYPiPs03KJYKvFeiZJHhSx993DCM8D2b0wCXWky0S0Z46gf1sEur0SN4Lvnt1WczTqxIBw==",
       "cpu": [
         "x64"
       ],
@@ -24587,9 +24587,9 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.80.4.tgz",
-      "integrity": "sha512-h/BmU7QONa7ScvQztFp4Th4aSo3X+Olu3I+RYsaH9s7P683WT3f2w5zr+wwP1V4roM5eyKDCRJBuefT3Fkkkgw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.79.4.tgz",
+      "integrity": "sha512-GaTI/mXYWYSzG5wxtM4H2cozLpATyh+4l+rO9FFKOL8e1sUOLAzTeRdU2nSBYCuRqsxRuTZIwCXhSz9Q3NRuNA==",
       "cpu": [
         "riscv64"
       ],
@@ -24603,9 +24603,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.80.4.tgz",
-      "integrity": "sha512-aZbZFs/X9bEmzDiBEiV4IAsKEA0zrCM+s/u2OzvrX4GRvZFJ+/XRTTvf+RTm7mgvTFgfPwCkNGVECQZ1eHh+6A==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.79.4.tgz",
+      "integrity": "sha512-f9laGkqHgC01h99Qt4LsOV+OLMffjvUcTu14hYWqMS9QVX5a4ihMwpf1NoAtTUytb7cVF3rYY/NVGuXt6G3ppQ==",
       "cpu": [
         "x64"
       ],
@@ -24619,9 +24619,9 @@
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.80.4.tgz",
-      "integrity": "sha512-8JiatFi2VVFqCdJzKNDteaPC4KPmh8/giaVh7TyMcDhKjnvRLeu3v5V1egTMiwwpnQHuwzU3uqBlm/llVNR2Pw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.79.4.tgz",
+      "integrity": "sha512-cidBvtaA2cJ6dNlwQEa8qak+ezypurzKs0h0QAHLH324+j/6Jum7LCnQhZRPYJBFjHl+WYd7KwzPnJ2X5USWnQ==",
       "cpu": [
         "arm64"
       ],
@@ -24635,9 +24635,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.80.4.tgz",
-      "integrity": "sha512-SodmTD6mjxEgoq44jWMibmBQvWkCfENK/70zp4qsztcBSOggg3nYUzwG0YpraClAMXpB1xOvzrArWu9/9fguAg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.79.4.tgz",
+      "integrity": "sha512-hexdmNTIZGTKNTzlMcdvEXzYuxOJcY89zqgsf45aQ2YMy4y2M8dTOxRI/Vz7p4iRxVp1Jow6LCtaLHrNI2Ordg==",
       "cpu": [
         "ia32"
       ],
@@ -24651,9 +24651,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.80.4.tgz",
-      "integrity": "sha512-7+oRRwCCcnOmw152qDiC7x7SphYBo1eLB4KdyThO+7+rYRO8AftXO+kqBPTVSkM8kGp4wxCMF9auPpYBZbjsow==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.79.4.tgz",
+      "integrity": "sha512-73yrpiWIbti6DkxhWURklkgSLYKfU9itDmvHxB+oYSb4vQveIApqTwSyTOuIUb/6Da/EsgEpdJ4Lbj4sLaMZWA==",
       "cpu": [
         "x64"
       ],
@@ -29659,7 +29659,7 @@
         "puppeteer": "^23.6.0",
         "rollup": "^4.19.1",
         "sass-color-helpers": "^2.1.1",
-        "sass-embedded": "^1.80.4",
+        "sass-embedded": "^1.79.4",
         "sassdoc": "^2.7.4",
         "slash": "^5.1.0"
       },
@@ -29760,7 +29760,7 @@
         "mime-types": "^2.1.35",
         "outdent": "^0.8.0",
         "puppeteer": "^23.6.0",
-        "sass-embedded": "^1.80.4",
+        "sass-embedded": "^1.79.4",
         "slug": "^9.1.0"
       },
       "engines": {
@@ -29843,7 +29843,7 @@
         "postcss-load-config": "^6.0.1",
         "puppeteer": "^23.6.0",
         "rollup": "^4.19.1",
-        "sass-embedded": "^1.80.4",
+        "sass-embedded": "^1.79.4",
         "slash": "^5.1.0",
         "slug": "^9.1.0",
         "yargs-parser": "^21.1.1"

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -85,7 +85,7 @@
     "puppeteer": "^23.6.0",
     "rollup": "^4.19.1",
     "sass-color-helpers": "^2.1.1",
-    "sass-embedded": "^1.80.4",
+    "sass-embedded": "^1.79.4",
     "sassdoc": "^2.7.4",
     "slash": "^5.1.0"
   }

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -27,7 +27,7 @@
     "mime-types": "^2.1.35",
     "outdent": "^0.8.0",
     "puppeteer": "^23.6.0",
-    "sass-embedded": "^1.80.4",
+    "sass-embedded": "^1.79.4",
     "slug": "^9.1.0"
   },
   "peerDependencies": {

--- a/shared/helpers/tests.js
+++ b/shared/helpers/tests.js
@@ -34,12 +34,7 @@ async function compileSassFile(path, options = {}) {
 async function compileSassString(source, options = {}) {
   return compileStringAsync(source, {
     loadPaths: sassPaths,
-    silenceDeprecations: [
-      'slash-div',
-      'mixed-decls',
-      'import',
-      'global-builtin'
-    ],
+    silenceDeprecations: ['slash-div', 'mixed-decls'],
     quietDeps: true,
     ...options
   })

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -22,7 +22,7 @@
     "postcss-load-config": "^6.0.1",
     "puppeteer": "^23.6.0",
     "rollup": "^4.19.1",
-    "sass-embedded": "^1.80.4",
+    "sass-embedded": "^1.79.4",
     "slash": "^5.1.0",
     "slug": "^9.1.0",
     "yargs-parser": "^21.1.1"


### PR DESCRIPTION
This reverts commit a9f5e155b503dee60d2f9b4e356deac62b72ae98, reversing changes made to a6d6eefa93a528bb566672f5c9dcdea61650e236.

Whilst it wasn't showing up in tests on #5442 for some reason, upon merging this PR our libsass tests stopped working on main. It makes sense given the change log was to deprecate `@import` but as I say, wasn't showing up in tests.