### PR TITLE
Fix background colour of .govuk-template--rebranded

### DIFF
--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -15,7 +15,7 @@
     @include _govuk-rebrand(
       "background-color",
       $govuk-canvas-background-colour,
-      $_govuk-rebrand-template-background-colour
+      $_govuk-rebrand-canvas-background-colour
     );
   }
 

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -33,7 +33,7 @@
     @include _govuk-rebrand(
       "background",
       $from: $govuk-footer-background,
-      $to: $_govuk-rebrand-template-background-colour
+      $to: $_govuk-rebrand-canvas-background-colour
     );
   }
 

--- a/src/govuk/objects/_template.scss
+++ b/src/govuk/objects/_template.scss
@@ -6,7 +6,11 @@
   .govuk-template {
     // Set the overall page background colour to the same colour as used by the
     // footer to give the illusion of a long footer.
-    background-color: $govuk-canvas-background-colour;
+    @include _govuk-rebrand(
+      background-color,
+      $govuk-canvas-background-colour,
+      $_govuk-rebrand-template-background-colour
+    );
 
     // Prevent automatic text sizing, as we already cater for small devices and
     // would like the browser to stay on 100% text zoom by default.

--- a/src/govuk/objects/_template.scss
+++ b/src/govuk/objects/_template.scss
@@ -9,7 +9,7 @@
     @include _govuk-rebrand(
       background-color,
       $govuk-canvas-background-colour,
-      $_govuk-rebrand-template-background-colour
+      $_govuk-rebrand-canvas-background-colour
     );
 
     // Prevent automatic text sizing, as we already cater for small devices and

--- a/src/govuk/settings/_colours-applied.scss
+++ b/src/govuk/settings/_colours-applied.scss
@@ -162,4 +162,4 @@ $govuk-link-active-colour: govuk-colour("black", $legacy: "light-blue") !default
 ///
 /// @type Colour
 /// @access private
-$_govuk-rebrand-template-background-colour: #f4f8fb; // Blue tint 95%
+$_govuk-rebrand-canvas-background-colour: #f4f8fb; // Blue tint 95%


### PR DESCRIPTION
The background colour of the page should be light blue rather than light grey for continuity with the footer and cookie banner, but we missed it during the port of the brand refresh from v5 to v4. 

This PR sets the background colour to `.govuk-template--rebranded`, and renames the variable storing the light blue to `$_govuk-rebrand-canvas-background-colour` for consistency with the variable it replaces when the refresh is active. Happy to drop the commit that does the renaming, though, if we think it's safer.