### PR TITLE
Disable editorconfig linting temporarily

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,10 +66,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [install]
 
-    env:
-      # Authorise GitHub API requests for EditorConfig checker binary
-      # https://www.npmjs.com/package/editorconfig-checker
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Disabled due to editorconfig-checker bug
+    # env:
+    # Authorise GitHub API requests for EditorConfig checker binary
+    # https://www.npmjs.com/package/editorconfig-checker
+    # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
       fail-fast: false
@@ -90,9 +91,10 @@ jobs:
             run: npm run lint:js
             cache: .cache/eslint
 
-          - description: EditorConfig
-            name: lint-editorconfig
-            run: npm run lint:editorconfig
+          # Disabled due to editorconfig-checker bug
+          # - description: EditorConfig
+          #   name: lint-editorconfig
+          #   run: npm run lint:editorconfig
 
           - description: Prettier
             name: lint-prettier


### PR DESCRIPTION
The [lint:editorconfig task is failing](https://github.com/alphagov/govuk-frontend/actions/runs/12687255381/job/35361300690)

This is likely due to some editorconfig-checker bug - the base package has had some [issues with missing binaries](https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v3.1.1)

Disabling this check to enable releasing v5.8.0.

We can wait on Dependabot to propagate any fix our way.