### PR TITLE
Add "deprecated" field and deprecate header navigation

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -2,7 +2,8 @@ params:
   - name: element
     type: string
     required: false
-    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if `href` is provided. This parameter will be removed in the next major version.
+    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if `href` is provided.
+    deprecated: '5.1.0'
   - name: text
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -10,7 +10,8 @@ params:
   - name: value
     type: string
     required: false
-    description: Deprecated. Optional initial value of the input.
+    description: Optional initial value of the input.
+    deprecated: '5.7.1'
   - name: disabled
     type: boolean
     required: false

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -11,51 +11,63 @@ params:
     type: string
     required: false
     description: The name of your service, included in the header.
+    deprecated: '5.9.0'
   - name: serviceUrl
     type: string
     required: false
     description: URL for the service name anchor.
+    deprecated: '5.9.0'
   - name: navigation
     type: array
     required: false
     description: Can be used to add navigation to the header component.
+    deprecated: '5.9.0'
     params:
       - name: text
         type: string
         required: true
         description: Text for the navigation item. If `html` is provided, the `text` option will be ignored.
+        deprecated: '5.9.0'
       - name: html
         type: string
         required: true
         description: HTML for the navigation item. If `html` is provided, the `text` option will be ignored.
+        deprecated: '5.9.0'
       - name: href
         type: string
         required: false
         description: URL of the navigation item anchor.
+        deprecated: '5.9.0'
       - name: active
         type: boolean
         required: false
         description: Flag to mark the navigation item as active or not.
+        deprecated: '5.9.0'
       - name: attributes
         type: object
         required: false
         description: HTML attributes (for example data attributes) to add to the navigation item anchor.
+        deprecated: '5.9.0'
   - name: navigationClasses
     type: string
     required: false
     description: Classes for the navigation section of the header.
+    deprecated: '5.9.0'
   - name: navigationLabel
     type: string
     required: false
     description: Text for the `aria-label` attribute of the navigation. Defaults to the same value as `menuButtonText`.
+    deprecated: '5.9.0'
   - name: menuButtonLabel
     type: string
     required: false
     description: Text for the `aria-label` attribute of the button that opens the mobile navigation, if there is a mobile navigation menu.
+    deprecated: '5.9.0'
   - name: menuButtonText
     type: string
     required: false
     description: Text of the button that opens the mobile navigation menu, if there is a mobile navigation menu. There is no enforced character limit, but there is a limited display space so keep text as short as possible. By default, this is set to 'Menu'.
+    deprecated: '5.9.0'
   - name: containerClasses
     type: string
     required: false
@@ -71,7 +83,8 @@ params:
   - name: useTudorCrown
     type: boolean
     required: false
-    description: Deprecated. If `true`, uses the Tudor crown from King Charles III's royal cypher. Otherwise, uses the St. Edward's crown. Default is `true`.
+    description: If `true`, uses the Tudor crown from King Charles III's royal cypher. Otherwise, uses the St. Edward's crown. Default is `true`.
+    deprecated: '5.2.0'
 
 previewLayout: full-width
 accessibilityCriteria: |

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -289,7 +289,8 @@ describe('packages/govuk-frontend/dist/', () => {
         expect(options).toBeInstanceOf(Array)
 
         // Component options requirements
-        const optionTasks = options.map(async (option) =>
+        const optionTasks = options.map(async (option) => {
+          // Required fields
           expect(option).toEqual(
             expect.objectContaining({
               name: expect.stringMatching(/^[A-Z]+$/i),
@@ -300,7 +301,18 @@ describe('packages/govuk-frontend/dist/', () => {
               description: expect.any(String)
             })
           )
-        )
+
+          // Optional fields
+          if (option.deprecated) {
+            if (typeof option.deprecated !== 'boolean') {
+              expect(option.deprecated).toMatch(/^\d+\.\d+\.\d+$/)
+            }
+          }
+
+          if (option.isComponent) {
+            expect(option.isComponent).toEqual(expect.any(Boolean))
+          }
+        })
 
         // Check all component options
         return Promise.all(optionTasks)


### PR DESCRIPTION
Adds `deprecated` field to macro options YAML schema to flag options which have been deprecated. It takes either a `boolean` or a string matching a semver version (eg: `'1.0.1'`).

Updates macro options test to account for optional fields.