### PR TITLE
Add option to File Upload macro to enable JS enhancements

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
@@ -7,9 +7,37 @@ describe('/components/file-upload', () => {
       const examples = await getExamples('file-upload')
 
       for (const exampleName in examples) {
-        await render(page, 'file-upload', examples[exampleName])
+        // JavaScript enhancements being optional, some examples will not have
+        // any element with `data-module="govuk-file-upload"`. This causes an error
+        // as `render` assumes that if a component is exported by GOV.UK Frontend
+        // its rendered markup will have a `data-module` and tried to initialise
+        // the JavaScript component, even if no element with the right `data-module`
+        // is on the page.
+        //
+        // Because of this, we need to filter `ElementError` thrown by the JavaScript
+        // component to examples that actually run the JavaScript enhancements
+        try {
+          await render(page, 'file-upload', examples[exampleName])
+        } catch (e) {
+          const macroOptions = /** @type {MacroOptions} */ (
+            examples[exampleName].context
+          )
+
+          const exampleUsesJavaScript = macroOptions.javascript
+          const exampleLackedRoot = e.message.includes(
+            'govuk-file-upload: Root element'
+          )
+
+          if (!exampleLackedRoot || exampleUsesJavaScript) {
+            throw e
+          }
+        }
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })
 })
+
+/**
+ * @typedef {import('@govuk-frontend/lib/components').MacroOptions} MacroOptions
+ */

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -51,7 +51,7 @@ describe('/components/file-upload', () => {
     describe('when JavaScript is available', () => {
       describe('on page load', () => {
         beforeAll(async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
         })
 
         describe('wrapper element', () => {
@@ -126,7 +126,7 @@ describe('/components/file-upload', () => {
             // set a value in the file chooser, then checks if that value was set
             // on the input as expected.
             const testFilename = 'test.gif'
-            await render(page, 'file-upload', examples.default)
+            await render(page, 'file-upload', examples.javascript)
 
             const [fileChooser] = await Promise.all([
               page.waitForFileChooser(),
@@ -153,7 +153,7 @@ describe('/components/file-upload', () => {
         const testFilename = 'fakefile.txt'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
@@ -196,7 +196,13 @@ describe('/components/file-upload', () => {
 
       describe('when selecting multiple files', () => {
         beforeEach(async () => {
-          await render(page, 'file-upload', examples['allows multiple files'])
+          await render(page, 'file-upload', examples.javascript, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('multiple', '')
+            }
+          })
 
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
@@ -258,7 +264,7 @@ describe('/components/file-upload', () => {
           '.govuk-file-upload-wrapper:not(.govuk-file-upload-wrapper--show-dropzone)'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           $wrapper = await page.$('.govuk-file-upload-wrapper')
           wrapperBoundingBox = await $wrapper.boundingBox()
@@ -395,7 +401,13 @@ describe('/components/file-upload', () => {
 
       describe('disabled state syncing', () => {
         it('disables the button if the input is disabled on page load', async () => {
-          await render(page, 'file-upload', examples.disabled)
+          await render(page, 'file-upload', examples.javascript, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('disabled', '')
+            }
+          })
 
           const buttonDisabled = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
@@ -405,7 +417,7 @@ describe('/components/file-upload', () => {
         })
 
         it('disables the button if the input is disabled programatically', async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           await page.$eval(inputSelector, (el) =>
             el.setAttribute('disabled', '')
@@ -419,7 +431,13 @@ describe('/components/file-upload', () => {
         })
 
         it('enables the button if the input is enabled programatically', async () => {
-          await render(page, 'file-upload', examples.disabled)
+          await render(page, 'file-upload', examples.javascript, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('disabled', '')
+            }
+          })
 
           const buttonDisabledBefore = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
@@ -443,7 +461,7 @@ describe('/components/file-upload', () => {
           await render(
             page,
             'file-upload',
-            examples['with error message and hint']
+            examples['javascript, with error message and hint']
           )
 
           const $button = await page.$(buttonSelector)
@@ -455,7 +473,7 @@ describe('/components/file-upload', () => {
         })
 
         it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
-          await render(page, 'file-upload', examples.default)
+          await render(page, 'file-upload', examples.javascript)
 
           const $button = await page.$(buttonSelector)
           const ariaDescribedBy = await $button.evaluate((el) =>
@@ -475,7 +493,7 @@ describe('/components/file-upload', () => {
 
         it('can throw a SupportError if appropriate', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               beforeInitialisation() {
                 document.body.classList.remove('govuk-frontend-supported')
               }
@@ -491,7 +509,7 @@ describe('/components/file-upload', () => {
 
         it('throws when initialised twice', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               async afterInitialisation($root) {
                 const { FileUpload } = await import('govuk-frontend')
                 new FileUpload($root)
@@ -506,7 +524,7 @@ describe('/components/file-upload', () => {
 
         it('throws when $root is not set', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               beforeInitialisation($root) {
                 $root.remove()
               }
@@ -521,7 +539,7 @@ describe('/components/file-upload', () => {
 
         it('throws when receiving the wrong type for $root', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            render(page, 'file-upload', examples.javascript, {
               beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
                 $root.outerHTML = `<svg data-module="govuk-file-upload"></svg>`
@@ -539,7 +557,7 @@ describe('/components/file-upload', () => {
         describe('missing or misconfigured elements', () => {
           it('throws if the input type is not "file"', async () => {
             await expect(
-              render(page, 'file-upload', examples.default, {
+              render(page, 'file-upload', examples.javascript, {
                 beforeInitialisation() {
                   document
                     .querySelector('[type="file"]')
@@ -557,7 +575,7 @@ describe('/components/file-upload', () => {
 
           it('throws if no label is present', async () => {
             await expect(
-              render(page, 'file-upload', examples.default, {
+              render(page, 'file-upload', examples.javascript, {
                 beforeInitialisation() {
                   document.querySelector('label').remove()
                 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -77,6 +77,10 @@ params:
             type: string
             required: true
             description: HTML to add after the input. If `html` is provided, the `text` option will be ignored.
+  - name: javascript
+    type: boolean
+    required: false
+    description: Whether to enable JavaScript enhancements for the component
   - name: selectFilesButtonText
     type: string
     required: false
@@ -170,6 +174,14 @@ examples:
         text: Upload a file
       formGroup:
         classes: extra-class
+  - name: javascript
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      javascript: true
+      multiple: true
   - name: translated
     options:
       id: file-upload-1
@@ -177,6 +189,7 @@ examples:
       label:
         text: Llwythwch ffeil i fyny
       multiple: true
+      javascript: true
       selectFilesButtonText: Dewiswch ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
@@ -258,3 +271,16 @@ examples:
         text: Error message
       hint:
         text: hint
+  - name: translated, no javascript enhancement
+    hidden: true
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Llwythwch ffeil i fyny
+      multiple: true
+      selectFilesButtonText: Dewiswch ffeil
+      filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
+      filesSelectedText:
+        other: "%{count} ffeil wedi'u dewis"
+        one: "%{count} ffeil wedi'i dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -175,6 +175,7 @@ examples:
       formGroup:
         classes: extra-class
   - name: javascript
+    screenshot: true
     options:
       id: file-upload-1
       name: file-upload-1

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -181,7 +181,6 @@ examples:
       label:
         text: Upload a file
       javascript: true
-      multiple: true
   - name: translated
     options:
       id: file-upload-1
@@ -271,6 +270,18 @@ examples:
         text: Error message
       hint:
         text: hint
+  - name: javascript, with error message and hint
+    hidden: true
+    options:
+      javascript: true
+      id: file-upload-3
+      name: file-upload-3
+      label:
+        text: Upload a file
+      hint:
+        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+      errorMessage:
+        text: Error message goes here
   - name: translated, no javascript enhancement
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -43,23 +43,27 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file" data-module="govuk-file-upload"
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if params.multiple %} multiple{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {{- govukI18nAttributes({
-    key: 'select-files-button',
-    message: params.selectFilesButtonText
-  }) -}}
-  {{- govukI18nAttributes({
-    key: 'files-selected-default',
-    message: params.filesSelectedDefaultText
-  }) -}}
-  {{- govukI18nAttributes({
-    key: 'files-selected',
-    messages: params.filesSelectedText
-  }) -}}
+  {%- if params.javascript %}
+    data-module="govuk-file-upload"
+
+    {{- govukI18nAttributes({
+      key: 'select-files-button',
+      message: params.selectFilesButtonText
+    }) -}}
+    {{- govukI18nAttributes({
+      key: 'files-selected-default',
+      message: params.filesSelectedDefaultText
+    }) -}}
+    {{- govukI18nAttributes({
+      key: 'files-selected',
+      messages: params.filesSelectedText
+    }) -}}
+  {%- endif %}
   {{- govukAttributes(params.attributes) }}>
 {% if params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup.afterInput.html else params.formGroup.afterInput.text }}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -208,6 +208,64 @@ describe('File upload', () => {
     })
   })
 
+  describe('`javascript` option', () => {
+    it('is falsy by default', () => {
+      const $ = render('file-upload', examples.javascript)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload input')
+      expect($input.attr('data-module')).toBeUndefined()
+    })
+
+    it('adds the data-module attribute to the input when `true`', () => {
+      const $ = render('file-upload', examples.javascript)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-module')).toBe('govuk-file-upload')
+    })
+
+    it('adds the data-module attribute when receiving an object', () => {
+      const $ = render('file-upload', examples.translated)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-module')).toBe('govuk-file-upload')
+    })
+
+    it('enables the rendering of translation messages when true', () => {
+      const $ = render('file-upload', examples.translated)
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-i18n.select-files-button')).toBe(
+        'Dewiswch ffeil'
+      )
+      expect($input.attr('data-i18n.files-selected-default')).toBe(
+        "Dim ffeiliau wedi'u dewis"
+      )
+      expect($input.attr('data-i18n.files-selected.one')).toBe(
+        "%{count} ffeil wedi'i dewis"
+      )
+      expect($input.attr('data-i18n.files-selected.other')).toBe(
+        "%{count} ffeil wedi'u dewis"
+      )
+    })
+
+    it('prevents the rendering of translation messages when false', () => {
+      const $ = render(
+        'file-upload',
+        examples['translated, no javascript enhancement']
+      )
+
+      const $input = $('.govuk-form-group > .govuk-file-upload')
+
+      expect($input.attr('data-i18n.select-files-button')).toBeUndefined()
+      expect($input.attr('data-i18n.files-selected-default')).toBeUndefined()
+      expect($input.attr('data-i18n.files-selected.one')).toBeUndefined()
+      expect($input.attr('data-i18n.files-selected.other')).toBeUndefined()
+    })
+  })
+
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('file-upload', examples.error)


### PR DESCRIPTION
The option triggers the rendering of the `data-module` attribute which will trigger the JavaScript enhancements. The option also controls the rendering of the translation strings, as they're not needed if the component does not run JavaScript enhancements.

The update required not only to update the template tests, but also the puppeteer tests. This is because the `render` helper we use to render and initialise components in Puppeteer tests expect components to have `data-module` rendered and errors if they don't (for good reason, as it'll help us spot if we ever mistakenly remove JavaScript enhancements from a specific component). The File Upload puppeteer tests were updated to account for the attribute not always being there:
- Javascript enabled tests running against examples that set the new `javascript` option
- Accessibility tests ignoring errors from `render` when not finding an element with `data-module` and not expecting JavaScript enhancements
- Percy tests needed a little update to add an extra screenshot for the JavaScript enhanced FileUpload, otherwise we'd have no visual regression test on it. Because the component now needs the use of the macro option to render the enhanced version, the screenshot for the default example has reverted to show the native component (which Percy flags on top of the 2 new screenshots)

## Thoughts

In the unlikely case that someone would want the translation strings, but not run our JavaScript enhancements, we could add a new option. In the meantime, the `attributes` option allows them to manually add the data attributes.

If more components start having optional JavaScript enhancements, we could look at updating `render` to have an option of whether or not to expect JavaScript, but this didn't feel useful at that point.