### PR TITLE
Outstanding style updates for File Upload component

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -97,10 +97,11 @@
     display: block;
     margin-bottom: govuk-spacing(2);
     padding: govuk-spacing(3) govuk-spacing(2);
+    background-color: govuk-colour("white");
     text-align: left;
   }
 
-  .govuk-file-upload__status--empty {
+  .govuk-file-upload__button--empty .govuk-file-upload__status {
     color: govuk-shade(govuk-colour("blue"), 60%);
     background-color: govuk-tint(govuk-colour("blue"), 70%);
   }
@@ -118,8 +119,8 @@
     width: 100%;
     // align the padding to be same as notification banner and error summary accounting for the thicker borders
     padding: (govuk-spacing(3) + $govuk-border-width - $file-upload-border-width);
-    border: $file-upload-border-width govuk-colour("mid-grey") dashed;
-    background-color: govuk-colour("white");
+    border: $file-upload-border-width govuk-colour("mid-grey") solid;
+    background-color: govuk-colour("light-grey");
     cursor: pointer;
 
     @include govuk-media-query($from: tablet) {
@@ -127,15 +128,31 @@
     }
   }
 
+  .govuk-file-upload__button--empty {
+    border-style: dashed;
+    background-color: govuk-colour("white");
+  }
+
+  .govuk-file-upload__button.govuk-file-upload__button--empty:hover {
+    background-color: govuk-colour("light-grey");
+  }
+
   .govuk-file-upload__button:disabled {
     pointer-events: none;
     opacity: 0.5;
   }
 
-  .govuk-file-upload__button--dragging:not(:disabled),
+  .govuk-file-upload__button--dragging.govuk-file-upload__button,
   .govuk-file-upload__button:hover {
-    border-color: govuk-shade(govuk-colour("mid-grey"), 20%);
+    background-color: govuk-tint(govuk-colour("mid-grey"), 20%);
+  }
+
+  .govuk-file-upload__button--dragging.govuk-file-upload__button--empty {
     background-color: govuk-colour("light-grey");
+  }
+
+  .govuk-file-upload__button--dragging:not(:disabled) {
+    border-color: govuk-shade(govuk-colour("mid-grey"), 20%);
   }
 
   .govuk-file-upload__button--dragging:not(:disabled) .govuk-file-upload__pseudo-button,
@@ -143,18 +160,19 @@
     background-color: govuk-shade(govuk-colour("light-grey"), 10%);
   }
 
-  .govuk-file-upload__button--dragging:not(:disabled) {
-    border: $file-upload-border-width solid govuk-colour("black");
-  }
-
-  .govuk-file-upload__button--dragging:not(:disabled) .govuk-file-upload__status--empty,
-  .govuk-file-upload__button:hover .govuk-file-upload__status--empty,
-  .govuk-file-upload__button:focus .govuk-file-upload__status--empty {
+  .govuk-file-upload__button--empty.govuk-file-upload__button--dragging:not(:disabled) .govuk-file-upload__status,
+  .govuk-file-upload__button--empty:hover .govuk-file-upload__status,
+  .govuk-file-upload__button--empty:focus .govuk-file-upload__status {
     background-color: govuk-tint(govuk-colour("blue"), 80%);
   }
 
-  .govuk-file-upload__button--dragging .govuk-file-upload__pseudo-button {
+  .govuk-file-upload__button .govuk-file-upload__pseudo-button,
+  .govuk-file-upload__button--empty.govuk-file-upload__button--dragging .govuk-file-upload__pseudo-button {
     background-color: govuk-colour("white");
+  }
+
+  .govuk-file-upload__button--empty .govuk-file-upload__pseudo-button {
+    background-color: govuk-colour("light-grey");
   }
 
   .govuk-file-upload__button:active,
@@ -163,13 +181,18 @@
     outline: $govuk-focus-width solid $govuk-focus-colour;
     // Ensure outline appears outside of the element
     outline-offset: 0;
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-tint(govuk-colour("mid-grey"), 20%);
     // Double the border by adding its width again. Use `box-shadow` for this
     // instead of changing `border-width` - this is for consistency with
     // components such as textarea where we avoid changing `border-width` as
     // it will change the element size. Also, `outline` cannot be utilised
     // here as it is already used for the yellow focus state.
     box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  }
+
+  .govuk-file-upload__button--empty:active,
+  .govuk-file-upload__button--empty:focus {
+    background-color: govuk-colour("light-grey");
   }
 
   .govuk-file-upload__button:focus .govuk-file-upload__pseudo-button {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -110,13 +110,13 @@
   .govuk-file-upload__button {
     width: 100%;
     // align the padding to be same as notification banner and error summary accounting for the thicker borders
-    padding: govuk-spacing(3) (govuk-spacing(3) + $govuk-border-width - $file-upload-border-width);
+    padding: (govuk-spacing(3) + $govuk-border-width - $file-upload-border-width);
     border: $file-upload-border-width govuk-colour("mid-grey") dashed;
     background-color: govuk-colour("white");
     cursor: pointer;
 
     @include govuk-media-query($from: tablet) {
-      padding: govuk-spacing(3) (govuk-spacing(4) + $govuk-border-width - $file-upload-border-width);
+      padding: (govuk-spacing(4) + $govuk-border-width - $file-upload-border-width);
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -55,6 +55,13 @@
     background-color: $govuk-body-background-colour;
   }
 
+  // required because disabling pointer events
+  // on the button means that the cursor style
+  // be applied on the button itself
+  .govuk-file-upload-wrapper--disabled {
+    cursor: not-allowed;
+  }
+
   .govuk-frontend-supported .govuk-file-upload-wrapper .govuk-file-upload {
     position: absolute;
     // Make the native control take up the entire space of the element, but
@@ -69,7 +76,7 @@
     opacity: 0;
   }
 
-  .govuk-frontend-supported .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload {
+  .govuk-frontend-supported .govuk-file-upload-wrapper .govuk-file-upload--dragging {
     z-index: 1;
   }
 
@@ -123,33 +130,30 @@
   .govuk-file-upload__button:disabled {
     pointer-events: none;
     opacity: 0.5;
-    cursor: not-allowed;
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button:not(:disabled),
+  .govuk-file-upload__button--dragging:not(:disabled),
   .govuk-file-upload__button:hover {
     border-color: govuk-shade(govuk-colour("mid-grey"), 20%);
     background-color: govuk-colour("light-grey");
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__pseudo-button,
+  .govuk-file-upload__button--dragging:not(:disabled) .govuk-file-upload__pseudo-button,
   .govuk-file-upload__button:hover .govuk-file-upload__pseudo-button {
     background-color: govuk-shade(govuk-colour("light-grey"), 10%);
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button:not(:disabled) {
+  .govuk-file-upload__button--dragging:not(:disabled) {
     border: $file-upload-border-width solid govuk-colour("black");
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button:not(:disabled) .govuk-file-upload__status--empty,
+  .govuk-file-upload__button--dragging:not(:disabled) .govuk-file-upload__status--empty,
   .govuk-file-upload__button:hover .govuk-file-upload__status--empty,
   .govuk-file-upload__button:focus .govuk-file-upload__status--empty {
     background-color: govuk-tint(govuk-colour("blue"), 80%);
   }
 
-  .govuk-file-upload-wrapper--show-dropzone
-    .govuk-file-upload__button:not(:disabled)
-    .govuk-file-upload__pseudo-button {
+  .govuk-file-upload__button--dragging .govuk-file-upload__pseudo-button {
     background-color: govuk-colour("white");
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -69,7 +69,7 @@
     opacity: 0;
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload {
+  .govuk-frontend-supported .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload {
     z-index: 1;
   }
 
@@ -120,36 +120,42 @@
     }
   }
 
-  .govuk-file-upload-wrapper:hover .govuk-file-upload__button {
+  .govuk-file-upload__button:disabled {
+    pointer-events: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button:not(:disabled),
+  .govuk-file-upload__button:hover {
     border-color: govuk-shade(govuk-colour("mid-grey"), 20%);
-  }
-
-  .govuk-file-upload-wrapper:hover .govuk-file-upload__pseudo-button {
-    background-color: govuk-shade(govuk-colour("light-grey"), 10%);
-  }
-
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button,
-  .govuk-file-upload-wrapper:hover .govuk-file-upload__button {
     background-color: govuk-colour("light-grey");
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__status--empty,
-  .govuk-file-upload-wrapper:hover .govuk-file-upload__status--empty,
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__pseudo-button,
+  .govuk-file-upload__button:hover .govuk-file-upload__pseudo-button {
+    background-color: govuk-shade(govuk-colour("light-grey"), 10%);
+  }
+
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button:not(:disabled) {
+    border: $file-upload-border-width solid govuk-colour("black");
+  }
+
+  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button:not(:disabled) .govuk-file-upload__status--empty,
+  .govuk-file-upload__button:hover .govuk-file-upload__status--empty,
   .govuk-file-upload__button:focus .govuk-file-upload__status--empty {
     background-color: govuk-tint(govuk-colour("blue"), 80%);
   }
 
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__button {
-    border: $file-upload-border-width solid govuk-colour("black");
-  }
-
-  .govuk-file-upload-wrapper--show-dropzone .govuk-file-upload__pseudo-button {
+  .govuk-file-upload-wrapper--show-dropzone
+    .govuk-file-upload__button:not(:disabled)
+    .govuk-file-upload__pseudo-button {
     background-color: govuk-colour("white");
   }
 
   .govuk-file-upload__button:active,
   .govuk-file-upload__button:focus {
-    border: 2px solid govuk-colour("black");
+    border: $file-upload-border-width solid govuk-colour("black");
     outline: $govuk-focus-width solid $govuk-focus-colour;
     // Ensure outline appears outside of the element
     outline-offset: 0;
@@ -167,7 +173,7 @@
     box-shadow: 0 2px 0 govuk-colour("black");
   }
 
-  .govuk-file-upload-wrapper:hover .govuk-file-upload__button:focus .govuk-file-upload__pseudo-button {
+  .govuk-file-upload__button:focus:hover .govuk-file-upload__pseudo-button {
     border-color: $govuk-focus-colour;
     outline: 3px solid transparent;
     background-color: govuk-colour("light-grey");

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -93,6 +93,7 @@ export class FileUpload extends ConfigurableComponent {
     $button.classList.add('govuk-file-upload__button')
     $button.type = 'button'
     $button.id = this.id
+    $button.classList.add('govuk-file-upload__button--empty')
 
     // Copy `aria-describedby` if present so hints and errors
     // are associated to the `<button>`
@@ -105,7 +106,6 @@ export class FileUpload extends ConfigurableComponent {
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload__status'
     $status.innerText = this.i18n.t('filesSelectedDefault')
-    $status.classList.add('govuk-file-upload__status--empty')
 
     $button.appendChild($status)
 
@@ -265,7 +265,7 @@ export class FileUpload extends ConfigurableComponent {
     if (fileCount === 0) {
       // If there are no files, show the default selection text
       this.$status.innerText = this.i18n.t('filesSelectedDefault')
-      this.$status.classList.add('govuk-file-upload__status--empty')
+      this.$button.classList.add('govuk-file-upload__button--empty')
     } else {
       if (
         // If there is 1 file, just show the file name
@@ -279,7 +279,7 @@ export class FileUpload extends ConfigurableComponent {
         })
       }
 
-      this.$status.classList.remove('govuk-file-upload__status--empty')
+      this.$button.classList.remove('govuk-file-upload__button--empty')
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -144,7 +144,7 @@ export class FileUpload extends ConfigurableComponent {
     $button.addEventListener('click', this.onClick.bind(this))
 
     // Assemble these all together
-    this.$root.insertAdjacentElement('beforeend', $button)
+    this.$root.insertAdjacentElement('afterbegin', $button)
 
     this.$input.setAttribute('tabindex', '-1')
     this.$input.setAttribute('aria-hidden', 'true')
@@ -225,11 +225,12 @@ export class FileUpload extends ConfigurableComponent {
           // Only update the class and make the announcement if not already visible
           // to avoid repeated announcements on NVDA (2024.4) + Firefox (133)
           if (
-            !this.$root.classList.contains(
-              'govuk-file-upload-wrapper--show-dropzone'
+            !this.$button.classList.contains(
+              'govuk-file-upload__button--dragging'
             )
           ) {
-            this.$root.classList.add('govuk-file-upload-wrapper--show-dropzone')
+            this.$button.classList.add('govuk-file-upload__button--dragging')
+            this.$input.classList.add('govuk-file-upload--dragging')
             this.$announcements.innerText = this.i18n.t('dropZoneEntered')
           }
         }
@@ -238,9 +239,7 @@ export class FileUpload extends ConfigurableComponent {
         // left the drop zone when they enter the page but haven't reached yet
         // the file upload component
         if (
-          this.$root.classList.contains(
-            'govuk-file-upload-wrapper--show-dropzone'
-          )
+          this.$button.classList.contains('govuk-file-upload__button--dragging')
         ) {
           this.hideDropZone()
         }
@@ -252,7 +251,8 @@ export class FileUpload extends ConfigurableComponent {
    * Hides the dropzone once user has dropped files on the `<input>`
    */
   hideDropZone() {
-    this.$root.classList.remove('govuk-file-upload-wrapper--show-dropzone')
+    this.$button.classList.remove('govuk-file-upload__button--dragging')
+    this.$input.classList.remove('govuk-file-upload--dragging')
     this.$announcements.innerText = this.i18n.t('dropZoneLeft')
   }
 
@@ -337,6 +337,12 @@ export class FileUpload extends ConfigurableComponent {
    */
   updateDisabledState() {
     this.$button.disabled = this.$input.disabled
+
+    if (this.$button.disabled) {
+      this.$root.classList.add('govuk-file-upload-wrapper--disabled')
+    } else {
+      this.$root.classList.remove('govuk-file-upload-wrapper--disabled')
+    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -255,9 +255,9 @@ describe('/components/file-upload', () => {
         }
 
         const selectorDropzoneVisible =
-          '.govuk-file-upload-wrapper.govuk-file-upload-wrapper--show-dropzone'
+          '.govuk-file-upload__button.govuk-file-upload__button--dragging'
         const selectorDropzoneHidden =
-          '.govuk-file-upload-wrapper:not(.govuk-file-upload-wrapper--show-dropzone)'
+          '.govuk-file-upload__button:not(.govuk-file-upload__button--dragging)'
 
         beforeEach(async () => {
           await render(page, 'file-upload', examples.enhanced)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -185,6 +185,16 @@ examples:
       label:
         text: Upload a file
       javascript: true
+  - name: enhanced, disabled
+    options:
+      javascript: true
+      disabled: true
+      id: file-upload-error
+      name: file-upload-error
+      label:
+        text: Upload a file
+      hint:
+        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
   - name: enhanced, with error message and hint
     options:
       javascript: true


### PR DESCRIPTION
## What

- Add disabled style to File Upload component
- Unify the padding in all directions in mobile and desktop viewports for the File Upload component
- Resolve background of file status disappearing in certain interactions and conditions

## Why

Input element can be disabled, so need styling for the enhanced component also.

Fixes #5686 and fixes https://github.com/alphagov/govuk-frontend/issues/5685