### PR TITLE
Fix issues with build release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_PAT }}
         run: |
           git config --global user.name '${{ github.actor }}'
           git config --global user.email '${{ github.actor }}@digital.cabinet-office.gov.uk'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -65,7 +65,8 @@ jobs:
         run: |
           git config --global user.name '${{ github.actor }}'
           git config --global user.email '${{ github.actor }}@digital.cabinet-office.gov.uk'
-          git commit -am "Release ${{ inputs.version }}"
+          git add .
+          git commit -m "Release ${{ inputs.version }}"
           git checkout -b release-${{ inputs.version }}
           git push -u origin release-${{ inputs.version }}
           gh pr create --base main --head release-${{ inputs.version }} --title "Release ${{ inputs.version }}" --body-file "release-notes-body"

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -15,7 +15,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 1. Before running the build release workflow, make sure that the [`CHANGELOG`](/CHANGELOG.md) is up to date with the latest release notes under the 'Unreleased' heading. If it isn't, do so in a separate pull request before proceeding.
 
-2. Open the actions tab on the `alphagov/govuk-frontend` repo.
+2. Open [the actions tab](https://github.com/alphagov/govuk-frontend/actions) on the `alphagov/govuk-frontend` repo.
 
 3. Select the ["RELEASE: Build release" workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/build-release.yml), provide the new version of GOV.UK Frontend you are releasing and run the workflow on the `main` branch. This will build the release and generate a pull request to review the new build.
 


### PR DESCRIPTION
## Change
Followup of the creation of the build release workflow to fix a couple of post-prod issues:

- Replaces `git commit -am ...` with a separate `git add .` and `git commit -m ...` because the `-am` flag doesn't pick up new files
- Replaces the `GITHUB_TOKEN` used to run the github cli in the PR creation step with `CI_PAT`. This is a personal access token attached to our [CI account](https://github.com/govuk-design-system-ci). Using a PAT bypasses an issue where [pull requests generated by workflows don't fire `pull_request` events](https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536184102)
- Add a link to the publishing docs for ease