### PR TITLE
Update colour of the copyright logo using CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ We've updated the border of the Footer component so it matches the border used o
 
 This change was introduced in [pull request #5792: Update footer top border to be consistent with GOV.UK](https://github.com/alphagov/govuk-frontend/pull/5792)
 
+#### Royal Arms in the Footer now matches the text's colour
+
+We've updated the colour of the Royal Arms in the [GOV.UK footer](https://design-system.service.gov.uk/components/footer/) so it matches the text colour in browsers supporting the `filter` CSS property.
+
+This improves its accessibility and reduces the number of colours used in the footer.
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -71,9 +71,10 @@
     text-wrap: balance;
   }
 
-  .govuk-footer__copyright-logo {
-    display: inline-block;
-    min-width: $govuk-footer-crest-image-width;
+  .govuk-footer__copyright-logo::before {
+    content: "";
+    display: block;
+    width: 100%;
     padding-top: ($govuk-footer-crest-image-height + govuk-spacing(2));
     background-image: govuk-image-url("govuk-crest.svg");
     background-repeat: no-repeat;
@@ -81,6 +82,7 @@
     background-size: $govuk-footer-crest-image-width $govuk-footer-crest-image-height;
     text-align: center;
     white-space: nowrap;
+    filter: brightness(calc(5 / 45));
   }
 
   .govuk-footer__inline-list {


### PR DESCRIPTION
## What

Update the colour of the copyright logo to be the same as the text colour (`govuk-colour("black")`) in the footer. This method uses CSS and not a new SVG asset.

## Why

To reduce the number of colours in the footer component and avoid a breaking change in the process.
