### PR TITLE
Copy `aria-describedby` attribute on `<button>`

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -78,6 +78,13 @@ export class FileUpload extends ConfigurableComponent {
     $button.type = 'button'
     $button.id = this.id
 
+    // Copy `aria-describedby` if present so hints and errors
+    // are associated to the `<button>`
+    const ariaDescribedBy = this.$root.getAttribute('aria-describedby')
+    if (ariaDescribedBy) {
+      $button.setAttribute('aria-describedby', ariaDescribedBy)
+    }
+
     const buttonSpan = document.createElement('span')
     buttonSpan.className =
       'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -438,6 +438,34 @@ describe('/components/file-upload', () => {
         })
       })
 
+      describe('aria-describedby', () => {
+        it('copies the `aria-describedby` attribute from the `<input>` to the `<button>`', async () => {
+          await render(
+            page,
+            'file-upload',
+            examples['with error message and hint']
+          )
+
+          const $button = await page.$(buttonSelector)
+          const ariaDescribedBy = await $button.evaluate((el) =>
+            el.getAttribute('aria-describedby')
+          )
+
+          expect(ariaDescribedBy).toBe('file-upload-3-hint file-upload-3-error')
+        })
+
+        it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
+          await render(page, 'file-upload', examples.default)
+
+          const $button = await page.$(buttonSelector)
+          const ariaDescribedBy = await $button.evaluate((el) =>
+            el.getAttribute('aria-describedby')
+          )
+
+          expect(ariaDescribedBy).toBeNull()
+        })
+      })
+
       describe('errors at instantiation', () => {
         let examples
 


### PR DESCRIPTION
This ensure hints and errors are associated with the `<button>` for assistive technology users.

For example, VoiceOver announcing the hint ("Your photo must be at least 50KB and no more than 10MB") visible before the file upload in this recording.

https://github.com/user-attachments/assets/51595afd-4b26-4391-8a5b-542f0f3f06c6


