### PR TITLE
Use features of base component for `FileUpload`

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,15 +1,15 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
-import { mergeConfigs, normaliseDataset } from '../../common/configuration.mjs'
+import { ConfigurableComponent } from '../../common/configuration.mjs'
 import { ElementError } from '../../errors/index.mjs'
-import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
  * File upload component
  *
  * @preserve
+ * @augments ConfigurableComponent<FileUploadConfig,HTMLInputElement>
  */
-export class FileUpload extends GOVUKFrontendComponent {
+export class FileUpload extends ConfigurableComponent {
   /**
    * @private
    */
@@ -25,14 +25,6 @@ export class FileUpload extends GOVUKFrontendComponent {
    */
   $status
 
-  /**
-   * @private
-   * @type {FileUploadConfig}
-   */
-  // eslint-disable-next-line
-  // @ts-ignore
-  config
-
   /** @private */
   i18n
 
@@ -41,23 +33,13 @@ export class FileUpload extends GOVUKFrontendComponent {
    * @param {FileUploadConfig} [config] - File Upload config
    */
   constructor($root, config = {}) {
-    super($root)
-
-    if (!(this.$root instanceof HTMLInputElement)) {
-      return
-    }
+    super($root, config)
 
     if (this.$root.type !== 'file') {
       throw new ElementError(
         'File upload: Form field must be an input of type `file`.'
       )
     }
-
-    this.config = mergeConfigs(
-      FileUpload.defaults,
-      config,
-      normaliseDataset(FileUpload, this.$root.dataset)
-    )
 
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
@@ -139,11 +121,6 @@ export class FileUpload extends GOVUKFrontendComponent {
     // eslint-disable-next-line
     // @ts-ignore
     const fileCount = this.$root.files.length // eslint-disable-line
-
-    // trying to appease typescript
-    if (!this.$status || !this.i18n) {
-      return
-    }
 
     if (fileCount === 0) {
       // If there are no files, show the default selection text

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,5 +1,6 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { ConfigurableComponent } from '../../common/configuration.mjs'
+import { formatErrorMessage } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -37,7 +38,10 @@ export class FileUpload extends ConfigurableComponent {
 
     if (this.$root.type !== 'file') {
       throw new ElementError(
-        'File upload: Form field must be an input of type `file`.'
+        formatErrorMessage(
+          FileUpload,
+          'Form field must be an input of type `file`.'
+        )
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -413,7 +413,7 @@ describe('/components/file-upload', () => {
               cause: {
                 name: 'ElementError',
                 message:
-                  'File upload: Form field must be an input of type `file`.'
+                  'govuk-file-upload: Form field must be an input of type `file`.'
               }
             })
           })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -326,6 +326,49 @@ describe('/components/file-upload', () => {
           expect(buttonDisabledAfter).toBeFalsy()
         })
       })
+
+      describe('errors at instantiation', () => {
+        let examples
+
+        beforeAll(async () => {
+          examples = await getExamples('file-upload')
+        })
+
+        describe('missing or misconfigured elements', () => {
+          it('throws if the input type is not "file"', async () => {
+            await expect(
+              render(page, 'file-upload', examples.default, {
+                beforeInitialisation() {
+                  document
+                    .querySelector('[type="file"]')
+                    .setAttribute('type', 'text')
+                }
+              })
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message:
+                  'File upload: Form field must be an input of type `file`.'
+              }
+            })
+          })
+
+          it('throws if no label is present', async () => {
+            await expect(
+              render(page, 'file-upload', examples.default, {
+                beforeInitialisation() {
+                  document.querySelector('label').remove()
+                }
+              })
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message: 'govuk-file-upload: No label not found'
+              }
+            })
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This PR makes `FileUpload` extend `ConfigurableComponent` rather than `GOVUKFrontendComponent` so it's consistent with the other components receiving configuration.

It also adds tests for the errors thrown during initialisation and makes their error message consistent.

Fixes alphagov/govuk-design-system#4417