### PR TITLE
Add missing installation instructions for 5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## v5.10.0 (Feature release)
 
+To install this version with npm, run `npm install govuk-frontend@5.10.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.
+
 ### New features
 
 #### Prepare to use the refreshed GOV.UK brand


### PR DESCRIPTION
Those were missed while running the release manually.