### PR TITLE
Small improvements to the automatic release process

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,7 +54,7 @@ jobs:
           script: |
             const { generateReleaseNotes } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
 
-            generateReleaseNotes()
+            generateReleaseNotes('${{ inputs.version }}')
 
       - name: Build release
         run: npm run build:release

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -55,7 +55,7 @@ jobs:
           script: |
             const { generateReleaseNotes } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
 
-            await generateReleaseNotes()
+            await generateReleaseNotes('${{ steps.create-github-tag.outputs.GH_TAG }}')
 
       - name: Create GitHub release
         run: |

--- a/.github/workflows/scripts/changelog-release-helper.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.mjs
@@ -129,16 +129,22 @@ export function updateChangelog(newVersion) {
  * Generates release notes from the most recent changelog
  *
  * Creates a text file 'release-notes-body' from the content between either the
- * first release heading (default) or the 'Unreleased' heading and the following
- * release heading
+ * release heading passed to it by newVersion or the 'Unreleased' heading and the
+ * following release heading if newVersion is tagged as internal
  *
- * @param {boolean} fromUnreleasedHeading
+ * @param {string} newVersion - Version used to find start point for release notes
  */
-export function generateReleaseNotes(fromUnreleasedHeading = false) {
+export function generateReleaseNotes(newVersion) {
+  // Get the identifier from the version if there is one as we'll use this to
+  // change what we pass to getChangelogLineIndexes if the version has an
+  // 'internal' tag
+  const identifier = versionIsAPrerelease(newVersion)
+    ? getPrereleaseIdentifier(newVersion)
+    : undefined
   const changelogLines = getChangelogLines()
   const [startIndex, previousReleaseLineIndex] = getChangelogLineIndexes(
     changelogLines,
-    fromUnreleasedHeading
+    identifier === 'internal' ? undefined : newVersion
   )
 
   const releaseNotes = changelogLines
@@ -176,25 +182,32 @@ function getChangelogLines() {
  * Gets the start and end headings in the changelog for processing by the
  * exported functions
  *
- * @param {Array<string>} changelogLines
- * @param {boolean} fromUnreleasedHeading - Specifies if we get the first index from the 'Unreleased' heading or the first version heading we find
+ * @param {Array<string>} changelogLines - Produced from getChangelogLines
+ * @param {string|undefined} heading - Optional query to look for heading
+ *   where the first index is pulled from eg: 'Unreleased'
  * @returns {Array<number>} - Indexes in the changelog identifying start and end lines
  */
-function getChangelogLineIndexes(changelogLines, fromUnreleasedHeading = true) {
-  const versionTitleRegex = /^\s*#+\s+v\d+\.\d+\.\d+(-.+\.\d+)?\s+\(.+\)$/i
+function getChangelogLineIndexes(changelogLines, heading = undefined) {
+  // Build regex for finding the correct heading in the changelog
+  // If a heading hasn't been passed to the function, use 'Unreleased'
+  const defaultHeadingRegex = '\\d+\\.\\d+\\.\\d+(-.+\\.\\d+)?'
+  const headingRegex = heading
+    ? heading.replaceAll('.', '\\.').replace('v', '')
+    : 'Unreleased'
+
   const startIndex = findIndexOfFirstMatchingLine(
     changelogLines,
-    fromUnreleasedHeading ? /^\s*#+\s+Unreleased\s*$/i : versionTitleRegex
+    buildHeadingRegexQuery(headingRegex)
   )
 
-  if (!startIndex) {
+  if (startIndex === -1) {
     throw new Error(processingErrorMessage)
   }
 
   const endIndex = findIndexOfFirstMatchingLine(
     changelogLines,
-    versionTitleRegex,
-    fromUnreleasedHeading ? 0 : startIndex + 1
+    buildHeadingRegexQuery(defaultHeadingRegex),
+    startIndex + 1
   )
 
   if (endIndex === -1) {
@@ -205,11 +218,21 @@ function getChangelogLineIndexes(changelogLines, fromUnreleasedHeading = true) {
 }
 
 /**
+ * Builds the search query for headings when getting indexes in the changelog
+ *
+ * @param {string} identifier - Either the semantic version or 'Unreleased'
+ * @returns {RegExp} - Complete heading regex including hashes and release type formatting
+ */
+function buildHeadingRegexQuery(identifier) {
+  return new RegExp(`^\\s*#+\\s+v?${identifier}\\s*(\\(.+\\))?$`, 'i')
+}
+
+/**
  * Get the first matching line in the changelog that matches the passed regex
  *
- * @param {Array<string>} changelogLines
- * @param {RegExp} regExp
- * @param {number} offset
+ * @param {Array<string>} changelogLines - Produced from getChangelogLines
+ * @param {RegExp} regExp - Regular Expression to match against
+ * @param {number} offset - Offset from start of the changelogLines array
  * @returns {number} - Index in changeLogLines or -1 if we can't locate the index
  */
 function findIndexOfFirstMatchingLine(changelogLines, regExp, offset = 0) {
@@ -227,7 +250,8 @@ function findIndexOfFirstMatchingLine(changelogLines, regExp, offset = 0) {
  * Presumes the heading param follows the changelog heading format of:
  * '## v{version} ({release type})'
  *
- * @param {string} heading
+ * @param {string} heading - Markdown heading from changelog to convert into a
+ *   processable SemVer
  * @returns {string|null} - Processed semver which we expect to have the format
  *   X.Y.Z(-{identifier}.{base})
  */
@@ -280,10 +304,11 @@ function getPrereleaseIdentifier(version) {
  * and the new version is 6.3.0-beta.0, the generated string would be
  * 'Beta feature'
  *
- * @param {string} incType
- * @param {string|null} version
- * @param {boolean} capitalise
- * @param {string|null} lastReleaseTitle
+ * @param {string} incType - SemVer increment type
+ * @param {string|null} version - SemVer version
+ * @param {boolean} capitalise - If the returned string should start with a capital
+ *   letter or not
+ * @param {string|null} lastReleaseTitle - Previous release title
  * @returns {string} - The reworded increment type
  */
 function convertIncTypeWord(

--- a/.github/workflows/scripts/changelog-release-helper.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.mjs
@@ -16,7 +16,7 @@ const processingErrorMessage =
  * - The version increments the current version by more than one possible
  * increment, eg: going from 3.1.0 to 5.0.0, 3.3.0 or 3.1.2
  *
- * @param {string} newVersion
+ * @param {string} newVersion - New version to validate
  */
 export function validateVersion(newVersion) {
   const changelogLines = getChangelogLines()
@@ -86,7 +86,9 @@ export function validateVersion(newVersion) {
  * Inserts a new heading between the 'Unreleased' heading and the most recent
  * content
  *
- * @param {string} newVersion
+ * @param {string} newVersion - New version to add to the changelog. We presume
+ *   that this is a valid version as this function is always run after validateVersion
+ *   has passed.
  */
 export function updateChangelog(newVersion) {
   // Skip the entire function if the release version is internal eg: 5.1.0-internal.0

--- a/.github/workflows/scripts/changelog-release-helper.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.mjs
@@ -149,22 +149,11 @@ export function generateReleaseNotes(newVersion) {
 
   const releaseNotes = changelogLines
     .slice(startIndex + 1, previousReleaseLineIndex - 1)
-    .filter((value, index, arr) => {
-      if (value !== '') {
-        return true
-      }
-      if (
-        arr[index + 1].startsWith('#') ||
-        (index > 0 && arr[index - 1].startsWith('#'))
-      ) {
-        return true
-      }
-      return false
-    })
-    .map((value) => {
-      const line = value.replace(/^\s+/, '')
-      return line.startsWith('##') ? line.substring(1) : line
-    })
+    .map((line) =>
+      line.replace(/^\s+/, '').startsWith('##')
+        ? line.replace(/^\s+/, '').substring(1)
+        : line
+    )
 
   writeFileSync('./release-notes-body', releaseNotes.join('\n'))
 }

--- a/.github/workflows/scripts/changelog-release-helper.test.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.test.mjs
@@ -134,15 +134,6 @@ describe('Changelog release helper', () => {
   })
 
   describe('Generate release notes', () => {
-    it('writes release notes from the changelog from the Unreleased heading', () => {
-      // Pass 'true' here so that the function reads from the 'Unreleased' heading
-      generateReleaseNotes(true)
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './release-notes-body',
-        expect.stringContaining('Bing bong')
-      )
-    })
-
     it('writes release notes from the changelog from the last version heading', () => {
       jest.mocked(fs.readFileSync).mockReturnValue(`
         ## Unreleased
@@ -156,7 +147,7 @@ describe('Changelog release helper', () => {
         ## v3.0.0 (Breaking release)
       `)
 
-      generateReleaseNotes()
+      generateReleaseNotes('3.1.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './release-notes-body',
         expect.stringContaining('Bing bong')
@@ -176,7 +167,15 @@ describe('Changelog release helper', () => {
         ## v3.0.0 (Breaking release)
       `)
 
-      generateReleaseNotes()
+      generateReleaseNotes('3.1.0-beta.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining('Bing bong')
+      )
+    })
+
+    it('writes release notes from the changelog from the Unreleased heading if the version is internal', () => {
+      generateReleaseNotes('3.1.0-internal.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './release-notes-body',
         expect.stringContaining('Bing bong')
@@ -184,7 +183,7 @@ describe('Changelog release helper', () => {
     })
 
     it('increases the heading levels from the changelog by one', () => {
-      generateReleaseNotes(true)
+      generateReleaseNotes('Unreleased')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './release-notes-body',
         expect.stringContaining('## Fixes')


### PR DESCRIPTION
## Changes

Makes the following improvements to the release process:

1. Updates the `generatesReleaseNotes` function to take a version param which it checks for an 'internal' identifier, which then cascades down to what part of the changelog is collected and turned into release notes
2. Fixes overzealous whitespace trimming during processing of the changelog for release notes generation
3. Improves the jsdocs of the auto release helper

Each of these changes can be interrogated further in the commit history.

Fixes https://github.com/alphagov/govuk-frontend/issues/5846
Fixes https://github.com/alphagov/govuk-frontend/issues/5845