### PR TITLE
Fix summary card actions appearance when there are lots of links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ This change was introduced in [pull request #5627: Deprecate legacy organisation
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5628: Add focused error state to Character count](https://github.com/alphagov/govuk-frontend/pull/5628)
-
 - [#5717: Fix prototype kit sass import path](https://github.com/alphagov/govuk-frontend/pull/5717)
+- [#5720: Fix summary card actions appearance when there are lots of links](https://github.com/alphagov/govuk-frontend/pull/5720)
 
 ## v5.8.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -96,18 +96,21 @@
     padding: 0; // Reset default user agent styles
   }
 
-  .govuk-summary-list__actions-list-item {
+  .govuk-summary-list__actions-list-item,
+  .govuk-summary-card__action {
     display: inline-block;
   }
 
   @include govuk-media-query($until: tablet) {
-    .govuk-summary-list__actions-list-item {
+    .govuk-summary-list__actions-list-item,
+    .govuk-summary-card__action {
       margin-right: govuk-spacing(2);
       padding-right: govuk-spacing(2);
       border-right: 1px solid $govuk-border-colour;
     }
 
-    .govuk-summary-list__actions-list-item:last-child {
+    .govuk-summary-list__actions-list-item:last-child,
+    .govuk-summary-card__action:last-child {
       margin-right: 0;
       padding-right: 0;
       border: 0;
@@ -115,16 +118,19 @@
   }
 
   @include govuk-media-query($from: tablet) {
-    .govuk-summary-list__actions-list-item {
+    .govuk-summary-list__actions-list-item,
+    .govuk-summary-card__action {
       margin-left: govuk-spacing(2);
       padding-left: govuk-spacing(2);
     }
 
-    .govuk-summary-list__actions-list-item:not(:first-child) {
+    .govuk-summary-list__actions-list-item:not(:first-child),
+    .govuk-summary-card__action:not(:first-child) {
       border-left: 1px solid $govuk-border-colour;
     }
 
-    .govuk-summary-list__actions-list-item:first-child {
+    .govuk-summary-list__actions-list-item:first-child,
+    .govuk-summary-card__action:first-child {
       margin-left: 0;
       padding-left: 0;
       border: 0;
@@ -220,13 +226,6 @@
 
   .govuk-summary-card__action {
     display: inline;
-    margin: 0 govuk-spacing(2) 0 0;
-    padding-right: govuk-spacing(2);
-    border-right: 1px solid $govuk-border-colour;
-
-    @include govuk-media-query($from: "tablet") {
-      margin-right: 0;
-    }
 
     // We use the following media query to target IE11 and 10 only to add margin
     // between actions.
@@ -243,14 +242,6 @@
   }
 
   .govuk-summary-card__action:last-child {
-    margin: 0;
-    padding-right: 0;
-    border-right: none;
-
-    @include govuk-media-query($from: "tablet") {
-      padding-left: govuk-spacing(2);
-    }
-
     // See above comment for why this is here
     @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
       margin-bottom: 0;

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -822,6 +822,77 @@ examples:
               - href: '#'
                 text: Change
                 visuallyHiddenText: date of birth
+  - name: as a summary card extreme
+    options:
+      card:
+        title:
+          text: Senior mid-level customer experience enhancement consultant
+        actions:
+          items:
+            - text: Bop it
+              href: '#'
+            - text: Twist it
+              href: '#'
+            - text: Pull it
+              href: '#'
+            - text: Flick it
+              href: '#'
+            - text: Spin it
+              href: '#'
+            - text: Shout it
+              href: '#'
+            - text: Shake it
+              href: '#'
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Barnaby Marmaduke Aloysius Benjy Cobweb Dartagnan Egbert Felix Gaspar Humbert Ignatius Jayden Kasper Leroy Maximilian Neddy Obiajulu Pepin Quilliam Rosencrantz Sexton Teddy Upwood Vivatma Wayland Xylon Yardley Zachary Usansky
+          actions:
+            items:
+              - href: '#'
+                text: Buy
+              - href: '#'
+                text: Use
+              - href: '#'
+                text: Break
+              - href: '#'
+                text: Fix
+              - href: '#'
+                text: Trash
+              - href: '#'
+                text: Change
+              - href: '#'
+                text: Mail
+              - href: '#'
+                text: Upgrade
+              - href: '#'
+                text: Charge
+              - href: '#'
+                text: Point
+              - href: '#'
+                text: Zoom
+              - href: '#'
+                text: Press
+              - href: '#'
+                text: Snap
+              - href: '#'
+                text: Work
+              - href: '#'
+                text: Quick
+              - href: '#'
+                text: Erase
+        - key:
+            text: Long website address
+          value:
+            html: |
+              <a class="govuk-link" href="https://cs.wikipedia.org/wiki/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch">https://cs.wikipedia.org/wiki/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch</a>
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: long website address
+
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes
     hidden: true


### PR DESCRIPTION
Fixes two minor cosmetic issues with the summary card actions list:
* Action links aren't spaced properly if there are three or more actions listed.
* The dividing line appears to the right of card-level links if the links have to wrap, whereas links elsewhere in the list place it to the left in that scenario.

Rather than exactly duplicate the conditional first/not-first logic of the summary list's action links, it seemed sensible and more performant to merge the styles for card- and list-level action links. 

## Changes
- Refactors summary list/card code so that action items use the same styles.
- Adds a review app example of a summary card with lots of actions.

## Screenshots
|Breakpoint|Before|After|
|:-|:-:|:-:|
|Mobile (no change)|![Screenshot of mobile summary card, with left-aligned action links separated by dividing lines.](https://github.com/user-attachments/assets/7c28f467-000b-4a94-9196-bec2dad9f714)|![Screenshot of mobile summary card, with left-aligned action links separated by dividing lines.](https://github.com/user-attachments/assets/7c28f467-000b-4a94-9196-bec2dad9f714)|
|Desktop|![Screenshot of a wider summary card, with right-aligned action links separated by dividing lines. All but two of the links have no spacing between them, with the text and dividing lines pressing up against one another.](https://github.com/user-attachments/assets/4e8214c1-a99e-4a3e-a6ab-20b3b9e30d4e)|![Screenshot of a wider summary card, with right-aligned action links separated by dividing lines. The spacing has now been fixed, with identical spacing between all action links.](https://github.com/user-attachments/assets/79835183-3fba-4337-ba6b-05a6e2cf9514)|

## Thoughts
- Is there a reason the styles for each action list started off separate? I'm not sure if there's some edge case that I'm missing.
- The summary card title and action links not having the same spacing seems visually squiffy, however this happens in the live component too, so is not a regression. 