### PR TITLE
Update pagination macro descriptions

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
+++ b/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
@@ -11,7 +11,7 @@ params:
       - name: visuallyHiddenText
         type: string
         required: false
-        description: The visually-hidden label for the pagination item, which will be applied to an `aria-label` and announced by screen readers on the pagination item link. Should include page number. Defaults to, for example "Page 1".
+        description: The visually hidden label for the pagination item, which will be applied to an `aria-label` and announced by screen readers on the pagination item link. Should include page number. Defaults to, for example "Page 1".
       - name: href
         type: string
         required: false


### PR DESCRIPTION
When porting this component across to the NHS design system, I noticed a couple of minor inconsistencies with the macro option descriptions.

`href` was marked as required but `number` was not marked as required. For both, they’re technically optional as they’re not required if the item is an ellipsis. This tries to make that clearer.

Have also add a clarification to the `visuallyHiddenText` to try and make it clearer that there is some default text, and you’d only need to set it if you wanted to change this.