### PR TITLE
Rename ellipses html class to ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ We made these changes in the following pull requests:
 - [#6264: Add media query functions](https://github.com/alphagov/govuk-frontend/pull/6264).
 - [#6265: Rewrite `govuk-media-query`, remove dependency on `sass-mq`](https://github.com/alphagov/govuk-frontend/pull/#6265).
 
+### Recommended changes
+
+#### Rename ellipses HTML class in pagination to ellipsis
+
+Within the pagination component, change the `govuk-pagination__item--ellipses` class to `govuk-pagination__item--ellipsis`.
+
+We introduced this change in [pull request #5882: Rename ellipses html class to ellipsis](https://github.com/alphagov/govuk-frontend/pull/5882).
+
 ### Fixes
 
 - [#6297: Output deprecation warning if $govuk-show-breakpoints is true](https://github.com/alphagov/govuk-frontend/pull/6297)

--- a/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
@@ -72,6 +72,7 @@
 
   // Only show first, last and non-link items on mobile
   .govuk-pagination__item--current,
+  .govuk-pagination__item--ellipsis,
   .govuk-pagination__item--ellipses,
   .govuk-pagination__item:first-child,
   .govuk-pagination__item:last-child {
@@ -92,6 +93,7 @@
     }
   }
 
+  .govuk-pagination__item--ellipsis,
   .govuk-pagination__item--ellipses {
     @include govuk-typography-weight-bold;
     color: $govuk-secondary-text-colour;

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -37,7 +37,7 @@
 {% endmacro -%}
 
 {%- macro _pageItem(item) -%}
-  <li class="govuk-pagination__item {%- if item.current %} govuk-pagination__item--current{% endif %} {%- if item.ellipsis %} govuk-pagination__item--ellipses{% endif %}">
+  <li class="govuk-pagination__item {%- if item.current %} govuk-pagination__item--current{% endif %} {%- if item.ellipsis %} govuk-pagination__item--ellipsis{% endif %}">
   {% if item.ellipsis %}
     &ctdot;
   {% else %}

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
@@ -55,7 +55,7 @@ describe('Pagination', () => {
     it('marks up pagination items as ellipses when specified', () => {
       const $ = render('pagination', examples['with many pages'])
       const $firstEllipsis = $(
-        '.govuk-pagination__item:nth-child(2).govuk-pagination__item--ellipses'
+        '.govuk-pagination__item:nth-child(2).govuk-pagination__item--ellipsis'
       )
 
       expect($firstEllipsis).toBeTruthy()


### PR DESCRIPTION
The param name uses `ellpisis` (singular) but the class name uses `ellipses` (plural), which is a bit confusing as there’s only one ellipsis within the list item? (At least, it confused me).

This switches to using the singular for both, but also supports the plural for backwards-compatibility (could be dropped in next major release?)