### PR TITLE
TEST branch for updated link and border colours

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
@@ -124,7 +124,7 @@ $govuk-success-colour: govuk-colour("green") !default;
 /// @type Colour
 /// @access public
 
-$govuk-border-colour: govuk-colour("mid-grey") !default;
+$govuk-border-colour: #cecece !default;
 
 /// Input border colour
 ///
@@ -160,14 +160,14 @@ $govuk-link-colour: govuk-colour("blue") !default;
 /// @type Colour
 /// @access public
 
-$govuk-link-visited-colour: govuk-colour("purple") !default;
+$govuk-link-visited-colour: #54319f !default;
 
 /// Link hover colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-link-hover-colour: govuk-colour("dark-blue") !default;
+$govuk-link-hover-colour: #0f385c !default;
 
 /// Active link colour
 ///


### PR DESCRIPTION
## What

A test branch which updates:
- $govuk-link-visited-colour from `#4c2c92` to  `#54319f`
- $govuk-link-hover-colour from `#003078` to `#0f385c`

and
- $govuk-border-colour from `#b1b4b6` to `#cecece`


## Why

To create a test environment for the proposed new link styles