### PR TITLE
Add explanations on how to fix `package.json` for `puppeteer-core`

### DIFF
--- a/package-lock.json.unit.test.mjs
+++ b/package-lock.json.unit.test.mjs
@@ -9,11 +9,12 @@ describe('package-lock.json', () => {
 
   describe('Dependabot updates', () => {
     /**
-     * When this check fails, the incorrect `package-lock.json` can be repaired
-     * by checking out the Dependabot branch and running `npm install` to remove
-     * the hoisted dependency
+     * When this check fails, the incorrect `package-lock.json` can be repaired by:
      *
-     * {@link https://team-playbook.design-system.service.gov.uk/how-we-work/version-control/pull-requests#reviewing-a-pr-from-dependabot}
+     * 1. checking out the Dependabot branch
+     * 2. running `npm install` to remove the hoisted dependency
+     *
+     * {@link https://team-playbook.design-system.service.gov.uk/guides/version-control/pull-requests/#reviewing-a-pr-from-dependabot}
      */
     it("should not hoist 'optionalDependencies' to 'dependencies'", () => {
       const { dependencies, optionalDependencies } = packages['']
@@ -55,7 +56,19 @@ describe('package-lock.json', () => {
       })
     })
 
-    it("should maintain `puppeteer` workspace 'devDependencies' compatibility", () => {
+    /**
+     * When this check fails, the incorrect `package-lock.json` can be repaired by:
+     *
+     * 1. checking out the Dependabot branch
+     * 2. updating the version of `puppeteer-core` in the `peerDependencies` of
+     *    `shared/helpers/package.json` so it is compatible with that of
+     *    `puppeteer` in the other workspaces (usually the version that
+     *    Dependabot will have bumped `puppeteer` to)
+     * 3. running `npm install` to install the correct version of `puppeteer-core`
+     *
+     * {@link https://team-playbook.design-system.service.gov.uk/guides/version-control/pull-requests/#reviewing-a-pr-from-dependabot}
+     */
+    it('should have compatible versions of `puppeteer-core` and `puppeteer` across workspaces', () => {
       const helpers = packages['shared/helpers']
 
       for (const name of /** @type {const} */ ([


### PR DESCRIPTION
Following on https://github.com/alphagov/govuk-frontend/pull/5750, figuring out what to update when the test fails was a little tricky, so I've added a comment and updated the test title to hopefully clarify.