### PR TITLE
File Upload `disabled` clean-up

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -179,6 +179,7 @@
 
   .govuk-file-upload-button--dragging {
     border-style: solid;
+    border-color: govuk-colour("black");
 
     // extra specificity to apply when
     // empty
@@ -190,17 +191,13 @@
       background-color: govuk-colour("light-grey");
     }
 
-    &:not(:disabled) {
-      border-color: govuk-colour("black");
-
-      .govuk-file-upload-button__pseudo-button {
-        background-color: govuk-shade(govuk-colour("light-grey"), 10%);
-      }
-    }
-
     &.govuk-file-upload-button--empty:not(:disabled) .govuk-file-upload-button__status,
     &.govuk-file-upload-button--empty .govuk-file-upload-button__pseudo-button {
       background-color: govuk-colour("white");
+    }
+
+    .govuk-file-upload-button__pseudo-button {
+      background-color: govuk-shade(govuk-colour("light-grey"), 10%);
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -178,6 +178,8 @@
   }
 
   .govuk-file-upload-button--dragging {
+    border-style: solid;
+
     // extra specificity to apply when
     // empty
     &.govuk-file-upload-button {
@@ -189,7 +191,7 @@
     }
 
     &:not(:disabled) {
-      border-color: govuk-shade(govuk-colour("mid-grey"), 20%);
+      border-color: govuk-colour("black");
 
       .govuk-file-upload-button__pseudo-button {
         background-color: govuk-shade(govuk-colour("light-grey"), 10%);

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -206,7 +206,7 @@ export class FileUpload extends ConfigurableComponent {
     })
 
     document.addEventListener('dragleave', () => {
-      if (!this.enteredAnotherElement) {
+      if (!this.enteredAnotherElement && !this.$button.disabled) {
         this.hideDraggingState()
         this.$announcements.innerText = this.i18n.t('leftDropZone')
       }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -221,6 +221,8 @@ export class FileUpload extends ConfigurableComponent {
    * @param {DragEvent} event - The `dragenter` event
    */
   updateDropzoneVisibility(event) {
+    if (this.$button.disabled) return
+
     // DOM interfaces only type `event.target` as `EventTarget`
     // so we first need to make sure it's a `Node`
     if (event.target instanceof Node) {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -364,7 +364,14 @@ describe('/components/file-upload', () => {
             structuredClone(dragData)
           )
 
+          const disabledAnnouncement = await page.$(
+            '.govuk-file-upload-announcements'
+          )
+
           await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
+          await expect(
+            disabledAnnouncement.evaluate((e) => e.textContent)
+          ).resolves.toBe('')
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -349,6 +349,23 @@ describe('/components/file-upload', () => {
             $announcements.evaluate((e) => e.textContent)
           ).resolves.toBe('Left drop zone')
         })
+
+        it('does not appear if button disabled', async () => {
+          await render(page, 'file-upload', examples.enhanced, {
+            beforeInitialisation() {
+              document
+                .querySelector('[type="file"]')
+                .setAttribute('disabled', '')
+            }
+          })
+
+          await page.mouse.dragEnter(
+            { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
+            structuredClone(dragData)
+          )
+
+          await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
+        })
       })
 
       describe('accessible name', () => {


### PR DESCRIPTION
## What

- Add back border to File Upload drop zone
- Don't add `--dragging` to the the File Upload button if it is disabled
- Don't announce `Left drop zone` if the File Upload button is disabled

## Why

Black border when drag zone active had disappeared, possibly from refactoring the CSS in prior commit.

Refactoring had resulted in the dropzone not behaving as expected when button was disabled.