### PR TITLE
[WIP] File upload refactorings

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -156,8 +156,7 @@ export class FileUpload extends ConfigurableComponent {
     this.$input.addEventListener('change', this.onChange.bind(this))
 
     // Synchronise the `disabled` state between the button and underlying input
-    this.updateDisabledState()
-    this.observeDisabledState()
+    this.synchroniseDisabledState()
 
     // Handle drop zone visibility
     // A live region to announce when users enter or leave the drop zone
@@ -175,6 +174,22 @@ export class FileUpload extends ConfigurableComponent {
       onEnter: this.onDropZoneEnter.bind(this),
       onLeave: this.onDropZoneLeave.bind(this)
     })
+  }
+
+  /**
+   * @returns {boolean} - Whether the component is disabled
+   */
+  get disabled() {
+    return this.$button.disabled
+  }
+
+  /**
+   * @private
+   * @param {boolean} value - Whether the component is disabled
+   */
+  set disabled(value) {
+    this.$button.disabled = value
+    this.$root.classList.toggle('govuk-drop-zone--disabled', value)
   }
 
   /**
@@ -197,7 +212,7 @@ export class FileUpload extends ConfigurableComponent {
    * @param {DragEvent} event - The `dragenter` event
    */
   onDropZoneEnter(event) {
-    if (this.$button.disabled) return
+    if (this.disabled) return
 
     if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
       // Only update the class and make the announcement if not already visible
@@ -213,7 +228,7 @@ export class FileUpload extends ConfigurableComponent {
    * Hides the dropzone if the user is already dragging
    */
   onDropZoneLeave() {
-    if (this.$button.disabled) return
+    if (this.disabled) return
 
     // Only hide the dropzone if it is visible to prevent announcing user
     // left the drop zone when they enter the page but haven't reached yet
@@ -303,14 +318,16 @@ export class FileUpload extends ConfigurableComponent {
   /**
    * Create a mutation observer to check if the input's attributes altered.
    */
-  observeDisabledState() {
+  synchroniseDisabledState() {
+    this.disabled = this.$input.disabled
+
     const observer = new MutationObserver((mutationList) => {
       for (const mutation of mutationList) {
         if (
           mutation.type === 'attributes' &&
           mutation.attributeName === 'disabled'
         ) {
-          this.updateDisabledState()
+          this.disabled = this.$input.disabled
         }
       }
     })
@@ -318,18 +335,6 @@ export class FileUpload extends ConfigurableComponent {
     observer.observe(this.$input, {
       attributes: true
     })
-  }
-
-  /**
-   * Synchronise the `disabled` state between the input and replacement button.
-   */
-  updateDisabledState() {
-    this.$button.disabled = this.$input.disabled
-
-    this.$root.classList.toggle(
-      'govuk-drop-zone--disabled',
-      this.$button.disabled
-    )
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -199,7 +199,7 @@ export class FileUpload extends ConfigurableComponent {
 
     document.addEventListener('dragleave', () => {
       if (!this.enteredAnotherElement && !this.$button.disabled) {
-        this.hideDraggingState()
+        this.dragging = false
         this.$announcements.innerText = this.i18n.t('leftDropZone')
       }
 
@@ -222,12 +222,8 @@ export class FileUpload extends ConfigurableComponent {
         if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
           // Only update the class and make the announcement if not already visible
           // to avoid repeated announcements on NVDA (2024.4) + Firefox (133)
-          if (
-            !this.$button.classList.contains(
-              'govuk-file-upload-button--dragging'
-            )
-          ) {
-            this.showDraggingState()
+          if (!this.dragging) {
+            this.dragging = true
             this.$announcements.innerText = this.i18n.t('enteredDropZone')
           }
         }
@@ -235,10 +231,8 @@ export class FileUpload extends ConfigurableComponent {
         // Only hide the dropzone if it is visible to prevent announcing user
         // left the drop zone when they enter the page but haven't reached yet
         // the file upload component
-        if (
-          this.$button.classList.contains('govuk-file-upload-button--dragging')
-        ) {
-          this.hideDraggingState()
+        if (this.dragging) {
+          this.dragging = false
           this.$announcements.innerText = this.i18n.t('leftDropZone')
         }
       }
@@ -246,17 +240,17 @@ export class FileUpload extends ConfigurableComponent {
   }
 
   /**
-   * Show the drop zone visually
+   * @returns {boolean} Whether the user is dragging
    */
-  showDraggingState() {
-    this.$button.classList.add('govuk-file-upload-button--dragging')
+  get dragging() {
+    return this.$button.classList.contains('govuk-file-upload-button--dragging')
   }
 
   /**
-   * Hides the drop zone visually
+   * @param {boolean} value - Whether the user is dragging
    */
-  hideDraggingState() {
-    this.$button.classList.remove('govuk-file-upload-button--dragging')
+  set dragging(value) {
+    this.$button.classList.toggle('govuk-file-upload-button--dragging', value)
   }
 
   /**
@@ -275,7 +269,7 @@ export class FileUpload extends ConfigurableComponent {
       // Use a `CustomEvent` so our events are distinguishable from browser's native events
       this.$input.dispatchEvent(new CustomEvent('change'))
 
-      this.hideDraggingState()
+      this.dragging = false
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -199,8 +199,7 @@ export class FileUpload extends ConfigurableComponent {
 
     document.addEventListener('dragleave', () => {
       if (!this.enteredAnotherElement && !this.$button.disabled) {
-        this.dragging = false
-        this.$announcements.innerText = this.i18n.t('leftDropZone')
+        this.onDropZoneLeave()
       }
 
       this.enteredAnotherElement = false
@@ -219,22 +218,9 @@ export class FileUpload extends ConfigurableComponent {
     // so we first need to make sure it's a `Node`
     if (event.target instanceof Node) {
       if (this.$root.contains(event.target)) {
-        if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
-          // Only update the class and make the announcement if not already visible
-          // to avoid repeated announcements on NVDA (2024.4) + Firefox (133)
-          if (!this.dragging) {
-            this.dragging = true
-            this.$announcements.innerText = this.i18n.t('enteredDropZone')
-          }
-        }
+        this.onDropZoneEnter(event)
       } else {
-        // Only hide the dropzone if it is visible to prevent announcing user
-        // left the drop zone when they enter the page but haven't reached yet
-        // the file upload component
-        if (this.dragging) {
-          this.dragging = false
-          this.$announcements.innerText = this.i18n.t('leftDropZone')
-        }
+        this.onDropZoneLeave()
       }
     }
   }
@@ -251,6 +237,35 @@ export class FileUpload extends ConfigurableComponent {
    */
   set dragging(value) {
     this.$button.classList.toggle('govuk-file-upload-button--dragging', value)
+  }
+
+  /**
+   * Shows the dropzone if user is not already dragging
+   *
+   * @param {DragEvent} event - The `dragenter` event
+   */
+  onDropZoneEnter(event) {
+    if (event.dataTransfer && isContainingFiles(event.dataTransfer)) {
+      // Only update the class and make the announcement if not already visible
+      // to avoid repeated announcements on NVDA (2024.4) + Firefox (133)
+      if (!this.dragging) {
+        this.dragging = true
+        this.$announcements.innerText = this.i18n.t('enteredDropZone')
+      }
+    }
+  }
+
+  /**
+   * Hides the dropzone if the user is already dragging
+   */
+  onDropZoneLeave() {
+    // Only hide the dropzone if it is visible to prevent announcing user
+    // left the drop zone when they enter the page but haven't reached yet
+    // the file upload component
+    if (this.dragging) {
+      this.dragging = false
+      this.$announcements.innerText = this.i18n.t('leftDropZone')
+    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -148,9 +148,6 @@ export class FileUpload extends ConfigurableComponent {
     // Assemble these all together
     this.$root.insertAdjacentElement('afterbegin', $button)
 
-    this.$input.setAttribute('tabindex', '-1')
-    this.$input.setAttribute('aria-hidden', 'true')
-
     // Make all these new variables available to the module
     this.$button = $button
     this.$status = $status

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -30,9 +30,6 @@ export class FileUpload extends ConfigurableComponent {
   /** @private */
   i18n
 
-  /** @private */
-  id
-
   /**
    * @param {Element | null} $root - File input element
    * @param {FileUploadConfig} [config] - File Upload config
@@ -61,37 +58,36 @@ export class FileUpload extends ConfigurableComponent {
     this.$input = /** @type {HTMLFileInputElement} */ ($input)
     this.$input.setAttribute('hidden', 'true')
 
-    if (!this.$input.id) {
+    const fieldId = this.$input.id
+    if (!fieldId) {
       throw new ElementError({
         component: FileUpload,
         identifier: 'File input (`<input type="file">`) attribute (`id`)'
       })
     }
 
-    this.id = this.$input.id
-
     this.i18n = new I18n(this.config.i18n, {
       // Read the fallback if necessary rather than have it set in the defaults
       locale: closestAttributeValue(this.$root, 'lang')
     })
 
-    const $label = this.findLabel()
+    const $label = this.findLabel(fieldId)
     // Add an ID to the label if it doesn't have one already
     // so it can be referenced by `aria-labelledby`
     if (!$label.id) {
-      $label.id = `${this.id}-label`
+      $label.id = `${fieldId}-label`
     }
 
     // we need to copy the 'id' of the root element
     // to the new button replacement element
     // so that focus will work in the error summary
-    this.$input.id = `${this.id}-input`
+    this.$input.id = `${fieldId}-input`
 
     // Create the file selection button
     const $button = document.createElement('button')
     $button.classList.add('govuk-file-upload-button')
     $button.type = 'button'
-    $button.id = this.id
+    $button.id = fieldId
     $button.classList.add('govuk-file-upload-button--empty')
 
     // Copy `aria-describedby` if present so hints and errors
@@ -112,7 +108,7 @@ export class FileUpload extends ConfigurableComponent {
     const commaSpan = document.createElement('span')
     commaSpan.className = 'govuk-visually-hidden'
     commaSpan.innerText = ', '
-    commaSpan.id = `${this.id}-comma`
+    commaSpan.id = `${fieldId}-comma`
 
     $button.appendChild(commaSpan)
 
@@ -317,17 +313,18 @@ export class FileUpload extends ConfigurableComponent {
    * Looks up the `<label>` element associated to the field
    *
    * @private
+   * @param {string} fieldId - The `id` of the field
    * @returns {HTMLElement} The `<label>` element associated to the field
    * @throws {ElementError} If the `<label>` cannot be found
    */
-  findLabel() {
+  findLabel(fieldId) {
     // Use `label` in the selector so TypeScript knows the type fo `HTMLElement`
-    const $label = document.querySelector(`label[for="${this.$input.id}"]`)
+    const $label = document.querySelector(`label[for="${fieldId}"]`)
 
     if (!$label) {
       throw new ElementError({
         component: FileUpload,
-        identifier: `Field label (\`<label for=${this.$input.id}>\`)`
+        identifier: `Field label (\`<label for=${fieldId}>\`)`
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -76,12 +76,12 @@ describe('/components/file-upload', () => {
         })
 
         describe('file input', () => {
-          it('sets tabindex to -1', async () => {
-            const inputElementTabindex = await page.$eval(inputSelector, (el) =>
-              el.getAttribute('tabindex')
+          it('becomes hidden in HTML', async () => {
+            const inputHiddenAttribute = await page.$eval(inputSelector, (el) =>
+              el.hasAttribute('hidden')
             )
 
-            expect(inputElementTabindex).toBe('-1')
+            expect(inputHiddenAttribute).toBe(true)
           })
         })
 


### PR DESCRIPTION
> [!NOTE]
> This can be merged after 5.9.0 ships as it's all internal, non-breaking changes

Moving code around without changing functionality of the component to improve the code structure.

Each commit focuses on one change and has a little explanation.

Last thing that'd be neat to update is the creation of the button. Wondering if it can be encapsulated in a function that takes all the 'variable' parts of the button, generates the HTML of the button using a string rather than `createElement` calls. That HTML could then be injected via `insertAdjacentHTML` and the `$button` and `$status` grabbed from the DOM. This would likely make it easier to understand the markup of the button at a glance, as well as reduce the code of the `FileUpload` class constructor a little bit.