### PR TITLE
Remove `color` property from review app's inverse example template

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
@@ -26,7 +26,6 @@
 
 // Darken page background for previewing inversely coloured components
 .app-template__body--inverse {
-  color: govuk-colour("white");
   background-color: govuk-colour("blue");
 }
 


### PR DESCRIPTION
Removes the text `color` style from inversely coloured component examples.

Historically, this template was only used to test components that appear on top of a darkened or blue background, where it could be assumed that the text colour has already been lightened. With the introduction of the [inverse service navigation](https://govuk-frontend-review.herokuapp.com/components/service-navigation/inverse/preview?rebrandOverride=true) we have an inverse variant that _introduces_ a blue background, rather than existing on one.

In that context, having a global text `color` is inappropriate, as it makes the example render with a text colour that it may not have in implementation, allowing issues like #6045 to slip by.