### PR TITLE
Fix service nav wrapper not filling available width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6018: Fix layout of Service navigation in Edge when forced colours are enabled](https://github.com/alphagov/govuk-frontend/pull/6018)
+- [#6019: Fix service nav wrapper not filling available width](https://github.com/alphagov/govuk-frontend/pull/6019), thanks to @joelanman for reporting and fixing this issue
 
 ## v5.10.2 (Patch release)
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow-slot/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow-slot/index.njk
@@ -21,12 +21,12 @@ notes: Based on Companies House "Find an update company information" service
 {% block head %}
   {{ super() }}
   <style>
-    .app-service-navigation .govuk-service-navigation__wrapper {
-      flex-grow: 1;
-    }
     .app-sign-out {
       margin-left: auto;
       padding: 15px 0 10px;
+    }
+    .govuk-template--rebranded .app-sign-out {
+      padding: 10px 0;
     }
     .app-sign-out .govuk-button {
       margin: 0;
@@ -52,7 +52,6 @@ notes: Based on Companies House "Find an update company information" service
     serviceUrl: "#0"
   }) }}
   {{ govukServiceNavigation({
-    classes: "app-service-navigation",
     navigation: [
       {
         href: '#1',

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -111,6 +111,13 @@
     @include govuk-link-style-text;
   }
 
+  // Allow navigation section to always take up maximum available space,
+  // rather than sizing to fit the content. This makes it easier to right align
+  // nav items and use slots.
+  .govuk-service-navigation__wrapper {
+    flex-grow: 1;
+  }
+
   //
   // Navigation list specific code
   //


### PR DESCRIPTION
Closes #5425.

Currently, the list of navigation items in the Service navigation component shrinks itself to fit its contents. It does this by default because of our use of flexbox, however, this makes it more difficult to right-align navigation items (such as sign in/out links) or make use of the `navigationEnd` slot. 

By making the navigation wrapper always fill the available width, developers don't have to provide their own styles to do this.

## Changes
- Adds `flex-grow: 1` to the service navigation wrapper, allowing the navigation portion of the component to take up all available width.
- Updates the full-page example of the service navigation with slots to remove this style being added there, and to tweak the styles used when the rebrand is enabled.

## Thoughts
There was a suggestion to determine an 'official' way of right-aligning navigation items. I think that probably expands the scope of this too much, as it creates multiple questions—e.g. grouping multiple right-aligned items, how they interact with the `navigationEnd` slot, if and how they're differentiated on mobile—that I think are best answered by implementers.