### PR TITLE
Enable skipLibCheck

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "noEmit": true,
     "noImplicitThis": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": false,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
> [!IMPORTANT]
> Remove 2nd commit before merging, it's only here to illustrate errors still being caught with `skipLibCheck` enabled

Enables TypeScript's `skipLibCheck` option to avoid TypeScript checking the types inside the code of our dependencies, which is out of our hands and has proved disruptive recently.

In terms of impacts:
- we still get type safety when we use the API of our dependencies (see second commit – soon to come for now)
- we still get type safety when using code inside of our repository (see second commit as well)
- we still get type safety when importing types from these libraries (see #https://github.com/alphagov/govuk-frontend/pull/5546 still failing after enabling the option because the types we declare using via import do not match the types expected by a dependency)

The first commit shows that our type checks still work OK.
The second commit (to be removed before merge) demonstrates that we still get type safety on:
- library calls, by introducing a call to `slug` with a mistyped argument
- calls of functions inside our repository, by introducing a call to our own `render` test helper with a mistyped argument

(Hopefully) closes #5549