### PR TITLE
Add changelog for inverse service navigation styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,23 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
-#### The Service Navigation component no longer uses a menu on mobile for a single link
+#### The Service navigation component no longer uses a menu on mobile for a single link
 
-If you're using our Nunjucks macros, the Service Navigation component will no longer collapse the navigation behind a 'Menu' toggle if there is only one navigation item.
+If you're using our Nunjucks macros, the Service navigation component will no longer collapse the navigation behind a 'Menu' toggle if there is only one navigation item.
 
 You can control this behaviour using the new `collapseNavigationOnMobile` Nunjucks option.
 
 If you are not using our Nunjucks macros, you can recreate this behaviour by omitting the 'Menu' `<button>` element if there is only one navigation item.
 
 This change was introduced in [pull request #6016: Don’t use menu for service nav with a single link](https://github.com/alphagov/govuk-frontend/pull/6016).
+
+#### Added inverse styling to Service navigation for use on product pages
+
+When the GOV.UK rebrand is enabled, you can now add the `govuk-service-navigation--inverse` class to the Service navigation component to use white links on a blue background.
+
+This allows the rebranded GOV.UK header and Service navigation to flow seamlessly with subsequent components that have a blue background, as is common on [GOV.UK Digital Service Platform](https://platforms.service.gov.uk/) pages.
+
+This change was made in [pull request #6015: Add inverse variant to Service navigation component](https://github.com/alphagov/govuk-frontend/pull/6015).
 
 ### Deprecated features
 


### PR DESCRIPTION
Adds missing changelog entry for #6015.

We're pretty inconsistent on how we capitalise component names, but sentence case seems to be more common in the existing changelog (i.e. "Service navigation" rather than "Service Navigation") so I've also updated the other entry to use that format. 