### PR TITLE
Fix infrastructure issues with `support/4.x`

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Cache build
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v4.2.3
       id: build-cache
 
       with:

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Cache dependencies
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v4.2.3
       id: npm-install-cache
 
       with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache browser download
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         with:
           enableCrossOsArchive: true
           key: puppeteer-${{ runner.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Cache linter
         if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         with:
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Cache task
         if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         with:
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,7 +195,7 @@ jobs:
         run: npx jest --color ${{ format('--maxWorkers={0} --selectProjects "{1}"', env.MAX_WORKERS, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: ${{ matrix.task.description }} coverage (${{ matrix.runner }})
           path: coverage


### PR DESCRIPTION
Resolve github action dependancy issues with our v4 branch so that we can backport brand update work unimpeded. Details of what's been updated is in the commit history.