### PR TITLE
Prevent menu button being overlaid

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -204,18 +204,9 @@
 
   .govuk-header__menu-button {
     @include govuk-font($size: 16);
-    position: absolute;
-    // calculate top offset by:
-    // - getting the vertical spacing for the top and the bottom of the header
-    // - adding that to the crown height
-    // - dividing it by 2 so you have the vertical centre of the header
-    // - subtracting half the height of the menu button
-    top: (((govuk-spacing($govuk-header-vertical-spacing-value) * 2) + $govuk-header-crown-height) / 2) -
-      ($govuk-header-menu-button-height / 2);
-    right: 0;
     max-width: $govuk-header-menu-button-width;
     min-height: $govuk-header-menu-button-height;
-    margin: 0;
+    margin-bottom: govuk-spacing(1);
     padding: 0;
     border: 0;
     color: govuk-colour("white");
@@ -243,6 +234,19 @@
 
     &[aria-expanded="true"]::after {
       @include govuk-shape-arrow($direction: up, $base: 10px, $display: inline-block);
+    }
+
+    @include govuk-media-query($from: mobile) {
+      position: absolute;
+      // calculate top offset by:
+      // - getting the vertical spacing for the top and the bottom of the header
+      // - adding that to the crown height
+      // - dividing it by 2 so you have the vertical centre of the header
+      // - subtracting half the height of the menu button
+      top: (((govuk-spacing($govuk-header-vertical-spacing-value) * 2) + $govuk-header-crown-height) / 2) -
+        ($govuk-header-menu-button-height / 2);
+      right: 0;
+      margin: 0;
     }
 
     @include govuk-media-query($from: tablet) {


### PR DESCRIPTION
We `position:absolute` our nav menu button, which means at high (250%+) zoom levels, it can slide under the GOV.UK lock-up.

A quick fix here to only apply the positioning from the mobile breakpoint, meaning the button appears on the next line until then.

Resolves #5703 

### Menu button at mobile breakpoint
![Menu button at mobile breakpoint](https://github.com/user-attachments/assets/41bbe1f7-99e1-4ccf-9420-2957e70536c3)

### Menu button at 300% zoom (desktop)
![Menu button at 300% zoom (desktop)](https://github.com/user-attachments/assets/91ac8ee0-d84c-487d-9e13-d23d519bed87)

### Menu button at 250% zoom (mobile)
![Menu button at 250% zoom on mobile (Samsung Internet)](https://github.com/user-attachments/assets/623c68d3-6069-49e1-b6ec-2a8fb67a8dff)


### Menu button hover at 300% zoom
![Menu button hover at 300% zoom](https://github.com/user-attachments/assets/fcbe7419-b681-4263-9d45-f7d27f9343f0)

### Menu button selected at 300% zoom
![Menu button selected at 300% zoom](https://github.com/user-attachments/assets/617e991f-96f3-4ace-afbd-ac2eba28c2a7)

### Menu button focused, menu closed at 300% zoom
![Menu button focused, menu closed at 300% zoom](https://github.com/user-attachments/assets/a7cad5e1-da25-4bd9-85da-b4b37623cee9)

