### PR TITLE
Update form control components to set a default `id` based on `name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### New features
+
+#### Form control components now have default `id` attributes
+
+If you're using the included Nunjucks macros, the Text input, Textarea, Password input, Character count, File upload, and Select components now automatically use the value of the `name` parameter for the `id` parameter.
+
+This means that you only have to provide the `name` parameters if they both have the same value.
+
+Note that the Date input component still requires an `id` attribute.
+
+This change was introduced in [pull request #5658: Update form control components to set a default `id` based on `name`](https://github.com/alphagov/govuk-frontend/pull/5658).
+
 ### Deprecated features
 
 #### Migrate to the new organisation colour palette

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the textarea.
+    required: false
+    description: The ID of the textarea. Defaults to the value of `name`.
   - name: name
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -135,7 +135,6 @@ examples:
   - name: default
     options:
       name: more-detail
-      id: more-detail
       maxlength: 10
       label:
         text: Can you provide more detail?
@@ -255,6 +254,14 @@ examples:
       label:
         text: With classes
       classes: app-character-count--custom-modifier
+  - name: id
+    hidden: true
+    options:
+      id: character-count-id
+      name: test-name
+      maxlength: 10
+      label:
+        text: With custom id
   - name: attributes
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -12,11 +12,12 @@
 {%- set textareaDescriptionLength = params.maxwords or params.maxlength -%}
 {%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') -%}
 {%- set textareaDescriptionTextNoLimit = textareaDescriptionText | replace('%{count}', textareaDescriptionLength) if not hasNoLimit -%}
+{%- set id = params.id if params.id else params.name -%}
 
 {%- set countMessageHtml %}
 {{ govukHint({
   text: textareaDescriptionTextNoLimit,
-  id: params.id + '-info',
+  id: id + '-info',
   classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
 }) | trim }}
 {% if params.formGroup.afterInput %}
@@ -91,9 +92,9 @@
 {% endfor -%}
 
 {{ govukTextarea({
-  id: params.id,
+  id: id,
   name: params.name,
-  describedBy: params.id + '-info',
+  describedBy: id + '-info',
   rows: params.rows,
   spellcheck: params.spellcheck,
   value: params.value,
@@ -112,7 +113,7 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   },
   hint: params.hint,
   errorMessage: params.errorMessage,

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
@@ -12,11 +12,11 @@ describe('Character count', () => {
   })
 
   describe('default example', () => {
-    it('renders with id', () => {
+    it('autopopulates default id from name', () => {
       const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('id')).toBe('more-detail')
+      expect($component.attr('id')).toBe($component.attr('name'))
     })
 
     it('renders with name', () => {
@@ -35,6 +35,14 @@ describe('Character count', () => {
   })
 
   describe('custom options', () => {
+    it('renders with id', () => {
+      const $ = render('character-count', examples.id)
+
+      const $component = $('.govuk-js-character-count')
+      expect($component.attr('id')).not.toBe($component.attr('name'))
+      expect($component.attr('id')).toBe('character-count-id')
+    })
+
     it('renders with classes', () => {
       const $ = render('character-count', examples.classes)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -85,7 +85,6 @@ params:
 examples:
   - name: default
     options:
-      id: file-upload-1
       name: file-upload-1
       label:
         text: Upload a file
@@ -149,6 +148,13 @@ examples:
       label:
         text: Upload a file
       classes: app-file-upload--custom-modifier
+  - name: id
+    hidden: true
+    options:
+      id: file-upload-id
+      name: test-name
+      label:
+        text: Upload a file
   - name: with describedBy
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -5,8 +5,8 @@ params:
     description: The name of the input, which is submitted with the form data.
   - name: id
     type: string
-    required: true
-    description: The ID of the input.
+    required: false
+    description: The ID of the input. Defaults to the value of `name`.
   - name: value
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -5,7 +5,9 @@
 
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
-{% set describedBy = params.describedBy if params.describedBy else "" %}
+{%- set describedBy = params.describedBy if params.describedBy else "" -%}
+{%- set id = params.id if params.id else params.name -%}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
   {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
@@ -14,10 +16,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -28,7 +30,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = id + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -42,7 +44,7 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -13,11 +13,11 @@ describe('File upload', () => {
   })
 
   describe('default example', () => {
-    it('renders with id', () => {
+    it('autopopulates default id from name', () => {
       const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('id')).toBe('file-upload-1')
+      expect($component.attr('id')).toBe($component.attr('name'))
     })
 
     it('renders with name', () => {
@@ -36,6 +36,14 @@ describe('File upload', () => {
   })
 
   describe('custom options', () => {
+    it('renders with id', () => {
+      const $ = render('file-upload', examples.id)
+
+      const $component = $('.govuk-file-upload')
+      expect($component.attr('id')).not.toBe($component.attr('name'))
+      expect($component.attr('id')).toBe('file-upload-id')
+    })
+
     it('renders with classes', () => {
       const $ = render('file-upload', examples.classes)
 

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the input.
+    required: false
+    description: The ID of the input. Defaults to the value of `name`.
   - name: name
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -166,7 +166,6 @@ examples:
     options:
       label:
         text: National Insurance number
-      id: input-example
       name: test-name
   - name: with hint text
     options:
@@ -397,6 +396,13 @@ examples:
       label:
         text: With classes
       classes: app-input--custom-modifier
+  - name: id
+    hidden: true
+    options:
+      id: input-id
+      name: testing-name
+      label:
+        text: With custom id
   - name: custom type
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/input/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.jsdom.test.js
@@ -17,8 +17,8 @@ describe('Input', () => {
       $label = document.querySelector('.govuk-label')
     })
 
-    it('sets the `id` attribute based on the `id` option', () => {
-      expect($component).toHaveAttribute('id', 'input-example')
+    it('autopopulates `id` based on the `name` option', () => {
+      expect($component).toHaveAttribute('id', $component.name)
     })
 
     it('sets the `name` attribute based on the `name` option', () => {
@@ -65,6 +65,13 @@ describe('Input', () => {
   })
 
   describe('custom options', () => {
+    it('sets the `id` attribute based on the `id` option', () => {
+      document.body.innerHTML = render('input', examples.id)
+
+      const $component = document.querySelector('.govuk-input')
+      expect($component).toHaveAttribute('id', 'input-id')
+    })
+
     it('includes additional classes from the `classes` option', () => {
       document.body.innerHTML = render('input', examples.classes)
 

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -17,6 +17,7 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else undefined -%}
+{%- set id = params.id if params.id else params.name -%}
 
 {%- set hasPrefix = true if params.prefix and (params.prefix.text or params.prefix.html) else false %}
 {%- set hasSuffix = true if params.suffix and (params.suffix.text or params.suffix.html) else false %}
@@ -27,7 +28,7 @@
   <input
     {{- govukAttributes({
       class: classNames,
-      id: params.id,
+      id: id,
       name: params.name,
       type: params.type | default("text", true),
       spellcheck: {
@@ -83,10 +84,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -97,7 +98,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = id + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the input.
+    required: false
+    description: The ID of the input. Defaults to the value of `name`.
   - name: name
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -124,7 +124,6 @@ examples:
     options:
       label:
         text: Password
-      id: password-input
       name: password
   - name: with hint text
     options:
@@ -189,6 +188,13 @@ examples:
       label:
         text: With classes
       classes: app-input--custom-modifier
+  - name: id
+    hidden: true
+    options:
+      id: password-id
+      name: testing-name
+      label:
+        text: With custom id
   - name: value
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -4,6 +4,8 @@
 {% from "../button/macro.njk" import govukButton -%}
 {% from "../input/macro.njk" import govukInput -%}
 
+{%- set id = params.id if params.id else params.name -%}
+
 {% set attributesHtml -%}
   {{- ' data-module="govuk-password-input"' | safe }}
 
@@ -49,7 +51,7 @@
   classes: "govuk-button--secondary govuk-password-input__toggle govuk-js-password-input-toggle" + (" " + params.button.classes if params.button.classes),
   text: params.showPasswordText | default("Show"),
   attributes: {
-    "aria-controls": params.id,
+    "aria-controls": id,
     "aria-label": params.showPasswordAriaLabelText | default("Show password"),
     "hidden": {
       value: true,
@@ -78,7 +80,7 @@
   hint: params.hint,
   classes: "govuk-password-input__input govuk-js-password-input-input" + (" " + params.classes if params.classes),
   errorMessage: params.errorMessage,
-  id: params.id,
+  id: id,
   name: params.name,
   type: "password",
   spellcheck: false,

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.test.js
@@ -9,11 +9,11 @@ describe('Password input', () => {
   })
 
   describe('default example', () => {
-    it('renders with id', () => {
+    it('autopopulates default id from name', () => {
       const $ = render('password-input', examples.default)
 
       const $component = $('.govuk-input')
-      expect($component.attr('id')).toBe('password-input')
+      expect($component.attr('id')).toBe($component.attr('name'))
     })
 
     it('renders with name', () => {
@@ -116,6 +116,14 @@ describe('Password input', () => {
   })
 
   describe('custom options', () => {
+    it('renders with id', () => {
+      const $ = render('password-input', examples.id)
+
+      const $component = $('.govuk-input')
+      expect($component.attr('id')).not.toBe($component.attr('name'))
+      expect($component.attr('id')).toBe('password-id')
+    })
+
     it('renders with classes', () => {
       const $ = render('password-input', examples.classes)
 

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: ID for each select box.
+    required: false
+    description: ID for the select box. Defaults to the value of `name`.
   - name: name
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -110,7 +110,6 @@ params:
 examples:
   - name: default
     options:
-      id: select-1
       name: select-1
       label:
         text: Label text goes here
@@ -123,6 +122,13 @@ examples:
         - value: 3
           text: GOV.UK frontend option 3
           disabled: true
+  - name: id
+    options:
+      id: select-id
+      name: test-name
+      label:
+        text: Horse with no name
+      items: []
   - name: with no items
     options:
       id: select-1

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -6,6 +6,8 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
+{%- set id = params.id if params.id else params.name -%}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
   {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
@@ -14,10 +16,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -28,7 +30,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = id + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -43,7 +45,7 @@
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
   <select class="govuk-select
-    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ id }}" name="{{ params.name }}"
     {%- if params.disabled %} disabled{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
     {{- govukAttributes(params.attributes) }}>

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -13,11 +13,11 @@ describe('Select', () => {
   })
 
   describe('by default', () => {
-    it('renders with id', () => {
+    it('autopopulates default id from name', () => {
       const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
-      expect($component.attr('id')).toBe('select-1')
+      expect($component.attr('id')).toBe($component.attr('name'))
     })
 
     it('renders with name', () => {
@@ -135,6 +135,14 @@ describe('Select', () => {
   })
 
   describe('custom options', () => {
+    it('renders with id', () => {
+      const $ = render('select', examples.id)
+
+      const $component = $('.govuk-select')
+      expect($component.attr('id')).not.toBe($component.attr('name'))
+      expect($component.attr('id')).toBe('select-id')
+    })
+
     it('renders with classes', () => {
       const $ = render('select', examples['with full width override'])
 

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.njk
@@ -6,6 +6,8 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
+{%- set id = params.id if params.id else params.name -%}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
   {{- govukAttributes(params.formGroup.attributes) }}>
   {{ govukLabel({
@@ -14,10 +16,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | trim | indent(2) }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
+  {% set hintId = id + '-hint' %}
   {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
@@ -28,7 +30,7 @@
   }) | trim | indent(2) }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
+  {% set errorId = id + '-error' %}
   {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
@@ -42,7 +44,7 @@
 {% if params.formGroup.beforeInput %}
   {{ params.formGroup.beforeInput.html | safe | trim | indent(2) if params.formGroup.beforeInput.html else params.formGroup.beforeInput.text }}
 {% endif %}
-  <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
+  <textarea class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ id }}" name="{{ params.name }}" rows="{{ params.rows | default(5, true) }}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
@@ -13,11 +13,11 @@ describe('Textarea', () => {
   })
 
   describe('default example', () => {
-    it('renders with id', () => {
+    it('autopopulates default id from name', () => {
       const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('id')).toBe('more-detail')
+      expect($component.attr('id')).toBe($component.attr('name'))
     })
 
     it('renders with name', () => {
@@ -43,6 +43,14 @@ describe('Textarea', () => {
   })
 
   describe('custom options', () => {
+    it('renders with id', () => {
+      const $ = render('textarea', examples.id)
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('id')).not.toBe($component.attr('name'))
+      expect($component.attr('id')).toBe('textarea-id')
+    })
+
     it('renders with classes', () => {
       const $ = render('textarea', examples.classes)
 

--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -1,8 +1,8 @@
 params:
   - name: id
     type: string
-    required: true
-    description: The ID of the textarea.
+    required: false
+    description: The ID of the textarea. Defaults to the value of `name`.
   - name: name
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -98,7 +98,6 @@ examples:
   - name: default
     options:
       name: more-detail
-      id: more-detail
       label:
         text: Can you provide more detail?
   - name: with hint
@@ -181,6 +180,13 @@ examples:
       spellcheck: false
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: id
+    hidden: true
+    options:
+      id: textarea-id
+      name: test-name
+      label:
+        text: With custom id
   - name: classes
     hidden: true
     options:


### PR DESCRIPTION
Updates form control components to use the value of the `name` parameter for the HTML `id` attribute, if the `id` parameter isn't set.

A reduced version of PR #5171. Related to #3497.

## Background

Many of the form-related components in the Design System have a functional requirement for an `id` to be defined in order to associate labels, hints and error messages to them. 

The values are often the same, creating annoying duplication. It has led to [instances of developers forgetting to set `id`s](https://github.com/alphagov/govuk-frontend/issues/3497#issuecomment-1697688942) and for some ports of Frontend to implement their own methods of setting default `id`s: the [ASP.NET Core](https://github.com/gunndabad/govuk-frontend-aspnetcore) and [Jinja](https://github.com/LandRegistry/govuk-frontend-jinja) ports both fall back to using `name` if `id` isn't specified, and the [Vue port](https://govukvue.org/) automatically generates a unique ID if one isn't provided. 

## Changes
- Updates the following components to use their `name` attribute as the default value for the `id` attribute. 
  - Character count
  - File upload
  - (Text) input
  - Password input
  - Select
  - Textarea
- Updates the Nunjucks macro documentation for each of the above to mark the `id` parameter as optional and note that it copies the `name` parameter by default. 

## Thoughts
- This PR omits the Date input component as it doesn't accept a single `name` parameter, instead having separate names for each of the inputs. For this component, setting an `id` parameter is still required.
- This PR doesn't change the Radios or Checkboxes components as they already have this behaviour.
- Unlike the PR this is derived from, it doesn't change any components not related to forms.
- Historically, `id` attribute values could only contain a subset of ASCII characters and were required to start with a letter, which meant that not all `name` values could be valid `id` values. Since HTML5, this has not been the case, and `id`s may be made up of any UTF-8 characters, with the only requirement that there be at least one character (i.e. the attribute isn't empty).
  - This means that there is a risk that `id`s may be invalid in particularly old browsers, however none of these browsers are within our current support list.
