### PR TITLE
css-based conditional reveal

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -171,7 +171,8 @@
     padding-left: $conditional-padding-left;
     border-left: $conditional-border-width solid $govuk-border-colour;
 
-    .govuk-frontend-supported &--hidden {
+    // Hide the conditional reveal if the checkbox is unchecked
+    .govuk-frontend-supported .govuk-checkboxes__item:has(input[type="checkbox"]:not(:checked)) + & {
       display: none;
     }
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -87,8 +87,8 @@ export class Checkboxes extends Component {
   /**
    * Sync conditional reveal with the input state
    *
-   * Synchronise the visibility of the conditional reveal, and its accessible
-   * state, with the input's checked state.
+   * Synchronise the accessible state of the conditional reveal with the input's
+   * checked state.
    *
    * @private
    * @param {HTMLInputElement} $input - Checkbox input
@@ -104,10 +104,6 @@ export class Checkboxes extends Component {
       const inputIsChecked = $input.checked
 
       $input.setAttribute('aria-expanded', inputIsChecked.toString())
-      $target.classList.toggle(
-        'govuk-checkboxes__conditional--hidden',
-        !inputIsChecked
-      )
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/radios/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_index.scss
@@ -190,7 +190,8 @@
     padding-left: $conditional-padding-left;
     border-left: $conditional-border-width solid $govuk-border-colour;
 
-    .govuk-frontend-supported &--hidden {
+    // Hide the conditional reveal if the radio is unchecked
+    .govuk-frontend-supported .govuk-radios__item:has(input[type="radio"]:not(:checked)) + & {
       display: none;
     }
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -87,8 +87,8 @@ export class Radios extends Component {
   /**
    * Sync conditional reveal with the input state
    *
-   * Synchronise the visibility of the conditional reveal, and its accessible
-   * state, with the input's checked state.
+   * Synchronise the accessible stateof the conditional reveal with the input's
+   * checked state.
    *
    * @private
    * @param {HTMLInputElement} $input - Radio input
@@ -104,10 +104,6 @@ export class Radios extends Component {
       const inputIsChecked = $input.checked
 
       $input.setAttribute('aria-expanded', inputIsChecked.toString())
-      $target.classList.toggle(
-        'govuk-radios__conditional--hidden',
-        !inputIsChecked
-      )
     }
   }
 


### PR DESCRIPTION
Current implementation of radiobutton/checkbox conditional reveal requires javascript enabled.
A much more elegant solution which doesn't require javascript is suggested with the use of CSS.
I left the remaining javascript as I wasn't sure how much you care about the "aria-controls".
Should you decide to keep the javascript (I think you can ditch the entire js file), I would recommend targeting the radio buttons being clicked or their status changed, instead of the more cumbersome current solution of being triggered by any click on the page. Doing so will allow simplifying the JS significantly