### PR TITLE
Backport rebrand sass mixin to v4 branch

### DIFF
--- a/src/govuk/tools/_all.scss
+++ b/src/govuk/tools/_all.scss
@@ -5,3 +5,4 @@
 @import "image-url";
 @import "px-to-em";
 @import "px-to-rem";
+@import "rebrand";

--- a/src/govuk/tools/_rebrand.scss
+++ b/src/govuk/tools/_rebrand.scss
@@ -1,0 +1,63 @@
+////
+/// @group tools
+////
+
+/// Wraps rebranded properties in the feature flag selector
+///
+/// @example scss - Wrap a block of multiple properties
+///   .foo {
+///     border-width: 1px;
+///     border-colour: #fff;
+///
+///     @include _govuk-rebrand() {
+///       border-width: 10px;
+///       border-colour: #000;
+///     }
+///   }
+///
+/// @example scss - Wrap a single property
+///   .foo {
+///     @include _govuk-rebrand("background-color", $from: #fff, $to: #000)
+///   }
+///
+///
+/// @param {String} $property - The name of the property being rebranded
+/// @param {String} $from - The original value of the property
+/// @param {String} $to - The rebranded value of the property
+/// @throw if `$property` is set but `$from` or `$to` are missing
+/// @access private
+@mixin _govuk-rebrand($property: null, $from: null, $to: null) {
+  @if $property {
+    @if not $from {
+      @error "`_govuk-rebrand` needs the original value, `$from`";
+    }
+
+    @if not $to {
+      @error "`_govuk-rebrand` needs the rebranded value, `$to`";
+    }
+
+    #{$property}: #{$from};
+
+    @include _govuk-rebrand-wrapper {
+      #{$property}: #{$to};
+    }
+  } @else {
+    @include _govuk-rebrand-wrapper {
+      @content;
+    }
+  }
+}
+
+@mixin _govuk-rebrand-wrapper() {
+  $selector: "#{&}";
+
+  @if $selector == ".govuk-template" {
+    @at-root .govuk-template--rebranded {
+      @content;
+    }
+  } @else {
+    .govuk-template--rebranded & {
+      @content;
+    }
+  }
+}

--- a/src/govuk/tools/rebrand.test.js
+++ b/src/govuk/tools/rebrand.test.js
@@ -1,0 +1,136 @@
+const { compileSassString } = require('govuk-frontend-helpers/tests')
+const { outdent } = require('outdent')
+
+describe('@mixin _govuk-rebrand', () => {
+  it('wraps arbitrary properties in a class', async () => {
+    const sass = `
+      $govuk-suppressed-warnings: ("legacy-organisation-colours");
+      @import "base";
+      .foo {
+        border-width: 1px;
+        border-colour: #fff;
+        @include _govuk-rebrand() {
+          border-width: 10px;
+          border-colour: #000;
+        }
+      }
+    `
+
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
+        .foo {
+          border-width: 1px;
+          border-colour: #fff;
+        }
+        .govuk-template--rebranded .foo {
+          border-width: 10px;
+          border-colour: #000;
+        }
+      `
+    })
+  })
+
+  describe('`$property` argument', () => {
+    it('renders both original and rebranded version', async () => {
+      const sass = `
+        $govuk-suppressed-warnings: ("legacy-organisation-colours");
+        @import "base";
+        .foo {
+          @include _govuk-rebrand("background-color", $from: #fff, $to: #000)
+        }
+      `
+
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
+          .foo {
+            background-color: #fff;
+          }
+          .govuk-template--rebranded .foo {
+            background-color: #000;
+          }
+        `
+      })
+    })
+
+    it('throws an error if not provided the original value', async () => {
+      const sass = `
+        $govuk-suppressed-warnings: ("legacy-organisation-colours");
+        @import "base";
+        .foo {
+          @include _govuk-rebrand("background-color", $to: #000)
+        }
+      `
+
+      await expect(compileSassString(sass)).rejects.toThrow(
+        '`_govuk-rebrand` needs the original value, `$from`'
+      )
+    })
+
+    it('throws an error if not provided the rebranded value', async () => {
+      const sass = `
+        $govuk-suppressed-warnings: ("legacy-organisation-colours");
+        @import "base";
+        .foo {
+          @include _govuk-rebrand("background-color", $from: #fff)
+        }
+      `
+
+      await expect(compileSassString(sass)).rejects.toThrow(
+        '`_govuk-rebrand` needs the rebranded value, `$to`'
+      )
+    })
+  })
+
+  describe('when used in `.govuk-template` it outputs a `.govuk-template--rebranded` class at root', () => {
+    it('when styling a block', async () => {
+      const sass = `
+        $govuk-suppressed-warnings: ("legacy-organisation-colours");
+        @import "base";
+        .govuk-template {
+          border-width: 1px;
+          border-colour: #fff;
+          @include _govuk-rebrand {
+            border-width: 10px;
+            border-colour: #000;
+          }
+        }
+      `
+
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
+          .govuk-template {
+            border-width: 1px;
+            border-colour: #fff;
+          }
+          .govuk-template--rebranded {
+            border-width: 10px;
+            border-colour: #000;
+          }
+        `
+      })
+    })
+
+    it('when styling a specific property', async () => {
+      const sass = `
+        $govuk-suppressed-warnings: ("legacy-organisation-colours");
+        @import "base";
+        .govuk-template {
+          @include _govuk-rebrand("background-color",
+            $from: #fff,
+            $to: #000)
+        }
+      `
+
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
+          .govuk-template {
+            background-color: #fff;
+          }
+          .govuk-template--rebranded {
+            background-color: #000;
+          }
+        `
+      })
+    })
+  })
+})


### PR DESCRIPTION
Backports the rebrand sass mixin, first introduced in First introduced in https://github.com/alphagov/govuk-frontend/pull/5798

Closes https://github.com/alphagov/govuk-frontend/issues/5890