### PR TITLE
Use the version in the govuk-frontend package.json for validation

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,8 +34,9 @@ jobs:
         with:
           script: |
             const { validateVersion } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
+            const frontendPackage = await import('../../../packages/govuk-frontend/package.json', { with: { type: 'json' })
 
-            validateVersion('${{ inputs.version }}')
+            validateVersion('${{ inputs.version }}', frontendPackage.version)
 
       - name: Update package version
         run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
@@ -45,8 +46,9 @@ jobs:
         with:
           script: |
             const { updateChangelog } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
+            const frontendPackage = await import('../../../packages/govuk-frontend/package.json', { with: { type: 'json' })
 
-            updateChangelog('${{ inputs.version }}')
+            updateChangelog('${{ inputs.version }}', frontendPackage.version)
 
       - name: Generate release notes
         uses: actions/github-script@v7.0.1

--- a/.github/workflows/scripts/changelog-release-helper.test.mjs
+++ b/.github/workflows/scripts/changelog-release-helper.test.mjs
@@ -11,30 +11,36 @@ jest.mock('fs')
 describe('Changelog release helper', () => {
   beforeEach(() => {
     jest.mocked(fs.readFileSync).mockReturnValue(`
-    ## Unreleased
+      ## Unreleased
 
-    ### Fixes
+      ### Fixes
 
-    Bing bong
+      Bing bong
 
-    ## v3.0.0 (Breaking release)
-  `)
+      ## v3.0.0 (Breaking release)
+    `)
   })
 
   describe('Validate version', () => {
     it('runs normally if a valid new version is parsed to it', () => {
-      expect(() => validateVersion('3.1.0')).not.toThrow()
+      expect(() => validateVersion('3.1.0', '3.0.0')).not.toThrow()
     })
 
     it('throws an error if an invalid semver is parsed', () => {
-      expect(() => validateVersion('pizza')).toThrow(
+      expect(() => validateVersion('pizza', '3.0.0')).toThrow(
         'New version number pizza could not be processed by Semver. Please ensure you are providing a valid semantic version'
       )
     })
 
     it('throws an error if new version is less than old version', () => {
-      expect(() => validateVersion('2.11.0')).toThrow(
+      expect(() => validateVersion('2.11.0', '3.0.0')).toThrow(
         'New version number 2.11.0 is less than or equal to the most recent version (3.0.0). Please provide a newer version number'
+      )
+    })
+
+    it('throws an error if the previous version is falsy or invalid', () => {
+      expect(() => validateVersion('3.1.0', 'pizza')).toThrow(
+        'Previous version number pizza could not be processed by Semver. Please ensure a valid version is being passed to the script via the govuk-frontend package.json package.'
       )
     })
 
@@ -63,24 +69,14 @@ describe('Changelog release helper', () => {
         badVersion: '3.0.2',
         type: 'patch',
         goodVersion: '3.0.1',
-        customLastTitle: '3.0.1-beta.15 (Beta patch release)'
+        customVersion: '3.0.1-beta.15'
       }
     ])(
       'throws an error if new version is more than one possible `$type` increment',
-      ({ badVersion, type, goodVersion, customLastTitle }) => {
-        if (customLastTitle) {
-          jest.mocked(fs.readFileSync).mockReturnValue(`
-          ## Unreleased
-
-          ### Fixes
-
-          Bing bong
-
-          ## v${customLastTitle}
-        `)
-        }
-
-        expect(() => validateVersion(badVersion)).toThrow(
+      ({ badVersion, type, goodVersion, customVersion }) => {
+        expect(() =>
+          validateVersion(badVersion, customVersion ?? '3.0.0')
+        ).toThrow(
           `New version number ${badVersion} is incrementing more than one for its increment type (${type}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${goodVersion}`
         )
       }
@@ -89,7 +85,7 @@ describe('Changelog release helper', () => {
 
   describe('Update changelog', () => {
     it('adds a new heading to the changelog for the new version', () => {
-      updateChangelog('3.1.0')
+      updateChangelog('3.1.0', '3.0.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './CHANGELOG.md',
         expect.stringContaining('## v3.1.0 (Feature release)')
@@ -97,7 +93,7 @@ describe('Changelog release helper', () => {
     })
 
     it('prefixes a new heading with a pre-release identifier if the new version is a pre-release', () => {
-      updateChangelog('3.1.0-beta.0')
+      updateChangelog('3.1.0-beta.0', '3.0.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './CHANGELOG.md',
         expect.stringContaining('## v3.1.0-beta.0 (Beta feature release)')
@@ -115,7 +111,7 @@ describe('Changelog release helper', () => {
         ## v3.1.0-beta.0 (Beta feature release)
       `)
 
-      updateChangelog('3.1.0-beta.1')
+      updateChangelog('3.1.0-beta.1', '3.1.0-beta.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './CHANGELOG.md',
         expect.stringContaining('## v3.1.0-beta.1 (Beta feature release)')
@@ -125,7 +121,7 @@ describe('Changelog release helper', () => {
     it('does not change the changelog if the provided version is an internal pre-release', () => {
       const consoleLogSpy = jest.spyOn(console, 'log')
 
-      updateChangelog('3.1.0-internal.0')
+      updateChangelog('3.1.0-internal.0', '3.0.0')
       expect(consoleLogSpy).toHaveBeenCalledWith(
         'This is an internal release, intended for testing only. The changelog will therefore not be updated.'
       )


### PR DESCRIPTION
## What

Updates the `validateVersion` and `updateChangelog` functions to take a `previousVersion` param that we get from importing `govuk-frontend/package.json` and looking for its version. This is instead of what we currently do which is to try and sniff out the previous version from the changelog headings.

We do some validation to this effect in the script to make sure it's valid semver.

## Why
We ran into this during an internal release today. We're getting the previous version from the changelog currently, but internal releases don't update the changelog, therefore a second internal pre-release will always be invalid. We use `npm version` later in the build release workflow to update the version so we can't run that workflow for 2nd internal releases.

This resloves that. Generally the `package.json` is a much more reliable source of truth for current/previous version anyway.