### PR TITLE
Fix examples that use the file upload in the review app

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
@@ -50,6 +50,10 @@
         "href": "#file"
       },
       {
+        "text": "Problem with file (enhanced)",
+        "href": "#file-enhanced"
+      },
+      {
         "text": "Problem with radios",
         "href": "#radios"
       },
@@ -190,6 +194,18 @@
     errorMessage: {
       "text": "Problem with file"
     }
+  }) }}
+
+  {{ govukFileUpload({
+    label: {
+      "text": 'Label for enhanced file upload'
+    },
+    id: "file-enhanced",
+    name: "file-enhanced",
+    errorMessage: {
+      "text": "Problem with file"
+    },
+    javascript: true
   }) }}
 
   {{ govukRadios({

--- a/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
@@ -28,6 +28,7 @@
     <li><a href="#date" class="govuk-link">Date pattern</a></li>
     <li><a href="#select" class="govuk-link">Select box</a></li>
     <li><a href="#file" class="govuk-link">File upload</a></li>
+    <li><a href="#file-enhanced" class="govuk-link">File upload (enhanced)</a></li>
   </ul>
 
   <form action="/" method="post">
@@ -171,6 +172,18 @@
         label: {
           text: 'Upload a file'
         }
+      }) -}}
+    {% endcall %}
+
+    {% call govukFieldset() %}
+      <span id="file-enhanced"></span>
+      {{- govukFileUpload({
+        id: 'file-upload-2',
+        name: 'file-upload-2',
+        label: {
+          text: 'Upload a file'
+        },
+        javascript: true
       }) -}}
     {% endcall %}
 

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -340,6 +340,21 @@
     }
   }) }}
 
+  {{ govukFileUpload({
+    id: "file-upload-1",
+    name: "file-upload-1",
+    label: {
+      text: "Llwythwch ffeil i fyny"
+    },
+    javascript: true,
+    selectFilesButtonText: "Dewiswch ffeil",
+    filesSelectedDefaultText: "Dim ffeiliau wedi'u dewis",
+    filesSelectedText: {
+        other: "%{count} ffeil wedi'u dewis",
+        one: "%{count} ffeil wedi'i dewis"
+    }
+  }) }}
+
   {{ govukFooter({
     classes: "govuk-!-margin-bottom-4",
     navigation: [

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -69,7 +69,8 @@ scenario: |
                 hint: {
                     text: "Your photo must be at least 50KB and no more than 10MB"
                 },
-                errorMessage: errors["photo"]
+                errorMessage: errors["photo"],
+                javascript: true
             }) }}
 
             {{ govukCheckboxes({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -71,7 +71,8 @@ scenario: |
                 hint: {
                     text: "Your photo must be at least 50KB and no more than 10MB"
                 },
-                errorMessage: errors["photo"]
+                errorMessage: errors["photo"],
+                javascript: true
             }) }}
 
             {{ govukCheckboxes({

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -51,7 +51,7 @@ describe('/components/file-upload', () => {
     describe('when JavaScript is available', () => {
       describe('on page load', () => {
         beforeAll(async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
         })
 
         describe('wrapper element', () => {
@@ -126,7 +126,7 @@ describe('/components/file-upload', () => {
             // set a value in the file chooser, then checks if that value was set
             // on the input as expected.
             const testFilename = 'test.gif'
-            await render(page, 'file-upload', examples.javascript)
+            await render(page, 'file-upload', examples.enhanced)
 
             const [fileChooser] = await Promise.all([
               page.waitForFileChooser(),
@@ -153,7 +153,7 @@ describe('/components/file-upload', () => {
         const testFilename = 'fakefile.txt'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
@@ -196,7 +196,7 @@ describe('/components/file-upload', () => {
 
       describe('when selecting multiple files', () => {
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.javascript, {
+          await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
                 .querySelector('[type="file"]')
@@ -264,7 +264,7 @@ describe('/components/file-upload', () => {
           '.govuk-file-upload-wrapper:not(.govuk-file-upload-wrapper--show-dropzone)'
 
         beforeEach(async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           $wrapper = await page.$('.govuk-file-upload-wrapper')
           wrapperBoundingBox = await $wrapper.boundingBox()
@@ -401,7 +401,7 @@ describe('/components/file-upload', () => {
 
       describe('disabled state syncing', () => {
         it('disables the button if the input is disabled on page load', async () => {
-          await render(page, 'file-upload', examples.javascript, {
+          await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
                 .querySelector('[type="file"]')
@@ -417,7 +417,7 @@ describe('/components/file-upload', () => {
         })
 
         it('disables the button if the input is disabled programatically', async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           await page.$eval(inputSelector, (el) =>
             el.setAttribute('disabled', '')
@@ -431,7 +431,7 @@ describe('/components/file-upload', () => {
         })
 
         it('enables the button if the input is enabled programatically', async () => {
-          await render(page, 'file-upload', examples.javascript, {
+          await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
                 .querySelector('[type="file"]')
@@ -461,7 +461,7 @@ describe('/components/file-upload', () => {
           await render(
             page,
             'file-upload',
-            examples['javascript, with error message and hint']
+            examples['enhanced, with error message and hint']
           )
 
           const $button = await page.$(buttonSelector)
@@ -473,7 +473,7 @@ describe('/components/file-upload', () => {
         })
 
         it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
-          await render(page, 'file-upload', examples.javascript)
+          await render(page, 'file-upload', examples.enhanced)
 
           const $button = await page.$(buttonSelector)
           const ariaDescribedBy = await $button.evaluate((el) =>
@@ -493,7 +493,7 @@ describe('/components/file-upload', () => {
 
         it('can throw a SupportError if appropriate', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               beforeInitialisation() {
                 document.body.classList.remove('govuk-frontend-supported')
               }
@@ -509,7 +509,7 @@ describe('/components/file-upload', () => {
 
         it('throws when initialised twice', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               async afterInitialisation($root) {
                 const { FileUpload } = await import('govuk-frontend')
                 new FileUpload($root)
@@ -524,7 +524,7 @@ describe('/components/file-upload', () => {
 
         it('throws when $root is not set', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               beforeInitialisation($root) {
                 $root.remove()
               }
@@ -539,7 +539,7 @@ describe('/components/file-upload', () => {
 
         it('throws when receiving the wrong type for $root', async () => {
           await expect(
-            render(page, 'file-upload', examples.javascript, {
+            render(page, 'file-upload', examples.enhanced, {
               beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
                 $root.outerHTML = `<svg data-module="govuk-file-upload"></svg>`
@@ -557,7 +557,7 @@ describe('/components/file-upload', () => {
         describe('missing or misconfigured elements', () => {
           it('throws if the input type is not "file"', async () => {
             await expect(
-              render(page, 'file-upload', examples.javascript, {
+              render(page, 'file-upload', examples.enhanced, {
                 beforeInitialisation() {
                   document
                     .querySelector('[type="file"]')
@@ -575,7 +575,7 @@ describe('/components/file-upload', () => {
 
           it('throws if no label is present', async () => {
             await expect(
-              render(page, 'file-upload', examples.javascript, {
+              render(page, 'file-upload', examples.enhanced, {
                 beforeInitialisation() {
                   document.querySelector('label').remove()
                 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -174,7 +174,7 @@ examples:
         text: Upload a file
       formGroup:
         classes: extra-class
-  - name: javascript
+  - name: enhanced
     screenshot: true
     options:
       id: file-upload-1
@@ -182,6 +182,17 @@ examples:
       label:
         text: Upload a file
       javascript: true
+  - name: enhanced, with error message and hint
+    options:
+      javascript: true
+      id: file-upload-3
+      name: file-upload-3
+      label:
+        text: Upload a file
+      hint:
+        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+      errorMessage:
+        text: Error message goes here
   - name: translated
     options:
       id: file-upload-1
@@ -271,18 +282,6 @@ examples:
         text: Error message
       hint:
         text: hint
-  - name: javascript, with error message and hint
-    hidden: true
-    options:
-      javascript: true
-      id: file-upload-3
-      name: file-upload-3
-      label:
-        text: Upload a file
-      hint:
-        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
-      errorMessage:
-        text: Error message goes here
   - name: translated, no javascript enhancement
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -217,7 +217,7 @@ describe('File upload', () => {
     })
 
     it('adds the data-module attribute to the input when `true`', () => {
-      const $ = render('file-upload', examples.javascript)
+      const $ = render('file-upload', examples.enhanced)
 
       const $input = $('.govuk-form-group > .govuk-file-upload')
 


### PR DESCRIPTION
- Enable the enhanced version in some of the existing examples or duplicates file upload fields to display both enhanced and not enhanced
- Fix the labelling of the enhanced version on the File Upload page so it reads correctly
- Make the enhanced example with hint and errors visible

Not quite sure how to implement the 'Form controls state' for the enhanced version.