### PR TITLE
Add percy screenshots for rebrand examples

### DIFF
--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -146,7 +146,8 @@ function goToExample (page, exampleName) {
  * @param {import('puppeteer').Page} page - Puppeteer page object
  * @param {string} componentName - Component name
  * @param {object} [options] - Component options
- * @param {string} options.exampleName - Example name
+ * @param {string} [options.exampleName] - Example name
+ * @param {string} [options.queryParam] - Query param
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
 function goToComponent (page, componentName, options) {
@@ -154,7 +155,7 @@ function goToComponent (page, componentName, options) {
     ? `/components/${componentName}/${options.exampleName}/preview`
     : `/components/${componentName}/preview`
 
-  return goTo(page, componentPath)
+  return goTo(page, options?.queryParam ? `${componentPath}?${options.queryParam}` : componentPath)
 }
 
 /**


### PR DESCRIPTION
Adds the following to our v4 percy setup to account for the brand updates:

- An array of components plus an extra specific header example which gets screenshotted seperate to the array of functions and screenshots via the `input` array
- An options paramerter which we use to pass in a call to the `use_rebrand` cookie to turn the rebrand on, a specific component example name and a specific '(rebranded)' screenshot name

This results in a total of 12 new screenshots with the rebrand feature flag on:

- The default header, with and without js
- The header with product name and navigation, with and without js
- The header with service name and navigation, with and without js
- The default footer
- The default cookie banner

...plus the non-rebranded header with product name and service name + nav, with and without js, to make sure we don't inadvertently impact them.

Closes https://github.com/alphagov/govuk-frontend/issues/5891