### PR TITLE
Frontload workflow names

### DIFF
--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -1,4 +1,4 @@
-name: 'RELEASE: Publish to GitHub'
+name: 'RELEASE: GitHub release'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,4 +1,4 @@
-name: 'RELEASE: Publish to npm'
+name: 'RELEASE: npm publish'
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This makes it easier to see whether you're selecting the npm or the GitHub release workflow.