### PR TITLE
Fix UMD files overriding existing global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ You do not need `/index` at the end of each import path if you’re using Dart S
 
 This change was introduced in [pull request #5518: Deprecate `govuk/all.scss` and only reference `govuk/index.scss` internally](https://github.com/alphagov/govuk-frontend/pull/5518).
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5533: Fix UMD files overriding existing global](https://github.com/alphagov/govuk-frontend/pull/5533)
+
 ## v5.7.1 (Fix release)
 
 To install this version with npm, run `npm install govuk-frontend@5.7.1`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/rollup.publish.config.mjs
+++ b/packages/govuk-frontend/rollup.publish.config.mjs
@@ -46,7 +46,12 @@ export default defineConfig(({ i: input }) => ({
       preserveModules: false,
 
       // Export via `window.GOVUKFrontend.${exportName}`
-      name: 'GOVUKFrontend'
+      name: 'GOVUKFrontend',
+
+      // Loading multiple files will add their export to the same
+      // `GOVUKFrontend` object rather than re-creating a new `GOVUKFrontend`
+      // for each and wiping the components previously loaded
+      extend: true
     }
   ],
 

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -232,7 +232,7 @@ describe('packages/govuk-frontend/dist/', () => {
 
         // Look for AMD module definition for 'GOVUKFrontend'
         expect(contents).toContain(
-          "(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.GOVUKFrontend = {}));"
+          "(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.GOVUKFrontend = global.GOVUKFrontend || {}));"
         )
 
         // Look for bundled components with CommonJS named exports
@@ -355,6 +355,12 @@ describe('packages/govuk-frontend/dist/', () => {
           )
 
           expect(moduleTextESM).toContain(`export { ${componentClassName} }`)
+
+          // Look for AMD module definition for 'GOVUKFrontend'
+          expect(moduleTextUMD).toContain(
+            "(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.GOVUKFrontend = global.GOVUKFrontend || {}));"
+          )
+
           expect(moduleTextUMD).toContain(
             `exports.${componentClassName} = ${componentClassName};`
           )


### PR DESCRIPTION
Enable Rollup's `extend` output option for the UMD bundles, so that when importing multiple components, each gets added to `window.GOVUKFrontend` rather than the latest component overriding everything.

Fixes #5047