### PR TITLE
[WIP][SPIKE] Accordion refactorings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,6 +136,13 @@ module.exports = {
       }
     },
     {
+      files: ['**/*.jsdom.test.{cjs,js,mjs}'],
+      env: {
+        jest: true,
+        browser: true
+      }
+    },
+    {
       // Matches Puppeteer environment in jest.config.mjs
       // to ignore unknown Jest Puppeteer globals
       files: ['**/*.puppeteer.test.{js,mjs}'],

--- a/packages/govuk-frontend/src/govuk/common/create-element.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/create-element.jsdom.test.mjs
@@ -1,0 +1,27 @@
+import { createElement } from './create-element.mjs'
+
+describe('createElement', () => {
+  it('creates an element of the specified type', () => {
+    const $element = createElement('input')
+
+    expect($element).toBeInstanceOf(HTMLInputElement)
+  })
+
+  it('sets all attributes', () => {
+    const $element = createElement('div', {
+      'data-polarity': 'reversed',
+      'data-confinement-beam': 'active'
+    })
+
+    expect($element).toHaveAttribute('data-polarity', 'reversed')
+    expect($element).toHaveAttribute('data-confinement-beam', 'active')
+  })
+
+  it('allows classes to be set by passing them as attributes', () => {
+    const $element = createElement('div', {
+      class: 'my-class'
+    })
+
+    expect($element).toHaveClass('my-class')
+  })
+})

--- a/packages/govuk-frontend/src/govuk/common/create-element.mjs
+++ b/packages/govuk-frontend/src/govuk/common/create-element.mjs
@@ -1,0 +1,17 @@
+/**
+ * Creates an element with the given attributes
+ *
+ * @internal
+ * @template {keyof HTMLElementTagNameMap} TagName
+ * @param {TagName} tagName - Type of element to create
+ * @param {{[key: string]: string}} [attributes] - Attributes to set on the element
+ * @returns {HTMLElementTagNameMap[TagName]} Created element
+ */
+export function createElement(tagName, attributes = {}) {
+  const el = document.createElement(tagName)
+  Object.entries(attributes).forEach(([name, value]) => {
+    el.setAttribute(name, value)
+  })
+
+  return el
+}

--- a/packages/govuk-frontend/src/govuk/common/create-element.mjs
+++ b/packages/govuk-frontend/src/govuk/common/create-element.mjs
@@ -5,13 +5,20 @@
  * @template {keyof HTMLElementTagNameMap} TagName
  * @param {TagName} tagName - Type of element to create
  * @param {{[key: string]: string}} [attributes] - Attributes to set on the element
+ * @param {Node[]} [children] - The list of child nodes for the element
  * @returns {HTMLElementTagNameMap[TagName]} Created element
  */
-export function createElement(tagName, attributes = {}) {
+export function createElement(tagName, attributes = {}, children) {
   const el = document.createElement(tagName)
   Object.entries(attributes).forEach(([name, value]) => {
     el.setAttribute(name, value)
   })
+
+  if (children) {
+    for (const child of children) {
+      el.appendChild(child)
+    }
+  }
 
   return el
 }

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -200,21 +200,6 @@ export class Accordion extends ConfigurableComponent {
       })
     }
 
-    // Create a button element that will replace the
-    // '.govuk-accordion__section-button' span
-    const $button = createElement('button', {
-      type: 'button',
-      'aria-controls': `${this.$root.id}-content-${index + 1}`
-    })
-
-    // Copy all attributes from $span to $button (except `id`, which gets added
-    // to the `$headingText` element)
-    for (const attr of Array.from($span.attributes)) {
-      if (attr.name !== 'id') {
-        $button.setAttribute(attr.name, attr.value)
-      }
-    }
-
     // Create container for heading text so it can be styled
     const $headingText = createElement('span', {
       class: sectionHeadingTextClass,
@@ -260,6 +245,21 @@ export class Accordion extends ConfigurableComponent {
         class: sectionToggleTextClass
       })
     )
+
+    // Create a button element that will replace the
+    // '.govuk-accordion__section-button' span
+    const $button = createElement('button', {
+      type: 'button',
+      'aria-controls': `${this.$root.id}-content-${index + 1}`
+    })
+
+    // Copy all attributes from $span to $button (except `id`, which gets added
+    // to the `$headingText` element)
+    for (const attr of Array.from($span.attributes)) {
+      if (attr.name !== 'id') {
+        $button.setAttribute(attr.name, attr.value)
+      }
+    }
 
     // Append elements to the button:
     // 1. Heading text

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -218,34 +218,6 @@ export class Accordion extends ConfigurableComponent {
       $headingTextFocus.appendChild($child)
     )
 
-    // Create container for show / hide icons and text.
-    const $showHideToggle = createElement('span', {
-      class: 'govuk-accordion__section-toggle',
-      // Tell Google not to index the 'show' text as part of the heading. Must be
-      // set on the element before it's added to the DOM.
-      // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
-      'data-nosnippet': ''
-    })
-
-    // Create an inner container to limit the width of the focus state
-    const $showHideToggleFocus = createElement('span', {
-      class: 'govuk-accordion__section-toggle-focus'
-    })
-
-    $showHideToggle.appendChild($showHideToggleFocus)
-    // Create wrapper for the show / hide text. Append text after the show/hide icon
-
-    $showHideToggleFocus.appendChild(
-      createElement('span', {
-        class: iconClass
-      })
-    )
-    $showHideToggleFocus.appendChild(
-      createElement('span', {
-        class: sectionToggleTextClass
-      })
-    )
-
     // Create a button element that will replace the
     // '.govuk-accordion__section-button' span
     const $button = createElement('button', {
@@ -278,10 +250,45 @@ export class Accordion extends ConfigurableComponent {
       $button.appendChild(this.getButtonPunctuationEl())
     }
 
-    $button.appendChild($showHideToggle)
+    $button.appendChild(this.createShowHideToggle())
 
     $heading.removeChild($span)
     $heading.appendChild($button)
+  }
+
+  /**
+   * Creates a `<span>` rendering the 'Show'/'Hide' toggle
+   *
+   * @returns {HTMLSpanElement} - The `<span>` with the visual representation of the 'Show/Hide' toggle
+   */
+  createShowHideToggle() {
+    // Create an inner container to limit the width of the focus state
+    const $showHideToggleFocus = createElement('span', {
+      class: 'govuk-accordion__section-toggle-focus'
+    })
+
+    $showHideToggleFocus.appendChild(
+      createElement('span', {
+        class: iconClass
+      })
+    )
+    $showHideToggleFocus.appendChild(
+      createElement('span', {
+        class: sectionToggleTextClass
+      })
+    )
+
+    const $showHideToggle = createElement('span', {
+      class: 'govuk-accordion__section-toggle',
+      // Tell Google not to index the 'show' text as part of the heading. Must be
+      // set on the element before it's added to the DOM.
+      // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
+      'data-nosnippet': ''
+    })
+
+    $showHideToggle.appendChild($showHideToggleFocus)
+
+    return $showHideToggle
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -200,24 +200,6 @@ export class Accordion extends ConfigurableComponent {
       })
     }
 
-    // Create container for heading text so it can be styled
-    const $headingText = createElement('span', {
-      class: sectionHeadingTextClass,
-      id: $span.id
-    })
-
-    // Create an inner heading text container to limit the width of the focus
-    // state
-    const $headingTextFocus = createElement('span', {
-      class: 'govuk-accordion__section-heading-text-focus'
-    })
-    $headingText.appendChild($headingTextFocus)
-    // span could contain HTML elements
-    // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
-    Array.from($span.childNodes).forEach(($child) =>
-      $headingTextFocus.appendChild($child)
-    )
-
     // Create a button element that will replace the
     // '.govuk-accordion__section-button' span
     const $button = createElement('button', {
@@ -238,7 +220,7 @@ export class Accordion extends ConfigurableComponent {
     // 2. Punctuation
     // 3. (Optional: Summary line followed by punctuation)
     // 4. Show / hide toggle
-    $button.appendChild($headingText)
+    $button.appendChild(this.createHeadingText($span))
     $button.appendChild(this.getButtonPunctuationEl())
 
     // If summary content exists add to DOM in correct order
@@ -289,6 +271,36 @@ export class Accordion extends ConfigurableComponent {
     $showHideToggle.appendChild($showHideToggleFocus)
 
     return $showHideToggle
+  }
+
+  /**
+   * Creates the `<span>` containing the text of the section's heading
+   *
+   * @param {Element} $span - The heading of the span
+   * @returns {HTMLSpanElement} - The `<span>` containing the text of the section's heading
+   */
+  createHeadingText($span) {
+    // Create an inner heading text container to limit the width of the focus
+    // state
+    const $headingTextFocus = createElement('span', {
+      class: 'govuk-accordion__section-heading-text-focus'
+    })
+
+    // span could contain HTML elements which need moving to the new span
+    // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
+    Array.from($span.childNodes).forEach(($child) =>
+      $headingTextFocus.appendChild($child)
+    )
+
+    // Create container for heading text so it can be styled
+    const $headingText = createElement('span', {
+      class: sectionHeadingTextClass,
+      id: $span.id
+    })
+
+    $headingText.appendChild($headingTextFocus)
+
+    return $headingText
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -1,4 +1,5 @@
 import { ConfigurableComponent } from '../../common/configuration.mjs'
+import { createElement } from '../../common/create-element.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -107,25 +108,29 @@ export class Accordion extends ConfigurableComponent {
    */
   initControls() {
     // Create "Show all" button and set attributes
-    this.$showAllButton = document.createElement('button')
-    this.$showAllButton.setAttribute('type', 'button')
-    this.$showAllButton.setAttribute('class', 'govuk-accordion__show-all')
-    this.$showAllButton.setAttribute('aria-expanded', 'false')
+    this.$showAllButton = createElement('button', {
+      type: 'button',
+      class: 'govuk-accordion__show-all',
+      'aria-expanded': 'false'
+    })
 
     // Create icon, add to element
-    this.$showAllIcon = document.createElement('span')
-    this.$showAllIcon.classList.add(this.iconClass)
+    this.$showAllIcon = createElement('span', {
+      class: this.iconClass
+    })
     this.$showAllButton.appendChild(this.$showAllIcon)
 
     // Create control wrapper and add controls to it
-    const $accordionControls = document.createElement('div')
-    $accordionControls.setAttribute('class', 'govuk-accordion__controls')
+    const $accordionControls = createElement('div', {
+      class: 'govuk-accordion__controls'
+    })
     $accordionControls.appendChild(this.$showAllButton)
     this.$root.insertBefore($accordionControls, this.$root.firstChild)
 
     // Build additional wrapper for Show all toggle text and place after icon
-    this.$showAllText = document.createElement('span')
-    this.$showAllText.classList.add('govuk-accordion__show-all-text')
+    this.$showAllText = createElement('span', {
+      class: 'govuk-accordion__show-all-text'
+    })
     this.$showAllButton.appendChild(this.$showAllText)
 
     // Handle click events on the show/hide all button
@@ -197,12 +202,10 @@ export class Accordion extends ConfigurableComponent {
 
     // Create a button element that will replace the
     // '.govuk-accordion__section-button' span
-    const $button = document.createElement('button')
-    $button.setAttribute('type', 'button')
-    $button.setAttribute(
-      'aria-controls',
-      `${this.$root.id}-content-${index + 1}`
-    )
+    const $button = createElement('button', {
+      type: 'button',
+      'aria-controls': `${this.$root.id}-content-${index + 1}`
+    })
 
     // Copy all attributes from $span to $button (except `id`, which gets added
     // to the `$headingText` element)
@@ -213,18 +216,16 @@ export class Accordion extends ConfigurableComponent {
     }
 
     // Create container for heading text so it can be styled
-    const $headingText = document.createElement('span')
-    $headingText.classList.add(this.sectionHeadingTextClass)
-    // Copy the span ID to the heading text to allow it to be referenced by
-    // `aria-labelledby` on the hidden content area without "Show this section"
-    $headingText.id = $span.id
+    const $headingText = createElement('span', {
+      class: this.sectionHeadingTextClass,
+      id: $span.id
+    })
 
     // Create an inner heading text container to limit the width of the focus
     // state
-    const $headingTextFocus = document.createElement('span')
-    $headingTextFocus.classList.add(
-      'govuk-accordion__section-heading-text-focus'
-    )
+    const $headingTextFocus = createElement('span', {
+      class: 'govuk-accordion__section-heading-text-focus'
+    })
     $headingText.appendChild($headingTextFocus)
     // span could contain HTML elements
     // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
@@ -233,23 +234,32 @@ export class Accordion extends ConfigurableComponent {
     )
 
     // Create container for show / hide icons and text.
-    const $showHideToggle = document.createElement('span')
-    $showHideToggle.classList.add('govuk-accordion__section-toggle')
-    // Tell Google not to index the 'show' text as part of the heading. Must be
-    // set on the element before it's added to the DOM.
-    // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
-    $showHideToggle.setAttribute('data-nosnippet', '')
+    const $showHideToggle = createElement('span', {
+      class: 'govuk-accordion__section-toggle',
+      // Tell Google not to index the 'show' text as part of the heading. Must be
+      // set on the element before it's added to the DOM.
+      // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
+      'data-nosnippet': ''
+    })
+
     // Create an inner container to limit the width of the focus state
-    const $showHideToggleFocus = document.createElement('span')
-    $showHideToggleFocus.classList.add('govuk-accordion__section-toggle-focus')
+    const $showHideToggleFocus = createElement('span', {
+      class: 'govuk-accordion__section-toggle-focus'
+    })
+
     $showHideToggle.appendChild($showHideToggleFocus)
     // Create wrapper for the show / hide text. Append text after the show/hide icon
-    const $showHideText = document.createElement('span')
-    const $showHideIcon = document.createElement('span')
-    $showHideIcon.classList.add(this.iconClass)
-    $showHideToggleFocus.appendChild($showHideIcon)
-    $showHideText.classList.add(this.sectionToggleTextClass)
-    $showHideToggleFocus.appendChild($showHideText)
+
+    $showHideToggleFocus.appendChild(
+      createElement('span', {
+        class: this.iconClass
+      })
+    )
+    $showHideToggleFocus.appendChild(
+      createElement('span', {
+        class: this.sectionToggleTextClass
+      })
+    )
 
     // Append elements to the button:
     // 1. Heading text
@@ -265,11 +275,12 @@ export class Accordion extends ConfigurableComponent {
       // original `div` to the new `span`. This is because the summary line text
       // is now inside a button element, which can only contain phrasing
       // content.
-      const $summarySpan = document.createElement('span')
+      const $summarySpan = createElement('span')
       // Create an inner summary container to limit the width of the summary
       // focus state
-      const $summarySpanFocus = document.createElement('span')
-      $summarySpanFocus.classList.add('govuk-accordion__section-summary-focus')
+      const $summarySpanFocus = createElement('span', {
+        class: 'govuk-accordion__section-summary-focus'
+      })
       $summarySpan.appendChild($summarySpanFocus)
 
       // Get original attributes, and pass them to the replacement
@@ -536,13 +547,12 @@ export class Accordion extends ConfigurableComponent {
    * @returns {Element} DOM element
    */
   getButtonPunctuationEl() {
-    const $punctuationEl = document.createElement('span')
-    $punctuationEl.classList.add(
-      'govuk-visually-hidden',
-      'govuk-accordion__section-heading-divider'
-    )
-    $punctuationEl.textContent = ', '
-    return $punctuationEl
+    const $element = createElement('span', {
+      class: 'govuk-visually-hidden govuk-accordion__section-heading-divider'
+    })
+
+    $element.textContent = ', '
+    return $element
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -25,7 +25,7 @@ export class Accordion extends ConfigurableComponent {
   sectionClass = 'govuk-accordion__section'
 
   /** @private */
-  sectionExpandedClass = 'govuk-accordion__section--expanded'
+  sectionExpandedModifier = 'govuk-accordion__section--expanded'
 
   /** @private */
   sectionButtonClass = 'govuk-accordion__section-button'
@@ -40,13 +40,13 @@ export class Accordion extends ConfigurableComponent {
   sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
 
   /** @private */
-  sectionShowHideTextClass = 'govuk-accordion__section-toggle-text'
+  sectionToggleTextClass = 'govuk-accordion__section-toggle-text'
 
   /** @private */
-  upChevronIconClass = 'govuk-accordion-nav__chevron'
+  iconClass = 'govuk-accordion-nav__chevron'
 
   /** @private */
-  downChevronIconClass = 'govuk-accordion-nav__chevron--down'
+  iconOpenModifier = 'govuk-accordion-nav__chevron--down'
 
   /** @private */
   sectionSummaryClass = 'govuk-accordion__section-summary'
@@ -114,7 +114,7 @@ export class Accordion extends ConfigurableComponent {
 
     // Create icon, add to element
     this.$showAllIcon = document.createElement('span')
-    this.$showAllIcon.classList.add(this.upChevronIconClass)
+    this.$showAllIcon.classList.add(this.iconClass)
     this.$showAllButton.appendChild(this.$showAllIcon)
 
     // Create control wrapper and add controls to it
@@ -246,9 +246,9 @@ export class Accordion extends ConfigurableComponent {
     // Create wrapper for the show / hide text. Append text after the show/hide icon
     const $showHideText = document.createElement('span')
     const $showHideIcon = document.createElement('span')
-    $showHideIcon.classList.add(this.upChevronIconClass)
+    $showHideIcon.classList.add(this.iconClass)
     $showHideToggleFocus.appendChild($showHideIcon)
-    $showHideText.classList.add(this.sectionShowHideTextClass)
+    $showHideText.classList.add(this.sectionToggleTextClass)
     $showHideToggleFocus.appendChild($showHideText)
 
     // Append elements to the button:
@@ -354,9 +354,9 @@ export class Accordion extends ConfigurableComponent {
    * @param {Element} $section - Section element
    */
   setExpanded(expanded, $section) {
-    const $showHideIcon = $section.querySelector(`.${this.upChevronIconClass}`)
+    const $showHideIcon = $section.querySelector(`.${this.iconClass}`)
     const $showHideText = $section.querySelector(
-      `.${this.sectionShowHideTextClass}`
+      `.${this.sectionToggleTextClass}`
     )
     const $button = $section.querySelector(`.${this.sectionButtonClass}`)
     const $content = $section.querySelector(`.${this.sectionContentClass}`)
@@ -410,12 +410,12 @@ export class Accordion extends ConfigurableComponent {
     // Swap icon, change class
     if (expanded) {
       $content.removeAttribute('hidden')
-      $section.classList.add(this.sectionExpandedClass)
-      $showHideIcon.classList.remove(this.downChevronIconClass)
+      $section.classList.add(this.sectionExpandedModifier)
+      $showHideIcon.classList.remove(this.iconOpenModifier)
     } else {
       $content.setAttribute('hidden', 'until-found')
-      $section.classList.remove(this.sectionExpandedClass)
-      $showHideIcon.classList.add(this.downChevronIconClass)
+      $section.classList.remove(this.sectionExpandedModifier)
+      $showHideIcon.classList.add(this.iconOpenModifier)
     }
 
     // See if "Show all sections" button text should be updated
@@ -430,7 +430,7 @@ export class Accordion extends ConfigurableComponent {
    * @returns {boolean} True if expanded
    */
   isExpanded($section) {
-    return $section.classList.contains(this.sectionExpandedClass)
+    return $section.classList.contains(this.sectionExpandedModifier)
   }
 
   /**
@@ -460,7 +460,7 @@ export class Accordion extends ConfigurableComponent {
     this.$showAllText.textContent = expanded
       ? this.i18n.t('hideAllSections')
       : this.i18n.t('showAllSections')
-    this.$showAllIcon.classList.toggle(this.downChevronIconClass, !expanded)
+    this.$showAllIcon.classList.toggle(this.iconOpenModifier, !expanded)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -22,15 +22,6 @@ export class Accordion extends ConfigurableComponent {
   i18n
 
   /** @private */
-  controlsClass = 'govuk-accordion__controls'
-
-  /** @private */
-  showAllClass = 'govuk-accordion__show-all'
-
-  /** @private */
-  showAllTextClass = 'govuk-accordion__show-all-text'
-
-  /** @private */
   sectionClass = 'govuk-accordion__section'
 
   /** @private */
@@ -46,19 +37,7 @@ export class Accordion extends ConfigurableComponent {
   sectionHeadingClass = 'govuk-accordion__section-heading'
 
   /** @private */
-  sectionHeadingDividerClass = 'govuk-accordion__section-heading-divider'
-
-  /** @private */
   sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
-
-  /** @private */
-  sectionHeadingTextFocusClass = 'govuk-accordion__section-heading-text-focus'
-
-  /** @private */
-  sectionShowHideToggleClass = 'govuk-accordion__section-toggle'
-
-  /** @private */
-  sectionShowHideToggleFocusClass = 'govuk-accordion__section-toggle-focus'
 
   /** @private */
   sectionShowHideTextClass = 'govuk-accordion__section-toggle-text'
@@ -71,9 +50,6 @@ export class Accordion extends ConfigurableComponent {
 
   /** @private */
   sectionSummaryClass = 'govuk-accordion__section-summary'
-
-  /** @private */
-  sectionSummaryFocusClass = 'govuk-accordion__section-summary-focus'
 
   /** @private */
   sectionContentClass = 'govuk-accordion__section-content'
@@ -133,7 +109,7 @@ export class Accordion extends ConfigurableComponent {
     // Create "Show all" button and set attributes
     this.$showAllButton = document.createElement('button')
     this.$showAllButton.setAttribute('type', 'button')
-    this.$showAllButton.setAttribute('class', this.showAllClass)
+    this.$showAllButton.setAttribute('class', 'govuk-accordion__show-all')
     this.$showAllButton.setAttribute('aria-expanded', 'false')
 
     // Create icon, add to element
@@ -143,13 +119,13 @@ export class Accordion extends ConfigurableComponent {
 
     // Create control wrapper and add controls to it
     const $accordionControls = document.createElement('div')
-    $accordionControls.setAttribute('class', this.controlsClass)
+    $accordionControls.setAttribute('class', 'govuk-accordion__controls')
     $accordionControls.appendChild(this.$showAllButton)
     this.$root.insertBefore($accordionControls, this.$root.firstChild)
 
     // Build additional wrapper for Show all toggle text and place after icon
     this.$showAllText = document.createElement('span')
-    this.$showAllText.classList.add(this.showAllTextClass)
+    this.$showAllText.classList.add('govuk-accordion__show-all-text')
     this.$showAllButton.appendChild(this.$showAllText)
 
     // Handle click events on the show/hide all button
@@ -246,7 +222,9 @@ export class Accordion extends ConfigurableComponent {
     // Create an inner heading text container to limit the width of the focus
     // state
     const $headingTextFocus = document.createElement('span')
-    $headingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
+    $headingTextFocus.classList.add(
+      'govuk-accordion__section-heading-text-focus'
+    )
     $headingText.appendChild($headingTextFocus)
     // span could contain HTML elements
     // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
@@ -256,14 +234,14 @@ export class Accordion extends ConfigurableComponent {
 
     // Create container for show / hide icons and text.
     const $showHideToggle = document.createElement('span')
-    $showHideToggle.classList.add(this.sectionShowHideToggleClass)
+    $showHideToggle.classList.add('govuk-accordion__section-toggle')
     // Tell Google not to index the 'show' text as part of the heading. Must be
     // set on the element before it's added to the DOM.
     // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
     $showHideToggle.setAttribute('data-nosnippet', '')
     // Create an inner container to limit the width of the focus state
     const $showHideToggleFocus = document.createElement('span')
-    $showHideToggleFocus.classList.add(this.sectionShowHideToggleFocusClass)
+    $showHideToggleFocus.classList.add('govuk-accordion__section-toggle-focus')
     $showHideToggle.appendChild($showHideToggleFocus)
     // Create wrapper for the show / hide text. Append text after the show/hide icon
     const $showHideText = document.createElement('span')
@@ -291,7 +269,7 @@ export class Accordion extends ConfigurableComponent {
       // Create an inner summary container to limit the width of the summary
       // focus state
       const $summarySpanFocus = document.createElement('span')
-      $summarySpanFocus.classList.add(this.sectionSummaryFocusClass)
+      $summarySpanFocus.classList.add('govuk-accordion__section-summary-focus')
       $summarySpan.appendChild($summarySpanFocus)
 
       // Get original attributes, and pass them to the replacement
@@ -561,7 +539,7 @@ export class Accordion extends ConfigurableComponent {
     const $punctuationEl = document.createElement('span')
     $punctuationEl.classList.add(
       'govuk-visually-hidden',
-      this.sectionHeadingDividerClass
+      'govuk-accordion__section-heading-divider'
     )
     $punctuationEl.textContent = ', '
     return $punctuationEl

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -245,30 +245,32 @@ export class Accordion extends ConfigurableComponent {
    */
   createShowHideToggle() {
     // Create an inner container to limit the width of the focus state
-    const $showHideToggleFocus = createElement('span', {
-      class: 'govuk-accordion__section-toggle-focus'
-    })
-
-    $showHideToggleFocus.appendChild(
-      createElement('span', {
-        class: iconClass
-      })
+    const $showHideToggleFocus = createElement(
+      'span',
+      {
+        class: 'govuk-accordion__section-toggle-focus'
+      },
+      [
+        createElement('span', {
+          class: iconClass
+        }),
+        createElement('span', {
+          class: sectionToggleTextClass
+        })
+      ]
     )
-    $showHideToggleFocus.appendChild(
-      createElement('span', {
-        class: sectionToggleTextClass
-      })
+
+    const $showHideToggle = createElement(
+      'span',
+      {
+        class: 'govuk-accordion__section-toggle',
+        // Tell Google not to index the 'show' text as part of the heading. Must be
+        // set on the element before it's added to the DOM.
+        // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
+        'data-nosnippet': ''
+      },
+      [$showHideToggleFocus]
     )
-
-    const $showHideToggle = createElement('span', {
-      class: 'govuk-accordion__section-toggle',
-      // Tell Google not to index the 'show' text as part of the heading. Must be
-      // set on the element before it's added to the DOM.
-      // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
-      'data-nosnippet': ''
-    })
-
-    $showHideToggle.appendChild($showHideToggleFocus)
 
     return $showHideToggle
   }
@@ -282,23 +284,25 @@ export class Accordion extends ConfigurableComponent {
   createHeadingText($span) {
     // Create an inner heading text container to limit the width of the focus
     // state
-    const $headingTextFocus = createElement('span', {
-      class: 'govuk-accordion__section-heading-text-focus'
-    })
-
-    // span could contain HTML elements which need moving to the new span
-    // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
-    Array.from($span.childNodes).forEach(($child) =>
-      $headingTextFocus.appendChild($child)
+    const $headingTextFocus = createElement(
+      'span',
+      {
+        class: 'govuk-accordion__section-heading-text-focus'
+      },
+      // span could contain HTML elements which need moving to the new span
+      // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
+      Array.from($span.childNodes)
     )
 
     // Create container for heading text so it can be styled
-    const $headingText = createElement('span', {
-      class: sectionHeadingTextClass,
-      id: $span.id
-    })
-
-    $headingText.appendChild($headingTextFocus)
+    const $headingText = createElement(
+      'span',
+      {
+        class: sectionHeadingTextClass,
+        id: $span.id
+      },
+      [$headingTextFocus]
+    )
 
     return $headingText
   }
@@ -316,23 +320,20 @@ export class Accordion extends ConfigurableComponent {
   createSummarySpan($summary) {
     // Create an inner summary container to limit the width of the summary
     // focus state
-    const $summarySpanFocus = createElement('span', {
-      class: 'govuk-accordion__section-summary-focus'
-    })
+    const $summarySpanFocus = createElement(
+      'span',
+      {
+        class: 'govuk-accordion__section-summary-focus'
+      },
+      Array.from($summary.childNodes)
+    )
 
-    const $summarySpan = createElement('span')
-
-    $summarySpan.appendChild($summarySpanFocus)
+    const $summarySpan = createElement('span', {}, [$summarySpanFocus])
 
     // Get original attributes, and pass them to the replacement
     for (const attr of Array.from($summary.attributes)) {
       $summarySpan.setAttribute(attr.name, attr.value)
     }
-
-    // Copy original contents of summary to the new summary span
-    Array.from($summary.childNodes).forEach(($child) =>
-      $summarySpanFocus.appendChild($child)
-    )
 
     return $summarySpan
   }

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -271,32 +271,10 @@ export class Accordion extends ConfigurableComponent {
 
     // If summary content exists add to DOM in correct order
     if ($summary) {
-      // Create a new `span` element and copy the summary line content from the
-      // original `div` to the new `span`. This is because the summary line text
-      // is now inside a button element, which can only contain phrasing
-      // content.
-      const $summarySpan = createElement('span')
-      // Create an inner summary container to limit the width of the summary
-      // focus state
-      const $summarySpanFocus = createElement('span', {
-        class: 'govuk-accordion__section-summary-focus'
-      })
-      $summarySpan.appendChild($summarySpanFocus)
-
-      // Get original attributes, and pass them to the replacement
-      for (const attr of Array.from($summary.attributes)) {
-        $summarySpan.setAttribute(attr.name, attr.value)
-      }
-
-      // Copy original contents of summary to the new summary span
-      Array.from($summary.childNodes).forEach(($child) =>
-        $summarySpanFocus.appendChild($child)
-      )
-
       // Replace the original summary `div` with the new summary `span`
       $summary.remove()
 
-      $button.appendChild($summarySpan)
+      $button.appendChild(this.createSummarySpan($summary))
       $button.appendChild(this.getButtonPunctuationEl())
     }
 
@@ -304,6 +282,40 @@ export class Accordion extends ConfigurableComponent {
 
     $heading.removeChild($span)
     $heading.appendChild($button)
+  }
+
+  /**
+   * Creates the `<span>` element with the summary for the section
+   *
+   * This is necessary because the summary line text is now inside
+   * a button element, which can only contain phrasing content, and
+   * not a `<div>` element
+   *
+   * @param {Element} $summary - The original `<div>` containing the summary
+   * @returns {HTMLSpanElement} - The `<span>` element containing the summary
+   */
+  createSummarySpan($summary) {
+    // Create an inner summary container to limit the width of the summary
+    // focus state
+    const $summarySpanFocus = createElement('span', {
+      class: 'govuk-accordion__section-summary-focus'
+    })
+
+    const $summarySpan = createElement('span')
+
+    $summarySpan.appendChild($summarySpanFocus)
+
+    // Get original attributes, and pass them to the replacement
+    for (const attr of Array.from($summary.attributes)) {
+      $summarySpan.setAttribute(attr.name, attr.value)
+    }
+
+    // Copy original contents of summary to the new summary span
+    Array.from($summary.childNodes).forEach(($child) =>
+      $summarySpanFocus.appendChild($child)
+    )
+
+    return $summarySpan
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -3,6 +3,39 @@ import { createElement } from '../../common/create-element.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
+/** @private */
+const sectionClass = 'govuk-accordion__section'
+
+/** @private */
+const sectionExpandedModifier = 'govuk-accordion__section--expanded'
+
+/** @private */
+const sectionButtonClass = 'govuk-accordion__section-button'
+
+/** @private */
+const sectionHeaderClass = 'govuk-accordion__section-header'
+
+/** @private */
+const sectionHeadingClass = 'govuk-accordion__section-heading'
+
+/** @private */
+const sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
+
+/** @private */
+const sectionToggleTextClass = 'govuk-accordion__section-toggle-text'
+
+/** @private */
+const iconClass = 'govuk-accordion-nav__chevron'
+
+/** @private */
+const iconOpenModifier = 'govuk-accordion-nav__chevron--down'
+
+/** @private */
+const sectionSummaryClass = 'govuk-accordion__section-summary'
+
+/** @private */
+const sectionContentClass = 'govuk-accordion__section-content'
+
 /**
  * Accordion component
  *
@@ -21,39 +54,6 @@ import { I18n } from '../../i18n.mjs'
 export class Accordion extends ConfigurableComponent {
   /** @private */
   i18n
-
-  /** @private */
-  sectionClass = 'govuk-accordion__section'
-
-  /** @private */
-  sectionExpandedModifier = 'govuk-accordion__section--expanded'
-
-  /** @private */
-  sectionButtonClass = 'govuk-accordion__section-button'
-
-  /** @private */
-  sectionHeaderClass = 'govuk-accordion__section-header'
-
-  /** @private */
-  sectionHeadingClass = 'govuk-accordion__section-heading'
-
-  /** @private */
-  sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
-
-  /** @private */
-  sectionToggleTextClass = 'govuk-accordion__section-toggle-text'
-
-  /** @private */
-  iconClass = 'govuk-accordion-nav__chevron'
-
-  /** @private */
-  iconOpenModifier = 'govuk-accordion-nav__chevron--down'
-
-  /** @private */
-  sectionSummaryClass = 'govuk-accordion__section-summary'
-
-  /** @private */
-  sectionContentClass = 'govuk-accordion__section-content'
 
   /** @private */
   $sections
@@ -85,11 +85,11 @@ export class Accordion extends ConfigurableComponent {
 
     this.i18n = new I18n(this.config.i18n)
 
-    const $sections = this.$root.querySelectorAll(`.${this.sectionClass}`)
+    const $sections = this.$root.querySelectorAll(`.${sectionClass}`)
     if (!$sections.length) {
       throw new ElementError({
         component: Accordion,
-        identifier: `Sections (\`<div class="${this.sectionClass}">\`)`
+        identifier: `Sections (\`<div class="${sectionClass}">\`)`
       })
     }
 
@@ -116,7 +116,7 @@ export class Accordion extends ConfigurableComponent {
 
     // Create icon, add to element
     this.$showAllIcon = createElement('span', {
-      class: this.iconClass
+      class: iconClass
     })
     this.$showAllButton.appendChild(this.$showAllIcon)
 
@@ -153,11 +153,11 @@ export class Accordion extends ConfigurableComponent {
    */
   initSectionHeaders() {
     this.$sections.forEach(($section, i) => {
-      const $header = $section.querySelector(`.${this.sectionHeaderClass}`)
+      const $header = $section.querySelector(`.${sectionHeaderClass}`)
       if (!$header) {
         throw new ElementError({
           component: Accordion,
-          identifier: `Section headers (\`<div class="${this.sectionHeaderClass}">\`)`
+          identifier: `Section headers (\`<div class="${sectionHeaderClass}">\`)`
         })
       }
 
@@ -182,21 +182,21 @@ export class Accordion extends ConfigurableComponent {
    * @param {number} index - Section index
    */
   constructHeaderMarkup($header, index) {
-    const $span = $header.querySelector(`.${this.sectionButtonClass}`)
-    const $heading = $header.querySelector(`.${this.sectionHeadingClass}`)
-    const $summary = $header.querySelector(`.${this.sectionSummaryClass}`)
+    const $span = $header.querySelector(`.${sectionButtonClass}`)
+    const $heading = $header.querySelector(`.${sectionHeadingClass}`)
+    const $summary = $header.querySelector(`.${sectionSummaryClass}`)
 
     if (!$heading) {
       throw new ElementError({
         component: Accordion,
-        identifier: `Section heading (\`.${this.sectionHeadingClass}\`)`
+        identifier: `Section heading (\`.${sectionHeadingClass}\`)`
       })
     }
 
     if (!$span) {
       throw new ElementError({
         component: Accordion,
-        identifier: `Section button placeholder (\`<span class="${this.sectionButtonClass}">\`)`
+        identifier: `Section button placeholder (\`<span class="${sectionButtonClass}">\`)`
       })
     }
 
@@ -217,7 +217,7 @@ export class Accordion extends ConfigurableComponent {
 
     // Create container for heading text so it can be styled
     const $headingText = createElement('span', {
-      class: this.sectionHeadingTextClass,
+      class: sectionHeadingTextClass,
       id: $span.id
     })
 
@@ -252,12 +252,12 @@ export class Accordion extends ConfigurableComponent {
 
     $showHideToggleFocus.appendChild(
       createElement('span', {
-        class: this.iconClass
+        class: iconClass
       })
     )
     $showHideToggleFocus.appendChild(
       createElement('span', {
-        class: this.sectionToggleTextClass
+        class: sectionToggleTextClass
       })
     )
 
@@ -321,7 +321,7 @@ export class Accordion extends ConfigurableComponent {
     }
 
     // Handle when fragment is inside section
-    const $section = $fragment.closest(`.${this.sectionClass}`)
+    const $section = $fragment.closest(`.${sectionClass}`)
     if ($section) {
       this.setExpanded(true, $section)
     }
@@ -365,17 +365,15 @@ export class Accordion extends ConfigurableComponent {
    * @param {Element} $section - Section element
    */
   setExpanded(expanded, $section) {
-    const $showHideIcon = $section.querySelector(`.${this.iconClass}`)
-    const $showHideText = $section.querySelector(
-      `.${this.sectionToggleTextClass}`
-    )
-    const $button = $section.querySelector(`.${this.sectionButtonClass}`)
-    const $content = $section.querySelector(`.${this.sectionContentClass}`)
+    const $showHideIcon = $section.querySelector(`.${iconClass}`)
+    const $showHideText = $section.querySelector(`.${sectionToggleTextClass}`)
+    const $button = $section.querySelector(`.${sectionButtonClass}`)
+    const $content = $section.querySelector(`.${sectionContentClass}`)
 
     if (!$content) {
       throw new ElementError({
         component: Accordion,
-        identifier: `Section content (\`<div class="${this.sectionContentClass}">\`)`
+        identifier: `Section content (\`<div class="${sectionContentClass}">\`)`
       })
     }
 
@@ -394,14 +392,12 @@ export class Accordion extends ConfigurableComponent {
     // Update aria-label combining
     const ariaLabelParts = []
 
-    const $headingText = $section.querySelector(
-      `.${this.sectionHeadingTextClass}`
-    )
+    const $headingText = $section.querySelector(`.${sectionHeadingTextClass}`)
     if ($headingText) {
       ariaLabelParts.push(`${$headingText.textContent}`.trim())
     }
 
-    const $summary = $section.querySelector(`.${this.sectionSummaryClass}`)
+    const $summary = $section.querySelector(`.${sectionSummaryClass}`)
     if ($summary) {
       ariaLabelParts.push(`${$summary.textContent}`.trim())
     }
@@ -421,12 +417,12 @@ export class Accordion extends ConfigurableComponent {
     // Swap icon, change class
     if (expanded) {
       $content.removeAttribute('hidden')
-      $section.classList.add(this.sectionExpandedModifier)
-      $showHideIcon.classList.remove(this.iconOpenModifier)
+      $section.classList.add(sectionExpandedModifier)
+      $showHideIcon.classList.remove(iconOpenModifier)
     } else {
       $content.setAttribute('hidden', 'until-found')
-      $section.classList.remove(this.sectionExpandedModifier)
-      $showHideIcon.classList.add(this.iconOpenModifier)
+      $section.classList.remove(sectionExpandedModifier)
+      $showHideIcon.classList.add(iconOpenModifier)
     }
 
     // See if "Show all sections" button text should be updated
@@ -441,7 +437,7 @@ export class Accordion extends ConfigurableComponent {
    * @returns {boolean} True if expanded
    */
   isExpanded($section) {
-    return $section.classList.contains(this.sectionExpandedModifier)
+    return $section.classList.contains(sectionExpandedModifier)
   }
 
   /**
@@ -471,7 +467,7 @@ export class Accordion extends ConfigurableComponent {
     this.$showAllText.textContent = expanded
       ? this.i18n.t('hideAllSections')
       : this.i18n.t('showAllSections')
-    this.$showAllIcon.classList.toggle(this.iconOpenModifier, !expanded)
+    this.$showAllIcon.classList.toggle(iconOpenModifier, !expanded)
   }
 
   /**
@@ -485,7 +481,7 @@ export class Accordion extends ConfigurableComponent {
    * @returns {string | undefined | null} Identifier for section
    */
   getIdentifier($section) {
-    const $button = $section.querySelector(`.${this.sectionButtonClass}`)
+    const $button = $section.querySelector(`.${sectionButtonClass}`)
 
     return $button?.getAttribute('aria-controls')
   }

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,4 +1,5 @@
 import { ConfigurableComponent } from '../../common/configuration.mjs'
+import { createElement } from '../../common/create-element.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -113,9 +114,10 @@ export class ExitThisPage extends ConfigurableComponent {
    * @private
    */
   initUpdateSpan() {
-    this.$updateSpan = document.createElement('span')
-    this.$updateSpan.setAttribute('role', 'status')
-    this.$updateSpan.className = 'govuk-visually-hidden'
+    this.$updateSpan = createElement('span', {
+      role: 'status',
+      class: 'govuk-visually-hidden'
+    })
 
     this.$root.appendChild(this.$updateSpan)
   }
@@ -146,15 +148,18 @@ export class ExitThisPage extends ConfigurableComponent {
   buildIndicator() {
     // Build container
     // Putting `aria-hidden` on it as it won't contain any readable information
-    this.$indicatorContainer = document.createElement('div')
-    this.$indicatorContainer.className = 'govuk-exit-this-page__indicator'
-    this.$indicatorContainer.setAttribute('aria-hidden', 'true')
+    this.$indicatorContainer = createElement('div', {
+      class: 'govuk-exit-this-page__indicator',
+      'aria-hidden': 'true'
+    })
 
     // Create three 'lights' and place them within the container
     for (let i = 0; i < 3; i++) {
-      const $indicator = document.createElement('div')
-      $indicator.className = 'govuk-exit-this-page__indicator-light'
-      this.$indicatorContainer.appendChild($indicator)
+      this.$indicatorContainer.appendChild(
+        createElement('div', {
+          class: 'govuk-exit-this-page__indicator-light'
+        })
+      )
     }
 
     // Append it all to the module
@@ -210,9 +215,10 @@ export class ExitThisPage extends ConfigurableComponent {
     // to prevent screen reader and sequential navigation users potentially
     // navigating through the page behind the overlay during loading
     document.body.classList.add('govuk-exit-this-page-hide-content')
-    this.$overlay = document.createElement('div')
-    this.$overlay.className = 'govuk-exit-this-page-overlay'
-    this.$overlay.setAttribute('role', 'alert')
+    this.$overlay = createElement('div', {
+      class: 'govuk-exit-this-page-overlay',
+      role: 'alert'
+    })
 
     // we do these this way round, thus incurring a second paint, because changing
     // the element text after adding it means that screen readers pick up the

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -1,5 +1,6 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { ConfigurableComponent } from '../../common/configuration.mjs'
+import { createElement } from '../../common/create-element.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -25,7 +26,10 @@ export class PasswordInput extends ConfigurableComponent {
    */
   $showHideButton
 
-  /** @private */
+  /**
+   * @private
+   * @type {HTMLDivElement}
+   */
   $screenReaderStatusMessage
 
   /**
@@ -84,10 +88,10 @@ export class PasswordInput extends ConfigurableComponent {
     // This is injected between the input and button so that users get a sensible reading order if
     // moving through the page content linearly:
     // [password input] -> [your password is visible/hidden] -> [show/hide password]
-    const $screenReaderStatusMessage = document.createElement('div')
-    $screenReaderStatusMessage.className =
-      'govuk-password-input__sr-status govuk-visually-hidden'
-    $screenReaderStatusMessage.setAttribute('aria-live', 'polite')
+    const $screenReaderStatusMessage = createElement('div', {
+      class: 'govuk-password-input__sr-status govuk-visually-hidden',
+      'aria-live': 'polite'
+    })
     this.$screenReaderStatusMessage = $screenReaderStatusMessage
     this.$input.insertAdjacentElement('afterend', $screenReaderStatusMessage)
 


### PR DESCRIPTION
> [!NOTE]
> Best reviewed commit by commit

Building upon works from @36degrees to [introduce a `createElement` function](https://github.com/alphagov/govuk-frontend/issues/2894), this PR aims to explore a couple of refactorings that look useful for the accordion.

Especially, the end goal would be to introduce an `AccordionSection` class representing each section of the `Accordion` an properly split responsibilities between:
- The `Accordion`, responsible for controlling all sections at once (and the initial opening state)
- The `AccordionSection` responsible for controlling an individual section

> [!IMPORTANT]
> This PR is far from being ready for review, just chipping at things at the moment, on the `accordion-section-component-wip` branch

The overall plan is to:

- [x] Refactor the code creating the section's header so it's a little easier to follow based on these two guidelines:
	- Extract creation of complex structures in their own methods. This allows to have a readable outline of the generated HTML structure
	- Prefer creating parent elements after their children when possible. This allows to take advantage of the `children` argument of `createElement`, as well as create a reverse pyramid mirroring the structure of the DOM being created
- [x]  Introduce the `AccordionSection` class with initial aim to store key elements of the section for reuse (in `setExpanded`, for example) without having to query the DOM again
	- This will hopefully allow to get rid of a few more of the variables storing classes.
- [x] Move accessing whether a section is expanded to `AccordionSection` as an `expanded` getter
- [x] Move setting whether a section is expanded to `AccordionSection` as an `expanded` setter
- [ ] Move updating rendering of the section based on `expanded` to `AccordionSection`
- [ ] Move click handling into the `AccordionSection`
- [ ] Possibly regroup the control of which section is open in its own class (to encapsulate complexity around `beforematch` and us storing state client side when `rememberExpanded` is set).	