### PR TITLE
Update build release scripts to support pre-releases

### DIFF
--- a/.github/workflows/scripts/changelog-release-helper.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.mjs
@@ -89,6 +89,18 @@ export function validateVersion(newVersion) {
  * @param {string} newVersion
  */
 export function updateChangelog(newVersion) {
+  // Skip the entire function if the release version is internal eg: 5.1.0-internal.0
+  if (versionIsAPrerelease(newVersion)) {
+    const identifier = getPrereleaseIdentifier(newVersion)
+
+    if (identifier === 'internal') {
+      console.log(
+        'This is an internal release, intended for testing only. The changelog will therefore not be updated.'
+      )
+      return
+    }
+  }
+
   const changelogLines = getChangelogLines()
   const [startIndex, previousReleaseLineIndex] =
     getChangelogLineIndexes(changelogLines)

--- a/.github/workflows/scripts/changelog-release-helper.test.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.test.mjs
@@ -121,6 +121,16 @@ describe('Changelog release helper', () => {
         expect.stringContaining('## v3.1.0-beta.1 (Beta feature release)')
       )
     })
+
+    it('does not change the changelog if the provided version is an internal pre-release', () => {
+      const consoleLogSpy = jest.spyOn(console, 'log')
+
+      updateChangelog('3.1.0-internal.0')
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        'This is an internal release, intended for testing only. The changelog will therefore not be updated.'
+      )
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
   })
 
   describe('Generate release notes', () => {

--- a/.github/workflows/scripts/changelog-release-helper.test.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.test.mjs
@@ -38,31 +38,53 @@ describe('Changelog release helper', () => {
       )
     })
 
-    it('throws an error if new version is more than one possible increment', () => {
-      const increments = [
-        {
-          badVersion: '5.0.0',
-          type: 'major',
-          goodVersion: '4.0.0'
-        },
-        {
-          badVersion: '3.2.0',
-          type: 'minor',
-          goodVersion: '3.1.0'
-        },
-        {
-          badVersion: '3.0.2',
-          type: 'patch',
-          goodVersion: '3.0.1'
-        }
-      ]
+    it.each([
+      {
+        badVersion: '5.0.0',
+        type: 'major',
+        goodVersion: '4.0.0'
+      },
+      {
+        badVersion: '3.2.0',
+        type: 'minor',
+        goodVersion: '3.1.0'
+      },
+      {
+        badVersion: '3.0.2',
+        type: 'patch',
+        goodVersion: '3.0.1'
+      },
+      {
+        badVersion: '3.0.2-beta.0',
+        type: 'prepatch',
+        goodVersion: '3.0.1-beta.0'
+      },
+      {
+        badVersion: '3.0.2',
+        type: 'patch',
+        goodVersion: '3.0.1',
+        customLastTitle: '3.0.1-beta.15 (Beta patch release)'
+      }
+    ])(
+      'throws an error if new version is more than one possible `$type` increment',
+      ({ badVersion, type, goodVersion, customLastTitle }) => {
+        if (customLastTitle) {
+          jest.mocked(fs.readFileSync).mockReturnValue(`
+          ## Unreleased
 
-      for (const increment of increments) {
-        expect(() => validateVersion(increment.badVersion)).toThrow(
-          `New version number ${increment.badVersion} is incrementing more than one for its increment type (${increment.type}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${increment.goodVersion}`
+          ### Fixes
+
+          Bing bong
+
+          ## v${customLastTitle}
+        `)
+        }
+
+        expect(() => validateVersion(badVersion)).toThrow(
+          `New version number ${badVersion} is incrementing more than one for its increment type (${type}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${goodVersion}`
         )
       }
-    })
+    )
   })
 
   describe('Update changelog', () => {
@@ -86,13 +108,30 @@ describe('Changelog release helper', () => {
     })
 
     it('writes release notes from the changelog from the last version heading', () => {
-      // re-mock the readFileSync return value as if we'd just run
-      // updateChangelog and the contents we wanted was between the new and
-      // current version headings
       jest.mocked(fs.readFileSync).mockReturnValue(`
         ## Unreleased
 
         ## v3.1.0 (Feature release)
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.0.0 (Breaking release)
+      `)
+
+      generateReleaseNotes()
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining('Bing bong')
+      )
+    })
+
+    it('writes release notes from the changelog from the last version heading if that version is a pre-release', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ## v3.1.0-beta.0 (Feature release)
 
         ### Fixes
 

--- a/.github/workflows/scripts/changelog-release-helper.test.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.test.mjs
@@ -95,6 +95,32 @@ describe('Changelog release helper', () => {
         expect.stringContaining('## v3.1.0 (Feature release)')
       )
     })
+
+    it('prefixes a new heading with a pre-release identifier if the new version is a pre-release', () => {
+      updateChangelog('3.1.0-beta.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining('## v3.1.0-beta.0 (Beta feature release)')
+      )
+    })
+
+    it('copies the previous release type if the new version is a prerelease increment', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.1.0-beta.0 (Beta feature release)
+      `)
+
+      updateChangelog('3.1.0-beta.1')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining('## v3.1.0-beta.1 (Beta feature release)')
+      )
+    })
   })
 
   describe('Generate release notes', () => {

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -14,6 +14,8 @@ if [ "$CURRENT_VERSION" = "$HIGHEST_PUBLISHED_VERSION" ]; then
   exit 1
 elif echo "$CURRENT_VERSION" | grep -q "internal"; then
   NPM_TAG="internal"
+elif echo "$CURRENT_VERSION" | grep -q "beta"; then
+  NPM_TAG="next"
 elif [ $(version "$CURRENT_VERSION") -ge $(version "$HIGHEST_PUBLISHED_VERSION") ]; then
   NPM_TAG="latest"
 else

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -16,6 +16,9 @@ elif echo "$CURRENT_VERSION" | grep -q "internal"; then
   NPM_TAG="internal"
 elif echo "$CURRENT_VERSION" | grep -q "beta"; then
   NPM_TAG="next"
+elif echo "$CURRENT_VERSION" | grep -q -E '^\d+\.\d+\.\d+-\D+(\.\d+)?$'; then
+  echo "⚠️ Pre-releases with an identifier other than 'beta' or 'internal' are not allowed, therefore we will not generate an npm tag. Please check your current version."
+  exit 1
 elif [ $(version "$CURRENT_VERSION") -ge $(version "$HIGHEST_PUBLISHED_VERSION") ]; then
   NPM_TAG="latest"
 else


### PR DESCRIPTION
## Change
Makes the following changes to the changelog-release-helper set of scripts:

- Diffs new and old versions in all instances, including pre-releases, and more accurately builds the 'only increment by one' error message if the new version is a pre-release
- Doesn't update the changelog with a new heading if the new version is an internal pre-release ie: following the format 0.0.0-**internal**.0
- Updates the regex for getting version headings to account for pre-release headings
- Follows the naming convetion of 'v{version} ({pre-release identifier} {increment type} release)' when generating new changelog headings eg: the version 6.1.0-beta.0 will generate the title 'v6.2.0-beta.0 (Beta feature release)' instead of just '(Feature release)'
- Cleans up some of the methods in the helper that were only being used in one place

It also makes the following changes to the `generate-npm-tag` shell script:

- Adds support for beta pre-releases, automatically generating a `next` tag
- Doesn't generate a tag if the version is a pre-release tagged with something other than beta or internal

Resolves https://github.com/alphagov/govuk-frontend/issues/5671