### PR TITLE
Update `createAll` types so they don't rely on component's defaults

### DIFF
--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -78,7 +78,7 @@ function initAll(config) {
  *
  * @template {CompatibleClass} ComponentClass
  * @param {ComponentClass} Component - class of the component to create
- * @param {ComponentClass["defaults"]} [config] - Config supplied to component
+ * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
  * @param {OnErrorCallback<ComponentClass> | Element | Document | CreateAllOptions<ComponentClass> } [createAllOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
  * @returns {Array<InstanceType<ComponentClass>>} - array of instantiated components
  */
@@ -203,10 +203,15 @@ export { initAll, createAll }
 
 /**
  * @template {CompatibleClass} ComponentClass
+ * @typedef {ComponentClass["defaults"]} ComponentConfig
+ */
+
+/**
+ * @template {CompatibleClass} ComponentClass
  * @typedef {object} ErrorContext
  * @property {Element} [element] - Element used for component module initialisation
  * @property {ComponentClass} [component] - Class of component
- * @property {ComponentClass["defaults"]} config - Config supplied to component
+ * @property {ComponentConfig<ComponentClass>} config - Config supplied to component
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -76,11 +76,11 @@ function initAll(config) {
  *
  * Any component errors will be caught and logged to the console.
  *
- * @template {CompatibleClass} T
- * @param {T} Component - class of the component to create
- * @param {T["defaults"]} [config] - Config supplied to component
- * @param {OnErrorCallback<T> | Element | Document | CreateAllOptions<T> } [createAllOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
- * @returns {Array<InstanceType<T>>} - array of instantiated components
+ * @template {CompatibleClass} ComponentClass
+ * @param {ComponentClass} Component - class of the component to create
+ * @param {ComponentClass["defaults"]} [config] - Config supplied to component
+ * @param {OnErrorCallback<ComponentClass> | Element | Document | CreateAllOptions<ComponentClass> } [createAllOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
+ * @returns {Array<InstanceType<ComponentClass>>} - array of instantiated components
  */
 function createAll(Component, config, createAllOptions) {
   let /** @type {Element | Document} */ $scope = document
@@ -202,23 +202,23 @@ export { initAll, createAll }
  */
 
 /**
- * @template {CompatibleClass} T
+ * @template {CompatibleClass} ComponentClass
  * @typedef {object} ErrorContext
  * @property {Element} [element] - Element used for component module initialisation
- * @property {T} [component] - Class of component
- * @property {T["defaults"]} config - Config supplied to component
+ * @property {ComponentClass} [component] - Class of component
+ * @property {ComponentClass["defaults"]} config - Config supplied to component
  */
 
 /**
- * @template {CompatibleClass} T
+ * @template {CompatibleClass} ComponentClass
  * @callback OnErrorCallback
  * @param {unknown} error - Thrown error
- * @param {ErrorContext<T>} context - Object containing the element, component class and configuration
+ * @param {ErrorContext<ComponentClass>} context - Object containing the element, component class and configuration
  */
 
 /**
- * @template {CompatibleClass} T
+ * @template {CompatibleClass} ComponentClass
  * @typedef {object} CreateAllOptions
  * @property {Element | Document} [scope] - scope of the document to search within
- * @property {OnErrorCallback<T>} [onError] - callback function if error throw by component on init
+ * @property {OnErrorCallback<ComponentClass>} [onError] - callback function if error throw by component on init
  */

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -162,7 +162,7 @@ export { initAll, createAll }
  **/
 
 /**
- * @typedef {{new (...args: any[]): any, defaults?: object, moduleName: string}} CompatibleClass
+ * @typedef {{new (...args: any[]): any, moduleName: string}} CompatibleClass
  */
 
 /* eslint-enable jsdoc/valid-types */
@@ -203,7 +203,7 @@ export { initAll, createAll }
 
 /**
  * @template {CompatibleClass} ComponentClass
- * @typedef {ComponentClass["defaults"]} ComponentConfig
+ * @typedef {ConstructorParameters<ComponentClass>[1]} ComponentConfig
  */
 
 /**


### PR DESCRIPTION
Use [TypeScript's `ConstructorParameters`](https://www.typescriptlang.org/docs/handbook/utility-types.html#constructorparameterstype) to pick the type for the component's configuration from the arguments of its constructor, rather than its `defaults` property. 

## Thoughts

This is closer to the actual behaviour of the function, which passes the config as the second argument of the constructor.

Testing in the `init.jsdom.test.mjs` (as it imports both `createAll` and components):

- Completions work OK for components that accept a configuration:
	<img width="508" alt="Screenshot of code editor using createAll to instantiate an Accordion, showing completions for the accordion configuration" src="https://github.com/user-attachments/assets/1baba46a-6cc5-4eb4-a65c-35cbbd5955c1">

- For components that do not accept configuration, config is typed as `any`
	<img width="669" alt="Screenshot of code editor using createAll to instantiate a component without config, showing the type any for the second argument of the function" src="https://github.com/user-attachments/assets/d38d4965-1eef-421a-9e9e-41d7cc3f6d88">

## Future work

Because `createAll` no longer relies on `defaults` we can set the `defaults` static property of the components as `@protected` to clarify the scope of our public API further. Given configuration passed to the constructor gets merged with those defaults, there's little need for them to be accessed outside of the component's class (or its descendents).