### PR TITLE
Update Jest tests for Sass warnings

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.unit.test.mjs
@@ -121,10 +121,9 @@ describe('GOV.UK Frontend', () => {
 
       await compileSassString(sass, sassConfig)
 
-      expect(mockWarnFunction.mock.calls[0]).toEqual(
-        expect.arrayContaining([
-          `Importing using 'govuk/all' is deprecated. Update your import statement to import 'govuk/index'. To silence this warning, update $govuk-suppressed-warnings with key: "import-using-all"`
-        ])
+      expect(mockWarnFunction).toHaveBeenCalledWith(
+        `Importing using 'govuk/all' is deprecated. Update your import statement to import 'govuk/index'. To silence this warning, update $govuk-suppressed-warnings with key: "import-using-all"`,
+        expect.anything()
       )
     })
 
@@ -156,9 +155,8 @@ describe('GOV.UK Frontend', () => {
           'components',
           'utilities',
           'overrides'
-        ].map((section, index) =>
-          expect(mockWarnFunction).toHaveBeenNthCalledWith(
-            index + 1,
+        ].map((section) =>
+          expect(mockWarnFunction).toHaveBeenCalledWith(
             `Importing using 'govuk/${section}/all' is deprecated. Update your import statement to import 'govuk/${section}/index'. To silence this warning, update $govuk-suppressed-warnings with key: "import-using-all"`,
             expect.anything()
           )

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -90,13 +90,12 @@ describe('@function govuk-colour', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the deprecation notice
-    expect(mockWarnFunction.mock.calls[0]).toEqual(
-      expect.arrayContaining([
-        'The `$legacy` parameter of `govuk-colour` is deprecated and is ' +
-          'non-operational. It will be removed in the next major version. To ' +
-          'silence this warning, update $govuk-suppressed-warnings with key: ' +
-          '"legacy-colour-param"'
-      ])
+    expect(mockWarnFunction).toHaveBeenCalledWith(
+      'The `$legacy` parameter of `govuk-colour` is deprecated and is ' +
+        'non-operational. It will be removed in the next major version. To ' +
+        'silence this warning, update $govuk-suppressed-warnings with key: ' +
+        '"legacy-colour-param"',
+      expect.anything()
     )
   })
 })
@@ -206,10 +205,9 @@ describe('@function govuk-organisation-colour', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the deprecation notice
-    expect(mockWarnFunction.mock.calls[0]).toEqual(
-      expect.arrayContaining([
-        'The House Elf Equalities Office was disbanded in 2007. To silence this warning, update $govuk-suppressed-warnings with key: "organisation-colours"'
-      ])
+    expect(mockWarnFunction).toHaveBeenCalledWith(
+      'The House Elf Equalities Office was disbanded in 2007. To silence this warning, update $govuk-suppressed-warnings with key: "organisation-colours"',
+      expect.anything()
     )
   })
 

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -415,10 +415,9 @@ describe('@mixin govuk-font-size', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the deprecation notice
-    expect(mockWarnFunction.mock.calls[0]).toEqual(
-      expect.arrayContaining([
-        'This point on the scale is deprecated. To silence this warning, update $govuk-suppressed-warnings with key: "test-key"'
-      ])
+    expect(mockWarnFunction).toHaveBeenCalledWith(
+      'This point on the scale is deprecated. To silence this warning, update $govuk-suppressed-warnings with key: "test-key"',
+      expect.anything()
     )
   })
 
@@ -698,12 +697,11 @@ describe('@mixin govuk-font-size', () => {
 
       // Expect our mocked @warn function to have been called once with a single
       // argument, which should be the deprecation notice
-      expect(mockWarnFunction.mock.calls[0]).toEqual(
-        expect.arrayContaining([
-          'govuk-typography-responsive is deprecated. Use govuk-font-size instead. ' +
-            'To silence this warning, update $govuk-suppressed-warnings with key: ' +
-            '"govuk-typography-responsive"'
-        ])
+      expect(mockWarnFunction).toHaveBeenCalledWith(
+        'govuk-typography-responsive is deprecated. Use govuk-font-size instead. ' +
+          'To silence this warning, update $govuk-suppressed-warnings with key: ' +
+          '"govuk-typography-responsive"',
+        expect.anything()
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/settings/warnings.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/warnings.unit.test.js
@@ -24,11 +24,10 @@ describe('Warnings mixin', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the test message
-    expect(mockWarnFunction.mock.calls[0]).toEqual(
-      expect.arrayContaining([
-        'This is a warning. To silence this warning, update ' +
-          '$govuk-suppressed-warnings with key: "test"'
-      ])
+    expect(mockWarnFunction).toHaveBeenCalledWith(
+      'This is a warning. To silence this warning, update ' +
+        '$govuk-suppressed-warnings with key: "test"',
+      expect.anything()
     )
   })
 


### PR DESCRIPTION
Changes how Jest tests that check for Sass warnings are tested for.

Currently for these tests, a mock logging function is created that pushes warnings to an array, the test is ran, and the first item in the array checked to see if it matches the expected warning. 

This is blocking on #5627, as tests may now have multiple warnings, with no guarantee that the warning being tested for is the first index.

## Changes
- Updates all tests that use the mock logging function pattern to use `toHaveBeenCalledWith` instead. This checks against at all of the warnings logged, rather than just the first one.
  - Note that the second parameter must be `expect.anything()`, as the second part of a log call is an object containing metadata and a stack trace. Omitting `expect.anything()` will raise an error.