### PR TITLE
Update class name to rebranded rather than rebrand

### DIFF
--- a/packages/govuk-frontend-review/src/views/layouts/_generic.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/_generic.njk
@@ -1,6 +1,6 @@
 {% extends "govuk/template.njk" %}
 
-{% set htmlClasses = ["govuk-template--rebrand", htmlClasses] | join(" ") if useRebrand else htmlClasses %}
+{% set htmlClasses = ["govuk-template--rebranded", htmlClasses] | join(" ") if useRebrand else htmlClasses %}
 
 {% block head %}
   <link rel="stylesheet" href="/stylesheets/app.min.css">


### PR DESCRIPTION
Fixes the toggle class name to the one used in `_govuk-rebrand`