### PR TITLE
Add redesigned header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,45 @@ These changes were made in the following pull requests:
 
 - [#5798: Add mixin to help rebrand specific properties](https://github.com/alphagov/govuk-frontend/pull/5798)
 - [#5793: Add GOV.UK logo macro](https://github.com/alphagov/govuk-frontend/pull/5793)
+- [#5794: Add redesigned header component](https://github.com/alphagov/govuk-frontend/pull/5794)
+
+#### Update to the new GOV.UK logo
+
+The GOV.UK logo has been updated to introduce a refreshed logotype design. This can be enabled using the feature flag described in the previous section.
+
+If you're not using the GOV.UK template, but are using the [GOV.UK header](https://design-system.service.gov.uk/components/header/) Nunjucks macro, you can enable this new logo by passing the `rebrand: true` in the component configuration.
+
+```nunjucks
+{{ govukHeader({
+  rebrand: true
+}) }}
+```
+
+If you're not using our Nunjucks macros, update your logo HTML to use the new SVG code.
+
+```html
+<svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 163 30" height="30" width="163" class="govuk-header__logotype" aria-label="GOV.UK">
+  <title>GOV.UK</title>
+  <g>
+    <circle cx="10.1" cy="8.8" r="1.8"></circle>
+    <circle cx="5.2" cy="11.7" r="1.8"></circle>
+    <circle cx="1.9" cy="16.6" r="1.8"></circle>
+    <circle cx="16" cy="15.3" r="1.8"></circle>
+    <circle cx="21.9" cy="8.8" r="1.8"></circle>
+    <circle cx="26.8" cy="11.7" r="1.8"></circle>
+    <circle cx="30.1" cy="16.6" r="1.8"></circle>
+    <circle cx="16" cy="15.3" r="1.8"></circle>
+    <path d="m16.7 4.9.2-.2 2.3 1.2V2.5l-2.3.7s-.1-.2-.2-.2l.9-2.9h-3.4l.9 2.9s-.2.1-.2.2l-2.3-.7v3.4l2.3-1.2.2.2-1.3 4c-.5 1.4.6 2.9 2.1 2.9s2.5-1.4 2.1-2.9l-1.3-4Zm2 14s-1.7 1.9-2.1 3c1.1 0 2.1-.3 3.2-1.4l-.4 4.3c-1-1.4-2.2-2-2.9-1.9 0 1.5.2 3.4 2.9 3.6 1.9.2 3.4-.8 3.5-1.9.2-1.3-1-2.2-1.9-.8-.7-2.3 1.2-3 2.5-1.6-1-2.2-.9-3.8 1.2-5.4 1.5 2 1.3 3.7-.6 5.5 1.2-.7 3.1 0 2 2.3-.6-1.4-1.8-1.1-2.1.1-.2.9.3 1.9 1.5 2.1.9.2 2.4-.5 3.5-2.9-.6 0-1.2.3-2 .8l1.2-4c.3 1.1.7 1.9 1.1 2.3.3-.8.2-1.4 0-2.7l2.5.9c-1.3 1.8-2.6 4.3-3.7 8.8-3.7-.5-7.9-.8-12.3-.8s-8.6.3-12.3.8c-1.1-4.4-2.3-7-3.7-8.8l2.5-.9c-.2 1.3-.3 1.9 0 2.7.4-.4.8-1.1 1.1-2.3l1.2 4c-.7-.5-1.3-.8-2-.8 1.2 2.5 2.6 3.1 3.5 2.9 1.1-.2 1.7-1.2 1.5-2.1-.3-1.2-1.5-1.5-2.1-.1-1.1-2.3.8-3 2-2.3-1.9-1.9-2.1-3.5-.6-5.5C9 18.4 9 20 8.1 22.2c1.2-1.4 3.2-.7 2.5 1.6-.9-1.4-2.1-.5-1.9.8.2 1.1 1.7 2.1 3.5 1.9 2.7-.2 2.9-2.1 2.9-3.6-.7-.1-1.9.5-2.9 1.9l-.4-4.3c1.1 1.1 2.1 1.4 3.2 1.4-.4-1.2-2.1-3-2.1-3h5.3Z"></path>
+  </g>
+  <circle class="govuk-logo-dot" cx="113.6" cy="18" r="3.7"></circle>
+  <path d="M47.4,18.1c0,.9.1,1.8.3,2.7s.6,1.6,1.1,2.3c.5.7,1.1,1.2,1.8,1.6.7.4,1.6.6,2.6.6s1.8-.2,2.4-.5c.7-.3,1.2-.7,1.6-1.2.4-.5.7-1,.8-1.5s.2-1,.2-1.5v-.2h-5.5v-3.3s9.8,0,9.8,0v12h-3.8v-2.7c-.3.4-.6.8-1,1.2-.4.4-.9.6-1.4.9-.5.2-1.1.4-1.7.6s-1.2.2-1.9.2c-1.6,0-3-.3-4.2-.9-1.2-.6-2.3-1.4-3.1-2.4s-1.5-2.2-1.9-3.5-.7-2.8-.7-4.4.2-3,.7-4.4c.5-1.4,1.2-2.5,2.1-3.5s2-1.8,3.3-2.4,2.7-.9,4.3-.9,2,.1,2.9.4c.9.2,1.8.6,2.5,1,.8.4,1.4,1,2,1.6.6.6,1.1,1.3,1.4,2.1l-3.8,2.2c-.2-.5-.5-.9-.8-1.3-.3-.4-.7-.7-1.1-1-.4-.3-.9-.5-1.4-.7s-1.1-.2-1.8-.2c-1,0-1.9.2-2.6.6-.7.4-1.3.9-1.8,1.6s-.8,1.4-1.1,2.3c-.2.9-.3,1.8-.3,2.7h0c0,.1,0,.1,0,.1ZM76.5,6.9c1.6,0,3.1.3,4.3.9s2.4,1.4,3.3,2.4,1.6,2.2,2,3.5.7,2.8.7,4.4-.2,3-.7,4.4c-.5,1.4-1.2,2.5-2,3.5s-2,1.8-3.3,2.4-2.7.9-4.3.9-3.1-.3-4.3-.9-2.4-1.4-3.2-2.4-1.6-2.2-2-3.5-.7-2.8-.7-4.4.2-3,.7-4.4,1.2-2.5,2-3.5,2-1.8,3.2-2.4,2.7-.9,4.3-.9ZM76.5,25.2c.9,0,1.8-.2,2.5-.5s1.3-.9,1.8-1.5.9-1.4,1.1-2.2c.2-.9.4-1.8.4-2.8h0c0-1.1-.1-2.1-.4-3s-.6-1.6-1.1-2.3c-.5-.6-1.1-1.1-1.8-1.5s-1.6-.5-2.5-.5-1.8.2-2.5.5c-.7.4-1.3.9-1.8,1.5s-.9,1.4-1.1,2.3-.4,1.8-.4,2.8h0c0,1.2.1,2.1.4,3,.2.9.6,1.6,1.1,2.2.5.6,1.1,1.1,1.8,1.5.7.4,1.6.5,2.5.5ZM94.6,29l-6.1-22h4.9l4.2,16.5h.2l4.1-16.5h4.9l-6.1,22h-6ZM131.5,25.2c.6,0,1.2,0,1.8-.3s1-.5,1.4-.9c.4-.4.7-.9.9-1.4.2-.6.4-1.3.4-2V7h4.3v14.2c0,1.2-.2,2.3-.7,3.3-.4,1-1.1,1.8-1.8,2.5s-1.7,1.2-2.8,1.6c-1.1.4-2.3.6-3.5.6s-2.5-.2-3.5-.6c-1.1-.4-2-.9-2.8-1.6s-1.4-1.5-1.8-2.5c-.4-1-.7-2.1-.7-3.3V7s4.3,0,4.3,0v13.6c0,.8.1,1.5.4,2,.2.6.6,1.1,1,1.4.4.4.9.7,1.4.9s1.1.3,1.8.3h0ZM144.2,7h4.4v9.6s7.8-9.6,7.8-9.6h5.4l-7.5,8.8,8,13.2h-5.1l-5.7-9.9-2.8,3.1v6.7s-4.4,0-4.4,0V7Z"></path>
+</svg>
+```
+
+These changes were made in the following pull requests:
+
+- [#5793: Add GOV.UK logo macro](https://github.com/alphagov/govuk-frontend/pull/5793)
+- [#5794: Add redesigned header component](https://github.com/alphagov/govuk-frontend/pull/5794)
 
 #### Footer top border is now consistent with GOV.UK
 

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -210,7 +210,7 @@ export default async () => {
 
       // Render component using fixture
       const componentView = render(componentName, {
-        context: fixture.options,
+        context: { ...fixture.options, rebrand: res.locals.useRebrand },
         env,
         fixture
       })
@@ -280,6 +280,7 @@ class NotFoundError extends Error {
  * @property {ComponentFixture} [componentFixture] - Single component fixture
  * @property {string} componentName - Component name
  * @property {string} [exampleName] - Example name
+ * @property {boolean} [useRebrand] - Whether to show rebranded examples
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -429,14 +429,34 @@
     }
   }
 
+  // Turn the logo lockup into an inline flexbox so we have more control over
+  // the margins when a product name is involved
+  .govuk-header__link--homepage {
+    display: inline-flex;
+    flex-wrap: wrap;
+  }
+
+  // IE doesn't support `gap`, only remove the logo's margin if we can use it
+  @supports (gap: 1px) {
+    .govuk-header__link--homepage {
+      gap: 7px;
+    }
+
+    .govuk-header__logotype {
+      margin-right: 0;
+    }
+  }
+
   .govuk-header__product-name {
+    // Stop reducing the product name size on narrow screens
+    font-size: govuk-px-to-rem(30px);
+
     // Reduce letter spacing (this is roughly equivalent to -3.5% in Figma)
     letter-spacing: -0.035em;
 
     // Change product name font-size to match the GOV.UK logotype on desktop
     @include govuk-media-query($from: desktop) {
-      margin-top: 0;
-      font-size: govuk-px-to-rem(29px);
+      margin-top: 1px;
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -253,12 +253,6 @@
     // logo with right padding using the button's width
     padding-right: $govuk-header-menu-button-width;
 
-    @include _govuk-rebrand {
-      // Apply margins to internal elements to emulate padding
-      margin-bottom: 0;
-      padding: govuk-spacing(3) $govuk-header-menu-button-width govuk-spacing(3) 0;
-    }
-
     @include govuk-media-query($from: desktop) {
       width: 33.33%;
       padding-right: $govuk-gutter-half;
@@ -271,6 +265,15 @@
         padding-right: 0;
         float: none;
       }
+    }
+
+    @include _govuk-rebrand {
+      // Apply margins to internal elements to emulate padding
+      margin-bottom: 0;
+
+      // Increase top/bottom padding
+      padding-top: govuk-spacing(3);
+      padding-bottom: govuk-spacing(3);
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -421,8 +421,16 @@
     }
 
     @include _govuk-rebrand {
-      // Remove the dividing lines between mobile nav items
-      border-bottom: none;
+      // Increase top padding of nav items...
+      padding-top: govuk-spacing(3);
+
+      // ...except on desktop
+      @include govuk-media-query($from: desktop) {
+        padding-top: govuk-spacing(1);
+      }
+
+      // Change the dividing line colour between mobile nav items
+      border-bottom-color: govuk-colour("white");
 
       // Reduce default weight of links so that we can use bold for active ones
       a {

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -344,6 +344,12 @@
   }
 
   .govuk-header__navigation {
+    @include govuk-media-query($until: mobile) {
+      @include _govuk-rebrand {
+        padding-bottom: govuk-spacing(3);
+      }
+    }
+
     @include govuk-media-query($from: desktop) {
       margin-bottom: govuk-spacing(2);
 
@@ -383,7 +389,7 @@
     }
 
     @include _govuk-rebrand {
-      @include govuk-media-query($until: desktop) {
+      @include govuk-media-query($from: mobile, $until: desktop) {
         padding-bottom: govuk-spacing(3);
       }
     }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -16,9 +16,18 @@
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
 
-    border-bottom: govuk-spacing(2) solid govuk-colour("white");
+    @include _govuk-rebrand(
+      "border-bottom",
+      $from: govuk-spacing(2) solid govuk-colour("white"),
+      $to: none
+    );
+    @include _govuk-rebrand(
+      "background",
+      $from: $govuk-header-background,
+      $to: $govuk-brand-colour
+    );
+
     color: $govuk-header-text;
-    background: $govuk-header-background;
   }
 
   .govuk-header__container--full-width {
@@ -36,6 +45,17 @@
     margin-bottom: -$govuk-header-border-width;
     padding-top: govuk-spacing($govuk-header-vertical-spacing-value);
     border-bottom: $govuk-header-border-width solid $govuk-header-border-color;
+
+    @include _govuk-rebrand {
+      // Remove the space allocated to the blue bar
+      margin-bottom: 0;
+
+      // Remove padding as the child elements are now responsible for spacing
+      padding-top: 0;
+
+      // Remove the blue bar
+      border-bottom: none;
+    }
   }
 
   .govuk-header--full-width-border {
@@ -97,6 +117,19 @@
         margin-top: $product-name-offset-tablet - 0.5px;
       }
     }
+
+    @include _govuk-rebrand {
+      // Stop reducing the product name size on narrow screens
+      font-size: govuk-px-to-rem(30px);
+
+      // Reduce letter spacing (this is roughly equivalent to -3.5% in Figma)
+      letter-spacing: -0.035em;
+
+      // Change product name font-size to match the GOV.UK logotype on desktop
+      @include govuk-media-query($from: desktop) {
+        margin-top: 1px;
+      }
+    }
   }
 
   .govuk-header__link {
@@ -136,6 +169,23 @@
       display: inline;
     }
 
+    @include _govuk-rebrand {
+      // Turn the logo lockup into an inline flexbox so we have more control over
+      // the margins when a product name is involved
+      display: inline-flex;
+      flex-wrap: wrap;
+
+      // IE doesn't support `gap`, only remove the logo's margin if we can use it
+      @supports (gap: 1px) {
+        gap: 7px;
+
+        // stylelint-disable-next-line max-nesting-depth
+        .govuk-header__logotype {
+          margin-right: 0;
+        }
+      }
+    }
+
     &:link,
     &:visited {
       text-decoration: none;
@@ -160,6 +210,15 @@
     margin-bottom: govuk-spacing(2);
     @include govuk-font-size($size: 24);
     @include govuk-typography-weight-bold;
+
+    @include _govuk-rebrand {
+      // Apply margins to internal elements to emulate padding
+      margin-bottom: govuk-spacing(3);
+
+      @include govuk-media-query($from: desktop) {
+        margin: govuk-spacing(3) 0;
+      }
+    }
   }
 
   .govuk-header__logo,
@@ -172,6 +231,12 @@
     // Protect the absolute positioned menu button from overlapping with the
     // logo with right padding using the button's width
     padding-right: $govuk-header-menu-button-width;
+
+    @include _govuk-rebrand {
+      // Apply margins to internal elements to emulate padding
+      margin-bottom: 0;
+      padding: govuk-spacing(3) 0;
+    }
 
     @include govuk-media-query($from: desktop) {
       width: 33.33%;
@@ -260,6 +325,22 @@
   .govuk-header__navigation {
     @include govuk-media-query($from: desktop) {
       margin-bottom: govuk-spacing(2);
+
+      @include _govuk-rebrand {
+        // Apply margins to internal elements to emulate padding
+        margin-bottom: 0;
+        padding: govuk-spacing(3) 0;
+      }
+    }
+  }
+
+  .govuk-header__service-name + .govuk-header__navigation {
+    @include _govuk-rebrand {
+      // If there's both a service name and navigation,
+      // remove the extra margin between them on desktop
+      @include govuk-media-query($from: desktop) {
+        padding-top: 0;
+      }
     }
   }
 
@@ -271,6 +352,12 @@
 
     &[hidden] {
       display: none;
+    }
+
+    @include _govuk-rebrand {
+      @include govuk-media-query($until: desktop) {
+        padding-bottom: govuk-spacing(3);
+      }
     }
   }
 
@@ -298,14 +385,33 @@
       @include govuk-typography-weight-bold;
       white-space: nowrap;
     }
+
+    @include _govuk-rebrand {
+      // Remove the dividing lines between mobile nav items
+      border-bottom: none;
+
+      // Reduce default weight of links so that we can use bold for active ones
+      a {
+        @include govuk-typography-weight-regular;
+      }
+    }
   }
 
   .govuk-header__navigation-item--active {
     a {
+      @include _govuk-rebrand {
+        // Change active links to use bold text instead of changing colour
+        @include govuk-typography-weight-bold;
+      }
+
       &:link,
       &:hover,
       &:visited {
         color: $govuk-header-link-active;
+
+        @include _govuk-rebrand {
+          color: inherit;
+        }
       }
 
       // When printing, use the normal blue as this contrasts better with the
@@ -344,119 +450,6 @@
       &::after {
         display: none;
       }
-    }
-  }
-}
-
-// Rebrand styles
-.govuk-header--rebrand {
-  // Remove border that placeholds the blue bar
-  border-bottom: none;
-
-  // Make the background brand blue
-  background-color: $govuk-brand-colour;
-
-  .govuk-header__container {
-    // Remove the space allocated to the blue bar
-    margin-bottom: 0;
-
-    // Remove padding as the child elements are now responsible for spacing
-    padding-top: 0;
-
-    // Remove the blue bar
-    border-bottom: none;
-  }
-
-  // Apply margins to internal elements to emulate padding
-  .govuk-header__logo {
-    margin-bottom: 0;
-    padding: govuk-spacing(3) 0;
-  }
-
-  .govuk-header__navigation {
-    @include govuk-media-query($from: desktop) {
-      margin-bottom: 0;
-      padding: govuk-spacing(3) 0;
-    }
-  }
-
-  .govuk-header__navigation-list {
-    @include govuk-media-query($until: desktop) {
-      padding-bottom: govuk-spacing(3);
-    }
-  }
-
-  .govuk-header__service-name {
-    margin-bottom: govuk-spacing(3);
-
-    @include govuk-media-query($from: desktop) {
-      margin: govuk-spacing(3) 0;
-    }
-  }
-
-  // If there's both a service name and navigation,
-  // remove the extra margin between them on desktop
-  .govuk-header__service-name + .govuk-header__navigation {
-    @include govuk-media-query($from: desktop) {
-      padding-top: 0;
-    }
-  }
-
-  .govuk-header__navigation-item {
-    // Remove the dividing lines between mobile nav items
-    border-bottom: none;
-
-    // Reduce default weight of links so that we can use bold for active ones
-    a {
-      @include govuk-typography-weight-regular;
-    }
-  }
-
-  // Change active links to use bold text instead of changing colour
-  .govuk-header__navigation-item--active {
-    a {
-      @include govuk-typography-weight-bold;
-
-      &:link,
-      &:hover,
-      &:visited {
-        color: inherit;
-      }
-
-      &:focus {
-        color: $govuk-focus-text-colour;
-      }
-    }
-  }
-
-  // Turn the logo lockup into an inline flexbox so we have more control over
-  // the margins when a product name is involved
-  .govuk-header__link--homepage {
-    display: inline-flex;
-    flex-wrap: wrap;
-  }
-
-  // IE doesn't support `gap`, only remove the logo's margin if we can use it
-  @supports (gap: 1px) {
-    .govuk-header__link--homepage {
-      gap: 7px;
-    }
-
-    .govuk-header__logotype {
-      margin-right: 0;
-    }
-  }
-
-  .govuk-header__product-name {
-    // Stop reducing the product name size on narrow screens
-    font-size: govuk-px-to-rem(30px);
-
-    // Reduce letter spacing (this is roughly equivalent to -3.5% in Figma)
-    letter-spacing: -0.035em;
-
-    // Change product name font-size to match the GOV.UK logotype on desktop
-    @include govuk-media-query($from: desktop) {
-      margin-top: 1px;
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -134,12 +134,6 @@
 
     @include govuk-media-query($from: desktop) {
       display: inline;
-
-      &:focus {
-        // Replicate the focus box shadow but without the -2px y-offset of the first yellow shadow
-        // This is to stop the logo getting cut off by the box shadow when focused on above a product name
-        box-shadow: 0 0 $govuk-focus-colour;
-      }
     }
 
     &:link,
@@ -350,6 +344,99 @@
       &::after {
         display: none;
       }
+    }
+  }
+}
+
+// Rebrand styles
+.govuk-header--rebrand {
+  // Remove border that placeholds the blue bar
+  border-bottom: none;
+
+  // Make the background brand blue
+  background-color: $govuk-brand-colour;
+
+  .govuk-header__container {
+    // Remove the space allocated to the blue bar
+    margin-bottom: 0;
+
+    // Remove padding as the child elements are now responsible for spacing
+    padding-top: 0;
+
+    // Remove the blue bar
+    border-bottom: none;
+  }
+
+  // Apply margins to internal elements to emulate padding
+  .govuk-header__logo {
+    margin-bottom: 0;
+    padding: govuk-spacing(3) 0;
+  }
+
+  .govuk-header__navigation {
+    @include govuk-media-query($from: desktop) {
+      margin-bottom: 0;
+      padding: govuk-spacing(3) 0;
+    }
+  }
+
+  .govuk-header__navigation-list {
+    @include govuk-media-query($until: desktop) {
+      padding-bottom: govuk-spacing(3);
+    }
+  }
+
+  .govuk-header__service-name {
+    margin-bottom: govuk-spacing(3);
+
+    @include govuk-media-query($from: desktop) {
+      margin: govuk-spacing(3) 0;
+    }
+  }
+
+  // If there's both a service name and navigation,
+  // remove the extra margin between them on desktop
+  .govuk-header__service-name + .govuk-header__navigation {
+    @include govuk-media-query($from: desktop) {
+      padding-top: 0;
+    }
+  }
+
+  .govuk-header__navigation-item {
+    // Remove the dividing lines between mobile nav items
+    border-bottom: none;
+
+    // Reduce default weight of links so that we can use bold for active ones
+    a {
+      @include govuk-typography-weight-regular;
+    }
+  }
+
+  // Change active links to use bold text instead of changing colour
+  .govuk-header__navigation-item--active {
+    a {
+      @include govuk-typography-weight-bold;
+
+      &:link,
+      &:hover,
+      &:visited {
+        color: inherit;
+      }
+
+      &:focus {
+        color: $govuk-focus-text-colour;
+      }
+    }
+  }
+
+  .govuk-header__product-name {
+    // Reduce letter spacing (this is roughly equivalent to -3.5% in Figma)
+    letter-spacing: -0.035em;
+
+    // Change product name font-size to match the GOV.UK logotype on desktop
+    @include govuk-media-query($from: desktop) {
+      margin-top: 0;
+      font-size: govuk-px-to-rem(29px);
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -469,6 +469,10 @@
       // contrast is still acceptable
       &:focus {
         color: $govuk-focus-text-colour;
+
+        @include _govuk-rebrand {
+          color: $govuk-focus-text-colour;
+        }
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -131,15 +131,22 @@
     }
 
     @include _govuk-rebrand {
+      // Remove top margin
+      margin-top: 0;
+
       // Stop reducing the product name size on narrow screens
       font-size: govuk-px-to-rem(30px);
 
       // Reduce letter spacing (this is roughly equivalent to -3.5% in Figma)
       letter-spacing: -0.035em;
 
-      // Change product name font-size to match the GOV.UK logotype on desktop
+      // Remove top margin on the breakpoints too
+      @include govuk-media-query($from: tablet) {
+        margin-top: 0;
+      }
+
       @include govuk-media-query($from: desktop) {
-        margin-top: 1px;
+        margin-top: 0;
       }
     }
   }
@@ -247,7 +254,7 @@
     @include _govuk-rebrand {
       // Apply margins to internal elements to emulate padding
       margin-bottom: 0;
-      padding: govuk-spacing(3) 0;
+      padding: govuk-spacing(3) $govuk-header-menu-button-width govuk-spacing(3) 0;
     }
 
     @include govuk-media-query($from: desktop) {

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -16,16 +16,8 @@
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
 
-    @include _govuk-rebrand(
-      "border-bottom",
-      $from: govuk-spacing(2) solid govuk-colour("white"),
-      $to: none
-    );
-    @include _govuk-rebrand(
-      "background",
-      $from: $govuk-header-background,
-      $to: $govuk-brand-colour
-    );
+    @include _govuk-rebrand("border-bottom", $from: govuk-spacing(2) solid govuk-colour("white"), $to: none);
+    @include _govuk-rebrand("background", $from: $govuk-header-background, $to: $govuk-brand-colour);
 
     color: $govuk-header-text;
   }
@@ -88,6 +80,26 @@
     // and focus states neat
     &:last-child {
       margin-right: 0;
+    }
+  }
+
+  // Colour in the Dot
+  .govuk-logo-dot {
+    fill: #11e0f1;
+
+    // Override Dot colour when printing
+    @include govuk-media-query($media-type: print) {
+      fill: currentcolor;
+    }
+
+    // Override Dot colour on forced colours mode
+    @media (forced-colors: active) {
+      fill: currentcolor;
+    }
+
+    // Override Dot colour on focus
+    :focus & {
+      fill: currentcolor;
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -235,7 +235,9 @@
       margin-bottom: govuk-spacing(3);
 
       @include govuk-media-query($from: desktop) {
-        margin: govuk-spacing(3) 0;
+        // Pixel nudging to align service name baseline with the GOV.UK logo
+        $govuk-service-name-offset: 2px;
+        margin: (govuk-spacing(3) + $govuk-service-name-offset) 0 (govuk-spacing(3) - $govuk-service-name-offset);
       }
     }
   }
@@ -346,19 +348,26 @@
       margin-bottom: govuk-spacing(2);
 
       @include _govuk-rebrand {
+        // Nudge pixels so that the bottom of the nav links aligns with the
+        // baseline of the GOV.UK logo
+        $govuk-navigation-offset: 5px;
+
         // Apply margins to internal elements to emulate padding
         margin-bottom: 0;
-        padding: govuk-spacing(3) 0;
+        padding: (govuk-spacing(3) + $govuk-navigation-offset) 0 (govuk-spacing(3) - $govuk-navigation-offset);
       }
     }
   }
 
   .govuk-header__service-name + .govuk-header__navigation {
     @include _govuk-rebrand {
-      // If there's both a service name and navigation,
-      // remove the extra margin between them on desktop
       @include govuk-media-query($from: desktop) {
+        // If there's both a service name and navigation,
+        // remove the extra padding between them on desktop
         padding-top: 0;
+
+        // Restore the full bottom padding as the navigation isn't standalone
+        padding-bottom: govuk-spacing(3);
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -287,24 +287,6 @@ examples:
         - text: Navigation item 2
         - text: Navigation item 3
 
-  - name: rebranded
-    description: With the refreshed design and logo.
-    options:
-      rebrand: true
-      productName: Product
-      serviceName: Service Name
-      serviceUrl: '/components/header'
-      navigation:
-        - href: '#1'
-          text: Navigation item 1
-          active: true
-        - href: '#2'
-          text: Navigation item 2
-        - href: '#3'
-          text: Navigation item 3
-        - href: '#4'
-          text: Navigation item 4
-
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes
     hidden: true

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -85,6 +85,10 @@ params:
     required: false
     description: If `true`, uses the Tudor crown from King Charles III's royal cypher. Otherwise, uses the St. Edward's crown. Default is `true`.
     deprecated: '5.2.0'
+  - name: rebrand
+    type: boolean
+    required: false
+    description: If `true`, use the redesigned header and new GOV.UK logotype. Default is `false`.
 
 previewLayout: full-width
 accessibilityCriteria: |
@@ -282,6 +286,24 @@ examples:
         - text: Navigation item 1
         - text: Navigation item 2
         - text: Navigation item 3
+
+  - name: rebranded
+    description: With the refreshed design and logo.
+    options:
+      rebrand: true
+      productName: Product
+      serviceName: Service Name
+      serviceUrl: '/components/header'
+      navigation:
+        - href: '#1'
+          text: Navigation item 1
+          active: true
+        - href: '#2'
+          text: Navigation item 2
+        - href: '#3'
+          text: Navigation item 3
+        - href: '#4'
+          text: Navigation item 4
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -349,8 +349,11 @@ examples:
           text: Navigation item 3
         - href: '#4'
           text: Navigation item 4
-
   - name: empty navigation array
     hidden: true
     options:
       navigation: []
+  - name: rebrand
+    hidden: true
+    options:
+      rebrand: true

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -3,7 +3,7 @@
 
 {%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
 
-<header class="govuk-header {%- if params.rebrand %} govuk-header--rebrand{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
+<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -3,7 +3,7 @@
 
 {%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
 
-<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
+<header class="govuk-header {%- if params.rebrand %} govuk-header--rebrand{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">
@@ -11,7 +11,8 @@
         {{ govukLogo({
           classes: "govuk-header__logotype",
           ariaLabelText: "GOV.UK",
-          useTudorCrown: params.useTudorCrown
+          useTudorCrown: params.useTudorCrown,
+          rebrand: params.rebrand
         }) }}
         {% if (params.productName) %}
         <span class="govuk-header__product-name">

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -13,7 +13,7 @@
           ariaLabelText: "GOV.UK",
           useTudorCrown: params.useTudorCrown,
           rebrand: params.rebrand
-        }) }}
+        }) | trim | indent(8) }}
         {% if (params.productName) %}
         <span class="govuk-header__product-name">
           {{ params.productName }}

--- a/packages/govuk-frontend/src/govuk/components/header/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/template.test.js
@@ -262,4 +262,14 @@ describe('header', () => {
       expect($('.govuk-header__content')).toHaveLength(0)
     })
   })
+
+  describe('rebrand', () => {
+    describe('when local `rebrand` parameter is enabled', () => {
+      it('renders the new GOV.UK logotype', () => {
+        const $ = render('header', examples.rebrand)
+
+        expect($('.govuk-logo-dot')).not.toBeNull()
+      })
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/macros/logo.njk
+++ b/packages/govuk-frontend/src/govuk/macros/logo.njk
@@ -70,8 +70,8 @@ releases of Frontend. #}
   >
     {%- if params.ariaLabelText %}<title>{{ params.ariaLabelText }}</title>{% endif %}
     {{ (_stEdwardsCrown if not useTudorCrown else _tudorCrown) | safe | trim | indent(2) }}
-    {%- if useLogotype %}
+    {% if useLogotype %}
       {{ (_dotLogotype if rebrand else _logotype) | safe | trim | indent(2) }}
-    {%- endif %}
+    {% endif %}
   </svg>
 {% endmacro %}


### PR DESCRIPTION
Adds the redesigned GOV.UK header component, via an opt-in parameter flag. This PR builds on top of #5793, as it makes use of the new logo macro.

Review app: https://govuk-frontend-pr-5794.herokuapp.com/components/header?rebrandOverride=true

> [!NOTE]
> This PR is so that we have something for the internal release. It doesn't need to be completely free of issues or be production-ready code. There will be a follow-up PR for further changes. 

## Changes
- Adds a `rebrand` parameter to the GOV.UK header component. 
  - Enabling it switches the logo macro to use the most recent crown and logotype.
- Adds new styles for the header. These are all activated by the feature flag introduced in #5788.
  - Changes the background colour to brand blue.
  - Removes the blue bar from the bottom of the header.
  - Increases the perceived top and bottom padding of the header, increasing it's overall height.
  - The manner in which spacing within the header has changed from utilising `margin-bottom` on each child element, to primarily using padding. This proved necessary as removing the styles for the blue bar caused these margins to collapse and broke the appearance of the component. 
  - Logo: Wraps the logo with an inline flexbox, to provide more granular control over logo + product name lockups.
  - Product name: Increases the font size to match the GOV.UK logotype. 
   - Product name: Reduces the `margin-top` of the product name to maintain alignment with the logo's baseline.
  - Product name: Adds negative `letter-spacing` to the product name. 
  - Service name: Now appears slightly lower so that its baseline is aligned with the GOV.UK logotype.
  - Navigation: Links are now unboldened by default. 
  - Navigation: The active state for links has been changed from a colour difference to becoming boldened. 
  - Navigation: If appearing without a service name, now appears lower down so the baseline of the links is aligned with the GOV.UK logotype.
  - Navigation: On mobile, the dividing lines between nav items has changed and there is more spacing between them.
- Adds styles to colour the Dot in the new logotype. 
  - Also adds styles to reset the Dot's colour on focus, in forced colours mode, and when printing.
  - These aren't gated behind the feature flag, as they use a new class and don't affect prior versions of the header.
- Add test for the `rebrand` parameter.
- Changes a bit of review app code to bubble the feature flag configuration down to component context, so that the GOV.UK logo toggles alongside the styles. From @romaricpascal.

## Thoughts
- Designs has been proposed that change the appearance of links in the header and service navigation. I've not implemented these as of yet, as I've struggled to find a way to make them work without requiring changes to the HTML structure and to how the navigation is visually laid out, which could both be considered breaking changes.
  - The HTML change is needed for non-linked navigation items. These would need to be styled differently from linked versions under this new scheme, but there isn't an existing variant class or child element to apply these styles to.
  - As the service name and navigation are deprecated and likely to be removed in the near future, I'm inclined towards us not implementing these changes in the header component.
  - There has also been a design proposed that changes the position of the mobile menu toggle, however, this is also due to be removed along with the navigation, so I similarly think it's best to not implement this change.

### Things that could use a look
- There are no tests for how the global `rebrand` feature flag affects the component, only how the local parameter does.
- The logo and product name lockup has been changed to use flexbox and `gap`, so that a 7px margin can be ensured for both the inline and stacked layouts. 
  - This has the side effect that the focus style for logo with product names is no longer 'shrinkwrapped' on the stacked layout and takes up the entire column width (if the product name wraps on desktop breakpoint). 
  - It also means that the link hover style is much wider than it needs to be when the layout stacks (if the product name wraps on desktop breakpoint).
  - An alternative approach might be to have the logo with product name always change to the stacked layout below a certain screen size, but this feels like a flakier approach given the large variance in product name lengths (e.g. "Pay" versus "Design System") 
- There is no visible bottom border in forced colours mode anymore.

## Todo
- [x] Update class names to align with the feature flag PR. (#5788)
- [x] Add tests for the rebrand parameter.
- [x] Colour in the Dot.
- [x] Align the service name and navigation with the baseline of the GOV.UK logotype.
- [x] Testing in forced colour modes.
- [x] Testing with print styles.
- [x] Testing in Firefox — we added some Firefox-specific styles that reposition the logo in v5.1.0, and should make sure these are still needed or remove them if not
  - Looked into and I don't think they need removing. They still look good to me. 