### PR TITLE
Reduce nav item margins on service navigation

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -34,7 +34,7 @@
     @include govuk-media-query($from: tablet) {
       margin-top: 0;
       margin-bottom: 0;
-      padding: govuk-spacing(4) 0;
+      padding: govuk-spacing(3) 0 govuk-spacing(4);
 
       &:not(:last-child) {
         @include govuk-responsive-margin(6, $direction: right);


### PR DESCRIPTION
## Changes
- Reduces the `margin-top` of navigation items on tablet and above, so that a single row of items is around 60 pixels tall, roughly aligning with the height of the refreshed GOV.UK header component.

## Thoughts
- This is a relatively minor change. I'm curious if this warrants being feature flagged like some of the other brand refresh work or not. 