### PR TITLE
Fix `govuk-font-size` mixin outputting the wrong font properties for size 14 text when compiled using libsass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5908: Fix footer licence link reflowing on focus in Safari](https://github.com/alphagov/govuk-frontend/pull/5908)
 - [#5919: Update deprecation warning message to make it clearer how to update to new organisation colour palette](https://github.com/alphagov/govuk-frontend/pull/5919)
 - [#5920: Fix transparency around edge of rebranded favicon.ico](https://github.com/alphagov/govuk-frontend/pull/5920)
+- [#5918: Fix `govuk-font-size` mixin outputting the wrong font properties for size 14 text when compiled using libsass](https://github.com/alphagov/govuk-frontend/pull/5918)
 
 ## v5.10.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -190,7 +190,7 @@
   // No match? Try with string type (e.g. $size: "16" not 16)
   @if not $font-map {
     @each $font-size in map-keys($govuk-typography-scale) {
-      @if not $font-map and #{$font-size} == #{$size} {
+      @if not $font-map and "#{$font-size}" == "#{$size}" {
         $font-map: map-get($govuk-typography-scale, $font-size);
       }
     }


### PR DESCRIPTION
We’re using interpolation to try and check whether a given variable matches any of the keys of the `$govuk-typography-scale map` when both the variable and the keys are treated as strings.

https://github.com/alphagov/govuk-frontend/blob/2c4383b50e29f0ec7a242d4c2a05413623ad9d6e/packages/govuk-frontend/src/govuk/helpers/_typography.scss#L190-L197

Unfortunately in libsass the interpolation results in the entire expression being treated as a string, rather than each side of the expression being interpolated into a separate string and then compared.

In other words, it’s equivalent to us writing `@if not $font-map and "#{$font-size} == #{$size}”` if we were using quoted strings [^1].

Because a string is truthy, the `@if` statement evaluates as true and $font-map is set to whatever the first entry in the map is, regardless of what `$size` is.

This means that the `govuk-font-size` mixin is currently outputting the font properties for size 80 in our typography scale when passed a `$size` that does not map directly to a key from the map, including any internal calls for `_14` because we end up with `$size` being a string because of the processing earlier in the mixin.

Quote both values so that they are correctly treated as separate strings and then compared.

There’s no point adding a test for this as all of our tests run under Dart Sass where this problem doesn’t exist.

Fixes #5415.

[^1]: We can see this by testing with some debug statements:
    ```
    @debug(true == false);
    @debug(#{true} == #{false});
    @debug("#{true} == #{false}");
    @debug("#{true}" == "#{false}");
    ```

    With Dart Sass, you get:
    test.scss:1 Debug: false
    test.scss:2 Debug: false
    test.scss:3 Debug: true == false
    test.scss:4 Debug: false

    With Node Sass, you get:
    test.scss:1 DEBUG: false
    test.scss:2 DEBUG: true == false
    test.scss:3 DEBUG: true == false
    test.scss:4 DEBUG: false