### PR TITLE
Automate GitHub Release

### DIFF
--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -1,0 +1,71 @@
+name: 'RELEASE: Publish to GitHub'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release-to-github:
+    name: Publish release to GitHub
+    runs-on: Ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up Git
+        run: |
+          git config user.name '${{ github.actor }}'
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+
+      - name: Create GitHub tag
+        id: create-github-tag
+        run: |
+          ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)
+          TAG="v${ALL_PACKAGE_VERSION}"
+
+          if [ $(git tag -l "$TAG") ]; then
+            echo "⚠️ Tag $TAG already exists. Please delete $TAG via the GitHub UI and re-run this workflow"
+            exit 1
+          else
+            echo "🗒 Tagging repo using tag version: $TAG ..."
+            git tag -a $TAG -m "GOV.UK Frontend release $TAG"
+            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} --tags
+            echo "🗒 Tag $TAG created and pushed to remote."
+            echo "GH_TAG=${TAG}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub archive
+        run: git archive -o ./release-${{ steps.create-github-tag.outputs.GH_TAG }}.zip HEAD:dist
+
+      - name: Generate release notes
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { generateReleaseNotes } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
+
+            await generateReleaseNotes()
+
+      - name: Create GitHub release
+        run: |
+          GH_TAG=${{ steps.create-github-tag.outputs.GH_TAG }}
+          RELEASE_NAME="GOV.UK Frontend $GH_TAG"
+          RELEASE_BODY=$(cat release-notes-body)
+
+          if gh release view "$GH_TAG" > /dev/null 2>&1; then
+            echo "⚠️ Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+            exit 1
+          else
+            gh release create "$GH_TAG" ./release-"${GH_TAG}".zip --title "GOV.UK Frontend ${RELEASE_NAME}" --notes "$RELEASE_BODY"
+          fi

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -39,14 +39,9 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 ## Create a release on Github
 
-To create a new GitHub release, do the following:
+1. Open the ["RELEASE: Publish to GitHub" workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/publish-release-to-github.yaml) and run the workflow on the `main` branch. This will generate a GitHub tag and release. If the workflow fails after creating a tag, or after creating a release, you'll need to manually delete these via [the GitHub tags UI](https://github.com/alphagov/govuk-frontend/tags) before running the workflow again.
 
-1. Select the tag corresponding to the release in [the list of tags on GitHub](https://github.com/alphagov/govuk-frontend/tags)
-2. Press **Create release from tag**
-3. Set 'GOV.UK Frontend v[version]' as the title
-4. Add release notes from [`CHANGELOG.md`](/CHANGELOG.md)
-5. Attach as release binary the ZIP file that has been generated at the root of this project during the npm publishing phase
-6. Publish release
+2. [Verify the release](https://github.com/alphagov/govuk-frontend/releases) and check that its description looks correct, and that its assets include a zip file named "release-[release version].zip".
 
 # After you publish the new release
 


### PR DESCRIPTION
## What

resolves #5608 

Automates our GitHub releases through a `workflow_dispatch` GitHub Actions workflow.

The workflow creates a GitHub tag for the version in the package.json file. It also creates a zip file, and generates release notes from the CHANGELOG, before creating a release.

If the tag or the release already exist, the job will fail, and these will need to be manually deleted via the UI.

## Notes

It's possible to skip the tag creation step, since `gh release` automatically creates a tag for the release if it doesn't exist. This PR keeps this step so that the tags/release are fully consistent with every previous release tag on the repo.