### PR TITLE
Add checks for `govukRebrand` nunjucks global

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -210,7 +210,7 @@ export default async () => {
 
       // Render component using fixture
       const componentView = render(componentName, {
-        context: { ...fixture.options, rebrand: res.locals.useRebrand },
+        context: fixture.options,
         env,
         fixture
       })

--- a/packages/govuk-frontend-review/src/common/middleware/feature-flags.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/feature-flags.mjs
@@ -37,6 +37,7 @@ router.post(`/set-${FEATURE_NAME}`, (req, res) => {
 router.use((req, res, next) => {
   const localVarName = `use${FEATURE_NAME.charAt(0).toUpperCase() + FEATURE_NAME.slice(1)}`
   const overrideQuery = `${FEATURE_NAME}Override`
+  const env = req.app.get('nunjucksEnv')
 
   res.locals[localVarName] =
     overrideQuery in req.query
@@ -47,6 +48,9 @@ router.use((req, res, next) => {
   res.locals.exampleStates = res.locals.showAllFlagStates
     ? [true, false]
     : [res.locals.useRebrand]
+
+  // set the govukRebrand global
+  env?.addGlobal('govukRebrand', res.locals[localVarName])
 
   next()
 })

--- a/packages/govuk-frontend-review/src/common/middleware/feature-flags.unit.test.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/feature-flags.unit.test.mjs
@@ -88,4 +88,18 @@ describe('Middleware: Feature flag toggling', () => {
       expect(res.header['set-cookie'][0]).not.toContain('use_rebrand=true;')
     })
   })
+
+  describe('Nunjucks global', () => {
+    it('sets a `govukRebrand` nunjucks global if the nunjucks env has been set', async () => {
+      // Mock nunjucks env so it can be pulled from the req in the middleware
+      const mockEnv = {
+        addGlobal: jest.fn()
+      }
+      app.set('nunjucksEnv', mockEnv)
+
+      await agent.get('/').set('Cookie', ['use_rebrand=true'])
+
+      expect(mockEnv.addGlobal.mock.calls).toHaveLength(1)
+    })
+  })
 })

--- a/packages/govuk-frontend-review/src/views/layouts/_generic.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/_generic.njk
@@ -1,7 +1,5 @@
 {% extends "govuk/template.njk" %}
 
-{% set govukRebrand = useRebrand %}
-
 {% block head %}
   <link rel="stylesheet" href="/stylesheets/app.min.css">
 

--- a/packages/govuk-frontend/src/govuk-prototype-kit/functions.js
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/functions.js
@@ -1,0 +1,4 @@
+const { addFunction } = require('govuk-prototype-kit').views
+const config = require('govuk-prototype-kit/lib/config.js').getConfig(null)
+
+addFunction('govukRebrand', () => config.rebrand ?? false)

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -61,7 +61,8 @@ export default async () => {
       }
     ],
     nunjucksMacros,
-    nunjucksPaths: ['/dist']
+    nunjucksPaths: ['/dist'],
+    nunjucksFunctions: ['/dist/govuk-prototype-kit/functions.js']
   }
 }
 
@@ -75,6 +76,7 @@ export default async () => {
  * @property {string[] | { path: string, type?: string }[]} scripts - JavaScripts to serve
  * @property {{ importFrom: string, macroName: string }[]} nunjucksMacros - Nunjucks macros to include
  * @property {string[]} nunjucksPaths - Nunjucks paths
+ * @property {string[]} nunjucksFunctions - Nunjucks functions
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -194,6 +194,12 @@ describe('GOV.UK Prototype Kit config', () => {
     it('includes paths', () => {
       expect(config.nunjucksPaths).toEqual(['/dist'])
     })
+
+    it('includes function paths', () => {
+      expect(config.nunjucksFunctions).toEqual([
+        '/dist/govuk-prototype-kit/functions.js'
+      ])
+    })
   })
 })
 

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -1,11 +1,12 @@
 {% from "../../macros/attributes.njk" import govukAttributes -%}
-
 {% from "../../macros/logo.njk" import govukLogo -%}
+
+{%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
 <footer class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
-    {% if params.rebrand %}
+    {% if _rebrand %}
       {{- govukLogo({
         classes: 'govuk-footer__crown',
         rebrand: true,

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('@govuk-frontend/helpers/nunjucks')
-const { getExamples } = require('@govuk-frontend/lib/components')
+const { nunjucksEnv, getExamples } = require('@govuk-frontend/lib/components')
 
 describe('footer', () => {
   let examples
@@ -278,6 +278,19 @@ describe('footer', () => {
 
     it('Does render the crown if the `rebrand` option is set', () => {
       const $ = render('footer', examples.rebrand)
+
+      const $crown = $('.govuk-footer__crown')
+      expect($crown).toHaveLength(1)
+    })
+
+    it('Does render the crown if the `govukRebrand` nunjucks global is set to true', () => {
+      const env = nunjucksEnv()
+      env.addGlobal('govukRebrand', true)
+
+      const $ = render('footer', {
+        ...examples.default,
+        env
+      })
 
       const $crown = $('.govuk-footer__crown')
       expect($crown).toHaveLength(1)

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -1,5 +1,7 @@
-{% from "../../macros/attributes.njk" import govukAttributes %}
-{% from "../../macros/logo.njk" import govukLogo %}
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+{% from "../../macros/logo.njk" import govukLogo -%}
+
+{%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
 {%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
 
@@ -12,7 +14,7 @@
           classes: "govuk-header__logotype",
           ariaLabelText: "GOV.UK",
           useTudorCrown: params.useTudorCrown,
-          rebrand: params.rebrand
+          rebrand: _rebrand
         }) | trim | indent(8) }}
         {% if (params.productName) %}
         <span class="govuk-header__product-name">

--- a/packages/govuk-frontend/src/govuk/components/header/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('@govuk-frontend/helpers/nunjucks')
-const { getExamples } = require('@govuk-frontend/lib/components')
+const { nunjucksEnv, getExamples } = require('@govuk-frontend/lib/components')
 
 describe('header', () => {
   let examples
@@ -267,6 +267,20 @@ describe('header', () => {
     describe('when local `rebrand` parameter is enabled', () => {
       it('renders the new GOV.UK logotype', () => {
         const $ = render('header', examples.rebrand)
+
+        expect($('.govuk-logo-dot')).not.toBeNull()
+      })
+    })
+
+    describe('when `govukRebrand` nunjucks global is set to `true`', () => {
+      it('renders the new GOV.UK logotype', () => {
+        const env = nunjucksEnv()
+        env.addGlobal('govukRebrand', true)
+
+        const $ = render('header', {
+          ...examples.default,
+          env
+        })
 
         expect($('.govuk-logo-dot')).not.toBeNull()
       })

--- a/packages/govuk-frontend/src/govuk/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/template.jsdom.test.js
@@ -94,6 +94,32 @@ describe('Template', () => {
       expect(document.documentElement).toHaveClass('govuk-template--rebranded')
     })
 
+    it('adds the rebrand class if govukRebrand is set to true as a nunjucks global bool', () => {
+      const env = nunjucksEnv()
+      env.addGlobal('govukRebrand', true)
+
+      replacePageWith(
+        renderTemplate('govuk/template.njk', {
+          env
+        })
+      )
+
+      expect(document.documentElement).toHaveClass('govuk-template--rebranded')
+    })
+
+    it('adds the rebrand class if govukRebrand is set to true as a nunjucks global function', () => {
+      const env = nunjucksEnv()
+      env.addGlobal('govukRebrand', () => true)
+
+      replacePageWith(
+        renderTemplate('govuk/template.njk', {
+          env
+        })
+      )
+
+      expect(document.documentElement).toHaveClass('govuk-template--rebranded')
+    })
+
     it('renders valid HTML', () => {
       expect(renderTemplate('govuk/template.njk')).toHTMLValidate({
         extends: ['html-validate:document'],
@@ -150,6 +176,23 @@ describe('Template', () => {
           context: {
             govukRebrand: true
           }
+        })
+      )
+      const $icon = document.querySelector('link[rel="icon"][sizes="48x48"]')
+
+      expect($icon).toHaveAttribute(
+        'href',
+        '/assets/rebrand/images/favicon.ico'
+      )
+    })
+
+    it('uses a default assets path of /assets/rebrand if govukRebrand is true as a nunjucks global', () => {
+      const env = nunjucksEnv()
+      env.addGlobal('govukRebrand', true)
+
+      replacePageWith(
+        renderTemplate('govuk/template.njk', {
+          env
         })
       )
       const $icon = document.querySelector('link[rel="icon"][sizes="48x48"]')
@@ -276,6 +319,20 @@ describe('Template', () => {
             context: {
               govukRebrand: true
             }
+          })
+        )
+        const $themeColor = document.querySelector('meta[name="theme-color"]')
+
+        expect($themeColor).toHaveAttribute('content', '#1d70b8')
+      })
+
+      it('has a default content of #1d70b8 if govukRebrand is true as a nunjucks global', () => {
+        const env = nunjucksEnv()
+        env.addGlobal('govukRebrand', true)
+
+        replacePageWith(
+          renderTemplate('govuk/template.njk', {
+            env
           })
         )
         const $themeColor = document.querySelector('meta[name="theme-color"]')

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -3,11 +3,14 @@
 {% from "./components/header/macro.njk" import govukHeader -%}
 {% from "./components/footer/macro.njk" import govukFooter -%}
 
+{%- set _rebrand = govukRebrand() if govukRebrand is callable else govukRebrand -%}
+
 {# Hardcoded value is $govuk-brand-blue if rebrand, otherwise govuk-colour("black") -#}
-{% set themeColor = themeColor | default("#1d70b8" if govukRebrand else "#0b0c0c", true) -%}
-{% set assetPath = assetPath | default("/assets/rebrand" if govukRebrand else "/assets", true) -%}
+{% set themeColor = themeColor | default("#1d70b8" if _rebrand else "#0b0c0c", true) -%}
+{% set assetPath = assetPath | default("/assets/rebrand" if _rebrand else "/assets", true) -%}
+
 <!DOCTYPE html>
-<html lang="{{ htmlLang | default("en", true) }}" class="govuk-template {%- if govukRebrand %} govuk-template--rebranded{% endif %} {%- if htmlClasses %} {{ htmlClasses }}{% endif %}">
+<html lang="{{ htmlLang | default("en", true) }}" class="govuk-template {%- if _rebrand %} govuk-template--rebranded{% endif %} {%- if htmlClasses %} {{ htmlClasses }}{% endif %}">
   <head>
     <meta charset="utf-8">
     <title {%- if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
@@ -42,7 +45,7 @@
 
     {% block header %}
       {{ govukHeader({
-        rebrand: govukRebrand
+        rebrand: _rebrand
       }) }}
     {% endblock %}
 
@@ -57,7 +60,7 @@
 
     {% block footer %}
       {{ govukFooter({
-        rebrand: govukRebrand
+        rebrand: _rebrand
       }) }}
     {% endblock %}
 


### PR DESCRIPTION
## Change
Adds a check in the page template and header and footer components for a `govukRebrand` nunjucks global which automatically applies the rebrand (class and `rebrand` params) if it's present.

As part of this, this PR adds:

- a function in the prototype kit govuk-frontend plugin config which applies `govukRebrand` as a function if a prototype has the line `"rebrand": true` in their app config
- the ability for the feature flag toggle system to create the global from within the feature flags middleware by passing the nunjucks `env` back into the middleware

Closes https://github.com/alphagov/govuk-frontend/issues/5865

## Notes
A few relevant github links:

- https://github.com/alphagov/govuk-frontend/issues/5837: The spike issue this work came out of
- https://github.com/alphagov/govuk-frontend/pull/5856: The original spike PR

The global can be accepted as either a function or a variable. We do this so that we can support `addFunction` in the prototype kit as it's currently the only way for users to set globals in their prototypes.

The `_rebrand` variable in all the templates it's used is set up so that `params.rebrand` for the header and footer takes precident over the global. For the template, this is `govukRebrand` as a variable, applied in https://github.com/alphagov/govuk-frontend/issues/5836

I'm a little wary of passing the nunjucks env to the middleware as an `app.set` however it's the simplest way to allow the global to be applied from every route. If you don't do this, you get situations where the toggle doesn't work properly on routes which are harder to access because we've abstracted them into their own files eg: the full page examples route. Open to opinions on this.