### PR TITLE
Uninstall yargs-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31245,8 +31245,7 @@
         "rollup": "^4.19.1",
         "sass-embedded": "^1.88.0",
         "slash": "^5.1.0",
-        "slug": "^9.1.0",
-        "yargs-parser": "^21.1.1"
+        "slug": "^9.1.0"
       },
       "engines": {
         "node": "^22.11.0",

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -24,7 +24,6 @@
     "rollup": "^4.19.1",
     "sass-embedded": "^1.88.0",
     "slash": "^5.1.0",
-    "slug": "^9.1.0",
-    "yargs-parser": "^21.1.1"
+    "slug": "^9.1.0"
   }
 }


### PR DESCRIPTION
The only place that yargs-parser was being used was in shared/tasks/helpers/task-arguments.mjs which got removed with https://github.com/alphagov/govuk-frontend/commit/2ad331924779ed1ff17cc19c261e299410ae7671. Therefore this dependency is redundant. GET IT OUTTA HERE.