### PR TITLE
`GOVUKFrontendComponentConfigurable` override functionality and `CharacterCount` extends Configurable class

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -3,6 +3,8 @@ import { GOVUKFrontendComponent } from '../govuk-frontend-component.mjs'
 
 import { isObject, formatErrorMessage } from './index.mjs'
 
+export const configOverride = Symbol.for('configOverride')
+
 /**
  * Base Component class
  *
@@ -14,6 +16,27 @@ import { isObject, formatErrorMessage } from './index.mjs'
  * @augments GOVUKFrontendComponent<RootElementType>
  */
 export class GOVUKFrontendComponentConfigurable extends GOVUKFrontendComponent {
+  /**
+   * configOverride
+   *
+   * Function which defines configuration overrides to prioritize
+   * properties from the root element's dataset.
+   *
+   * It should take a subset of configuration as input and return
+   * a new configuration object with properties that should be
+   * overridden based on the root element's dataset. A Symbol
+   * is used for indexing to prevent conflicts.
+   *
+   * @internal
+   * @virtual
+   * @param {ObjectNested} [param] - Configuration object
+   * @returns {ObjectNested} return - Configuration object
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  [configOverride](param) {
+    return {}
+  }
+
   /**
    * Returns the root element of the component
    *
@@ -52,11 +75,16 @@ export class GOVUKFrontendComponentConfigurable extends GOVUKFrontendComponent {
       )
     }
 
+    const datasetConfig = /** @type {ConfigurationType} */ (
+      normaliseDataset(childConstructor, this._$root.dataset)
+    )
+
     this._config = /** @type {ConfigurationType} */ (
       mergeConfigs(
         childConstructor.defaults,
         config ?? {},
-        normaliseDataset(childConstructor, this._$root.dataset)
+        this[configOverride](datasetConfig),
+        datasetConfig
       )
     )
   }

--- a/packages/govuk-frontend/src/govuk/common/configuration/govuk-frontend-component-configurable.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/govuk-frontend-component-configurable.jsdom.test.mjs
@@ -1,5 +1,8 @@
 import { ConfigError } from '../../errors/index.mjs'
-import { GOVUKFrontendComponentConfigurable } from '../configuration.mjs'
+import {
+  GOVUKFrontendComponentConfigurable,
+  configOverride
+} from '../configuration.mjs'
 
 describe('GOVUKFrontendComponentConfigurable', () => {
   beforeEach(() => {
@@ -156,6 +159,44 @@ describe('GOVUKFrontendComponentConfigurable', () => {
       })
 
       expect(configComponent._config).toMatchObject({ randomAttribute: 12 })
+    })
+
+    it('dataset overrides if configOverride set', () => {
+      const configOverrideFunction = jest.fn((config) => {
+        return { randomAttribute: undefined }
+      })
+
+      document.body.innerHTML = `
+        <div id="test-component" data-random-attribute="13"></div>
+      `
+
+      class ConfigurableComponent extends GOVUKFrontendComponentConfigurable {
+        [configOverride](config) {
+          return configOverrideFunction(config)
+        }
+
+        static moduleName = 'config-component'
+
+        static schema = {
+          properties: {
+            randomAttribute: { type: 'number' }
+          }
+        }
+
+        static defaults = {
+          randomAttribute: 0
+        }
+      }
+
+      const testComponent = document.querySelector('#test-component')
+
+      const configComponent = new ConfigurableComponent(testComponent, {
+        randomAttribute: '14'
+      })
+
+      expect(configComponent._config).toMatchObject({ randomAttribute: 13 })
+
+      expect(configOverrideFunction).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## What

- Config override support in Configurable class, adds `[configOverride]` function to `GOVUKFrontendComponentConfigurable` and exports `configOverride` symbol for other classes to use as index for function
- Character count extends Configurable class using the `configOverride` symbol

## Why

Fixes https://github.com/alphagov/govuk-frontend/issues/5458

