### PR TITLE
Fix colour of refreshed GOV.UK logo's dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#5953: Move organisation legacy colour palette warning into the govuk-organisation-colour mixin](https://github.com/alphagov/govuk-frontend/pull/5953)
 - [#5920: Fix transparency around edge of rebranded favicon.ico](https://github.com/alphagov/govuk-frontend/pull/5920)
 - [#5918: Fix `govuk-font-size` mixin outputting the wrong font properties for size 14 text when compiled using libsass](https://github.com/alphagov/govuk-frontend/pull/5918)
+- [#5962: Fix colour of refreshed GOV.UK logo's dot](https://github.com/alphagov/govuk-frontend/pull/5962)
 
 ## v5.10.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -104,7 +104,7 @@
 
   // Colour in the Dot
   .govuk-logo-dot {
-    fill: #11e0f1;
+    fill: #00ffe0;
 
     // Override Dot colour when printing
     @include govuk-media-query($media-type: print) {


### PR DESCRIPTION
We'd missed that the dot didn't use the right accent colour and used blue's instead of teal's accent.

| Main | Updated |
|--------|--------|
| ![GOV.UK Logo with blue accent](https://github.com/user-attachments/assets/c0a1b488-d147-493a-b7e6-69b3cd8d6936)| ![GOV.UK Logo with blue accent](https://github.com/user-attachments/assets/52142a9b-f5de-44bc-8308-6ec89ea7f07f)|
|[Review app](https://govuk-frontend-review.herokuapp.com/components/header?rebrandOverride=true)|[Preview app](https://govuk-frontend-pr-5962.herokuapp.com/components/header?rebrandOverride=true)|

