### PR TITLE
Automate publish to npm

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,36 @@
+name: 'RELEASE: Publish to npm'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate tag
+        id: generate_tag
+        run: |
+          NPM_TAG=$(npm run generate-npm-tag --silent)
+          echo "NPM_TAG=${NPM_TAG#*=}" >> $GITHUB_OUTPUT
+
+      - name: Build npm package
+        run: npm run build:package
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace govuk-frontend --dry-run --tag ${{steps.generate_tag.outputs.NPM_TAG}}

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -7,6 +7,8 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -24,8 +26,8 @@ jobs:
       - name: Generate tag
         id: generate_tag
         run: |
-          NPM_TAG=$(npm run generate-npm-tag --silent)
-          echo "NPM_TAG=${NPM_TAG#*=}" >> $GITHUB_OUTPUT
+          TAG=$(npm run generate-npm-tag --silent)
+          echo "NPM_TAG=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Build npm package
         run: npm run build:package
@@ -33,4 +35,4 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --workspace govuk-frontend --dry-run --tag ${{steps.generate_tag.outputs.NPM_TAG}}
+        run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -9,14 +9,16 @@ CURRENT_VERSION=$(npm run version --silent --workspace govuk-frontend)
 
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
-if [ $CURRENT_VERSION == $HIGHEST_PUBLISHED_VERSION ]; then
+if [ "$CURRENT_VERSION" = "$HIGHEST_PUBLISHED_VERSION" ]; then
   echo "⚠️ Git tag $TAG already exists. Check you have run \`npm version\` correctly."
   exit 1
-elif [ $(version $CURRENT_VERSION) -ge $(version $HIGHEST_PUBLISHED_VERSION) ]; then
+elif echo "$CURRENT_VERSION" | grep -q "internal"; then
+  NPM_TAG="internal"
+elif [ $(version "$CURRENT_VERSION") -ge $(version "$HIGHEST_PUBLISHED_VERSION") ]; then
   NPM_TAG="latest"
 else
-  major_version_num=$(echo $CURRENT_VERSION | cut -d. -f1)
+  major_version_num=$(echo "$CURRENT_VERSION" | cut -d. -f1)
   NPM_TAG="latest-$major_version_num"
 fi
 
-echo $NPM_TAG
+echo "$NPM_TAG"

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -7,14 +7,16 @@ HIGHEST_PUBLISHED_VERSION=$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/d
 # Extract tag version from ./packages/govuk-frontend/package.json
 CURRENT_VERSION=$(npm run version --silent --workspace govuk-frontend)
 
-function version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
 if [ $CURRENT_VERSION == $HIGHEST_PUBLISHED_VERSION ]; then
-  echo "⚠️ Git tag $TAG already exists. Check you have run `npm version` correctly."
+  echo "⚠️ Git tag $TAG already exists. Check you have run \`npm version\` correctly."
   exit 1
 elif [ $(version $CURRENT_VERSION) -ge $(version $HIGHEST_PUBLISHED_VERSION) ]; then
   NPM_TAG="latest"
 else
-  major_version_num="${CURRENT_VERSION:0:1}"
+  major_version_num=$(echo $CURRENT_VERSION | cut -d. -f1)
   NPM_TAG="latest-$major_version_num"
 fi
+
+echo $NPM_TAG

--- a/bin/publish-prerelease.sh
+++ b/bin/publish-prerelease.sh
@@ -1,19 +1,14 @@
 #!/bin/sh
 set -e
 
-source ./bin/generate-npm-tag.sh
+echo "Publishing a pre-release to npm."
 
-# Check npm tag looks as expected
-# https://npm.github.io/publishing-pkgs-docs/updating/using-tags.html#publishing-with-tags
-echo "This will publish the package with the following npm tag:"
-echo $NPM_TAG
-echo " "
+# User should enter "internal" or "beta", as per the documentation for pre-releases
+echo "Enter the npm tag for this pre-release."
+echo "For internal releases, use 'internal'."
+echo "For beta releases, use 'beta'."
 
-read -r -p "Does this look correct? [y/N] " continue_prompt
-
-if [[ $continue_prompt != 'y' ]]; then
-    read -r -p "What should the npm tag be: " NPM_TAG
-fi
+read -r -p "Enter npm tag: " NPM_TAG
 
 echo "Starting a release..."
 echo " "

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -97,31 +97,29 @@ Developers should pair on pre-releases. When working remotely, it can be useful 
 
 2. Sign in to npm (`npm login`), using the credentials for the govuk-patterns-and-tools npm user from Bitwarden.
 
-3. Run `npm run publish-release`, which will prompt you to check whether the npm tag looks as expected.
-
-4. Enter `N` to continue to set the npm tag corresponding to the kind of release you're publishing:
+3. Run `npm run publish-prerelease`, which will prompt you to enter an NPM tag. Set the npm tag corresponding to the kind of release you're publishing:
 
    - `internal` for internal pre-releases
    - `next` for beta pre-releases
 
-5. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
+4. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
 
    This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
 
    This step will also automatically create a tag in GitHub which you can use to create a GitHub release in the following section.
 
-6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
+5. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
 
    If the pre-release has been assigned the wrong tag (mistakes happen),
    you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.
 
-7. Have a quick look at the diff of the new package with the previous one at:
+6. Have a quick look at the diff of the new package with the previous one at:
 
    ```txt
    https://diff.intrinsic.com/govuk-frontend/<PREVIOUS_VERSION_NUMBER>/<RELEASED_VERSION_NUMBER>
    ```
 
-8. Run `npm logout` to log out from npm. If you've logged in through your browser, remember to log out from <https://npmjs.com> there as well.
+7. Run `npm logout` to log out from npm. If you've logged in through your browser, remember to log out from <https://npmjs.com> there as well.
 
 ## If publishing a beta pre-release, create a release on GitHub
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -65,42 +65,17 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 ## Publish a release to npm
 
-1. Check out the **main** branch and pull the latest changes.
+1. Once the release pull request has been merged, open the Actions tab on the `alphagov/govuk-frontend` repo.
 
-   If there was an interruption between the raising of the PR and its merge,
-   or it's another developer running the publication to npm, rebuild the package with:
+2. Select the ["RELEASE: Publish to npm" workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/publish-to-npm.yaml) and run the workflow on the `main` branch. This will publish the release to npm.
 
-   ```shell
-   npm run build:package
-   ```
+3. Verify the presence of the release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
 
-2. Sign in to npm (`npm login`), using the credentials for the **govuk-patterns-and-tools** npm user from Bitwarden.
-
-3. Run `npm run publish-release`, which will prompt you to check whether the npm tag looks as expected.
-
-   If you're following these instructions, you're probably doing a sequential release, meaning
-   the tag should be 'latest'.
-
-4. Enter `y` to continue. If you think the tag should be different, enter `N` to have the option to set your own npm tag.
-
-5. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
-
-   This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
-
-   This step will also automatically create a tag in Github which you can use to create a Github release in the following section.
-
-6. Verify the presence of the release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
-
-   If the release has been assigned the wrong tag (mistakes happen),
-   you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.
-
-7. Have a quick look at the diff of the new package with the previous one at:
+4. Have a quick look at the diff of the new package with the previous one at:
 
    ```txt
    https://npmdiff.dev/govuk-frontend/<PREVIOUS_VERSION_NUMBER>/<RELEASED_VERSION_NUMBER>
    ```
-
-8. Run `npm logout` to log out from npm in the command line. If you've logged in through your browser, remember to log out from <https://npmjs.com> there as well.
 
 ## Create a release on Github
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "npm run dev",
     "generate-npm-tag": "./bin/generate-npm-tag.sh",
     "build-release": "./bin/build-release.sh",
-    "publish-release": "./bin/publish-release.sh",
+    "publish-prerelease": "./bin/publish-prerelease.sh",
     "publish-preview": "./bin/publish-preview.sh",
     "predev": "npm run build -- --ignore-scripts",
     "dev": "concurrently \"npm run dev --workspace @govuk-frontend/review\" \"npm run dev --workspace govuk-frontend\" --kill-others --names \"app,pkg\" --prefix-colors \"red.dim,blue.dim\"",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "postinstall": "npm ls --depth=0",
     "start": "npm run dev",
+    "generate-npm-tag": "./bin/generate-npm-tag.sh",
     "build-release": "./bin/build-release.sh",
     "publish-release": "./bin/publish-release.sh",
     "publish-preview": "./bin/publish-preview.sh",


### PR DESCRIPTION
## What

resolves  #5604

Adds a workflow for publishing to npm.

### workflow_dispatch
The workflow must be manually dispatched. A release will be split into 3 workflows: building a release, publishing to npm and publishing to GitHub.

The end result of the build release stage is a PR which will require human review. Only once this PR has been approved and merge should the publish to npm step be run.

### provenance
Provenance statements enable you to "[publicly establish where a package was built and who published a package](https://docs.npmjs.com/generating-provenance-statements)". This provides an extra layer of supply-chain assurance for folks who use our package. We now publish to npm with provenance.

### `generate-npm-tag`

The `generate-npm-tag` shell script has been updated to add logic to deal with `internal` releases. It now works as follows:
  - If we're trying to publish a version that already has a git tag, the script fails. The user will have to manually delete the git tag if they want to publish.
  - If the publish version contains the string `"internal"`, the npm tag will be set to `internal`
  - If the version is higher than the latest published version, it gets the `latest` tag
  - If the version is lower than the latest published verison, it gets the `latest-[major-number]` tag

We've added this script as an npm script to enable direct access. It's also used within the `publish-release` script, which is currently used for pre-releases. However, our documentation has the user _ignore_ the result of the script during pre-releases anyway, so this PR rejigs the `publish-release` script to no longer use `generate-npm-tag` and renames the script to `publish-prerelease`.

It should be pretty easy to update the `generate-npm-tag` script with pre-release logic when we switch pre-releases over to GitHub Actions.
