### PR TITLE
Tidy up last little issues with File Upload component

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -348,11 +348,14 @@
     },
     javascript: true,
     chooseFilesButtonText: "Dewiswch ffeil",
-    noFileChosenText: "Dim ffeiliau wedi'u dewis",
+    dropInstructionText: "neu ollwng ffeil",
+    noFileChosenText: "Dim ffeil wedi'i dewis",
     multipleFilesChosenText: {
-        other: "%{count} ffeil wedi'u dewis",
-        one: "%{count} ffeil wedi'i dewis"
-    }
+      other: "%{count} ffeil wedi'u dewis",
+      one: "%{count} ffeil wedi'i dewis"
+    },
+    enteredDropZoneText: "Wedi mynd i mewn i'r parth gollwng",
+    leftDropZoneText: "Parth gollwng i'r chwith"
   }) }}
 
   {{ govukFooter({

--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
@@ -39,5 +39,5 @@ describe('/components/file-upload', () => {
 })
 
 /**
- * @typedef {import('@govuk-frontend/lib/components').MacroOptions} MacroOptions
+ * @import {MacroOptions} from '@govuk-frontend/lib/components'
  */

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -43,19 +43,17 @@ export class FileUpload extends ConfigurableComponent {
     const $input = this.$root.querySelector('input')
 
     if ($input === null) {
-      throw new ElementError(
-        formatErrorMessage(
-          FileUpload,
-          'File upload wrapper must have `input` element of type `file`'
-        )
-      )
+      throw new ElementError({
+        component: FileUpload,
+        identifier: 'File inputs (`<input type="file">`)'
+      })
     }
 
     if ($input.type !== 'file') {
       throw new ElementError(
         formatErrorMessage(
           FileUpload,
-          'Form field must be an input of type `file`.'
+          'File input (`<input type="file">`) attribute (`type`) is not `file`'
         )
       )
     }
@@ -63,10 +61,11 @@ export class FileUpload extends ConfigurableComponent {
     this.$input = /** @type {HTMLFileInputElement} */ ($input)
     this.$input.setAttribute('hidden', 'true')
 
-    if (!this.$input.id.length) {
-      throw new ElementError(
-        formatErrorMessage(FileUpload, 'Form field must specify an `id`.')
-      )
+    if (!this.$input.id) {
+      throw new ElementError({
+        component: FileUpload,
+        identifier: 'File input (`<input type="file">`) attribute (`id`)'
+      })
     }
 
     this.id = this.$input.id
@@ -328,7 +327,7 @@ export class FileUpload extends ConfigurableComponent {
     if (!$label) {
       throw new ElementError({
         component: FileUpload,
-        identifier: 'No label'
+        identifier: `Field label (\`<label for=${this.$input.id}>\`)`
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -367,11 +367,10 @@ export class FileUpload extends ConfigurableComponent {
   updateDisabledState() {
     this.$button.disabled = this.$input.disabled
 
-    if (this.$button.disabled) {
-      this.$root.classList.add('govuk-drop-zone--disabled')
-    } else {
-      this.$root.classList.remove('govuk-drop-zone--disabled')
-    }
+    this.$root.classList.toggle(
+      'govuk-drop-zone--disabled',
+      this.$button.disabled
+    )
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -77,7 +77,6 @@ export class FileUpload extends ConfigurableComponent {
     })
 
     const $label = this.findLabel()
-    $label.setAttribute('for', `${this.id}-input`)
     // Add an ID to the label if it doesn't have one already
     // so it can be referenced by `aria-labelledby`
     if (!$label.id) {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -649,6 +649,38 @@ describe('/components/file-upload', () => {
         })
 
         describe('missing or misconfigured elements', () => {
+          it('throws if the input is missing', async () => {
+            await expect(
+              render(page, 'file-upload', examples.enhanced, {
+                beforeInitialisation() {
+                  document.querySelector('[type="file"]').remove()
+                }
+              })
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message:
+                  'govuk-file-upload: File inputs (`<input type="file">`) not found'
+              }
+            })
+          })
+
+          it('throws if the input has no `id` attribute', async () => {
+            await expect(
+              render(page, 'file-upload', examples.enhanced, {
+                beforeInitialisation() {
+                  document.querySelector('[type="file"]').removeAttribute('id')
+                }
+              })
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message:
+                  'govuk-file-upload: File input (`<input type="file">`) attribute (`id`) not found'
+              }
+            })
+          })
+
           it('throws if the input type is not "file"', async () => {
             await expect(
               render(page, 'file-upload', examples.enhanced, {
@@ -662,7 +694,7 @@ describe('/components/file-upload', () => {
               cause: {
                 name: 'ElementError',
                 message:
-                  'govuk-file-upload: Form field must be an input of type `file`.'
+                  'govuk-file-upload: File input (`<input type="file">`) attribute (`type`) is not `file`'
               }
             })
           })
@@ -677,7 +709,8 @@ describe('/components/file-upload', () => {
             ).rejects.toMatchObject({
               cause: {
                 name: 'ElementError',
-                message: 'govuk-file-upload: No label not found'
+                message:
+                  'govuk-file-upload: Field label (`<label for=file-upload-1>`) not found'
               }
             })
           })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -506,11 +506,15 @@ describe('/components/file-upload', () => {
           const buttonDisabled = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
           )
+          const dropZoneDisabled = await page.$eval(wrapperSelector, (el) =>
+            el.classList.contains('govuk-drop-zone--disabled')
+          )
 
           expect(buttonDisabled).toBeTruthy()
+          expect(dropZoneDisabled).toBeTruthy()
         })
 
-        it('disables the button if the input is disabled programatically', async () => {
+        it('disables the button if the input is disabled programmatically', async () => {
           await render(page, 'file-upload', examples.enhanced)
 
           await page.$eval(inputSelector, (el) =>
@@ -520,11 +524,15 @@ describe('/components/file-upload', () => {
           const buttonDisabledAfter = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
           )
+          const dropZoneDisabled = await page.$eval(wrapperSelector, (el) =>
+            el.classList.contains('govuk-drop-zone--disabled')
+          )
 
           expect(buttonDisabledAfter).toBeTruthy()
+          expect(dropZoneDisabled).toBeTruthy()
         })
 
-        it('enables the button if the input is enabled programatically', async () => {
+        it('enables the button if the input is enabled programmatically', async () => {
           await render(page, 'file-upload', examples.enhanced, {
             beforeInitialisation() {
               document
@@ -533,20 +541,19 @@ describe('/components/file-upload', () => {
             }
           })
 
-          const buttonDisabledBefore = await page.$eval(buttonSelector, (el) =>
-            el.hasAttribute('disabled')
-          )
-
           await page.$eval(inputSelector, (el) =>
             el.removeAttribute('disabled')
           )
 
-          const buttonDisabledAfter = await page.$eval(buttonSelector, (el) =>
+          const buttonDisabled = await page.$eval(buttonSelector, (el) =>
             el.hasAttribute('disabled')
           )
+          const dropZoneDisabled = await page.$eval(wrapperSelector, (el) =>
+            el.classList.contains('govuk-drop-zone--disabled')
+          )
 
-          expect(buttonDisabledBefore).toBeTruthy()
-          expect(buttonDisabledAfter).toBeFalsy()
+          expect(buttonDisabled).toBeFalsy()
+          expect(dropZoneDisabled).toBeFalsy()
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -85,6 +85,15 @@ describe('/components/file-upload', () => {
           })
         })
 
+        describe('label element', () => {
+          it('targets the button in its `for` attribute', async () => {
+            const buttonId = await page.$eval(buttonSelector, (el) => el.id)
+            const label = await page.$(`[for="${buttonId}"]`)
+
+            expect(label).not.toBeNull()
+          })
+        })
+
         describe('choose file button', () => {
           it('renders the button element', async () => {
             const buttonElement = await page.$eval(buttonSelector, (el) => el)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -322,7 +322,8 @@ examples:
         text: Llwythwch ffeil i fyny
       multiple: true
       chooseFilesButtonText: Dewiswch ffeil
-      noFileChosenText: Dim ffeiliau wedi'u dewis
+      dropInstructionText: neu ollwng ffeil
+      noFileChosenText: Dim ffeil wedi'i dewis
       multipleFilesChosenText:
         other: "%{count} ffeil wedi'u dewis"
         one: "%{count} ffeil wedi'i dewis"


### PR DESCRIPTION
Addresses the issues noted in [this review](https://github.com/alphagov/govuk-frontend/pull/5305#pullrequestreview-2641860188), one commit per issue (except for the error messages, bundled into a single commit) and adding tests when none were present.

As noted in the commit, updating the `<label>`'s `for` attribute to point to the `<button>` rather than the `<input>` does not change the accessible name of the  `<button>` as we use `aria-labelledby`. Announcements seemed OK in:
- NVDA + Chrome
- NVDA + Firefox
- JAWS + Chrome
- VoiceOver + Safari