### PR TITLE
Update silenced warnings for Sass compiler

### DIFF
--- a/shared/config/index.js
+++ b/shared/config/index.js
@@ -9,6 +9,7 @@ const { NODE_ENV = 'development' } = process.env
  */
 const paths = require('./paths')
 const ports = require('./ports')
+const sass = require('./sass')
 const urls = require('./urls')
 
 /**
@@ -25,6 +26,7 @@ module.exports = {
   paths,
   pkg,
   ports,
+  sass,
   urls,
   version
 }

--- a/shared/config/sass.js
+++ b/shared/config/sass.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('sass-embedded').Options<"async">}
+ */
+const deprecationOptions = {
+  silenceDeprecations: ['slash-div', 'mixed-decls', 'import', 'global-builtin'],
+  quietDeps: true
+}
+
+module.exports = {
+  deprecationOptions
+}

--- a/shared/helpers/tests.js
+++ b/shared/helpers/tests.js
@@ -1,6 +1,6 @@
 const { join } = require('path')
 
-const { paths } = require('@govuk-frontend/config')
+const { paths, sass: sassConfig } = require('@govuk-frontend/config')
 const { compileAsync, compileStringAsync } = require('sass-embedded')
 
 const sassPaths = [
@@ -18,13 +18,7 @@ const sassPaths = [
 async function compileSassFile(path, options = {}) {
   return compileAsync(path, {
     loadPaths: sassPaths,
-    silenceDeprecations: [
-      'slash-div',
-      'mixed-decls',
-      'import',
-      'global-builtin'
-    ],
-    quietDeps: true,
+    ...sassConfig.deprecationOptions,
     ...options
   })
 }
@@ -39,13 +33,7 @@ async function compileSassFile(path, options = {}) {
 async function compileSassString(source, options = {}) {
   return compileStringAsync(source, {
     loadPaths: sassPaths,
-    silenceDeprecations: [
-      'slash-div',
-      'mixed-decls',
-      'import',
-      'global-builtin'
-    ],
-    quietDeps: true,
+    ...sassConfig.deprecationOptions,
     ...options
   })
 }

--- a/shared/helpers/tests.js
+++ b/shared/helpers/tests.js
@@ -18,7 +18,12 @@ const sassPaths = [
 async function compileSassFile(path, options = {}) {
   return compileAsync(path, {
     loadPaths: sassPaths,
-    silenceDeprecations: ['slash-div', 'mixed-decls'],
+    silenceDeprecations: [
+      'slash-div',
+      'mixed-decls',
+      'import',
+      'global-builtin'
+    ],
     quietDeps: true,
     ...options
   })

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import { join, parse } from 'path'
 
-import { paths } from '@govuk-frontend/config'
+import { paths, sass as sassConfig } from '@govuk-frontend/config'
 import { getListing } from '@govuk-frontend/lib/files'
 import { packageTypeToPath } from '@govuk-frontend/lib/names'
 import PluginError from 'plugin-error'
@@ -80,13 +80,7 @@ export async function compileStylesheet([
       alertColor: true,
 
       // Turn off dependency warnings
-      quietDeps: true,
-      silenceDeprecations: [
-        'slash-div',
-        'mixed-decls',
-        'import',
-        'global-builtin'
-      ],
+      ...sassConfig.deprecationOptions,
 
       // Enable source maps
       sourceMap: true,

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -81,7 +81,12 @@ export async function compileStylesheet([
 
       // Turn off dependency warnings
       quietDeps: true,
-      silenceDeprecations: ['slash-div', 'mixed-decls'],
+      silenceDeprecations: [
+        'slash-div',
+        'mixed-decls',
+        'import',
+        'global-builtin'
+      ],
 
       // Enable source maps
       sourceMap: true,


### PR DESCRIPTION
Missed a couple of places we were silencing Sass dependencies when I updated #5442, which this PR fixes (adding the ignoring of `import` and `global-builtin').

In addition, it also centralise the configuration related to deprecations in the `@govuk-frontend/config` module. While this scatters the configuration a little, it'll reduce the risk that the silencing of deprecations gets updated in one part of our build but not another. 