### PR TITLE
Add inverse variant to Service navigation component

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/product-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/product-page/index.njk
@@ -24,30 +24,31 @@ title: GOV.UK Pay
   }) }}
 
   {{ govukServiceNavigation({
-  navigation: [
-    {
-      href: "#",
-      text: "Features"
-    },
-    {
-      href: "#",
-      text: "Get started",
-      active: true
-    },
-    {
-      href: "#",
-      text: "Documentation"
-    },
-    {
-      href: "#",
-      text: "Support"
-    },
-    {
-      href: "#",
-      text: "Sign in"
-    }
-  ]
-}) }}
+    classes: "govuk-service-navigation--inverse",
+    navigation: [
+      {
+        href: "#",
+        text: "Features"
+      },
+      {
+        href: "#",
+        text: "Get started",
+        active: true
+      },
+      {
+        href: "#",
+        text: "Documentation"
+      },
+      {
+        href: "#",
+        text: "Support"
+      },
+      {
+        href: "#",
+        text: "Sign in"
+      }
+    ]
+  }) }}
 
 
 {% endblock%}

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -48,7 +48,13 @@
 
       @include _govuk-rebrand {
         padding: govuk-spacing(3) 0;
-        line-height: 1.5;
+
+        // More magic numbers ahoy:
+        // 29 is the desired height of the element (60), minus top and bottom
+        // padding (2×15), minus bottom border (1); 19 is the font-size at this
+        // point. This gives us the perfect fractional line height to make the
+        // overall component 60px high
+        line-height: (29 / 19);
       }
 
       &:not(:last-child) {
@@ -181,5 +187,41 @@
   // inherit the parent font-weight.
   .govuk-service-navigation__active-fallback {
     font-weight: inherit;
+  }
+
+  // Inverted colour scheme style intended for product pages
+  .govuk-service-navigation--inverse {
+    @include _govuk-rebrand {
+      // Remove bottom border to add width-container ones
+      border-bottom: none;
+      background-color: $govuk-brand-colour;
+
+      .govuk-width-container {
+        border-width: 1px 0;
+        border-style: solid;
+        border-color: $_govuk-rebrand-border-colour-on-blue-tint-95;
+      }
+
+      // Subtract 1px of space to account for the extra border-top
+      .govuk-service-navigation__container {
+        margin-top: -1px;
+      }
+
+      // Override the 'active' border colour
+      .govuk-service-navigation__item,
+      .govuk-service-navigation__service-name {
+        border-color: govuk-colour("white");
+      }
+
+      // Override link styles
+      .govuk-service-navigation__link {
+        @include govuk-link-style-inverse;
+      }
+
+      // Override mobile menu toggle colour when not focused
+      .govuk-service-navigation__toggle:not(:focus) {
+        color: govuk-colour("white");
+      }
+    }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -205,6 +205,24 @@ examples:
           text: Navigation item 3
         - href: '#/4'
           text: Navigation item 4
+  - name: inverse
+    description: Service navigation that appears between other areas of brand blue. Rebrand only.
+    previewLayoutModifiers:
+      - inverse
+    options:
+      classes: govuk-service-navigation--inverse
+      serviceName: Apply for a juggling license
+      serviceUrl: '#/'
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+        - href: '#/2'
+          text: Navigation item 2
+          active: true
+        - href: '#/3'
+          text: Navigation item 3
+        - href: '#/4'
+          text: Navigation item 4
 
   # Hidden examples
   - name: with no options set


### PR DESCRIPTION
Add 'inverse' (white on blue) variant of the Service navigation component. For #6013.

This variant is intended for use on pages where the GOV.UK header and Service navigation are followed by another element with a blue background, such as on [Digital Service Platforms pages](https://platforms.service.gov.uk/), to create a seamless blue area at the top of the page.

## Changes
- Adds an inversely coloured variant of the Service navigation component.
- Change how line-height is calculated on service name and navigation items.
- Review app:
  - Adds an example of the inverse styles to the review app.
  - Updates the 'product page' full page example to use the inverse variant.

## Thoughts
- The appearance of the inverse component means that non-linked service names and navigation items look identical to their linked equivalents. This might be okay—the non-inverse version of the component doesn't distinguish between linked and non-linked service names either, and links are distinguished only by colour—but could potentially be better.