### PR TITLE
Update announcement when dropping a file to be the status

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -289,13 +289,14 @@ describe('/components/file-upload', () => {
         })
 
         it('gets hidden when dropping on the field', async () => {
-          // Add a little pixel to make sure we're effectively within the element
+          // Puppeteer's Mouse.drop is meant to do both the `dragEnter` and
+          // `drop` in a row but it seems to do this too quickly for the
+          // `<input>` to effectively receive the drop
           await page.mouse.dragEnter(
             { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
             structuredClone(dragData)
           )
 
-          // Add a little pixel to make sure we're effectively within the element
           await page.mouse.drop(
             { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
             structuredClone(dragData)
@@ -306,7 +307,7 @@ describe('/components/file-upload', () => {
           // rather than being in the initial state
           await expect(
             $announcements.evaluate((e) => e.textContent)
-          ).resolves.toBe('Left drop zone')
+          ).resolves.toBe('file-upload.puppeteer.test.js')
         })
 
         it('gets hidden when dragging a file and leaving the field', async () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -288,7 +288,13 @@ describe('/components/file-upload', () => {
           ).resolves.toBe('Entered drop zone')
         })
 
-        xit('gets hidden when dropping on the field', async () => {
+        it('gets hidden when dropping on the field', async () => {
+          // Add a little pixel to make sure we're effectively within the element
+          await page.mouse.dragEnter(
+            { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
+            structuredClone(dragData)
+          )
+
           // Add a little pixel to make sure we're effectively within the element
           await page.mouse.drop(
             { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },


### PR DESCRIPTION
Fixes the test for the drop announcement, which seems to not give enough time between the `dragEnter` and `drop` events simulated by Puppeteer for the `<input>` to receive the drop.

Updates the handling of the user dropping on the component so it announces the status rather than 'Left drop zone'.

## Thoughts

Because the `drop` event happens before the `change` event updating the status, a little coordination is necessary.

I chose the more compact solution of adding a listener for the next `change` event so there's only one place to update. An alternative could have been the following, but it has many more moving parts (so chances for issues):
- set a `this.announce` boolean on drop
- then use it in `onChange` to 
	- decide whether to announce or not
	- an not forget to unset it (in a `try { } finally { }` block for safety)

The [`once` option of `addEventListener` is available on all browsers that support ES Module](https://caniuse.com/once-event-listener,es6-module), so it's fine to use here.

Fixes #5683
