### PR TITLE
Remove deprecated `reviewers` option from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,9 +72,6 @@ updates:
       - dependency-name: 'iframe-resizer'
         update-types: ['version-update:semver-major']
 
-    reviewers:
-      - alphagov/design-system-developers
-
     # Schedule run every Monday, local time
     schedule:
       interval: monthly
@@ -94,8 +91,6 @@ updates:
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /
-    reviewers:
-      - alphagov/design-system-developers
 
     # Schedule run every Monday, local time
     schedule:
@@ -106,8 +101,6 @@ updates:
   # Update GitHub Actions (Build)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/build
-    reviewers:
-      - alphagov/design-system-developers
 
     # Schedule run every Monday, local time
     schedule:
@@ -118,8 +111,6 @@ updates:
   # Update GitHub Actions (Install dependencies)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/install-node
-    reviewers:
-      - alphagov/design-system-developers
 
     # Schedule run every Monday, local time
     schedule:
@@ -130,8 +121,6 @@ updates:
   # Update GitHub Actions (Setup Node.js)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/setup-node
-    reviewers:
-      - alphagov/design-system-developers
 
     # Schedule run every Monday, local time
     schedule:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,8 @@
 # Ensure any changes to GitHub Actions workflows are reviewed by developers
 .github/workflows/  @alphagov/design-system-developers
+
+# Track changes to package.json or package-lock.json
+/package*.json  @alphagov/design-system-developers
+
+# Protect the CODEOWNERS file itself against malicious changes
+CODEOWNERS  @alphagov/design-system-developers


### PR DESCRIPTION
Dependabot's `reviewers` option is being removed on 27th May, with its functionality being merged with the `CODEOWNERS` file, [as described on the GitHub blog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

## Changes
- Updates the `CODEOWNERS` file to include the **root** `package.json` and `package-lock.json` files explicitly, to match npm dependencies being protected by the `reviewers` option in Dependabot's config.
- Updates the `CODEOWNERS` file to include the `CODEOWNERS` file itself, requiring approval from codeowners to change it in future. [This is a recommended security practice.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection)
- Removes the `reviewers` option from Dependabot config.

## Thoughts
- Pull requests are usually approved by at least one developer on the team, regardless of source. We could simplify the `CODEOWNERS` file to have _all_ changes require codeowner review. Is there a reason for us not to do that? 