### PR TITLE
Add status announcement after file change

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -106,6 +106,7 @@ export class FileUpload extends ConfigurableComponent {
     // Create status element that shows what/how many files are selected
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload-button__status'
+    $status.setAttribute('aria-live', 'polite')
     $status.innerText = this.i18n.t('noFileChosen')
 
     $button.appendChild($status)
@@ -283,7 +284,6 @@ export class FileUpload extends ConfigurableComponent {
       // Use a `CustomEvent` so our events are distinguishable from browser's native events
       this.$input.dispatchEvent(new CustomEvent('change'))
 
-      this.$announcements.innerText = this.$status.innerText
       this.hideDraggingState()
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -102,13 +102,15 @@ describe('/components/file-upload', () => {
               (el) => el.innerHTML.trim()
             )
 
-            const statusElementText = await page.$eval(
-              `${buttonSelector} ${statusSelector}`,
-              (el) => el.innerHTML.trim()
-            )
+            const [statusElementText, statusElementAriaLiveAttribute] =
+              await page.$eval(`${buttonSelector} ${statusSelector}`, (el) => [
+                el.innerHTML.trim(),
+                el.getAttribute('aria-live')
+              ])
 
             expect(buttonElementText).toBe('Choose file')
             expect(statusElementText).toBe('No file chosen')
+            expect(statusElementAriaLiveAttribute).toBe('polite')
           })
         })
       })
@@ -270,9 +272,17 @@ describe('/components/file-upload', () => {
 
         it('is not shown by default', async () => {
           await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
-          await expect(
-            $announcements.evaluate((e) => e.textContent)
-          ).resolves.toBe('')
+
+          const [announcementsText, announcementsAriaLive] =
+            await $announcements.evaluate((e) => [
+              e.textContent,
+              e.getAttribute('aria-live')
+            ])
+
+          expect(announcementsText).toBe('')
+          // As the announcement is feedback while user is dragging,
+          // best to announce it as soon as the user enters the zone
+          expect(announcementsAriaLive).toBe('assertive')
         })
 
         it('gets shown when entering the field', async () => {
@@ -303,11 +313,11 @@ describe('/components/file-upload', () => {
           )
 
           await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
-          // The presence of 'Left drop zone' confirms we handled the leaving of the drop zone
+          // The presence of 'Entered drop zone' confirms we entered the drop zone
           // rather than being in the initial state
           await expect(
             $announcements.evaluate((e) => e.textContent)
-          ).resolves.toBe('file-upload.puppeteer.test.js')
+          ).resolves.toBe('Entered drop zone')
         })
 
         it('gets hidden when dragging a file and leaving the field', async () => {


### PR DESCRIPTION
Adds an automatic announcement of the status after users pick a file.

This should reassure JAWS users that their selection has been taken into account, as JAWS announces the accessible name of the button before the file picker was open, sometimes without re-announcing afterwards the accessible name once a file is picked.

Testing confirmed it to be a better option than manipulating which element is focused (see #5726)