### PR TITLE
Swap package version updating and changelog updating jobs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,9 +38,6 @@ jobs:
 
             validateVersion('${{ inputs.version }}', frontendPackage.default.version)
 
-      - name: Update package version
-        run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
-
       - name: Update CHANGELOG
         uses: actions/github-script@v7.0.1
         with:
@@ -49,6 +46,9 @@ jobs:
             const frontendPackage = await import('${{ github.workspace }}/packages/govuk-frontend/package.json', { with: { type: 'json' }})
 
             updateChangelog('${{ inputs.version }}', frontendPackage.default.version)
+
+      - name: Update package version
+        run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
 
       - name: Generate release notes
         uses: actions/github-script@v7.0.1


### PR DESCRIPTION
Swaps the `Update package version` job to be after the `Update CHANGELOG` job in the build release workflow.

This was previously triping up releases because:

During the runup to 5.10, we'd made several updated to the build release scripts to make them more robust and work better with internal releases. One of these changes included passing the previous version of govuk-frontend from the package itself rather than using headings in the changelog.

In the `updateChangelog` script, we diff the new version (passed upon hitting 'run') and the old version (from the package, previously retrieved from the last changelog heading which wasn't super reliable). This diff is there to help `updateChangelog` with generating a new release heading. However given that we update the package after validating the new version, that diff is now comparing the new version with the new version and this returns nothing, causing the script to error.

This change moves the package update to after the changelog update so that the diff works as expected.

Validated with testing on this branch:
- [Workflow run
](https://github.com/alphagov/govuk-frontend/actions/runs/15777790385/job/44476055701)
- [Generated PR](https://github.com/alphagov/govuk-frontend/pull/6038)