### PR TITLE
Fix compiler error "does not satisfy the constraint 'ObjectNested'"

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -149,6 +149,7 @@ export function normaliseString(value, property) {
  *
  * @internal
  * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
+ * @template {[keyof ConfigurationType, SchemaProperty | undefined][]} SchemaEntryType
  * @param {{ schema?: Schema<ConfigurationType>, moduleName: string }} Component - Component class
  * @param {DOMStringMap} dataset - HTML element dataset
  * @returns {ObjectNested} Normalised dataset
@@ -163,13 +164,16 @@ export function normaliseDataset(Component, dataset) {
     )
   }
 
-  const out = /** @type {ReturnType<typeof normaliseDataset>} */ ({})
+  const out = /** @type {ObjectNested} */ ({})
+  const entries = /** @type {SchemaEntryType} */ (
+    Object.entries(Component.schema.properties)
+  )
 
   // Normalise top-level dataset ('data-*') values using schema types
-  for (const entries of /** @type {[keyof ConfigurationType, SchemaProperty | undefined][]} */ (
-    Object.entries(Component.schema.properties)
-  )) {
-    const [namespace, property] = entries
+  for (const entry of entries) {
+    const [namespace, property] = entry
+
+    // Cast the `namespace` to string so it can be used to access the dataset
     const field = namespace.toString()
 
     if (field in dataset) {

--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -66,7 +66,7 @@ export class ConfigurableComponent extends GOVUKFrontendComponent {
     const childConstructor =
       /** @type {ChildClassConstructor<ConfigurationType>} */ (this.constructor)
 
-    if (typeof childConstructor.defaults === 'undefined') {
+    if (!isObject(childConstructor.defaults)) {
       throw new ConfigError(
         formatErrorMessage(
           childConstructor,
@@ -154,7 +154,7 @@ export function normaliseString(value, property) {
  * @returns {ObjectNested} Normalised dataset
  */
 export function normaliseDataset(Component, dataset) {
-  if (typeof Component.schema === 'undefined') {
+  if (!isObject(Component.schema)) {
     throw new ConfigError(
       formatErrorMessage(
         Component,
@@ -217,7 +217,6 @@ export function mergeConfigs(...configObjects) {
       // keys with object values will be merged, otherwise the new value will
       // override the existing value.
       if (isObject(option) && isObject(override)) {
-        // @ts-expect-error Index signature for type 'string' is missing
         formattedConfigObject[key] = mergeConfigs(option, override)
       } else {
         // Apply override
@@ -306,7 +305,7 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
      * `{ i18n: { textareaDescription: { other } } }`
      */
     for (const [index, name] of keyParts.entries()) {
-      if (typeof current === 'object') {
+      if (isObject(current)) {
         // Drop down to nested object until the last part
         if (index < keyParts.length - 1) {
           // New nested object (optionally) replaces existing value

--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -11,7 +11,7 @@ export const configOverride = Symbol.for('configOverride')
  * Centralises the behaviours shared by our components
  *
  * @virtual
- * @template {ObjectNested} [ConfigurationType={}]
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
  * @template {Element & { dataset: DOMStringMap }} [RootElementType=HTMLElement]
  * @augments GOVUKFrontendComponent<RootElementType>
  */
@@ -29,8 +29,8 @@ export class ConfigurableComponent extends GOVUKFrontendComponent {
    *
    * @internal
    * @virtual
-   * @param {ObjectNested} [param] - Configuration object
-   * @returns {ObjectNested} return - Configuration object
+   * @param {Partial<ConfigurationType>} [param] - Configuration object
+   * @returns {Partial<ConfigurationType>} return - Configuration object
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   [configOverride](param) {
@@ -148,7 +148,7 @@ export function normaliseString(value, property) {
  * optionally expanding nested `i18n.field`
  *
  * @internal
- * @template {ObjectNested} ConfigurationType
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
  * @param {{ schema?: Schema<ConfigurationType>, moduleName: string }} Component - Component class
  * @param {DOMStringMap} dataset - HTML element dataset
  * @returns {ObjectNested} Normalised dataset
@@ -237,7 +237,7 @@ export function mergeConfigs(...configObjects) {
  * {@link https://ajv.js.org/packages/ajv-errors.html#single-message}
  *
  * @internal
- * @template {ObjectNested} ConfigurationType
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
  * @param {Schema<ConfigurationType>} schema - The schema of a component
  * @param {ConfigurationType} config - Component config
  * @returns {string[]} List of validation errors
@@ -272,7 +272,7 @@ export function validateConfig(schema, config) {
  * object, removing the namespace in the process, normalising all values
  *
  * @internal
- * @template {ObjectNested} ConfigurationType
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
  * @param {Schema<ConfigurationType>} schema - The schema of a component
  * @param {DOMStringMap} dataset - The object to extract key-value pairs from
  * @param {keyof ConfigurationType} namespace - The namespace to filter keys with
@@ -335,7 +335,7 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
 /**
  * Schema for component config
  *
- * @template {ObjectNested} ConfigurationType
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
  * @typedef {object} Schema
  * @property {Record<keyof ConfigurationType, SchemaProperty | undefined>} properties - Schema properties
  * @property {SchemaCondition<ConfigurationType>[]} [anyOf] - List of schema conditions
@@ -351,14 +351,14 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
 /**
  * Schema condition for component config
  *
- * @template {ObjectNested} [ConfigurationType={}]
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
  * @typedef {object} SchemaCondition
  * @property {(keyof ConfigurationType)[]} required - List of required config fields
  * @property {string} errorMessage - Error message when required config fields not provided
  */
 
 /**
- * @template {ObjectNested} [ConfigurationType={}]
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
  * @typedef ChildClass
  * @property {string} moduleName - The module name that'll be looked for in the DOM when initialising the component
  * @property {Schema<ConfigurationType>} [schema] - The schema of the component configuration
@@ -366,6 +366,6 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
  */
 
 /**
- * @template {ObjectNested} [ConfigurationType={}]
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
  * @typedef {typeof GOVUKFrontendComponent & ChildClass<ConfigurationType>} ChildClassConstructor<ConfigurationType>
  */

--- a/packages/govuk-frontend/src/govuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
@@ -4,9 +4,9 @@ import { extractConfigByNamespace } from '../configuration.mjs'
 
 describe('extractConfigByNamespace', () => {
   /**
-   * @satisfies {Schema}
+   * @satisfies {Schema<Config1>}
    */
-  const schema = {
+  const schema1 = {
     properties: {
       a: { type: 'string' },
       b: { type: 'object' },
@@ -14,6 +14,17 @@ describe('extractConfigByNamespace', () => {
       d: { type: 'string' },
       e: { type: 'string' },
       f: { type: 'object' }
+    }
+  }
+
+  /**
+   * @satisfies {Schema<Config2>}
+   */
+  const schema2 = {
+    properties: {
+      i18n: {
+        type: 'object'
+      }
     }
   }
 
@@ -40,13 +51,13 @@ describe('extractConfigByNamespace', () => {
   it('defaults to empty config for known namespaces only', () => {
     const { dataset } = $element
 
-    const nonObject1 = extractConfigByNamespace(schema, dataset, 'a')
-    const nonObject2 = extractConfigByNamespace(schema, dataset, 'd')
-    const nonObject3 = extractConfigByNamespace(schema, dataset, 'e')
+    const nonObject1 = extractConfigByNamespace(schema1, dataset, 'a')
+    const nonObject2 = extractConfigByNamespace(schema1, dataset, 'd')
+    const nonObject3 = extractConfigByNamespace(schema1, dataset, 'e')
 
-    const namespaceKnown = extractConfigByNamespace(schema, dataset, 'f')
+    const namespaceKnown = extractConfigByNamespace(schema1, dataset, 'f')
     const namespaceUnknown = extractConfigByNamespace(
-      schema,
+      schema1,
       dataset,
       'unknown'
     )
@@ -64,7 +75,7 @@ describe('extractConfigByNamespace', () => {
   })
 
   it('can extract config from key-value pairs', () => {
-    const result = extractConfigByNamespace(schema, $element.dataset, 'b')
+    const result = extractConfigByNamespace(schema1, $element.dataset, 'b')
     expect(result).toEqual({ a: 'bat', e: 'bear', o: 'boar' })
   })
 
@@ -79,15 +90,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example2')
-    const result = extractConfigByNamespace(
-      {
-        properties: {
-          i18n: { type: 'object' }
-        }
-      },
-      dataset,
-      'i18n'
-    )
+    const result = extractConfigByNamespace(schema2, dataset, 'i18n')
 
     expect(result).toEqual({ key1: 'One', key2: 'Two', key3: 'Three' })
   })
@@ -103,15 +106,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example2')
-    const result = extractConfigByNamespace(
-      {
-        properties: {
-          i18n: { type: 'object' }
-        }
-      },
-      dataset,
-      'i18n'
-    )
+    const result = extractConfigByNamespace(schema2, dataset, 'i18n')
 
     expect(result).toEqual({ key1: 'One', key2: 'Two', key3: 'Three' })
   })
@@ -132,7 +127,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example')
-    const result = extractConfigByNamespace(schema, dataset, 'c')
+    const result = extractConfigByNamespace(schema1, dataset, 'c')
 
     expect(result).toEqual({ a: 'cat', o: 'cow' })
   })
@@ -154,7 +149,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example')
-    const result = extractConfigByNamespace(schema, dataset, 'c')
+    const result = extractConfigByNamespace(schema1, dataset, 'c')
 
     expect(result).toEqual({ a: 'cat', c: 'crow', o: 'cow' })
   })
@@ -176,7 +171,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example')
-    const result = extractConfigByNamespace(schema, dataset, 'c')
+    const result = extractConfigByNamespace(schema1, dataset, 'c')
 
     expect(result).toEqual({ a: 'cat', c: 'crow', o: 'cow' })
   })
@@ -196,7 +191,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example')
-    const result = extractConfigByNamespace(schema, dataset, 'f')
+    const result = extractConfigByNamespace(schema1, dataset, 'f')
 
     expect(result).toEqual({ e: { l: 'elephant' } })
   })
@@ -211,15 +206,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example2')
-    const result = extractConfigByNamespace(
-      {
-        properties: {
-          i18n: { type: 'object' }
-        }
-      },
-      dataset,
-      'i18n'
-    )
+    const result = extractConfigByNamespace(schema2, dataset, 'i18n')
 
     expect(result).toEqual({
       key1: 'This, That',
@@ -243,15 +230,7 @@ describe('extractConfigByNamespace', () => {
     `
 
     const { dataset } = document.getElementById('app-example2')
-    const result = extractConfigByNamespace(
-      {
-        properties: {
-          i18n: { type: 'object' }
-        }
-      },
-      dataset,
-      'i18n'
-    )
+    const result = extractConfigByNamespace(schema2, dataset, 'i18n')
 
     expect(result).toEqual({
       key1: 'This, That',
@@ -261,5 +240,21 @@ describe('extractConfigByNamespace', () => {
 })
 
 /**
+ * @typedef {object} Config1
+ * @property {string} a - Item A
+ * @property {string | { a: string, e: string, o: string }} b - Item B
+ * @property {string | { a: string, c?: string, o: string }} c - Item C
+ * @property {string} d - Item D
+ * @property {string} [e] - Item E
+ * @property {{ e: string | { l: string } }} [f] - Item F
+ */
+
+/**
+ * @typedef {object} Config2
+ * @property {{ key1: string | TranslationPluralForms, key2: string | TranslationPluralForms }} i18n - Translations
+ */
+
+/**
  * @import { Schema } from '../configuration.mjs'
+ * @import { TranslationPluralForms } from '../../i18n.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
@@ -59,6 +59,7 @@ describe('extractConfigByNamespace', () => {
     const namespaceUnknown = extractConfigByNamespace(
       schema1,
       dataset,
+      // @ts-expect-error - Allow unknown schema key for test
       'unknown'
     )
 

--- a/packages/govuk-frontend/src/govuk/common/configuration/normalise-dataset.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/normalise-dataset.jsdom.test.mjs
@@ -1,14 +1,20 @@
-import { normaliseDataset } from '../configuration.mjs'
+import {
+  ConfigurableComponent,
+  normaliseDataset
+} from '../../common/configuration.mjs'
 
 describe('normaliseDataset', () => {
   it('normalises the entire dataset', () => {
     expect(
       normaliseDataset(
-        class Component {
+        /**
+         * @augments ConfigurableComponent<Config>
+         */
+        class Component extends ConfigurableComponent {
           static moduleName = 'Component'
 
           /**
-           * @satisfies {Schema}
+           * @satisfies {Schema<Config>}
            */
           static schema = {
             properties: {
@@ -54,5 +60,17 @@ describe('normaliseDataset', () => {
 })
 
 /**
- * @import { Schema } from './../configuration.mjs'
+ * @typedef {object} Config
+ * @property {number} aNumber - A number
+ * @property {number} aDecimalNumber - A decimal number
+ * @property {boolean} aBoolean - A boolean
+ * @property {string} aString - A string
+ * @property {'true' | 'false'} aStringBoolean - A string boolean
+ * @property {string} aStringNumber - A string number
+ * @property {string} [anOptionalString] - An optional string
+ * @property {{ one: string, two: string, three: string }} anObject - An object
+ */
+
+/**
+ * @import { Schema } from '../configuration.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -138,8 +138,9 @@ function isArray(option) {
  * Check for an object
  *
  * @internal
- * @param {unknown} option - Option to check
- * @returns {boolean} Whether the option is an object
+ * @template {Partial<Record<keyof ObjectType, unknown>>} [ObjectType=ObjectNested]
+ * @param {unknown | ObjectType} option - Option to check
+ * @returns {option is ObjectType} Whether the option is an object
  */
 export function isObject(option) {
   return !!option && typeof option === 'object' && !isArray(option)
@@ -169,3 +170,7 @@ export function formatErrorMessage(Component, message) {
  */
 
 /* eslint-enable jsdoc/valid-types */
+
+/**
+ * @import { ObjectNested } from './configuration.mjs'
+ */

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -595,7 +595,7 @@ export class Accordion extends ConfigurableComponent {
    * Accordion config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<AccordionConfig>}
    */
   static schema = Object.freeze({
     properties: {

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -104,7 +104,7 @@ export class Button extends ConfigurableComponent {
    * Button config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<ButtonConfig>}
    */
   static schema = Object.freeze({
     properties: {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -436,7 +436,7 @@ export class CharacterCount extends ConfigurableComponent {
    * Character count config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<CharacterCountConfig>}
    */
   static schema = Object.freeze({
     properties: {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -171,7 +171,7 @@ export class ErrorSummary extends ConfigurableComponent {
    * Error summary config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<ErrorSummaryConfig>}
    */
   static schema = Object.freeze({
     properties: {

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -417,7 +417,7 @@ export class ExitThisPage extends ConfigurableComponent {
    * Exit this page config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<ExitThisPageConfig>}
    */
   static schema = Object.freeze({
     properties: {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -54,7 +54,7 @@ export class NotificationBanner extends ConfigurableComponent {
    * Notification banner config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<NotificationBannerConfig>}
    */
   static schema = Object.freeze({
     properties: {

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -209,7 +209,7 @@ export class PasswordInput extends ConfigurableComponent {
    * Password input config schema
    *
    * @constant
-   * @satisfies {Schema}
+   * @satisfies {Schema<PasswordInputConfig>}
    */
   static schema = Object.freeze({
     properties: {


### PR DESCRIPTION
This PR fixes https://github.com/alphagov/govuk-frontend/issues/5606

Affects [`ConfigurableComponent<CustomConfig>` in **v5.8.0**](https://github.com/alphagov/govuk-frontend/releases/tag/v5.8.0) where `CustomConfig` doesn't extend `ObjectNested`

```patch
   * @virtual
-  * @template {ObjectNested} [ConfigurationType={}]
+  * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
   * @template {Element & { dataset: DOMStringMap }} [RootElementType=HTMLElement]
   * @augments GOVUKFrontendComponent<RootElementType>
```

I've shared the config type via ~`Schema`~ `Schema<ConfigurationType>` for use in `@param` and `@returns` too

This may not have affected JSDoc due to [The Empty Object Type in TypeScript](https://www.totaltypescript.com/the-empty-object-type-in-typescript)