### PR TITLE
Fix prototype kit sass import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5628: Add focused error state to Character count](https://github.com/alphagov/govuk-frontend/pull/5628)
 
+- [#5717: Fix prototype kit sass import path](https://github.com/alphagov/govuk-frontend/pull/5717)
+
 ## v5.8.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@5.8.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk-prototype-kit/init.scss
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/init.scss
@@ -8,4 +8,4 @@ $govuk-assets-path: if(
 
 $govuk-global-styles: true !default;
 
-@import "../govuk/all";
+@import "../govuk/index";


### PR DESCRIPTION
Frontend has deprecated the `govuk/all` path in favour of `govuk/index` - this updates the prototype kit integration