### PR TITLE
Use scope option in percy snapshots

### DIFF
--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -114,24 +114,6 @@ export async function screenshotComponent(browser, componentName, options) {
 export async function screenshotExample(browser, exampleName) {
   const page = await goToExample(browser, exampleName)
 
-  // Dismiss app banner
-  await page.setCookie({
-    name: 'dismissed-app-banner',
-    value: 'yes',
-    url: page.url()
-  })
-
-  await page.reload({ waitUntil: 'load' })
-
-  // Remove feature flag banner
-  await page.evaluate(() => {
-    const featureFlagBanner = document.querySelector('.app-feature-flag-banner')
-
-    if (featureFlagBanner) {
-      featureFlagBanner.remove()
-    }
-  })
-
   // Screenshot preview page
   await percySnapshot(page, `js: ${exampleName} (example)`, {
     scope: '.govuk-main-wrapper'

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -72,6 +72,13 @@ export async function screenshots() {
 export async function screenshotComponent(browser, componentName, options) {
   const componentFiles = await getComponentFiles(componentName)
 
+  // Percy snapshot options
+  // Scope is .app-wihtespace-highlight rather than .govuk-main-wrapper like with
+  // the examples so that margin that isn't part of the component doesn't get
+  // included in the screenshot
+  /** @type {SnapshotOptions} */
+  const snapshotOptions = { scope: '.app-whitespace-highlight' }
+
   // Navigate to component
   const page = await goToComponent(browser, componentName, options)
 
@@ -81,7 +88,7 @@ export async function screenshotComponent(browser, componentName, options) {
     : componentName
 
   // Screenshot preview page (with JavaScript)
-  await percySnapshot(page, `js: ${screenshotName}`)
+  await percySnapshot(page, `js: ${screenshotName}`, snapshotOptions)
 
   // Check for "JavaScript enabled" components
   if (componentFiles.some(filterPath([`**/${componentName}.mjs`]))) {
@@ -89,7 +96,7 @@ export async function screenshotComponent(browser, componentName, options) {
 
     // Screenshot preview page (without JavaScript)
     await page.reload({ waitUntil: 'load' })
-    await percySnapshot(page, `no-js: ${screenshotName}`)
+    await percySnapshot(page, `no-js: ${screenshotName}`, snapshotOptions)
   }
 
   // Close page
@@ -126,7 +133,9 @@ export async function screenshotExample(browser, exampleName) {
   })
 
   // Screenshot preview page
-  await percySnapshot(page, `js: ${exampleName} (example)`)
+  await percySnapshot(page, `js: ${exampleName} (example)`, {
+    scope: '.govuk-main-wrapper'
+  })
 
   // Close page
   return page.close()
@@ -134,4 +143,5 @@ export async function screenshotExample(browser, exampleName) {
 
 /**
  * @import { Browser } from 'puppeteer'
+ * @import { SnapshotOptions } from '@percy/core'
  */


### PR DESCRIPTION
## Change

Uses Percy's [scope option](https://www.browserstack.com/docs/percy/take-percy-snapshots/snapshots-via-scripts#screenshot-a-single-element) to specify that snapshots should only capture what's within `.app-whitespace-highlight` for components and `.govuk-main-wrapper` for examples. This makes our VRT tests neater and means we don't need to add code to manage stuff happening within our review app templates eg: removing the 'this is a review app' banner.

Resolves https://github.com/alphagov/govuk-frontend/issues/6051

## Notes

It doesn't look like this change saves us lots of time in terms of test running:

- [A test run taken from this PR](https://github.com/alphagov/govuk-frontend/actions/runs/16022999333/job/45204327679?pr=6068) completed in 1m 25s
- [A test run in `main`](https://github.com/alphagov/govuk-frontend/actions/runs/16023148029/job/45204647531) completed in 1m 23s

The few seconds of variability is standard amoung our tests. It already wasn't a hugely taxing test so that doesn't strike me as a problem.