### PR TITLE
Fix character count not having error border colour when rendered with error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5920: Fix transparency around edge of rebranded favicon.ico](https://github.com/alphagov/govuk-frontend/pull/5920)
 - [#5918: Fix `govuk-font-size` mixin outputting the wrong font properties for size 14 text when compiled using libsass](https://github.com/alphagov/govuk-frontend/pull/5918)
 - [#5962: Fix colour of refreshed GOV.UK logo's dot](https://github.com/alphagov/govuk-frontend/pull/5962)
+- [#5896: Fix character count not having error border colour when rendered with error message](https://github.com/alphagov/govuk-frontend/pull/5896)
 
 ## v5.10.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -123,6 +123,9 @@ export class CharacterCount extends ConfigurableComponent {
       })
     }
 
+    // Pre-existing validation error rendered from server
+    this.$errorMessage = this.$root.querySelector('.govuk-error-message')
+
     // Inject a description for the textarea if none is present already
     // for when the component was rendered with no maxlength, maxwords
     // nor custom textareaDescriptionText
@@ -288,7 +291,12 @@ export class CharacterCount extends ConfigurableComponent {
     )
 
     // Update styles
-    this.$textarea.classList.toggle('govuk-textarea--error', isError)
+    if (!this.$errorMessage) {
+      // Only toggle the textarea error class if there isn't an error message
+      // already, as it may be unrelated to the limit (eg: allowed characters)
+      // and would set the border colour back to black.
+      this.$textarea.classList.toggle('govuk-textarea--error', isError)
+    }
     this.$visibleCountMessage.classList.toggle('govuk-error-message', isError)
     this.$visibleCountMessage.classList.toggle('govuk-hint', !isError)
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -65,6 +65,20 @@ describe('Character count', () => {
         )
         expect(messageClasses).toContain('govuk-visually-hidden')
       })
+
+      it('retains error class if there is already an error', async () => {
+        await render(
+          page,
+          'character-count',
+          examples['custom classes with error message']
+        )
+
+        const textAreaclasses = await page.$eval(
+          '.govuk-textarea',
+          (el) => el.className
+        )
+        expect(textAreaclasses).toContain('govuk-textarea--error')
+      })
     })
 
     describe('when counting characters', () => {
@@ -144,6 +158,27 @@ describe('Character count', () => {
           (el) => el.innerHTML.trim()
         )
         expect(srMessage).toBe('You have 1 character remaining')
+      })
+
+      it('retains error class if there is already an error', async () => {
+        await render(
+          page,
+          'character-count',
+          examples['custom classes with error message']
+        )
+
+        await page.type('.govuk-js-character-count', 'A', {
+          delay: 50
+        })
+
+        // Wait for debounced update to happen
+        await setTimeout(debouncedWaitTime)
+
+        const textAreaClasses = await page.$eval(
+          '.govuk-textarea',
+          (el) => el.className
+        )
+        expect(textAreaClasses).toContain('govuk-textarea--error')
       })
 
       describe('when the character limit is exceeded', () => {


### PR DESCRIPTION
When the character count JS inits it toggles off the the textarea error class if its value is under the limit, even if it was rendered with a validation error. This means on page load invalid character counts will revert to having a black outline if they are under the character limit.

To fix this, I've added a check for an existing error message before the error class is toggled on and off.

| Before | After |
| - | - |
| ![Screenshot showing character count component with error message and incorrect black border](https://github.com/user-attachments/assets/073c3113-65d2-419c-8e96-65c0a2866f87) | ![Screenshot showing character count component with error message and correct red border](https://github.com/user-attachments/assets/14f45c2d-4681-4eb3-9025-c223d239987a) |

Fixes #1858