### PR TITLE
Update our deprecated libsass tests to use node 6 instead of 4

### DIFF
--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -80,9 +80,9 @@ jobs:
         run: |
           ! grep "\$govuk-" .tmp/all.css
 
-  # Node Sass v3.4.0 = LibSass v3.3.0
+  # Node Sass v3.7.0 = LibSass v3.5.0
   lib-sass:
-    name: LibSass v3.3.0 (deprecated)
+    name: LibSass v3.5.0 (deprecated)
     runs-on: ubuntu-latest
 
     steps:
@@ -93,11 +93,11 @@ jobs:
         uses: actions/setup-node@v4.1.0
         with:
           cache: npm
-          node-version: 4 # Node.js 4 supported by Node Sass v3.4.0
+          node-version: 6 # Node.js 6 supported by Node Sass v3.7.0
 
       - name: Install package
         run: |
-          npm install -g node-sass@v3.4.0
+          npm install -g node-sass@v3.7.0
           node-sass --version
 
       - name: Run command


### PR DESCRIPTION
Updates the node-sass version in the old libsass tests to 3.5.0 over 3.3.0.

This resolves an issue with our automated testing where a dependancy chain has caused the test to break at install. We've tried reverting dependabots to resolve this but haven't been able to identify the point at which the dependancy broke. Instead of trying to unpick our 2nd/3rd/4th/5th level dependencies, this is the simpler solution.