### PR TITLE
Add engines info to package file

### DIFF
--- a/.github/workflows/bundler-integrations/package.json
+++ b/.github/workflows/bundler-integrations/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@govuk-frontend/bundler-integrations",
   "description": "Boilerplate to verify that GOV.UK Frontend works OK with main bundlers",
+  "engines": {
+    "node": "^22.11.0",
+    "npm": "^10.1.0"
+  },
   "private": true,
   "scripts": {
     "rollup": "npm run rollup:single-component && npm run rollup:initAll",


### PR DESCRIPTION
We've had [lots of failures from dependabot](https://github.com/alphagov/govuk-frontend/actions/workflows/dependabot/dependabot-updates) in the last few months.

Most seem related to `.github/workflows/bundler-integrations/package.json` packages, and relate to dependabot struggling to pick and install a version of `npm` and `node` (related issue here: https://github.com/dependabot/dependabot-core/issues/11234).

As far as I can tell from that discussion, there's still some work getting done by the dependabot team on this, but in the meantime, I think we should be able to set an `engines` property and hopefully dependabot will pick that up. Worth a try, at least.