### PR TITLE
Improve handling of visual feedback for the drop zone

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -98,6 +98,7 @@ export class FileUpload extends ConfigurableComponent {
     // Handle drop zone visibility
     // A live region to announce when users enter or leave the drop zone
     this.$announcements = document.createElement('span')
+    this.$announcements.classList.add('govuk-file-upload-announcements')
     this.$announcements.classList.add('govuk-visually-hidden')
     this.$announcements.setAttribute('aria-live', 'assertive')
     this.$wrapper.insertAdjacentElement('afterend', this.$announcements)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -98,46 +98,34 @@ export class FileUpload extends ConfigurableComponent {
     // Handle drag'n'drop events
     this.$wrapper.addEventListener('drop', this.onDrop.bind(this))
 
-    this.$wrapper.addEventListener('dragenter', this.onDragEnter.bind(this))
-    this.$wrapper.addEventListener('dragleave', this.onDragLeave.bind(this))
+    document.addEventListener('dragenter', this.onDragEnter.bind(this))
   }
 
   /**
-   * Handles the users entering the area where they can drop their files
+   * Handles the users entering elements on the page
    *
-   * Reveals the drop zone if the user components accepts what the user
-   * is dragging
+   * Because of Safari's lack of support for `relatedTarget` on `dragleave`,
+   * we need to use this both to reveal the drop zone when user's cursor enter it,
+   * and hide it when leaving (ie. entering another element).
+   * https://bugs.webkit.org/show_bug.cgi?id=66547
    *
    * @param {DragEvent} event - The `dragenter` event
    */
   onDragEnter(event) {
-    // TypeScript anticipates that `event.dataTransfer` may be `null`
-    // so we need to check for falsiness first
-    if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
-      this.$wrapper.classList.add('govuk-file-upload-wrapper--show-dropzone')
-    }
-  }
-
-  /**
-   * Hides the drop zone visually when users mouse leave it
-   *
-   * `dragleave` events will fire for each element that the user moves
-   * their move out of. We only want to remove the styling when
-   * they either leave the wrapper or the window altogether
-   *
-   * @param {DragEvent} event - The `dragleave` event
-   */
-  onDragLeave(event) {
-    // `relatedTarget` is only an `EventTarget` so we need to check if it's :
-    // - it's a `Node` in which case we'd still be on the page
-    // - something else in which case user has left the page
-    const relatedTarget =
-      event.relatedTarget instanceof Node ? event.relatedTarget : null
-
-    const leavesWindow = !relatedTarget
-    const leavesDropZone = !this.$wrapper.contains(relatedTarget)
-    if (leavesWindow || leavesDropZone) {
-      this.$wrapper.classList.remove('govuk-file-upload-wrapper--show-dropzone')
+    // DOM interfaces only type `event.target` as `EventTarget`
+    // so we first need to make sure it's a `Node`
+    if (event.target instanceof Node) {
+      if (this.$wrapper.contains(event.target)) {
+        if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
+          this.$wrapper.classList.add(
+            'govuk-file-upload-wrapper--show-dropzone'
+          )
+        }
+      } else {
+        this.$wrapper.classList.remove(
+          'govuk-file-upload-wrapper--show-dropzone'
+        )
+      }
     }
   }
 


### PR DESCRIPTION
- Only show the dropzone when the user drags into it rather than when entering the document. This will prevent multiple announcements when we add feedback for screenreaders, in case there's multiple `FileUpload`s on the page
- Only show the dropzone if the user is dragging files into it rather than any kind of content.
- Fix disappearance of the dropzone due to many `dragleave` events being triggered as user drags over the different elements inside the wrapper

The component still relies on the native `<input>` receiving the files being dropped, as it ensures a `change` event gets triggered on drop (which we'd have to simulate if setting its `files` properties programmatically).

## Thoughts

The main thing this PR had to work through are that:
1. `dragleave` events are triggered for each descendant of the drop zone element, including when the mouse moves from the drop zone itself to one of the descendant. As the event [bubbles](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling), a listener on the drop zone is triggered for each element the mouse goes over within the drop zone and we need to account for that.
2. [Safari doesn't set a `relatedTarget` event on `dragleave`](https://bugs.webkit.org/show_bug.cgi?id=66547), meaning we can't use it when leaving the drop zone for outside the window (which can happen if the drop zone is cut by the bottom edge of the browser due to scrolling) and need to rely on the lack of `dragenter` event when exiting the viewport (as the mouse is not going over any element).

Regarding announcements, those only happen when the browser is in the foreground (tested in both VO + Safari, NVDA + Chrome and NVDA + Firefox, all showing consistent behaviour).

Any design adjustments will be made in a future PR once we've implemented the chosen design for the component.