### PR TITLE
[SPIKE] Use TypeScript for the Accordion's defaults immutability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "stylelint": "^16.9.0",
         "stylelint-config-gds": "^2.0.0",
         "stylelint-order": "^6.0.4",
+        "type-fest": "^4.26.1",
         "typescript": "^5.5.4"
       },
       "engines": {
@@ -6695,6 +6696,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -27598,12 +27612,13 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "stylelint": "^16.9.0",
     "stylelint-config-gds": "^2.0.0",
     "stylelint-order": "^6.0.4",
+    "type-fest": "^4.26.1",
     "typescript": "^5.5.4"
   },
   "optionalDependencies": {

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -577,9 +577,9 @@ export class Accordion extends GOVUKFrontendComponentConfigurable {
    *
    * @see {@link AccordionConfig}
    * @constant
-   * @type {AccordionConfig}
+   * @type {ReadonlyDeep<AccordionConfig>}
    */
-  static defaults = Object.freeze({
+  static defaults = {
     i18n: {
       hideAllSections: 'Hide all sections',
       hideSection: 'Hide',
@@ -589,7 +589,7 @@ export class Accordion extends GOVUKFrontendComponentConfigurable {
       showSectionAriaLabel: 'Show this section'
     },
     rememberExpanded: true
-  })
+  }
 
   /**
    * Accordion config schema
@@ -603,6 +603,11 @@ export class Accordion extends GOVUKFrontendComponentConfigurable {
       rememberExpanded: { type: 'boolean' }
     }
   })
+}
+
+Accordion.defaults.rememberExpanded = false
+if (Accordion.defaults.i18n?.hideSection) {
+  Accordion.defaults.i18n.hideSection = 'Some new string'
 }
 
 /**
@@ -640,4 +645,9 @@ export class Accordion extends GOVUKFrontendComponentConfigurable {
 
 /**
  * @typedef {import('../../common/configuration.mjs').Schema} Schema
+ */
+
+/**
+ * @template T
+ * @typedef {import('type-fest').ReadonlyDeep<T>} ReadonlyDeep<T>
  */


### PR DESCRIPTION
`Object.freeze` only does a shallow freeze of the object, meaning we have nothing checking our code against something setting one of the keys of `i18n`. The [`ReadonlyDeep<T>` type from `type-fest`](https://github.com/sindresorhus/type-fest/blob/main/source/readonly-deep.d.ts) allows TypeScript to check that even deep properties cannot be updated by our code.

This spike illustrates how we would use the `ReadonlyDeep<t>` type, using the `Accordion` component and building on the fact that we define the types for each component's configuration as `<COMPONENT_NAME>Config`.

> [!IMPORTANT]
> Tests are expected to fail on this spike to demonstrate that TypeScript does indeed pick up on nested properties of the `Accordion`'s `defaults` getting modified when they shouldn't

## Thoughts

### Removing `Object.freeze`

Because `Object.freeze` only does a shallow freeze, it provide a false sense of safety that deep keys are immutable if you're not aware of its shallowness. Implementing a function to deep freeze an object recursively would mean extra code shipped to the browser for the sake of preventing users' code from modifying a component's defaults. 

Leaving these defaults unprotected by removing `Object.freeze` doesn't seem a massive risk. If anything it allows an undocumented way to set defaults for all the components of a given class, while allowing multiple calls to `createAll` or `initAll` to override those defaults with specific configurations for given pages or parts of pages. And it shaves a little bit of code which won't be sent to the browser.

## Keeping things readonly in our code

This doesn't mean we cannot check that our code doesn't inadvertently try to update one of the properties in `defaults`. TypeScript's `Readonly<T>` type unfortunately works shallowly, just like `Object.freeze`. However, [the `type-fest` package](https://github.com/sindresorhus/type-fest/tree/main) provides a `ReadonlyDeep<T>` type that ensures nested objects/Maps/Sets/Arrays are also readonly (and is [heavily tested](https://github.com/sindresorhus/type-fest/blob/main/test-d/readonly-deep.ts)).

The `type-fest` package doesn't add to our own dependencies as type checking happens at build time, so it only needs to be a `devDependency`. However, it'll have impact on the `@types/govuk-frontend` package, for which it's become a dependency (unless there's a system for vendoring it).