### PR TITLE
Simplify prefix for breakpoint custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Deprecated features
+
+#### Replace references to CSS custom properties for breakpoints
+
+We've renamed the CSS custom properties for breakpoints to simplify the prefix from `--govuk-frontend` to just `--govuk`.
+
+| Old name                            | New name                   |
+| ----------------------------------- | -------------------------- |
+| --govuk-frontend-breakpoint-mobile  | --govuk-breakpoint-mobile  |
+| --govuk-frontend-breakpoint-tablet  | --govuk-breakpoint-tablet  |
+| --govuk-frontend-breakpoint-desktop | --govuk-breakpoint-desktop |
+
+You can still use the old names, but we'll remove them in the next breaking release (GOV.UK Frontend v6.0.0).
+
+This change was introduced in [pull request #6014: Simplify prefix for breakpoint custom properties](https://github.com/alphagov/govuk-frontend/pull/6014).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -78,12 +78,12 @@ describe('Common JS utilities', () => {
       const stylesheet = document.createElement('style')
       stylesheet.innerHTML = outdent`
         :root {
-          --govuk-frontend-breakpoint-mobile: 40em;
-          --govuk-frontend-breakpoint-tablet: 80em;
+          --govuk-breakpoint-mobile: 40em;
+          --govuk-breakpoint-tablet: 80em;
         }
 
         body {
-          --govuk-frontend-breakpoint-tablet: 90em;
+          --govuk-breakpoint-tablet: 90em;
         }
       `
       document.body.appendChild(stylesheet)
@@ -91,21 +91,21 @@ describe('Common JS utilities', () => {
 
     it('returns the breakpoint value if it exists', () => {
       expect(getBreakpoint('mobile')).toEqual({
-        property: '--govuk-frontend-breakpoint-mobile',
+        property: '--govuk-breakpoint-mobile',
         value: '40em'
       })
     })
 
     it('returns the value as set on the HTML (root) element', () => {
       expect(getBreakpoint('tablet')).toEqual({
-        property: '--govuk-frontend-breakpoint-tablet',
+        property: '--govuk-breakpoint-tablet',
         value: '80em'
       })
     })
 
     it('returns an undefined value if the breakpoint does not exist', () => {
       expect(getBreakpoint('giant-video-wall')).toEqual({
-        property: '--govuk-frontend-breakpoint-giant-video-wall',
+        property: '--govuk-breakpoint-giant-video-wall',
         value: undefined
       })
     })

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -32,7 +32,7 @@ export function getFragmentFromUrl(url) {
  * @returns {{ property: string, value?: string }} Breakpoint object
  */
 export function getBreakpoint(name) {
-  const property = `--govuk-frontend-breakpoint-${name}`
+  const property = `--govuk-breakpoint-${name}`
 
   // Get value from `<html>` with breakpoints on CSS :root
   const value = window

--- a/packages/govuk-frontend/src/govuk/core/_govuk-frontend-properties.scss
+++ b/packages/govuk-frontend/src/govuk/core/_govuk-frontend-properties.scss
@@ -5,6 +5,9 @@
 
   // CSS custom property for each breakpoint
   @each $name, $value in $govuk-breakpoints {
-    --govuk-frontend-breakpoint-#{$name}: #{govuk-px-to-rem($value)};
+    --govuk-breakpoint-#{$name}: #{govuk-px-to-rem($value)};
+
+    // Deprecated, use `--govuk-breakpoint-[name]` instead
+    --govuk-frontend-breakpoint-#{$name}: var(--govuk-breakpoint-#{$name});
   }
 }

--- a/packages/govuk-frontend/tasks/build/release.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/release.unit.test.mjs
@@ -58,13 +58,9 @@ describe('dist/', () => {
       expect(stylesheet).toContain(`--govuk-frontend-version:"${pkg.version}"`)
 
       // Breakpoints for `window.matchMedia()` in Header, Tabs components
-      expect(stylesheet).toContain('--govuk-frontend-breakpoint-mobile:20rem')
-      expect(stylesheet).toContain(
-        '--govuk-frontend-breakpoint-tablet:40.0625rem'
-      )
-      expect(stylesheet).toContain(
-        '--govuk-frontend-breakpoint-desktop:48.0625rem'
-      )
+      expect(stylesheet).toContain('--govuk-breakpoint-mobile:20rem')
+      expect(stylesheet).toContain('--govuk-breakpoint-tablet:40.0625rem')
+      expect(stylesheet).toContain('--govuk-breakpoint-desktop:48.0625rem')
     })
   })
 


### PR DESCRIPTION
Since #4562 we’ve exposed our breakpoints (mobile, tablet, desktop) as CSS custom properties so that we can use them in `matchMedia` functions in our JavaScript without having to duplicate the values.

When we introduced them we prefixed them with `--govuk-frontend`, I think to align with the existing `--govuk-frontend-version` property.

But the `--govuk-frontend-version` property is _about_ GOV.UK Frontend, whereas I think we can simplify the prefix for the rest of our custom properties to just `--govuk`, matching what we do in Sass for our functions, mixins and variables.

Keep the existing custom property names as aliases just in case anyone else is using them, but mark them as deprecated to be removed in the next major release.