### PR TITLE
Remove use of pre-compiled fixtures on Heroku and CI

### DIFF
--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -155,13 +155,6 @@ function render(componentName, options) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  // On Heroku / CI we know we're running against an up-to-date build so we can
-  // use the generated HTML from the component JSON (where it exists) to make
-  // things faster
-  if ((process.env.HEROKU_APP || process.env.CI) && options?.fixture?.html) {
-    return options.fixture.html
-  }
-
   return renderMacro(macroName, macroPath, options)
 }
 


### PR DESCRIPTION
The `render` function was using the content from the `html` fields in `fixtures.json`. This made it unpredictable when updating examples's `context` for rendering with the `rebrand` flag which we need:
- for the review app, to render component examples respecting the feature flag toggled in the UI
- in tests, to enable adjusting existing examples by updating their context in the test themselves rather than adding more examples

Comparing test duration [with caching](https://github.com/alphagov/govuk-frontend/actions/runs/14241757022?pr=5795) and [without caching](https://github.com/alphagov/govuk-frontend/actions/runs/14265204592), no flagrant difference appears (both on initial run and subsequent runs), so I've removed the caching from the `render` helper in components to make its behaviour more predictable.