### PR TITLE
Move organisation legacy colour palette warning into the `govuk-organisation-colour` mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5905: Fix unnecessary whitespace after logo](https://github.com/alphagov/govuk-frontend/pull/5905)
 - [#5908: Fix footer licence link reflowing on focus in Safari](https://github.com/alphagov/govuk-frontend/pull/5908)
 - [#5919: Update deprecation warning message to make it clearer how to update to new organisation colour palette](https://github.com/alphagov/govuk-frontend/pull/5919)
+- [#5953: Move organisation legacy colour palette warning into the govuk-organisation-colour mixin](https://github.com/alphagov/govuk-frontend/pull/5953)
 - [#5920: Fix transparency around edge of rebranded favicon.ico](https://github.com/alphagov/govuk-frontend/pull/5920)
 - [#5918: Fix `govuk-font-size` mixin outputting the wrong font properties for size 14 text when compiled using libsass](https://github.com/alphagov/govuk-frontend/pull/5918)
 

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -66,6 +66,17 @@
     @error "Unknown organisation `#{$organisation}`";
   }
 
+  // Output a deprecation warning if the legacy colour palette is being used.
+  // Remove in next major version.
+  $is-legacy: $govuk-colours-organisations == $_govuk-legacy-organisation-colours;
+  @if $is-legacy and _should-warn("legacy-organisation-colours") {
+    @warn _warning-text("legacy-organisation-colours",
+      "We've updated the organisation colour palette. Opt in to the new " +
+      "colours using `$govuk-new-organisation-colours: true`. The old " +
+      "palette is deprecated and we'll remove it in the next major version."
+    );
+  }
+
   // Output a warning if $websafe is set.
   @if $websafe and _should-warn("organisation-colour-websafe-param") {
     @warn _warning-text("organisation-colour-websafe-param",

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -318,4 +318,57 @@ describe('@function govuk-organisation-colour', () => {
       })
     })
   })
+
+  describe('legacy deprecation message', () => {
+    it('throws a deprecation warning if the legacy palette is being used', async () => {
+      const sass = `
+      @import "helpers/colour";
+
+      .dft {
+        border-color: govuk-organisation-colour('department-for-transport');
+      }
+    `
+
+      await compileSassString(sass, sassConfig)
+
+      // Expect our mocked @warn function to have been called once with a single
+      // argument, which should be the deprecation notice
+      expect(mockWarnFunction).toHaveBeenCalledWith(
+        "We've updated the organisation colour palette. Opt in to the new " +
+          'colours using `$govuk-new-organisation-colours: true`. The old ' +
+          "palette is deprecated and we'll remove it in the next major " +
+          'version. To silence this warning, update $govuk-suppressed-warnings ' +
+          'with key: "legacy-organisation-colours"',
+        expect.anything()
+      )
+    })
+
+    it('does not throw a deprecation warning if the new palette is being used', async () => {
+      const sass = `
+      $govuk-new-organisation-colours: true;
+      @import "settings/colours-organisations";
+    `
+
+      await compileSassString(sass, sassConfig)
+
+      // Expect our mocked @warn function to have not been called
+      expect(mockWarnFunction).not.toHaveBeenCalled()
+    })
+
+    it('does not throw a deprecation warning if the palette has been customised', async () => {
+      const sass = `
+      $govuk-colours-organisations: (
+        "department-of-administrative-affairs": (
+          colour: "#226623"
+        )
+      );
+      @import "settings/colours-organisations";
+    `
+
+      await compileSassString(sass, sassConfig)
+
+      // Expect our mocked @warn function to have not been called
+      expect(mockWarnFunction).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -359,17 +359,6 @@ $govuk-colours-organisations: $_govuk-legacy-organisation-colours !default;
   $govuk-colours-organisations: $_govuk-organisation-colours;
 }
 
-// Output a deprecation warning if the legacy colour palette is being used.
-// Remove in next major version.
-@if $govuk-colours-organisations == $_govuk-legacy-organisation-colours {
-  @include _warning(
-    "legacy-organisation-colours",
-    "We've updated the organisation colour palette. Opt in to the new " +
-      "colours using `$govuk-new-organisation-colours: true`. The old palette " +
-      "is deprecated and we'll remove it in the next major version."
-  );
-}
-
 /// Organisation colour aliases
 ///
 /// Some organisations have been renamed within our code over time. Here we

--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -1,15 +1,4 @@
 const { compileSassString } = require('@govuk-frontend/helpers/tests')
-const { sassNull } = require('sass-embedded')
-
-// Create a mock warn function that we can use to override the native @warn
-// function, that we can make assertions about post-render.
-const mockWarnFunction = jest.fn().mockReturnValue(sassNull)
-
-const sassConfig = {
-  logger: {
-    warn: mockWarnFunction
-  }
-}
 
 describe('Organisation colours', () => {
   it('should define contrast-safe colours that meet contrast requirements', async () => {
@@ -67,50 +56,5 @@ describe('Organisation colours', () => {
     `
 
     await expect(compileSassString(sass)).resolves.not.toThrow()
-  })
-
-  describe('legacy deprecation message', () => {
-    it('throws a deprecation warning if the legacy palette is being used', async () => {
-      const sass = `
-      @import "settings/colours-organisations";
-    `
-
-      await compileSassString(sass, sassConfig)
-
-      // Expect our mocked @warn function to have been called once with a single
-      // argument, which should be the deprecation notice
-      expect(mockWarnFunction).toHaveBeenCalledWith(
-        'We\'ve updated the organisation colour palette. Opt in to the new colours using `$govuk-new-organisation-colours: true`. The old palette is deprecated and we\'ll remove it in the next major version. To silence this warning, update $govuk-suppressed-warnings with key: "legacy-organisation-colours"',
-        expect.anything()
-      )
-    })
-
-    it('does not throw a deprecation warning if the new palette is being used', async () => {
-      const sass = `
-      $govuk-new-organisation-colours: true;
-      @import "settings/colours-organisations";
-    `
-
-      await compileSassString(sass, sassConfig)
-
-      // Expect our mocked @warn function to have not been called
-      expect(mockWarnFunction).not.toHaveBeenCalled()
-    })
-
-    it('does not throw a deprecation warning if the palette has been customised', async () => {
-      const sass = `
-      $govuk-colours-organisations: (
-        "department-of-administrative-affairs": (
-          colour: "#226623"
-        )
-      );
-      @import "settings/colours-organisations";
-    `
-
-      await compileSassString(sass, sassConfig)
-
-      // Expect our mocked @warn function to have not been called
-      expect(mockWarnFunction).not.toHaveBeenCalled()
-    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -33,6 +33,8 @@ describe('Organisation colours', () => {
 
   it('should define websafe colours that meet contrast requirements (legacy colours)', async () => {
     const sass = `
+      $govuk-suppressed-warnings: ("legacy-organisation-colours");
+
       @import "settings/colours-palette";
       @import "settings/colours-organisations";
       @import "settings/colours-applied";


### PR DESCRIPTION
Move the warning about the change to the organisation colour palette to the `govuk-organisation-colour` mixin so that it’s only outputted if the mixin is called.

We’ve updated the organisation colour palette using a feature flag, and added a deprecation message to tell people to opt in to the new palette if they haven’t already done so.

We originally decided to output this warning from the settings file if the organisation colours were not set to the new palette, rather than outputting the message from the `govuk-organisation-colour ` mixin.

This was done because we’ve seen a lot of users referring to the map directly, rather than using the mixin.

However, this creates a lot of noise, especially as the majority of our users don’t use the organisation colours at all.

It’s also creating a lot of noise in our test output.

Given that it’s relatively trivial for users to update to the new colour palette, it’s not a huge issue if they don’t see the deprecation warning – especially as we’ve also mentioned it in our release notes.