### PR TITLE
Fix functionality of enhanced File Upload when no CSS

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -62,24 +62,6 @@
     cursor: not-allowed;
   }
 
-  .govuk-file-upload--enhanced {
-    position: absolute;
-    // Make the native control take up the entire space of the element, but
-    // invisible and behind the other elements until we need it
-    z-index: -1;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    opacity: 0;
-  }
-
-  .govuk-file-upload--dragging {
-    z-index: 1;
-  }
-
   .govuk-file-upload-button__pseudo-button {
     width: auto;
     margin-right: govuk-spacing(2);

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -61,6 +61,7 @@ export class FileUpload extends ConfigurableComponent {
     }
 
     this.$input = /** @type {HTMLFileInputElement} */ ($input)
+    this.$input.setAttribute('hidden', 'true')
 
     if (!this.$input.id.length) {
       throw new ElementError(
@@ -144,6 +145,10 @@ export class FileUpload extends ConfigurableComponent {
       `${$label.id} ${commaSpan.id} ${$button.id}`
     )
     $button.addEventListener('click', this.onClick.bind(this))
+    $button.addEventListener('dragover', (event) => {
+      // prevent default to allow drop
+      event.preventDefault()
+    })
 
     // Assemble these all together
     this.$root.insertAdjacentElement('afterbegin', $button)
@@ -179,6 +184,10 @@ export class FileUpload extends ConfigurableComponent {
     // event to be automatically fired from the element and saves us from having
     // to do anything more than hiding the dropzone on drop.
     this.$input.addEventListener('drop', this.onDrop.bind(this))
+
+    // if there is no CSS and input is hidden
+    // button will need to handle drop event
+    this.$button.addEventListener('drop', this.onDrop.bind(this))
 
     // While user is dragging, it gets a little more complex because of Safari.
     // Safari doesn't fill `relatedTarget` on `dragleave` (nor `dragenter`).
@@ -270,20 +279,23 @@ export class FileUpload extends ConfigurableComponent {
 
   /**
    * Handles user dropping on the component
+   *
+   * @param {DragEvent} event - The `dragenter` event
    */
-  onDrop() {
-    this.hideDraggingState()
+  onDrop(event) {
+    event.preventDefault()
 
-    // The change event updating the text will only happen after the `drop`
-    // Because this listener is registered after `onChange`, it'll run after
-    // the status is updated and can pick it up for announcement
-    this.$input.addEventListener(
-      'change',
-      () => {
-        this.$announcements.innerText = this.$status.innerText
-      },
-      { once: true }
-    )
+    if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
+      this.$input.files = event.dataTransfer.files
+
+      // Dispatch a `change` event so external code that would rely on the `<input>`
+      // dispatching an event when files are dropped still work.
+      // Use a `CustomEvent` so our events are distinguishable from browser's native events
+      this.$input.dispatchEvent(new CustomEvent('change'))
+
+      this.$announcements.innerText = this.$status.innerText
+      this.hideDraggingState()
+    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -155,8 +155,6 @@ export class FileUpload extends ConfigurableComponent {
 
     this.$input.setAttribute('tabindex', '-1')
     this.$input.setAttribute('aria-hidden', 'true')
-    this.$input.classList.remove('govuk-file-upload')
-    this.$input.classList.add('govuk-file-upload--enhanced')
 
     // Make all these new variables available to the module
     this.$button = $button
@@ -176,14 +174,6 @@ export class FileUpload extends ConfigurableComponent {
     this.$announcements.classList.add('govuk-visually-hidden')
     this.$announcements.setAttribute('aria-live', 'assertive')
     this.$root.insertAdjacentElement('afterend', this.$announcements)
-
-    // The easy bit, when dropping hide the dropzone
-    //
-    // Note: the component relies on the native behaviour to get the files
-    // being dragged set as value of the `<input>`. This allows a `change`
-    // event to be automatically fired from the element and saves us from having
-    // to do anything more than hiding the dropzone on drop.
-    this.$input.addEventListener('drop', this.onDrop.bind(this))
 
     // if there is no CSS and input is hidden
     // button will need to handle drop event
@@ -266,7 +256,6 @@ export class FileUpload extends ConfigurableComponent {
    */
   showDraggingState() {
     this.$button.classList.add('govuk-file-upload-button--dragging')
-    this.$input.classList.add('govuk-file-upload--dragging')
   }
 
   /**
@@ -274,7 +263,6 @@ export class FileUpload extends ConfigurableComponent {
    */
   hideDraggingState() {
     this.$button.classList.remove('govuk-file-upload-button--dragging')
-    this.$input.classList.remove('govuk-file-upload--dragging')
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -7,7 +7,6 @@ const {
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 const inputSelector = '.govuk-file-upload'
-const enhancedInputSelector = '.govuk-file-upload--enhanced'
 const wrapperSelector = '.govuk-drop-zone'
 const buttonSelector = '.govuk-file-upload-button'
 const statusSelector = '.govuk-file-upload-button__status'
@@ -67,7 +66,7 @@ describe('/components/file-upload', () => {
 
           it('moves the file input inside of the wrapper element', async () => {
             const inputElementParent = await page.$eval(
-              enhancedInputSelector,
+              inputSelector,
               (el) => el.parentNode
             )
             const wrapperElement = await page.$eval(wrapperSelector, (el) => el)
@@ -78,9 +77,8 @@ describe('/components/file-upload', () => {
 
         describe('file input', () => {
           it('sets tabindex to -1', async () => {
-            const inputElementTabindex = await page.$eval(
-              enhancedInputSelector,
-              (el) => el.getAttribute('tabindex')
+            const inputElementTabindex = await page.$eval(inputSelector, (el) =>
+              el.getAttribute('tabindex')
             )
 
             expect(inputElementTabindex).toBe('-1')
@@ -134,7 +132,7 @@ describe('/components/file-upload', () => {
             await fileChooser.accept([testFilename])
 
             const inputElementValue = await page.$eval(
-              enhancedInputSelector,
+              inputSelector,
               (el) =>
                 // @ts-ignore
                 el.value
@@ -162,14 +160,14 @@ describe('/components/file-upload', () => {
 
         it('updates the file input value', async () => {
           const inputElementValue = await page.$eval(
-            enhancedInputSelector,
+            inputSelector,
             (el) =>
               // @ts-ignore
               el.value
           )
 
           const inputElementFiles = await page.$eval(
-            enhancedInputSelector,
+            inputSelector,
             (el) =>
               // @ts-ignore
               el.files
@@ -211,14 +209,14 @@ describe('/components/file-upload', () => {
 
         it('updates the file input value', async () => {
           const inputElementValue = await page.$eval(
-            enhancedInputSelector,
+            inputSelector,
             (el) =>
               // @ts-ignore
               el.value
           )
 
           const inputElementFiles = await page.$eval(
-            enhancedInputSelector,
+            inputSelector,
             (el) =>
               // @ts-ignore
               el.files
@@ -472,7 +470,7 @@ describe('/components/file-upload', () => {
         it('disables the button if the input is disabled programatically', async () => {
           await render(page, 'file-upload', examples.enhanced)
 
-          await page.$eval(enhancedInputSelector, (el) =>
+          await page.$eval(inputSelector, (el) =>
             el.setAttribute('disabled', '')
           )
 
@@ -496,7 +494,7 @@ describe('/components/file-upload', () => {
             el.hasAttribute('disabled')
           )
 
-          await page.$eval(enhancedInputSelector, (el) =>
+          await page.$eval(inputSelector, (el) =>
             el.removeAttribute('disabled')
           )
 


### PR DESCRIPTION
## What

- `input` element hidden during File Upload enhancement initialisation
- `button` listens for drop event and updates status and input accordingly

## Why

Fixes #5688 