### PR TITLE
Deprecate `$govuk-canvas-background-colour`, use `$govuk-template-background-colour` instead 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5785: Add missing Sass imports of components depended on](https://github.com/alphagov/govuk-frontend/pull/5785) - thanks to @matthew-shaw for reporting this issue and proposing a fix
 
+### Deprecated features
+
+#### Deprecation of `$govuk-canvas-background-colour`
+
+The responsibilities of the `$govuk-canvas-background-colour` were unclear due to its naming and use by components outside of its description.
+
+We're replacing it with a `$govuk-template-background-colour` variable, with a more appropriate name and better defined role to control only the background colour of the `<html>` element and background colour of elements that need to match for visual continuity, such as in the Footer and Cookie banner components.
+
+If you were using `$govuk-canvas-background-colour` to match the background colour of the `<html>` element then use `$govuk-template-background-colour` instead.
+
+If you were using `$govuk-canvas-background-colour` to set the background colour in your custom styling to `light-grey` then use `govuk-colour('light-grey')` instead.
+
 ## v5.9.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@5.9.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -1,5 +1,5 @@
 @include govuk-exports("govuk/component/footer") {
-  $govuk-footer-background: $govuk-canvas-background-colour;
+  $govuk-footer-background: $govuk-template-background-colour;
   $govuk-footer-border: $govuk-border-colour;
   $govuk-footer-text: $govuk-text-colour;
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -1,6 +1,6 @@
 @include govuk-exports("govuk/component/service-navigation") {
   $govuk-service-navigation-active-link-border-width: govuk-spacing(1);
-  $govuk-service-navigation-background: $govuk-canvas-background-colour;
+  $govuk-service-navigation-background: govuk-colour("light-grey");
   $govuk-service-navigation-border-colour: $govuk-border-colour;
 
   // We make the link colour a little darker than normal here so that it has

--- a/packages/govuk-frontend/src/govuk/objects/_template.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.scss
@@ -5,7 +5,7 @@
   .govuk-template {
     // Set the overall page background colour to the same colour as used by the
     // footer to give the illusion of a long footer.
-    background-color: $govuk-canvas-background-colour;
+    background-color: $govuk-template-background-colour;
 
     // Prevent automatic text sizing, as we already cater for small devices and
     // would like the browser to stay on 100% text zoom by default.

--- a/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
@@ -29,8 +29,30 @@ $govuk-text-colour: govuk-colour("black") !default;
 ///
 /// @type Colour
 /// @access public
-
+/// @deprecated "$govuk-canvas-background-colour has been deprecated and will be removed in the next major
+/// version. Use `$govuk-template-background-colour` if you want to change the background of
+/// the `<html>` element and background colour of elements that need to match for visual
+/// continuity.
 $govuk-canvas-background-colour: govuk-colour("light-grey") !default;
+
+// Output a deprecation warning if $govuk-canvas-background-colour is being overridden
+// Remove in next major version.
+@if $govuk-canvas-background-colour != govuk-colour("light-grey") {
+  @include _warning(
+    "$govuk-canvas-background-colour",
+    "$govuk-canvas-background-colour has been deprecated and will be removed in the next major version."
+  );
+}
+
+/// Template background colour
+///
+/// Used by components that want to give the illusion of extending
+/// the template background (such as the footer and cookie banner).
+///
+/// @type Colour
+/// @access public
+
+$govuk-template-background-colour: govuk-colour("light-grey") !default;
 
 /// Body background colour
 ///


### PR DESCRIPTION
## What

- Replace `$govuk-canvas-background-colour` with `govuk-colour("light-grey")` 
- Rename `$govuk-canvas-background-colour` to `$govuk-template-background-colour`
- Deprecate `$govuk-canvas-background-colour`

Fixes https://github.com/alphagov/govuk-frontend/issues/5789

## Why

The Service Navigation component uses `$govuk-canvas-background-colour` variable to set background-colour. This wasn't what the variable was intended for [as specified by the Sass API reference](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-canvas-background-colour).

The variable has been renamed to `$govuk-template-background-colour`, to make it clearer that the variable is intended to be used to extend the background colour of the template.

As a result of the changes in this PR, `Service Navigation` has been updated to use `govuk-colour("light-grey")`.
