### PR TITLE
Fix layout of Service navigation in Edge when forced colours are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#6018: Fix layout of Service navigation in Edge when forced colours are enabled](https://github.com/alphagov/govuk-frontend/pull/6018)
+
 ## v5.10.2 (Patch release)
 
 To install this version with npm, run `npm install govuk-frontend@5.10.2`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -42,6 +42,9 @@
     border: 0 solid $govuk-service-navigation-link-colour;
 
     @include govuk-media-query($from: tablet) {
+      // inline-block is used as a fallback for browsers that don't support flexbox
+      display: inline-block;
+
       margin-top: 0;
       margin-bottom: 0;
       padding: govuk-spacing(4) 0;
@@ -171,11 +174,10 @@
       // However... IE11 totally trips over flexbox and doesn't wrap anything,
       // making all of the items into a single, horizontally scrolling row,
       // which is no good. This CSS hack removes the flexbox definition for
-      // IE 10 & 11, reverting it to the flawed, but OK, non-flexbox version.
+      // IE 9–11, reverting it to the flawed, but OK, non-flexbox version.
       //
-      // CSS hack taken from https://stackoverflow.com/questions/11173106/apply-style-only-on-ie#answer-36448860
-      // which also includes an explanation of why this works
-      @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+      // CSS hack from http://browserhacks.com/#hack-a60b03e301a67f76a5a22221c739dc64
+      @media screen and (min-width: 0\0) {
         display: block;
       }
     }


### PR DESCRIPTION
Fixes #5871.

## Background
The crux of the issue was that navigation items didn't have an overriding `display` property, so they were defaulting to `list-item`. This was present when the Service navigation component was being developed, but was erroneously removed before release.

Whilst fixing this, however, I noticed that the media query hack being used to target IE11 was also being matched in current versions of Edge, which doesn't need the fallback. I've now changed it to a different media query hack that correctly appears to only match older browsers (IE 9–11, Edge 12–17, Safari 4). 

## Changes
- Adds `display: inline-block` to navigation items.
- Updates the media query hack that disables flexbox on the navigation list in older browsers.