### PR TITLE
[EXPERIMENT] Update hover and active states of service nav

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -1,5 +1,5 @@
 @include govuk-exports("govuk/component/service-navigation") {
-  $govuk-service-navigation-active-link-border-width: 1px;
+  $govuk-service-navigation-active-link-border-width: 3px;
   $govuk-service-navigation-link-hover-border-width: govuk-spacing(1);
   $govuk-service-navigation-background: $govuk-canvas-background-colour;
   $govuk-service-navigation-border-colour: $govuk-border-colour;
@@ -80,6 +80,10 @@
         width: 100%;
         height: 0;
         background-color: $govuk-link-colour;
+
+        // Although this pseudo-element is attached to the link, we don't want
+        // it to be clickable like the link as the element is visually separate.
+        pointer-events: none;
       }
 
       &:hover {
@@ -87,6 +91,7 @@
 
         &::after {
           height: 5px;
+          background-color: $govuk-link-hover-colour;
         }
       }
 
@@ -107,7 +112,7 @@
       @include govuk-typography-weight-bold;
 
       &::after {
-        height: 1px;
+        height: $govuk-service-navigation-active-link-border-width;
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -1,5 +1,6 @@
 @include govuk-exports("govuk/component/service-navigation") {
-  $govuk-service-navigation-active-link-border-width: govuk-spacing(1);
+  $govuk-service-navigation-active-link-border-width: 1px;
+  $govuk-service-navigation-link-hover-border-width: govuk-spacing(1);
   $govuk-service-navigation-background: $govuk-canvas-background-colour;
   $govuk-service-navigation-border-colour: $govuk-border-colour;
 
@@ -34,7 +35,6 @@
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
       margin-bottom: 0;
-      padding: govuk-spacing(4) 0;
 
       &:not(:last-child) {
         @include govuk-responsive-margin(6, $direction: right);
@@ -50,11 +50,6 @@
       padding-left: govuk-spacing(2);
       border-left-width: $govuk-service-navigation-active-link-border-width;
     }
-
-    @include govuk-media-query($from: tablet) {
-      padding-bottom: govuk-spacing(4) - $govuk-service-navigation-active-link-border-width;
-      border-bottom-width: $govuk-service-navigation-active-link-border-width;
-    }
   }
 
   .govuk-service-navigation__link {
@@ -66,6 +61,54 @@
       // We set the colour here as we don't want to override the hover or
       // focus colours
       color: $govuk-service-navigation-link-colour;
+    }
+
+    @include govuk-media-query($from: tablet) {
+      display: block;
+      position: relative;
+      margin: govuk-spacing(4) 0;
+    }
+  }
+
+  .govuk-service-navigation__item .govuk-service-navigation__link {
+    @include govuk-media-query($from: tablet) {
+      &::after {
+        content: "";
+        display: block;
+        position: absolute;
+        bottom: govuk-spacing(-4);
+        width: 100%;
+        height: 0;
+        background-color: $govuk-link-colour;
+      }
+
+      &:hover {
+        text-decoration: none;
+
+        &::after {
+          height: 5px;
+        }
+      }
+
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        &::after {
+          background-color: LinkText;
+        }
+
+        &:hover {
+          @include govuk-link-common;
+        }
+      }
+    }
+  }
+
+  .govuk-service-navigation__item--active .govuk-service-navigation__link {
+    @include govuk-media-query($from: tablet) {
+      @include govuk-typography-weight-bold;
+
+      &::after {
+        height: 1px;
+      }
     }
   }
 


### PR DESCRIPTION
## Change
A rough proof to test out a possible solution for https://github.com/alphagov/govuk-design-system/issues/4510

Specific changes, localised to large screens only:

- Remove the standard link underline on hover
- Make the 'active' link bold with a thin bottom 'border'
- The link hover state adds the 5px bottom border that the active link was using
- In forced colours mode, rest the standard link styles

## Notes
The service name is still bold, which was a reason that bold couldn't be used for hover states previously as multiple bold elements could be confused in forced colours mode. That's a separate problem to solve once we've better validated a potential solution to the states issue.

I've deviated from the initial design noted in [this comment on the linked issue](https://github.com/alphagov/govuk-design-system/issues/4510#issuecomment-2688682150) by way of the focus states. In this issue, the focus states follow our typical 'shrink wrapped' style for links rather than the 'button' style. This is why the border on active and hove aren't literal CSS borders but pseudo elements. I've done this to keep in line with how our focus states for focusable free-floating text like links or accrdion headings normally behave. I'm not especially wedded to this idea, just something I forgot to note earlier.

I'm also wondering how necessary the underline on forced colours mode is given that the bottom border hover state is also visible in forced colours mode.