### PR TITLE
Enhanced File Upload NVDA Fix

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -96,4 +96,8 @@
     margin-bottom: 0;
     margin-left: govuk-spacing(2);
   }
+
+  .govuk-file-upload-wrapper:active button {
+    background-color: $govuk-focus-colour;
+  }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -83,6 +83,8 @@ export class FileUpload extends GOVUKFrontendComponent {
       'govuk-button govuk-button--secondary govuk-file-upload__button'
     $button.type = 'button'
     $button.innerText = this.i18n.t('selectFilesButton')
+    // Prevent the button being tabbed to by keyboard users
+    $button.setAttribute('tabindex', '-1')
     $button.addEventListener('click', this.onClick.bind(this))
 
     // Create status element that shows what/how many files are selected
@@ -105,9 +107,6 @@ export class FileUpload extends GOVUKFrontendComponent {
     this.$wrapper = $wrapper
     this.$button = $button
     this.$status = $status
-
-    // Prevent the hidden input being tabbed to by keyboard users
-    this.$root.setAttribute('tabindex', '-1')
 
     // Syncronise the `disabled` state between the button and underlying input
     this.updateDisabledState()


### PR DESCRIPTION
## What

- Remove `tabindex="=-1"` from input
- Add `tabindex="-1"` to button
- Add focus style to button when hidden input is focused

## Why

[Fix issue in which NVDA read out the button only and not the status of the input.](https://github.com/alphagov/govuk-frontend/pull/5305#issuecomment-2507491244)