### PR TITLE
Update background colour of Cookie banner for brand refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ For advice on how to use these release notes see [our guidance on staying up to 
 > Placeholder for instructions on enabling the brand and when it's allowed to be deployed to live.
 > If you're not using our Page Template:
 
-1. Add the `govuk-template--rebranded` to use the rebranded styles of Footer
+1. Add the `govuk-template--rebranded` to the `<html>` element of your page to use the rebranded styles of Footer and Cookie banner components.
 
 These changes affect the Header, Footer, Service navigation, and Cookie banner components. Ensure that they still work as expected after enabling the refreshed brand.
 
 These changes were made in the following pull requests:
 
 - [#5796: Update template background colour and components using it](https://github.com/alphagov/govuk-frontend/pull/5796)
+- [#5806: Update background colour of Cookie banner for brand refresh](https://github.com/alphagov/govuk-frontend/pull/5806)
 - [#5798: Add mixin to help rebrand specific properties](https://github.com/alphagov/govuk-frontend/pull/5798)
 - [#5793: Add GOV.UK logo macro](https://github.com/alphagov/govuk-frontend/pull/5793)
 

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
@@ -13,7 +13,11 @@
     // changes colours in their browser.
     border-bottom: $border-bottom-width solid transparent;
 
-    background-color: $govuk-canvas-background-colour;
+    @include _govuk-rebrand(
+      "background-color",
+      $govuk-template-background-colour,
+      $_govuk-rebrand-template-background-colour
+    );
   }
 
   // Support older browsers which don't hide elements with the `hidden` attribute


### PR DESCRIPTION
Use the `_govuk-rebrand` mixin to change the background to the rebranded template background colour.

Also fix the value when the rebrand is not active, which had remained to `$govuk-canvas-background-colour`, possibly rolled back during a rebase.