### PR TITLE
Update template background colour and components using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ For advice on how to use these release notes see [our guidance on staying up to 
 #### Use the refreshed GOV.UK brand
 
 > Placeholder for instructions on enabling the brand and when it's allowed to be deployed to live.
+> If you're not using our Page Template:
+
+1. Add the `govuk-template--rebranded` to use the rebranded styles of Footer
 
 These changes affect the Header, Footer, Service navigation, and Cookie banner components. Ensure that they still work as expected after enabling the refreshed brand.
 
 These changes were made in the following pull requests:
 
+- [#5796: Update template background colour and components using it](https://github.com/alphagov/govuk-frontend/pull/5796)
 - [#5798: Add mixin to help rebrand specific properties](https://github.com/alphagov/govuk-frontend/pull/5798)
 - [#5793: Add GOV.UK logo macro](https://github.com/alphagov/govuk-frontend/pull/5793)
 

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -14,7 +14,11 @@
 
     border-top: 10px solid $govuk-brand-colour;
     color: $govuk-footer-text;
-    background: $govuk-footer-background;
+    @include _govuk-rebrand(
+      "background",
+      $from: $govuk-footer-background,
+      $to: $_govuk-rebrand-template-background-colour
+    );
   }
 
   .govuk-footer__link {
@@ -26,7 +30,12 @@
     margin: 0; // Reset `<hr>` default margins
     @include govuk-responsive-margin(8, "bottom");
     border: 0; // Reset `<hr>` default borders
-    border-bottom: 1px solid $govuk-footer-content-border;
+    border-bottom: 1px solid;
+    @include _govuk-rebrand(
+      "border-bottom-color",
+      $from: $govuk-footer-content-border,
+      $to: $_govuk-rebrand-border-colour-on-blue-tint-95
+    );
   }
 
   .govuk-footer__meta {
@@ -106,7 +115,13 @@
     @include govuk-media-query($until: tablet) {
       padding-bottom: govuk-spacing(2);
     }
-    border-bottom: 1px solid $govuk-footer-content-border;
+
+    border-bottom: 1px solid;
+    @include _govuk-rebrand(
+      "border-bottom-color",
+      $from: $govuk-footer-content-border,
+      $to: $_govuk-rebrand-border-colour-on-blue-tint-95
+    );
   }
 
   .govuk-footer__navigation {

--- a/packages/govuk-frontend/src/govuk/objects/_template.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.scss
@@ -5,7 +5,11 @@
   .govuk-template {
     // Set the overall page background colour to the same colour as used by the
     // footer to give the illusion of a long footer.
-    background-color: $govuk-template-background-colour;
+    @include _govuk-rebrand(
+      background-color,
+      $from: $govuk-template-background-colour,
+      $to: $_govuk-rebrand-template-background-colour
+    );
 
     // Prevent automatic text sizing, as we already cater for small devices and
     // would like the browser to stay on 100% text zoom by default.

--- a/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
@@ -175,3 +175,13 @@ $govuk-link-hover-colour: govuk-colour("dark-blue") !default;
 /// @access public
 
 $govuk-link-active-colour: govuk-colour("black") !default;
+
+// =============================================================================
+// Brand refresh
+// =============================================================================
+
+/// Updated template background colour
+///
+/// @type Colour
+/// @access private
+$_govuk-rebrand-template-background-colour: #f4f8fb; // Blue tint 95%

--- a/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
@@ -185,3 +185,9 @@ $govuk-link-active-colour: govuk-colour("black") !default;
 /// @type Colour
 /// @access private
 $_govuk-rebrand-template-background-colour: #f4f8fb; // Blue tint 95%
+
+/// Border colour for areas on a light-blue background
+///
+/// @type Colour
+/// @access private
+$_govuk-rebrand-border-colour-on-blue-tint-95: #8eb8dc; // Blue tint 50%


### PR DESCRIPTION
Uses the mixin introduced by #5798 to update:
- the background colour of the `.govuk-template` element to the 95% tint of the brand blue
- the background colour of the `.govuk-footer` to match, and the border within it to the 50% tint of the brand blue

## Thoughts

The PR does not update `$govuk-canvas-background-colour` as the change needs to happen behind the feature flag.

To avoid future headaches the colours are not added to `$govuk-colours` but instead kept private:
- as a private variable for th 95% blue tint, as it needs using in multiple components
- as a local private fariable for the 50% blue tint as it's only used within the footer, but multiple times