### PR TITLE
Add focused error state to Character count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5628: Add focused error state to Character count](https://github.com/alphagov/govuk-frontend/pull/5628)
+
 ## v5.8.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@5.8.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
@@ -11,6 +11,14 @@
     .govuk-textarea {
       margin-bottom: govuk-spacing(1);
     }
+
+    // If the textarea enters the error state whilst the user is focused on it,
+    // show the error state. This presents feedback to the user that the value
+    // has become invalid without needing to see the counter.
+    .govuk-textarea--error:focus {
+      border-color: $govuk-error-colour;
+      box-shadow: inset 0 0 0 $govuk-border-width-form-element $govuk-error-colour;
+    }
   }
 
   .govuk-character-count__message {


### PR DESCRIPTION
Resolves #1908.

## Background
If a user goes over the character limit whilst typing, their only feedback for having done so is in the count message below the textarea (for a sighted user) or in the buffered announcement (for a screen reader user).

This means that users on small screens or using high magnification settings may not be aware that they have gone past the character limit until they have left the textarea and scrolled down. A sighted user may also simply not notice the character count text changing to alert them of the issue.

It was suggested in #1908 that the character count should maintain having the error state border even when the field has focus, so that there is an additional mechanism for communicating the error state.

## Changes
- Adds CSS to override the `border-color` and `box-shadow` colour of the Character count component's textarea when it simultaneously has the error class and focus.

## Thoughts
This deviates from the appearance used on other input types, however, as the character count is the only form control component that performs 'live' validation of user input, the exception may make sense here.

There was some thought over whether only one part of the 'border' should change to being red (either the border itself, or the box-shadow). I decided against this for a few reasons:
- The focus style's box-shadow is intended to be perceived as the existing border increasing in thickness, so the border and box-shadow should be the same colour.
- Having the border be composed of three colours (black, red, and the focus's standard yellow) would be visually confusing.
- Continuing to have black appear adjacent to red would lessen the visibility of the border changing to become red.

As error red is being used in place of black in this focus state, we want it to meet the minimum contrast ratio against light colours, as black normally does. Red on white has a contrast ratio of 4.86:1, seemingly satisfying the [non-text contrast criterion](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html). A red and yellow focus state is already used on the [Error summary component](https://design-system.service.gov.uk/components/error-summary/).

## Screenshots
|Before|After|
|:-:|:-:|
|<img width="620" alt="Screenshot of a character count that's gone over the limit, with a black and yellow focus outline." src="https://github.com/user-attachments/assets/4abf089e-1d50-45d3-9fa3-cdfc77607ae3" />|<img width="620" alt="Screenshot of a character count that's gone over the limit, with a red and yellow focus outline." src="https://github.com/user-attachments/assets/8a63fee1-5da2-40fd-a095-f0b5616e04bc" />|