### PR TITLE
Pass the `rebrand` option to examples in the review app

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -210,7 +210,7 @@ export default async () => {
 
       // Render component using fixture
       const componentView = render(componentName, {
-        context: fixture.options,
+        context: { ...fixture.options, rebrand: res.locals.useRebrand },
         env,
         fixture
       })
@@ -280,6 +280,7 @@ class NotFoundError extends Error {
  * @property {ComponentFixture} [componentFixture] - Single component fixture
  * @property {string} componentName - Component name
  * @property {string} [exampleName] - Example name
+ * @property {boolean} [useRebrand] - Whether to show rebranded examples
  */
 
 /**


### PR DESCRIPTION
When rendering examples in the review app, sets the `rebrand` option based on the `useRebrand` local computed by from the cookie or query parametes, so that examples accepting a `rebrand` option get toggled when the feature flag is toggled in the UI.