### PR TITLE
Fix use of package.json in build release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           script: |
             const { validateVersion } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
-            const frontendPackage = await import('../../../packages/govuk-frontend/package.json', { with: { type: 'json' }})
+            const frontendPackage = await import('${{ github.workspace }}/packages/govuk-frontend/package.json', { with: { type: 'json' }})
 
-            validateVersion('${{ inputs.version }}', frontendPackage.version)
+            validateVersion('${{ inputs.version }}', frontendPackage.default.version)
 
       - name: Update package version
         run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
@@ -46,9 +46,9 @@ jobs:
         with:
           script: |
             const { updateChangelog } = await import('${{ github.workspace }}/.github/workflows/scripts/changelog-release-helper.mjs')
-            const frontendPackage = await import('../../../packages/govuk-frontend/package.json', { with: { type: 'json' }})
+            const frontendPackage = await import('${{ github.workspace }}/packages/govuk-frontend/package.json', { with: { type: 'json' }})
 
-            updateChangelog('${{ inputs.version }}', frontendPackage.version)
+            updateChangelog('${{ inputs.version }}', frontendPackage.default.version)
 
       - name: Generate release notes
         uses: actions/github-script@v7.0.1


### PR DESCRIPTION
Fixes 2 problems with the build release workflow:

1. Imports `package.json` using `github.workspace` rather than an absolute path
2. Uses `frontendPackage.default.version` rather than `frontendPackage.version` as this wasn't actually returning anything

Validated using a test run https://github.com/alphagov/govuk-frontend/actions/runs/14778355098/job/41491536980 This fails but that's intentional as 5.13.0 _should_ fail.