### PR TITLE
Update tests to import using “index”, not “all”

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.unit.test.mjs
@@ -10,7 +10,7 @@ describe('GOV.UK Frontend', () => {
   describe('global styles', () => {
     it('are disabled by default', async () => {
       const sass = `
-        @import "all";
+        @import "index";
       `
       const results = compileSassString(sass)
 
@@ -26,7 +26,7 @@ describe('GOV.UK Frontend', () => {
     it('are enabled if $global-styles variable is set to true', async () => {
       const sass = `
         $govuk-global-styles: true;
-        @import "all";
+        @import "index";
       `
 
       const results = compileSassString(sass)
@@ -72,7 +72,7 @@ describe('GOV.UK Frontend', () => {
   // the compiled CSS - if it finds anything, it will result in the test
   // failing.
   it('does not contain any unexpected govuk- function calls', async () => {
-    const sass = '@import "all"'
+    const sass = '@import "index"'
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: expect.not.stringMatching(/_?govuk-[\w-]+\(.*?\)/g)


### PR DESCRIPTION
Following (and thus silencing) our own deprecation warnings, as we prefer users to import using “govuk/index” now so we can use [index files][1].

[1]: https://sass-lang.com/documentation/at-rules/import/#index-files