### PR TITLE
Fix footer licence link reflowing on focus in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5905: Fix unnecessary whitespace after logo](https://github.com/alphagov/govuk-frontend/pull/5905)
+- [#5908: Fix footer licence link reflowing on focus in Safari](https://github.com/alphagov/govuk-frontend/pull/5908)
 
 ## v5.10.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/helpers/_focused.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_focused.scss
@@ -24,9 +24,19 @@
   // box shadow adds the "underline"
   text-decoration: none;
 
-  // When a focused box is broken by e.g. a line break, ensure that the
-  // box-shadow is applied to each fragment independently.
-  box-decoration-break: clone;
+  // Fixes an issue in Chromium 108–111 where the box-shadow on the focus state
+  // is missing on links that wrap across multiple lines [1].
+  //
+  // However, text-wrap: balance doesn't play nicely with box-decoration-break:
+  // clone, causing links to re-flow when focused [2]. As text-wrap: balance
+  // wasn't introduced until Chromium 114 we can use it as a way to target
+  // this fix to just 108–111.
+  //
+  // [1]: http://crbug.com/40884971
+  // [2]: https://github.com/alphagov/govuk-frontend/issues/5878
+  @supports not (text-wrap: balance) {
+    box-decoration-break: clone;
+  }
 }
 
 /// Focused box


### PR DESCRIPTION
Safari [does not currently support `text-wrap: balance` alongside `box-decoration-break: clone`][1]. This has the odd effect at the minute that when the license link in the footer is focused it reflows, as though `text-wrap: balance` has been disabled on its parent.

We’ve been using `box-decoration-break: clone` on focused links since 05ed7c9 to work around an issue introduced in Chromium 108, where the box-shadow was missing from the focus state for links split over multiple lines.

That issue was fixed in Chromium 112. Unfortunately because Chromium 109 was [the last version to work with Windows 7, Windows Server 2008 R2, Windows 8, Windows Server 2012, Windows 8.1 and Windows Server 2012 R2 there’s a peak of users stuck on this version of Chromium][2], so we ideally want to keep the fix in place for the time-being.

As Chromium didn’t introduce support for `text-wrap: balance` until 114 we can use it to guard the `box-decoration-break: clone` property.

Chromium 108-111 will continue to use `box-decoration-break: clone` for focused links. Newer browsers that support `text-wrap: balance` will not, avoiding the conflict.

[1]: https://bugs.webkit.org/show_bug.cgi?id=260351
[2]: https://github.com/alphagov/govuk-frontend/issues/5878#issuecomment-2838369733

Fixes #5878 