### PR TITLE
Update name and description of macro options in docs and code

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -349,7 +349,7 @@
     javascript: true,
     chooseFilesButtonText: "Dewiswch ffeil",
     noFileChosenText: "Dim ffeiliau wedi'u dewis",
-    filesSelectedText: {
+    multipleFilesChosenText: {
         other: "%{count} ffeil wedi'u dewis",
         one: "%{count} ffeil wedi'i dewis"
     }

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -348,7 +348,7 @@
     },
     javascript: true,
     chooseFilesButtonText: "Dewiswch ffeil",
-    filesSelectedDefaultText: "Dim ffeiliau wedi'u dewis",
+    noFileChosenText: "Dim ffeiliau wedi'u dewis",
     filesSelectedText: {
         other: "%{count} ffeil wedi'u dewis",
         one: "%{count} ffeil wedi'i dewis"

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -347,7 +347,7 @@
       text: "Llwythwch ffeil i fyny"
     },
     javascript: true,
-    selectFilesButtonText: "Dewiswch ffeil",
+    chooseFilesButtonText: "Dewiswch ffeil",
     filesSelectedDefaultText: "Dim ffeiliau wedi'u dewis",
     filesSelectedText: {
         other: "%{count} ffeil wedi'u dewis",

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -122,7 +122,7 @@ export class FileUpload extends ConfigurableComponent {
     const buttonSpan = document.createElement('span')
     buttonSpan.className =
       'govuk-button govuk-button--secondary govuk-file-upload__pseudo-button'
-    buttonSpan.innerText = this.i18n.t('selectFilesButton')
+    buttonSpan.innerText = this.i18n.t('chooseFilesButton')
 
     containerSpan.appendChild(buttonSpan)
 
@@ -359,7 +359,7 @@ export class FileUpload extends ConfigurableComponent {
    */
   static defaults = Object.freeze({
     i18n: {
-      selectFilesButton: 'Choose file',
+      chooseFilesButton: 'Choose file',
       filesSelectedDefault: 'No file chosen',
       filesSelected: {
         // the 'one' string isn't used as the component displays the filename

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -424,13 +424,15 @@ function isContainingFiles(dataTransfer) {
  * @typedef {object} FileUploadTranslations
  *
  * Messages used by the component
- * @property {string} [selectFiles] - Text of button that opens file browser
- * @property {TranslationPluralForms} [multipleFilesChosen] - Text indicating how
- *   many files have been selected
- * @property {string} [enteredDropZone] - Text announced to assistive technology
- *   when users entered the drop zone while dragging
- * @property {string} [leftDropZone] - Text announced to assistive technology
- *   when users left the drop zone while dragging
+ * @property {string} [chooseFile] - The text of the button that opens the file picker
+ * @property {string} [dropInstruction] - The text informing users they can drop files
+ * @property {TranslationPluralForms} [multipleFilesChosen] - The text displayed when multiple files
+ *   have been chosen by the user
+ * @property {string} [noFileChosen] - The text to displayed when no file has been chosen by the user
+ * @property {string} [enteredDropZone] - The text announced by assistive technology
+ *   when user drags files and enters the drop zone
+ * @property {string} [leftDropZone] - The text announced by assistive technology
+ *   when user drags files and leaves the drop zone without dropping
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -253,7 +253,7 @@ export class FileUpload extends ConfigurableComponent {
   hideDropZone() {
     this.$button.classList.remove('govuk-file-upload__button--dragging')
     this.$input.classList.remove('govuk-file-upload--dragging')
-    this.$announcements.innerText = this.i18n.t('dropZoneLeft')
+    this.$announcements.innerText = this.i18n.t('leftDropZone')
   }
 
   /**
@@ -369,7 +369,7 @@ export class FileUpload extends ConfigurableComponent {
         other: '%{count} files chosen'
       },
       enteredDropZone: 'Entered drop zone',
-      dropZoneLeft: 'Left drop zone'
+      leftDropZone: 'Left drop zone'
     }
   })
 
@@ -429,7 +429,7 @@ function isContainingFiles(dataTransfer) {
  *   many files have been selected
  * @property {string} [enteredDropZone] - Text announced to assistive technology
  *   when users entered the drop zone while dragging
- * @property {string} [dropZoneLeft] - Text announced to assistive technology
+ * @property {string} [leftDropZone] - Text announced to assistive technology
  *   when users left the drop zone while dragging
  */
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -274,7 +274,7 @@ export class FileUpload extends ConfigurableComponent {
         this.$status.innerText = this.$input.files[0].name
       } else {
         // Otherwise, tell the user how many files are selected
-        this.$status.innerText = this.i18n.t('filesSelected', {
+        this.$status.innerText = this.i18n.t('multipleFilesChosen', {
           count: fileCount
         })
       }
@@ -362,7 +362,7 @@ export class FileUpload extends ConfigurableComponent {
       chooseFilesButton: 'Choose file',
       dropInstruction: 'or drop file',
       noFileChosen: 'No file chosen',
-      filesSelected: {
+      multipleFilesChosen: {
         // the 'one' string isn't used as the component displays the filename
         // instead, however it's here for coverage's sake
         one: '%{count} file chosen',
@@ -425,7 +425,7 @@ function isContainingFiles(dataTransfer) {
  *
  * Messages used by the component
  * @property {string} [selectFiles] - Text of button that opens file browser
- * @property {TranslationPluralForms} [filesSelected] - Text indicating how
+ * @property {TranslationPluralForms} [multipleFilesChosen] - Text indicating how
  *   many files have been selected
  * @property {string} [dropZoneEntered] - Text announced to assistive technology
  *   when users entered the drop zone while dragging

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -132,7 +132,7 @@ export class FileUpload extends ConfigurableComponent {
 
     const instructionSpan = document.createElement('span')
     instructionSpan.className = 'govuk-body govuk-file-upload__instruction'
-    instructionSpan.innerText = this.i18n.t('instruction')
+    instructionSpan.innerText = this.i18n.t('dropInstruction')
 
     containerSpan.appendChild(instructionSpan)
 
@@ -360,6 +360,7 @@ export class FileUpload extends ConfigurableComponent {
   static defaults = Object.freeze({
     i18n: {
       chooseFilesButton: 'Choose file',
+      dropInstruction: 'or drop file',
       filesSelectedDefault: 'No file chosen',
       filesSelected: {
         // the 'one' string isn't used as the component displays the filename
@@ -368,8 +369,7 @@ export class FileUpload extends ConfigurableComponent {
         other: '%{count} files chosen'
       },
       dropZoneEntered: 'Entered drop zone',
-      dropZoneLeft: 'Left drop zone',
-      instruction: 'or drop file'
+      dropZoneLeft: 'Left drop zone'
     }
   })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -231,7 +231,7 @@ export class FileUpload extends ConfigurableComponent {
           ) {
             this.$button.classList.add('govuk-file-upload__button--dragging')
             this.$input.classList.add('govuk-file-upload--dragging')
-            this.$announcements.innerText = this.i18n.t('dropZoneEntered')
+            this.$announcements.innerText = this.i18n.t('enteredDropZone')
           }
         }
       } else {
@@ -368,7 +368,7 @@ export class FileUpload extends ConfigurableComponent {
         one: '%{count} file chosen',
         other: '%{count} files chosen'
       },
-      dropZoneEntered: 'Entered drop zone',
+      enteredDropZone: 'Entered drop zone',
       dropZoneLeft: 'Left drop zone'
     }
   })
@@ -427,7 +427,7 @@ function isContainingFiles(dataTransfer) {
  * @property {string} [selectFiles] - Text of button that opens file browser
  * @property {TranslationPluralForms} [multipleFilesChosen] - Text indicating how
  *   many files have been selected
- * @property {string} [dropZoneEntered] - Text announced to assistive technology
+ * @property {string} [enteredDropZone] - Text announced to assistive technology
  *   when users entered the drop zone while dragging
  * @property {string} [dropZoneLeft] - Text announced to assistive technology
  *   when users left the drop zone while dragging

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -105,7 +105,7 @@ export class FileUpload extends ConfigurableComponent {
     // Create status element that shows what/how many files are selected
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload__status'
-    $status.innerText = this.i18n.t('filesSelectedDefault')
+    $status.innerText = this.i18n.t('noFileChosen')
 
     $button.appendChild($status)
 
@@ -264,7 +264,7 @@ export class FileUpload extends ConfigurableComponent {
 
     if (fileCount === 0) {
       // If there are no files, show the default selection text
-      this.$status.innerText = this.i18n.t('filesSelectedDefault')
+      this.$status.innerText = this.i18n.t('noFileChosen')
       this.$button.classList.add('govuk-file-upload__button--empty')
     } else {
       if (
@@ -361,7 +361,7 @@ export class FileUpload extends ConfigurableComponent {
     i18n: {
       chooseFilesButton: 'Choose file',
       dropInstruction: 'or drop file',
-      filesSelectedDefault: 'No file chosen',
+      noFileChosen: 'No file chosen',
       filesSelected: {
         // the 'one' string isn't used as the component displays the filename
         // instead, however it's here for coverage's sake

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -415,7 +415,7 @@ describe('/components/file-upload', () => {
           )
 
           expect(buttonElementText).toBe('Dewiswch ffeil')
-          expect(statusElementText).toBe("Dim ffeiliau wedi'u dewis")
+          expect(statusElementText).toBe("Dim ffeil wedi'i dewis")
         })
 
         describe('status element', () => {
@@ -424,7 +424,7 @@ describe('/components/file-upload', () => {
               el.innerHTML.trim()
             )
 
-            expect(statusText).toBe("Dim ffeiliau wedi'u dewis")
+            expect(statusText).toBe("Dim ffeil wedi'i dewis")
           })
 
           it('uses the correct translation when multiple files are selected', async () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -103,7 +103,7 @@ params:
     description: The text announced by assistive technology when user drags files and enters the drop zone. Default is `"Entered drop zone"`. If `javascript` is not provided, this option will be ignored.
   - name: leftDropZoneText
     type: string
-    require: false
+    required: false
     description: The text announced by assistive technology when user drags files and leaves the drop zone without dropping. Default is `"Left drop zone"`. If `javascript` is not provided, this option will be ignored.
   - name: classes
     type: string
@@ -229,6 +229,7 @@ examples:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"
       enteredDropZoneText: Wedi mynd i mewn i'r parth gollwng
+      leftDropZoneText: Parth gollwng i'r chwith
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value
@@ -326,3 +327,4 @@ examples:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"
       enteredDropZoneText: Wedi mynd i mewn i'r parth gollwng
+      leftDropZoneText: Parth gollwng i'r chwith

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -228,6 +228,7 @@ examples:
       multipleFilesChosenText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"
+      enteredDropZoneText: Wedi mynd i mewn i'r parth gollwng
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value
@@ -324,3 +325,4 @@ examples:
       multipleFilesChosenText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"
+      enteredDropZoneText: Wedi mynd i mewn i'r parth gollwng

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -224,7 +224,7 @@ examples:
       javascript: true
       chooseFilesButtonText: Dewiswch ffeil
       dropInstructionText: neu ollwng ffeil
-      filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
+      noFileChosenText: Dim ffeil wedi'i dewis
       filesSelectedText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"
@@ -320,7 +320,7 @@ examples:
         text: Llwythwch ffeil i fyny
       multiple: true
       chooseFilesButtonText: Dewiswch ffeil
-      filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
+      noFileChosenText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -80,23 +80,31 @@ params:
   - name: javascript
     type: boolean
     required: false
-    description: Whether to enable JavaScript enhancements for the component
-  - name: selectFilesButtonText
+    description: Can be used to enable JavaScript enhancements for the component.
+  - name: chooseFilesButtonText
     type: string
     required: false
-    description: The text of the button that opens the file picker. JavaScript enhanced version of the component only. Default is "Choose file".
-  - name: instructionText
+    description: The text of the button that opens the file picker. Default is `"Choose file"`. If `javascript` is not provided, this option will be ignored.
+  - name: dropInstructionText
     type: string
     required: false
-    description: The text of the instruction text that follows the button that opens the file picker. JavaScript enhanced version of the component only. Default is "or drop file".
-  - name: filesSelected
+    description: The text informing users they can drop files. Default is `"or drop file"`. If `javascript` is not provided, this option will be ignored.
+  - name: multipleFilesChosenText
     type: object
     required: false
-    description: The text to display when multiple files has been chosen by the user. JavaScript enhanced version of the component only. The component will replace the `%{count}` placeholder with the number of files selected. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
-  - name: filesSelectedDefault
+    description: The text displayed when multiple files have been chosen by the user. The component will replace the `%{count}` placeholder with the number of files selected. [Our pluralisation rules apply to this macro option](https://frontend.design-system.service.gov.uk/localise-govuk-frontend/#understanding-pluralisation-rules). If `javascript` is not provided, this option will be ignored.
+  - name: noFileChosenText
     type: string
     required: false
-    description: The text to display when no file has been chosen by the user. JavaScript enhanced version of the component only. Default is "No file chosen".
+    description: The text displayed when no file has been chosen by the user. Default is `"No file chosen"`. If `javascript` is not provided, this option will be ignored.
+  - name: enteredDropZoneText
+    type: string
+    required: false
+    description: The text announced by assistive technology when user drags files and enters the drop zone. Default is `"Entered drop zone"`. If `javascript` is not provided, this option will be ignored.
+  - name: leftDropZoneText
+    type: string
+    require: false
+    description: The text announced by assistive technology when user drags files and leaves the drop zone without dropping. Default is `"Left drop zone"`. If `javascript` is not provided, this option will be ignored.
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -222,7 +222,7 @@ examples:
         text: Llwythwch ffeil i fyny
       multiple: true
       javascript: true
-      selectFilesButtonText: Dewiswch ffeil
+      chooseFilesButtonText: Dewiswch ffeil
       instructionText: neu ollwng ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
@@ -319,7 +319,7 @@ examples:
       label:
         text: Llwythwch ffeil i fyny
       multiple: true
-      selectFilesButtonText: Dewiswch ffeil
+      chooseFilesButtonText: Dewiswch ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
         other: "%{count} ffeil wedi'u dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -225,7 +225,7 @@ examples:
       chooseFilesButtonText: Dewiswch ffeil
       dropInstructionText: neu ollwng ffeil
       noFileChosenText: Dim ffeil wedi'i dewis
-      filesSelectedText:
+      multipleFilesChosenText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"
 
@@ -321,6 +321,6 @@ examples:
       multiple: true
       chooseFilesButtonText: Dewiswch ffeil
       noFileChosenText: Dim ffeiliau wedi'u dewis
-      filesSelectedText:
+      multipleFilesChosenText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -223,7 +223,7 @@ examples:
       multiple: true
       javascript: true
       chooseFilesButtonText: Dewiswch ffeil
-      instructionText: neu ollwng ffeil
+      dropInstructionText: neu ollwng ffeil
       filesSelectedDefaultText: Dim ffeiliau wedi'u dewis
       filesSelectedText:
         other: "%{count} ffeil wedi'u dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -54,8 +54,8 @@
       message: params.chooseFilesButtonText
     }) -}}
     {{- govukI18nAttributes({
-      key: 'files-selected-default',
-      message: params.filesSelectedDefaultText
+      key: 'no-file-chosen',
+      message: params.noFileChosenText
     }) -}}
     {{- govukI18nAttributes({
       key: 'files-selected',

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -58,8 +58,8 @@
       message: params.noFileChosenText
     }) -}}
     {{- govukI18nAttributes({
-      key: 'files-selected',
-      messages: params.filesSelectedText
+      key: 'multiple-files-chosen',
+      messages: params.multipleFilesChosenText
     }) -}}
     {{- govukI18nAttributes({
       key: 'drop-instruction',

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -69,6 +69,10 @@
       key: 'entered-drop-zone',
       message: params.enteredDropZoneText
     }) -}}
+    {{- govukI18nAttributes({
+      key: 'left-drop-zone',
+      message: params.leftDropZoneText
+    }) -}}
   >
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -50,8 +50,8 @@
     class="govuk-file-upload-wrapper"
     data-module="govuk-file-upload"
     {{- govukI18nAttributes({
-      key: 'select-files-button',
-      message: params.selectFilesButtonText
+      key: 'choose-files-button',
+      message: params.chooseFilesButtonText
     }) -}}
     {{- govukI18nAttributes({
       key: 'files-selected-default',

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -62,8 +62,8 @@
       messages: params.filesSelectedText
     }) -}}
     {{- govukI18nAttributes({
-      key: 'instruction',
-      message: params.instructionText
+      key: 'drop-instruction',
+      message: params.dropInstructionText
     }) -}}
   >
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -65,6 +65,10 @@
       key: 'drop-instruction',
       message: params.dropInstructionText
     }) -}}
+    {{- govukI18nAttributes({
+      key: 'entered-drop-zone',
+      message: params.enteredDropZoneText
+    }) -}}
   >
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -245,7 +245,7 @@ describe('File upload', () => {
 
       const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
-      expect($wrapper.attr('data-i18n.select-files-button')).toBe(
+      expect($wrapper.attr('data-i18n.choose-files-button')).toBe(
         'Dewiswch ffeil'
       )
       expect($wrapper.attr('data-i18n.files-selected-default')).toBe(

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -260,6 +260,9 @@ describe('File upload', () => {
       expect($wrapper.attr('data-i18n.multiple-files-chosen.other')).toBe(
         "%{count} ffeil wedi'u dewis"
       )
+      expect($wrapper.attr('data-i18n.entered-drop-zone')).toBe(
+        "Wedi mynd i mewn i'r parth gollwng"
+      )
     })
 
     it('prevents the rendering of translation messages when false', () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -254,10 +254,10 @@ describe('File upload', () => {
       expect($wrapper.attr('data-i18n.no-file-chosen')).toBe(
         "Dim ffeil wedi'i dewis"
       )
-      expect($wrapper.attr('data-i18n.files-selected.one')).toBe(
+      expect($wrapper.attr('data-i18n.multiple-files-chosen.one')).toBe(
         "%{count} ffeil wedi'i dewis"
       )
-      expect($wrapper.attr('data-i18n.files-selected.other')).toBe(
+      expect($wrapper.attr('data-i18n.multiple-files-chosen.other')).toBe(
         "%{count} ffeil wedi'u dewis"
       )
     })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -251,8 +251,8 @@ describe('File upload', () => {
       expect($wrapper.attr('data-i18n.drop-instruction')).toBe(
         'neu ollwng ffeil'
       )
-      expect($wrapper.attr('data-i18n.files-selected-default')).toBe(
-        "Dim ffeiliau wedi'u dewis"
+      expect($wrapper.attr('data-i18n.no-file-chosen')).toBe(
+        "Dim ffeil wedi'i dewis"
       )
       expect($wrapper.attr('data-i18n.files-selected.one')).toBe(
         "%{count} ffeil wedi'i dewis"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -263,6 +263,9 @@ describe('File upload', () => {
       expect($wrapper.attr('data-i18n.entered-drop-zone')).toBe(
         "Wedi mynd i mewn i'r parth gollwng"
       )
+      expect($wrapper.attr('data-i18n.left-drop-zone')).toBe(
+        "Parth gollwng i'r chwith"
+      )
     })
 
     it('prevents the rendering of translation messages when false', () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -248,6 +248,9 @@ describe('File upload', () => {
       expect($wrapper.attr('data-i18n.choose-files-button')).toBe(
         'Dewiswch ffeil'
       )
+      expect($wrapper.attr('data-i18n.drop-instruction')).toBe(
+        'neu ollwng ffeil'
+      )
       expect($wrapper.attr('data-i18n.files-selected-default')).toBe(
         "Dim ffeiliau wedi'u dewis"
       )


### PR DESCRIPTION
Pairing with @seaemsi , we updated the name and description of the macro options in the documentation so that:

- Consistently talk about 'choosing a file' to align with the button's default.
- Ensure order is consistent between description, default and condition for translation options.
- Ensure all translation options are suffixed by 'Text'

The changes were the reported on the code to ensure they matched the documentation.