### PR TITLE
Service navigation spacing adjustments

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -47,7 +47,8 @@
       padding: govuk-spacing(4) 0;
 
       @include _govuk-rebrand {
-        padding-top: govuk-spacing(3);
+        padding: govuk-spacing(3) 0;
+        line-height: 1.5;
       }
 
       &:not(:last-child) {
@@ -66,7 +67,11 @@
     }
 
     @include govuk-media-query($from: tablet) {
-      padding-bottom: govuk-spacing(4) - $govuk-service-navigation-active-link-border-width;
+      @include _govuk-rebrand(
+        "padding-bottom",
+        $from: govuk-spacing(4) - $govuk-service-navigation-active-link-border-width,
+        $to: govuk-spacing(3) - $govuk-service-navigation-active-link-border-width
+      );
       border-bottom-width: $govuk-service-navigation-active-link-border-width;
     }
   }


### PR DESCRIPTION
Fiddles with the service navigation spacing to have items vertically centre aligned again.

## Background
In the first iteration of the component, the service navigation has 20 pixels of top and bottom padding on the service name and on each navigation item. Along with the 25 pixels of line height ([the design system's default for this font size](https://github.com/alphagov/govuk-frontend/blob/5a456e24612643accea8f6512a023f5f1104a5f9/packages/govuk-frontend/src/govuk/settings/_typography-responsive.scss#L114-L126)), this made for a component that was 65 pixels tall.

For the rebrand work, a desire was expressed to reduce the height of the service navigation to around 60 pixels, to match the increased height of the GOV.UK header. This was initially achieved by reducing the top padding to 15 pixels as, with the 5 pixel border added to active nav items, this maintained centred vertical alignment for active items and baseline alignment across all of the nav items.

This PR changes the method of vertically centring nav items to result in a centred vertical alignment for non-active nav items instead. 

## Changes
- Reduces the top and bottom padding of service name and navigation items to 15 pixels.
- Increases the line-height of service name and navigation items to 1.5 (approx. 29 pixels). 
- Along with the 1 pixel bottom border, this results in a total navigation height of 60 pixels (on a 72 PPI display).
