### PR TITLE
Add examples with errors to the Character Count

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -160,6 +160,29 @@ examples:
         text: Don't include personal or financial information, eg your
           National Insurance number or credit card details.
 
+  - name: with error
+    options:
+      name: with-error
+      id: with-error
+      maxlength: 10
+      label:
+        text: Can you provide more detail?
+      errorMessage:
+        text: Please provide more detail
+
+  - name: with hint and error
+    options:
+      name: with-error
+      id: with-error
+      maxlength: 10
+      label:
+        text: Can you provide more detail?
+      errorMessage:
+        text: Please provide more detail
+      hint:
+        text: Don't include personal or financial information, eg your
+          National Insurance number or credit card details.
+
   - name: with default value
     options:
       id: with-default-value


### PR DESCRIPTION
Add examples of Character Count components with empty values and errors (both [without a hint](https://govuk-frontend-pr-5914.herokuapp.com/components/character-count#heading-with-error) and [with a hint](heading-with-hint-and-error)) so we can see how the component behaves when an error is displayed but the content of the field isn't above the limit.

Until now, we only had an example with error where the content exceeded the limit, triggering the component into rendering a red border which is not present if the value is under the limit.