### PR TITLE
Deprecate legacy organisation colour palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Deprecated features
+
+#### Migrate to the new organisation colour palette
+
+The legacy organisation colour palette has been deprecated and will be removed in the next major version.
+
+If your service uses the organisation colour palette, make sure that things still look as expected with the `$govuk-new-organisation-colours` feature flag enabled.
+
+This change was introduced in [pull request #5627: Deprecate legacy organisation colour palette](https://github.com/alphagov/govuk-frontend/pull/5627).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -67,7 +67,7 @@
   }
 
   // Output a warning if $websafe is set.
-  @if $websafe and not index($govuk-suppressed-warnings, "organisation-colour-websafe-param") {
+  @if $websafe and _should-warn("organisation-colour-websafe-param") {
     @warn _warning-text("organisation-colour-websafe-param",
       "The `$websafe` parameter of `govuk-organisation-colour` has been " +
       "renamed to `$contrast-safe`. The old parameter name will be removed in " +
@@ -77,7 +77,7 @@
 
   $org-colour: map-get($govuk-colours-organisations, $organisation);
 
-  @if map-has-key($org-colour, deprecation-message) and not index($govuk-suppressed-warnings, "organisation-colours") {
+  @if map-has-key($org-colour, deprecation-message) and _should-warn("organisation-colours") {
     @warn _warning-text(
       "organisation-colours",
       map-get($org-colour, deprecation-message)

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -1,3 +1,5 @@
+@import "../settings/warnings";
+
 ////
 /// @group settings/colours
 ////
@@ -11,6 +13,7 @@
 ///
 /// @type Boolean
 /// @access public
+/// @deprecated Using new organisation colours will become the default in Frontend v6.0.
 
 $govuk-new-organisation-colours: false !default;
 
@@ -211,6 +214,7 @@ $_govuk-organisation-colours: (
 ///   nor provide better contrast than the base colour.
 ///
 /// @access private
+/// @deprecated Migrate to using the new organisation colour palette instead.
 
 $_govuk-legacy-organisation-colours: (
   "attorney-generals-office": (
@@ -349,11 +353,20 @@ $_govuk-legacy-organisation-colours: (
 /// @type Map
 /// @access public
 
-$govuk-colours-organisations: if(
-  $govuk-new-organisation-colours,
-  $_govuk-organisation-colours,
-  $_govuk-legacy-organisation-colours
-) !default;
+$govuk-colours-organisations: $_govuk-legacy-organisation-colours !default;
+
+@if $govuk-new-organisation-colours and $govuk-colours-organisations == $_govuk-legacy-organisation-colours {
+  $govuk-colours-organisations: $_govuk-organisation-colours;
+}
+
+// Output a deprecation warning if the legacy colour palette is being used.
+// Remove in next major version.
+@if $govuk-colours-organisations == $_govuk-legacy-organisation-colours {
+  @include _warning(
+    "legacy-organisation-colours",
+    "The legacy organisation colour palette has been deprecated and will be removed in the next major version."
+  );
+}
 
 /// Organisation colour aliases
 ///


### PR DESCRIPTION
Deprecates the legacy organisation colour palette, which was replaced by an updated palette in 5.5.0.

> [!WARNING]
> This PR is dependent upon #5636. 

Closes #5254.

## Changes
- Deprecates the feature flag `$govuk-new-organisation-colours` in SassDoc.
- Deprecates the private variable that holds the legacy colours, `$_govuk-legacy-organisation-colours`, in SassDoc.
- Adds a check in the organisation palette file that produces a deprecation warning if the legacy palette is being used (i.e. the feature flag has not been activated and the `$govuk-colours-organisations` variable hasn't been overridden. 
- Adds tests for the deprecation message to ensure it's only returned when applicable.