### PR TITLE
[SPIKE] Fix announcement after picking files when using JAWS

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -156,6 +156,15 @@ export class FileUpload extends ConfigurableComponent {
     this.$input.setAttribute('tabindex', '-1')
     this.$input.setAttribute('aria-hidden', 'true')
 
+    // Create a hidden empty span to take focus before opening the file picker
+    // (the focus moves to the file picker straight away anyways)
+    //
+    // This helps JAWS announce the accessible name of the button after it gets updated
+    // with the new file name consistently
+    this.$focusMagnet = document.createElement('span')
+    this.$focusMagnet.setAttribute('tabindex', '-1')
+    this.$root.appendChild(this.$focusMagnet)
+
     // Make all these new variables available to the module
     this.$button = $button
     this.$status = $status
@@ -340,6 +349,20 @@ export class FileUpload extends ConfigurableComponent {
    * When the button is clicked, emulate clicking the actual, hidden file input
    */
   onClick() {
+    // Move the focus out of the button before opening the picker
+    this.$focusMagnet.focus({ preventScroll: true })
+
+    // Once back in the document, set the focus on the button
+    // which lets JAWS announce the correct accessible name
+    // rather than the one before picking a file
+    document.addEventListener(
+      'focusin',
+      () => this.$button.focus({ preventScroll: true }),
+      {
+        once: true
+      }
+    )
+
     this.$input.click()
   }
 


### PR DESCRIPTION
After selecting a file, JAWS announces the accessible name of the button as it was before selecting. Sometimes this is the last announcement, which can make it confusing for users as the last thing they'll hear is the wrong state (potentially 'No file chosen' if it's the first time they use the component).

This PR adds an empty `<span>` to the component. Before the file picker opens, the focus is moved to that element (effectively with no accessible name). This doesn't have any adverse effect as the focus moves straight away to the file picker. 

Upon returning on the page, we explicitely set the focus to the button so users are in the correct position on the page.

This allows JAWS + Chrome to announce the correct state for the button 🥳  Tests in NVDA + Chrome and VoiceOver + Safari sounded OK as well.

## Thoughts

### Button's labelling

Testing other ways to label the `<button>` (using the button's content or `aria-label`) showed that this was not an issue with our use of `aria-labelledby` to set the accessible name.

### JAWS Announcement

JAWS is very eager to announce a ton of information when coming back to the page from the file picker:
1. [Title of the page] - Google Chrome Unavailable (not sure why Unavailable, possibly remnant from when the file picker is open?)
2. [Title of the page] - Google Chrome page
3. [Title of the page] main region
4. Upload a file, `<STATUS_BEFORE_PICKING>`, Chose file or drop file button, to activate press Enter
5. Upload a file, `<SELECTED_FILE_NAME>`, Chose file or drop file button

Sometimes 5 gets announced at the start of the list, making it very confusing to users as the last thing they'll hear is the status of the file picker before they clicked. Even when announced at the end of the list, the name of the button is announced twice in a row, with just a slight difference in the middle 😔 

### Alternative solutions considered

#### Moving the focus explicitly, immediately

First idea was to move the focus explicitly to the button, immediately when coming back into the document.

Updating `onClick` to:

```js
  onClick() {
    document.addEventListener('focusin',
      () => this.$button.focus(),
      {
        once:true
      }
    )

    this.$input.click()
  }
```

No change to the announcement unfortunately.

#### Moving the focus explicitly, delayed

Same as before, but with a 2 second delay

Updating `onClick` to:

```js
  onClick() {
     document.addEventListener('focusin',
      () => setTimeout(() => this.$button.focus(), 2000),
      {
        once:true
      }
    )

    this.$input.click()
  }
```

No change to the announcement either.

#### Announcement of the status, immediately

When the status changes, make an announcement of the new status. This can be easily added by setting `aria-live="polite"` to the status element.

This seems to reliably add an announcement of the file name after step 4. Meaning that if 5. happens as the first thing, the last thing people hear is the name of the selected file or 'N selected files'. There's still a double announcement of the button.

## Announcement of the status, debounced

Given the immediate announcement of the status already happens after JAWS re-announces the window, page, landmark you're in, I don't think it'll make a difference to delay the announcement to be debounced by a couple of seconds.