### PR TITLE
Update deprecation warning message to make it clearer how to update to new organisation colour palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#5905: Fix unnecessary whitespace after logo](https://github.com/alphagov/govuk-frontend/pull/5905)
 - [#5908: Fix footer licence link reflowing on focus in Safari](https://github.com/alphagov/govuk-frontend/pull/5908)
+- [#5919: Update deprecation warning message to make it clearer how to update to new organisation colour palette](https://github.com/alphagov/govuk-frontend/pull/5919)
 
 ## v5.10.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -364,7 +364,9 @@ $govuk-colours-organisations: $_govuk-legacy-organisation-colours !default;
 @if $govuk-colours-organisations == $_govuk-legacy-organisation-colours {
   @include _warning(
     "legacy-organisation-colours",
-    "The legacy organisation colour palette has been deprecated and will be removed in the next major version."
+    "We've updated the organisation colour palette. Opt in to the new " +
+      "colours using `$govuk-new-organisation-colours: true`. The old palette " +
+      "is deprecated and we'll remove it in the next major version."
   );
 }
 

--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -80,7 +80,7 @@ describe('Organisation colours', () => {
       // Expect our mocked @warn function to have been called once with a single
       // argument, which should be the deprecation notice
       expect(mockWarnFunction).toHaveBeenCalledWith(
-        'The legacy organisation colour palette has been deprecated and will be removed in the next major version. To silence this warning, update $govuk-suppressed-warnings with key: "legacy-organisation-colours"',
+        'We\'ve updated the organisation colour palette. Opt in to the new colours using `$govuk-new-organisation-colours: true`. The old palette is deprecated and we\'ll remove it in the next major version. To silence this warning, update $govuk-suppressed-warnings with key: "legacy-organisation-colours"',
         expect.anything()
       )
     })


### PR DESCRIPTION
We're telling people that the legacy organisation colour palette is deprecated but we're not telling them what actually needs to be done.

Update the deprecation warning message to:

- tell people the organisation colour palette has been updated, so they understand why there's a new and old palette
- tell them how to opt in to use the new palette
- tell them the old (legacy) palette will go away in the future