### PR TITLE
Update prototype kit plugin rebrand function to be specific to govuk-frontend

### DIFF
--- a/packages/govuk-frontend/src/govuk-prototype-kit/functions.js
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/functions.js
@@ -1,4 +1,25 @@
 const { addFunction } = require('govuk-prototype-kit').views
-const config = require('govuk-prototype-kit/lib/config.js').getConfig(null)
+const config = require('govuk-prototype-kit/lib/config.js').getConfig()
 
-addFunction('govukRebrand', () => config.rebrand ?? false)
+/**
+ * Adds a global function to the nunjucks env of prototypes to define the state
+ * of `govukRebrand`.
+ *
+ * Only applies the rebrand if the following is present in a user's prototype config:
+ *
+ * "plugins": {
+ *  "govuk-frontend": {
+ *    "rebrand": true
+ *  }
+ * }
+ *
+ * Steps through each required param to check that they're present, then returns
+ * the state of `rebrand`. If any of the params aren't present or `rebrand` is
+ * falsey, return a falsey value.
+ *
+ * We're finicky about checking each param because, besides the fact that we don't
+ * know if each param might be present, `getConfig` by default swallows the error
+ * if ./app/config.json isn't present so this makes sure that a user's prototype
+ * still runs even if their config doesn't exist for some reason.
+ */
+addFunction('govukRebrand', () => config?.plugins?.['govuk-frontend']?.rebrand)


### PR DESCRIPTION
## What

Renames the expected attribute in prototype configs to turn on the rebrand, going from:

```json
"rebrand": true
```

...to:

```json
"plugins": {
  "govuk-frontend": {
    "rebrand": true
  }
}
```

## Why

Responding to @romaricpascal's [comment just here](https://github.com/alphagov/govuk-frontend/pull/5874#discussion_r2053613651). In summary, this avoids the risk of conflicts by making the config attribute more specific.

## Notes

Tested with a local prototype, including without the config changes (no brand changes applied), with them (brand changes applied), with bits of them eg: `"plugins": "pizza"` or `"plugins": { "govuk-frontend": "pizza" }` (not applied) and without a `./app/config.json` file present at all (not applied).

This change makes use of an optional chaining operator, which has been [supported mostly since Node 14.5.0 and fully since 16.3.0](https://node.green/#ES2020-features-optional-chaining-operator-----). The prototype kit is currently set to use `lts/iron` which is 20.9.0 so we're ok to use this.