### PR TITLE
Fix unnecessary whitespace after logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#5905: Fix unnecessary whitespace after logo](https://github.com/alphagov/govuk-frontend/pull/5905)
+
 ## v5.10.0 (Feature release)
 
 ### New features

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -94,6 +94,11 @@
     @include _govuk-rebrand {
       margin-right: govuk-px-to-rem(7px); // 1 'dot'
       margin-bottom: $govuk-header-rebrand-logo-bottom-margin;
+
+      // Remove right-margin if there's no product name
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes there being additional whitespace after the rebrand logo when there's no product name, which becomes visible when hovering or focusing the logo.

Fixes #5902.

## Changes
- Add CSS to remove `margin-right` on the logo graphic if it's the last element within the link.

## Screenshots

||Before|After|
|:-|:-|:-|
|Hover|<img width="193" alt="Logo being hovered. The hover underline extends slightly past the right-hand side of the logo." src="https://github.com/user-attachments/assets/2229ab95-44e3-473a-b36e-3521aaa23497" />|<img width="191" alt="Logo being hovered, the underline now neatly beneath the logo only." src="https://github.com/user-attachments/assets/82032d78-625d-4639-828b-2cbbd1c0cf1d" />|
|Focus|<img width="199" alt="Logo being focused. The black underline and yellow background extend slightly past the right-hand side of the logo. " src="https://github.com/user-attachments/assets/e763f827-0769-4d26-95b9-5c0868e078c4" />|<img width="183" alt="Logo being focused, the underline and background now wrapped tightly around the logo." src="https://github.com/user-attachments/assets/ff1c2186-d8b8-4e38-91d3-5d37fb448641" />|