### PR TITLE
[SPIKE] Move focus and announce status on selection

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -106,6 +106,7 @@ export class FileUpload extends ConfigurableComponent {
     // Create status element that shows what/how many files are selected
     const $status = document.createElement('span')
     $status.className = 'govuk-body govuk-file-upload-button__status'
+    $status.setAttribute('aria-live', 'polite')
     $status.innerText = this.i18n.t('noFileChosen')
 
     $button.appendChild($status)
@@ -292,7 +293,6 @@ export class FileUpload extends ConfigurableComponent {
       // Use a `CustomEvent` so our events are distinguishable from browser's native events
       this.$input.dispatchEvent(new CustomEvent('change'))
 
-      this.$announcements.innerText = this.$status.innerText
       this.hideDraggingState()
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -156,6 +156,15 @@ export class FileUpload extends ConfigurableComponent {
     this.$input.setAttribute('tabindex', '-1')
     this.$input.setAttribute('aria-hidden', 'true')
 
+    // Create a hidden empty span to take focus before opening the file picker
+    // (the focus moves to the file picker straight away anyways)
+    //
+    // This helps JAWS announce the accessible name of the button after it gets updated
+    // with the new file name consistently
+    this.$focusMagnet = document.createElement('span')
+    this.$focusMagnet.setAttribute('tabindex', '-1')
+    this.$root.appendChild(this.$focusMagnet)
+
     // Make all these new variables available to the module
     this.$button = $button
     this.$status = $status
@@ -340,6 +349,20 @@ export class FileUpload extends ConfigurableComponent {
    * When the button is clicked, emulate clicking the actual, hidden file input
    */
   onClick() {
+    // Move the focus out of the button before opening the picker
+    this.$focusMagnet.focus({ preventScroll: true })
+
+    // Once back in the document, set the focus on the button
+    // which lets JAWS announce the correct accessible name
+    // rather than the one before picking a file
+    document.addEventListener(
+      'focusin',
+      () => this.$button.focus({ preventScroll: true }),
+      {
+        once: true
+      }
+    )
+
     this.$input.click()
   }
 


### PR DESCRIPTION
Combines #5729 and #5726 to cater for JAWS + Firefox still announcing the accessible name of the button before the file picker is open.