### PR TITLE
Revert "Bump tar-fs from 3.0.8 to 3.0.9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27939,9 +27939,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
The tests are currently failing on `main`, possibly relating to an issue restoring caches. We're seeing messages like this in [the build output](https://github.com/alphagov/govuk-frontend/actions/runs/15530807296/job/43719308884#step:4:14):

```
/usr/bin/tar: node_modules/@govuk-frontend/config: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/config/tsconfig.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/helpers: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/helpers/tsconfig.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/lib: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/lib/tsconfig.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/review: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/review/tsconfig.build.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/review: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/review/tsconfig.dev.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/stats: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/stats/tsconfig.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/tasks: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/tasks/tsconfig.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/@govuk-frontend/workflow-scripts: Cannot mkdir: File exists
/usr/bin/tar: node_modules/@govuk-frontend/workflow-scripts/tsconfig.tsbuildinfo: Cannot hard link to '.github/workflows/scripts/tsconfig.tsbuildinfo': No such file or directory
/usr/bin/tar: node_modules/govuk-frontend: Cannot mkdir: File exists
/usr/bin/tar: node_modules/govuk-frontend/tsconfig.build.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: node_modules/govuk-frontend: Cannot mkdir: File exists
/usr/bin/tar: node_modules/govuk-frontend/tsconfig.dev.tsbuildinfo: Cannot open: No such file or directory
/usr/bin/tar: packages/govuk-frontend/tsconfig.build.tsbuildinfo: Cannot hard link to 'node_modules/govuk-frontend/tsconfig.build.tsbuildinfo': No such file or directory
/usr/bin/tar: packages/govuk-frontend/tsconfig.dev.tsbuildinfo: Cannot hard link to 'node_modules/govuk-frontend/tsconfig.dev.tsbuildinfo': No such file or directory
/usr/bin/tar: packages/govuk-frontend-review/tsconfig.build.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/review/tsconfig.build.tsbuildinfo': No such file or directory
/usr/bin/tar: packages/govuk-frontend-review/tsconfig.dev.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/review/tsconfig.dev.tsbuildinfo': No such file or directory
/usr/bin/tar: shared/config/tsconfig.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/config/tsconfig.tsbuildinfo': No such file or directory
/usr/bin/tar: shared/helpers/tsconfig.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/helpers/tsconfig.tsbuildinfo': No such file or directory
/usr/bin/tar: shared/lib/tsconfig.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/lib/tsconfig.tsbuildinfo': No such file or directory
/usr/bin/tar: shared/stats/tsconfig.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/stats/tsconfig.tsbuildinfo': No such file or directory
/usr/bin/tar: shared/tasks/tsconfig.tsbuildinfo: Cannot hard link to 'node_modules/@govuk-frontend/tasks/tsconfig.tsbuildinfo': No such file or directory
/usr/bin/tar: Exiting with failure status due to previous errors
```

We don't really understand how `tar-fs` interacts with `tar`, but given this was the last changed merged to main, and the changes in `tar-fs` 3.0.9 [relate to how directories are handled on Windows](https://github.com/mafintosh/tar-fs/pull/115) it's worth raising to see if it makes the tests pass again…