### PR TITLE
Adjustments to header spacing and alignment

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -142,10 +142,10 @@
 
       // Remove 1px from the bottom to account for the font-size being 1px
       // larger than the logo height.
-      margin-bottom: -1px;
+      margin-bottom: govuk-px-to-rem(-1px);
 
       // Magic number font-size that visually aligns with GOV.UK logo.
-      // Stop reducing the product name size on narrow screens
+      // Also stops reducing the product name size on narrow screens
       font-size: govuk-px-to-rem(31px);
 
       // Reduce letter spacing
@@ -193,7 +193,7 @@
     // in Firefox
     display: inline-block;
     margin-right: govuk-spacing(2);
-    font-size: govuk-px-to-rem(31px); // We don't have a mixin that produces 30px font size
+    font-size: 30px; // We don't have a mixin that produces 30px font size
 
     @include govuk-media-query($from: desktop) {
       display: inline;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -69,6 +69,12 @@
     fill: currentcolor;
     vertical-align: top;
 
+    @include _govuk-rebrand {
+      // Magic number. In combination with the glyph spacing in Transport,
+      // this makes for 7px of spacing between the logo and product name.
+      margin-right: -2px;
+    }
+
     // Prevent readability backplate from obscuring underline in Windows High
     // Contrast Mode
     @media (forced-colors: active) {
@@ -134,11 +140,16 @@
       // Remove top margin
       margin-top: 0;
 
-      // Stop reducing the product name size on narrow screens
-      font-size: govuk-px-to-rem(30px);
+      // Remove 1px from the bottom to account for the font-size being 1px
+      // larger than the logo height.
+      margin-bottom: -1px;
 
-      // Reduce letter spacing (this is roughly equivalent to -3.5% in Figma)
-      letter-spacing: -0.035em;
+      // Magic number font-size that visually aligns with GOV.UK logo.
+      // Stop reducing the product name size on narrow screens
+      font-size: govuk-px-to-rem(31px);
+
+      // Reduce letter spacing
+      letter-spacing: -0.015em;
 
       // Remove top margin on the breakpoints too
       @include govuk-media-query($from: tablet) {
@@ -182,27 +193,10 @@
     // in Firefox
     display: inline-block;
     margin-right: govuk-spacing(2);
-    font-size: 30px; // We don't have a mixin that produces 30px font size
+    font-size: govuk-px-to-rem(31px); // We don't have a mixin that produces 30px font size
 
     @include govuk-media-query($from: desktop) {
       display: inline;
-    }
-
-    @include _govuk-rebrand {
-      // Turn the logo lockup into an inline flexbox so we have more control over
-      // the margins when a product name is involved
-      display: inline-flex;
-      flex-wrap: wrap;
-
-      // IE doesn't support `gap`, only remove the logo's margin if we can use it
-      @supports (gap: 1px) {
-        gap: 7px;
-
-        // stylelint-disable-next-line max-nesting-depth
-        .govuk-header__logotype {
-          margin-right: 0;
-        }
-      }
     }
 
     &:link,
@@ -235,8 +229,9 @@
       margin-bottom: govuk-spacing(3);
 
       @include govuk-media-query($from: desktop) {
-        // Pixel nudging to align service name baseline with the GOV.UK logo
-        $govuk-service-name-offset: 2px;
+        // Magic number to align service name baseline with the GOV.UK logo
+        $govuk-service-name-offset: 3px;
+
         margin: (govuk-spacing(3) + $govuk-service-name-offset) 0 (govuk-spacing(3) - $govuk-service-name-offset);
       }
     }
@@ -249,6 +244,7 @@
 
   .govuk-header__logo {
     @include govuk-responsive-margin($govuk-header-vertical-spacing-value, "bottom");
+
     // Protect the absolute positioned menu button from overlapping with the
     // logo with right padding using the button's width
     padding-right: $govuk-header-menu-button-width;
@@ -357,9 +353,9 @@
       margin-bottom: govuk-spacing(2);
 
       @include _govuk-rebrand {
-        // Nudge pixels so that the bottom of the nav links aligns with the
+        // Magic number so that the bottom of the nav links aligns with the
         // baseline of the GOV.UK logo
-        $govuk-navigation-offset: 5px;
+        $govuk-navigation-offset: 6px;
 
         // Apply margins to internal elements to emulate padding
         margin-bottom: 0;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -13,6 +13,10 @@
   $govuk-header-menu-button-height: 24px;
   $govuk-header-menu-button-width: 80px;
 
+  $govuk-header-rebrand-background: $govuk-brand-colour;
+  $govuk-header-rebrand-vertical-spacing-value: 3;
+  $govuk-header-rebrand-logo-bottom-margin: 2px;
+
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
 
@@ -22,7 +26,7 @@
       $from: govuk-spacing(2) solid govuk-colour("white"),
       $to: 1px solid transparent
     );
-    @include _govuk-rebrand("background", $from: $govuk-header-background, $to: $govuk-brand-colour);
+    @include _govuk-rebrand("background", $from: $govuk-header-background, $to: $govuk-header-rebrand-background);
 
     color: $govuk-header-text;
   }
@@ -86,6 +90,11 @@
     // and focus states neat
     &:last-child {
       margin-right: 0;
+    }
+
+    @include _govuk-rebrand {
+      margin-right: govuk-px-to-rem(7px); // 1 'dot'
+      margin-bottom: $govuk-header-rebrand-logo-bottom-margin;
     }
   }
 
@@ -218,18 +227,19 @@
     }
 
     @include _govuk-rebrand {
-      display: inline-flex;
-      flex-wrap: wrap;
+      display: inline;
 
-      // Magic number some gaps.
-      column-gap: 7px;
-      row-gap: 2px;
+      // Remove word-spacing from within the logo so we can ignore
+      // whitespace characters in the HTML
+      word-spacing: govuk-px-to-rem(-6px);
 
-      // If `gap`s are supported, remove the margin the logo normally has
-      @supports (row-gap: 1px) and (column-gap: 1px) {
-        .govuk-header__logotype {
-          margin-right: 0;
-        }
+      // Reset word-spacing for child elements
+      > * {
+        word-spacing: 0;
+      }
+
+      &:not(:focus) {
+        background-color: $govuk-header-rebrand-background;
       }
     }
   }
@@ -242,13 +252,14 @@
 
     @include _govuk-rebrand {
       // Apply margins to internal elements to emulate padding
-      margin-bottom: govuk-spacing(3);
+      margin-bottom: govuk-spacing($govuk-header-rebrand-vertical-spacing-value);
 
       @include govuk-media-query($from: desktop) {
         // Magic number to align service name baseline with the GOV.UK logo
         $govuk-service-name-offset: 3px;
 
-        margin: (govuk-spacing(3) + $govuk-service-name-offset) 0 (govuk-spacing(3) - $govuk-service-name-offset);
+        margin: (govuk-spacing($govuk-header-rebrand-vertical-spacing-value) + $govuk-service-name-offset) 0
+          (govuk-spacing($govuk-header-rebrand-vertical-spacing-value) - $govuk-service-name-offset);
       }
     }
   }
@@ -285,7 +296,7 @@
 
       // Increase top/bottom padding
       padding-top: govuk-spacing(3);
-      padding-bottom: govuk-spacing(3);
+      padding-bottom: govuk-spacing(3) - $govuk-header-rebrand-logo-bottom-margin;
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -16,7 +16,11 @@
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
 
-    @include _govuk-rebrand("border-bottom", $from: govuk-spacing(2) solid govuk-colour("white"), $to: none);
+    // Add a transparent bottom border for forced-colour modes
+    @include _govuk-rebrand("border-bottom",
+      $from: govuk-spacing(2) solid govuk-colour("white"),
+      $to: 1px solid transparent
+    );
     @include _govuk-rebrand("background", $from: $govuk-header-background, $to: $govuk-brand-colour);
 
     color: $govuk-header-text;
@@ -50,6 +54,7 @@
     }
   }
 
+  // TODO: Remove this when _govuk-rebrand becomes the default
   .govuk-header--full-width-border {
     border-bottom-color: $govuk-header-border-color;
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -14,7 +14,6 @@
   $govuk-header-menu-button-width: 80px;
 
   $govuk-header-rebrand-background: $govuk-brand-colour;
-  $govuk-header-rebrand-vertical-spacing-value: 3;
   $govuk-header-rebrand-logo-bottom-margin: 2px;
 
   .govuk-header {
@@ -261,14 +260,13 @@
 
     @include _govuk-rebrand {
       // Apply margins to internal elements to emulate padding
-      margin-bottom: govuk-spacing($govuk-header-rebrand-vertical-spacing-value);
+      margin-bottom: govuk-spacing(3);
 
       @include govuk-media-query($from: desktop) {
         // Magic number to align service name baseline with the GOV.UK logo
-        $govuk-service-name-offset: 4px;
+        $service-name-offset: 4px;
 
-        margin: (govuk-spacing($govuk-header-rebrand-vertical-spacing-value) + $govuk-service-name-offset) 0
-          (govuk-spacing($govuk-header-rebrand-vertical-spacing-value) - $govuk-service-name-offset);
+        margin: (govuk-spacing(3) + $service-name-offset) 0 (govuk-spacing(3) - $service-name-offset);
       }
     }
   }
@@ -303,7 +301,7 @@
       // Apply margins to internal elements to emulate padding
       margin-bottom: 0;
 
-      // Magic numbers, set top/bottom padding
+      // Magic numbers, set padding to vertically centre align the logo
       padding-top: 16px;
       padding-bottom: 14px - $govuk-header-rebrand-logo-bottom-margin;
     }
@@ -391,11 +389,11 @@
       @include _govuk-rebrand {
         // Magic number so that the bottom of the nav links aligns with the
         // baseline of the GOV.UK logo
-        $govuk-navigation-offset: 7px;
+        $navigation-offset: 7px;
 
         // Apply margins to internal elements to emulate padding
         margin-bottom: 0;
-        padding: (govuk-spacing(3) + $govuk-navigation-offset) 0 (govuk-spacing(3) - $govuk-navigation-offset);
+        padding: (govuk-spacing(3) + $navigation-offset) 0 (govuk-spacing(3) - $navigation-offset);
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -265,7 +265,7 @@
 
       @include govuk-media-query($from: desktop) {
         // Magic number to align service name baseline with the GOV.UK logo
-        $govuk-service-name-offset: 3px;
+        $govuk-service-name-offset: 4px;
 
         margin: (govuk-spacing($govuk-header-rebrand-vertical-spacing-value) + $govuk-service-name-offset) 0
           (govuk-spacing($govuk-header-rebrand-vertical-spacing-value) - $govuk-service-name-offset);
@@ -303,9 +303,9 @@
       // Apply margins to internal elements to emulate padding
       margin-bottom: 0;
 
-      // Increase top/bottom padding
-      padding-top: govuk-spacing(3);
-      padding-bottom: govuk-spacing(3) - $govuk-header-rebrand-logo-bottom-margin;
+      // Magic numbers, set top/bottom padding
+      padding-top: 16px;
+      padding-bottom: 14px - $govuk-header-rebrand-logo-bottom-margin;
     }
   }
 
@@ -391,7 +391,7 @@
       @include _govuk-rebrand {
         // Magic number so that the bottom of the nav links aligns with the
         // baseline of the GOV.UK logo
-        $govuk-navigation-offset: 6px;
+        $govuk-navigation-offset: 7px;
 
         // Apply margins to internal elements to emulate padding
         margin-bottom: 0;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -17,7 +17,8 @@
     @include govuk-font($size: 16, $line-height: 1);
 
     // Add a transparent bottom border for forced-colour modes
-    @include _govuk-rebrand("border-bottom",
+    @include _govuk-rebrand(
+      "border-bottom",
       $from: govuk-spacing(2) solid govuk-colour("white"),
       $to: 1px solid transparent
     );
@@ -73,12 +74,6 @@
     margin-right: govuk-spacing(1);
     fill: currentcolor;
     vertical-align: top;
-
-    @include _govuk-rebrand {
-      // Magic number. In combination with the glyph spacing in Transport,
-      // this makes for 7px of spacing between the logo and product name.
-      margin-right: -2px;
-    }
 
     // Prevent readability backplate from obscuring underline in Windows High
     // Contrast Mode
@@ -220,6 +215,22 @@
     &:focus {
       margin-bottom: 0;
       border-bottom: 0;
+    }
+
+    @include _govuk-rebrand {
+      display: inline-flex;
+      flex-wrap: wrap;
+
+      // Magic number some gaps.
+      column-gap: 7px;
+      row-gap: 2px;
+
+      // If `gap`s are supported, remove the margin the logo normally has
+      @supports (row-gap: 1px) and (column-gap: 1px) {
+        .govuk-header__logotype {
+          margin-right: 0;
+        }
+      }
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -160,6 +160,15 @@
       // Reduce letter spacing
       letter-spacing: -0.015em;
 
+      // Prevent forced colour modes from applying a background colour behind
+      // the product name, which cuts off the underline that appears on hover.
+      forced-color-adjust: none;
+
+      @media screen and (forced-colors: active) {
+        color: LinkText;
+        background: transparent;
+      }
+
       // Remove top margin on the breakpoints too
       @include govuk-media-query($from: tablet) {
         margin-top: 0;

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -260,7 +260,7 @@ examples:
           text: Navigation item 3
 
   - name: with full width border
-    description: Makes the header's bottom border full width without affecting the header's content.
+    description: Makes the header's bottom border full width without affecting the header's content. Removed with redesign.
     options:
       classes: govuk-header--full-width-border
       productName: Product Name

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -16,7 +16,7 @@
         }) | trim | indent(8) }}
         {% if (params.productName) %}
         <span class="govuk-header__product-name">
-          {{ params.productName }}
+          {{- params.productName -}}
         </span>
         {% endif %}
       </a>


### PR DESCRIPTION
Adjust spacing and alignment between elements in the header and logo. A lot of the changes here are 🪄 magic numbers 🔢 that aim to achieve the spacing desired by the brand guidelines, rather than good old reliable design system numbers. Here be dragons. 

Based on top of #5857 so that things are measured against the most recent logo graphic. Closes alphagov/govuk-design-system#4612 and alphagov/govuk-design-system#4615.

## Changes
- Made the space between the logo and product name 7 pixels (when inline) and 2 pixels (when stacked).
- Increased the font size of the product name to 31 pixels.
  - Because of the spacing inherent in typeface glyphs, this results in type that is visually 22 pixels from baseline to cap height—the same height as the GOV.UK wordmark. 
- Changed the vertical alignment of the service name and first line of navigation to align with the updated logo asset's wordmark baseline.
- Increased letter-spacing on product names.

## Thoughts
Alignment is very heavily affected by things like browser, operating system, the PPI of the display being used, UI scaling settings, and browser zoom settings. Much of this work, particularly alignment of text baselines, is quite likely to change with different hardware and software configurations. Tests for that are below.

Trying to maintain 7 pixels of space as a static amount is grossly impractical, as it relies on the whitespace included in the character glyph to not change. It does change. The 'P' we use in test is 7 pixels away, but curved letters like 'C' and 'O' are only 5 pixels from the wordmark boundaries. Ideally we should not be aiming for 7 pixels of perfection for every situation.

## Testing
[Testing grid](https://docs.google.com/spreadsheets/d/1RXe0c0bT9Be3lWDpUoH3ZVT3Z6Fw3IrMUl8Z0SpvL7A/edit?usp=sharing) looking at the variance in layouts across hardware and software configurations.

Chrome 135, macOS 15.3, and a 72 PPI display was the configuration used in development and is the baseline that other configurations are compared against.