### PR TITLE
Omit ‘empty’ nav items from service navigation

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -279,6 +279,30 @@ examples:
       navigation:
         - href: '#/1'
           text: Navigation item 1
+  - name: with navigation having empty values
+    hidden: true
+    options:
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+        - null
+        - false
+        - ''
+        -
+        - href: '#/2'
+          text: Navigation item 2
+  - name: with navigation having only empty values
+    hidden: true
+    options:
+      navigation:
+        - null
+        - false
+        -
+        - ''
+  - name: with navigation being an empty array
+    hidden: true
+    options:
+      navigation: []
   - name: with slotted content
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
@@ -32,7 +32,8 @@ data-module="govuk-service-navigation"
       {% endif %}
 
       {# Navigation #}
-      {% if params.navigation | length or params.slots.navigationStart or params.slots.navigationEnd %}
+      {% set navigationItems = params.navigation | default([]) | select("truthy") %}
+      {% if navigationItems | length or params.slots.navigationStart or params.slots.navigationEnd %}
         <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-service-navigation__wrapper {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
           <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="{{ navigationId }}" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
             {{ menuButtonText }}
@@ -43,7 +44,7 @@ data-module="govuk-service-navigation"
             {# Slot: navigationStart #}
             {%- if params.slots.navigationStart %}{{ params.slots.navigationStart | safe }}{% endif -%}
 
-            {% for item in params.navigation %}
+            {% for item in navigationItems %}
               {% set linkInnerContent %}
                 {# We wrap active links in strong tags so that users who
                   override colours or styles will still have some indicator of

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
@@ -88,6 +88,38 @@ describe('Service Navigation', () => {
       expect($navToggle.attr('aria-controls')).toBe(navId)
     })
 
+    it('omits empty items from the navigation', () => {
+      const $ = render(
+        'service-navigation',
+        examples['with navigation having empty values']
+      )
+      const $listItems = $('.govuk-service-navigation__list li')
+
+      expect($listItems).toHaveLength(2)
+    })
+
+    it('omits the entire navigation if only empty items are included', () => {
+      const $ = render(
+        'service-navigation',
+        examples['with navigation having only empty values']
+      )
+
+      const $navWrapper = $('.govuk-service-navigation__wrapper')
+
+      expect($navWrapper).toHaveLength(0)
+    })
+
+    it('omits the entire navigation if navigation is an empty array', () => {
+      const $ = render(
+        'service-navigation',
+        examples['with navigation being an empty array']
+      )
+
+      const $navWrapper = $('.govuk-service-navigation__wrapper')
+
+      expect($navWrapper).toHaveLength(0)
+    })
+
     describe('custom options', () => {
       it('renders custom navigation classes', () => {
         const $ = render(


### PR DESCRIPTION
When defining the list of navigation items, users might opt to selectively include certain items depending on a condition, for example the user being logged in or having certain permissions.

For example, you might omit an ‘admin’ link conditionally like this:

```njk
{% set showAdmin = "false" %}

{{
  govukServiceNavigation({
    navigation: [
      {
        href: "/reports",
        text: "View reports"
      },
      {
        href: "/admin",
        text: "Admin"
      } if showAdmin,
      {
        href: "/roles",
        text: "Roles"
      }
    ]
  })
}}
```

These entries are still present in the `params.navigation` array when the condition is not met but are falsey. When looping over `params.navigation` we still include an empty `<li>` for this falsey entry. As these list items have a margin, this also results in a gap appearing in the navigation where the conditional item would have appeared.

Filter out the falsey values using the Nunjucks `select` filter. We do this before we check if any navigation items are present so we can omit the navigation entirely if all navigation items are falsey.

Closes #5862