### PR TITLE
Update examples for form input components

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -143,16 +143,6 @@ examples:
       label:
         text: Can you provide more detail?
 
-  - name: with custom textarea description
-    description: with textarea description translated into Welsh.
-    options:
-      name: custom-textarea-description
-      id: custom-textarea-description
-      maxlength: 10
-      label:
-        text: Can you provide more detail?
-      textareaDescriptionText: Gallwch ddefnyddio hyd at %{count} nod
-
   - name: with hint
     options:
       name: with-hint
@@ -163,16 +153,6 @@ examples:
       hint:
         text: Don't include personal or financial information, eg your
           National Insurance number or credit card details.
-
-  - name: with error
-    options:
-      name: with-error
-      id: with-error
-      maxlength: 10
-      label:
-        text: Can you provide more detail?
-      errorMessage:
-        text: Please provide more detail
 
   - name: with hint and error
     options:
@@ -249,29 +229,17 @@ examples:
       label:
         text: Full address
 
-  - name: with translations
+  # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: with custom textarea description
+    hidden: true
+    description: with textarea description translated into Welsh.
     options:
-      id: with-translations
-      name: with-translations
+      name: custom-textarea-description
+      id: custom-textarea-description
       maxlength: 10
       label:
-        text: Full address
-      charactersUnderLimitText:
-        other: '%{count} characters to go'
-        one: 'One character to go'
-      charactersAtLimitText: 'Zero characters left'
-      charactersOverLimitText:
-        other: '%{count} characters too many'
-        one: 'One character too many'
-      wordsUnderLimitText:
-        other: '%{count} words to go'
-        one: 'One word to go'
-      wordsAtLimitText: 'Zero words left'
-      wordsOverLimitText:
-        other: '%{count} words too many'
-        one: 'One word too many'
-
-  # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+        text: Can you provide more detail?
+      textareaDescriptionText: Gallwch ddefnyddio hyd at %{count} nod
   - name: classes
     hidden: true
     options:
@@ -396,3 +364,25 @@ examples:
       name: no-maximum
       label:
         text: Full address
+  - name: with translations
+    hidden: true
+    options:
+      id: with-translations
+      name: with-translations
+      maxlength: 10
+      label:
+        text: Full address
+      charactersUnderLimitText:
+        other: '%{count} characters to go'
+        one: 'One character to go'
+      charactersAtLimitText: 'Zero characters left'
+      charactersOverLimitText:
+        other: '%{count} characters too many'
+        one: 'One character too many'
+      wordsUnderLimitText:
+        other: '%{count} words to go'
+        one: 'One word to go'
+      wordsAtLimitText: 'Zero words left'
+      wordsOverLimitText:
+        other: '%{count} words too many'
+        one: 'One word too many'

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -90,11 +90,7 @@ describe('Checkboxes', () => {
         let $inputs
 
         beforeAll(async () => {
-          await render(
-            page,
-            'checkboxes',
-            examples['with conditional item checked']
-          )
+          await render(page, 'checkboxes', examples['with pre-checked values'])
 
           $component = await page.$('.govuk-checkboxes')
           $inputs = await $component.$$('.govuk-checkboxes__input')
@@ -111,7 +107,7 @@ describe('Checkboxes', () => {
         })
 
         it('has no conditional content revealed that is associated with an unchecked input', async () => {
-          const $input = $inputs[$inputs.length - 1] // Last input, unchecked
+          const $input = $inputs[1] // second input, unchecked
           const $conditional = await $component.$(
             `[id="${await getAttribute($input, 'aria-controls')}"]`
           )

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -163,12 +163,28 @@ accessibilityCriteria: |
 
 examples:
   - name: default
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       name: nationality
+      fieldset:
+        legend:
+          text: What is your nationality?
+      items:
+        - value: british
+          text: British
+        - value: irish
+          text: Irish
+        - value: other
+          text: Citizen of another country
+
+  - name: with hint
+    options:
+      name: nationality
+      fieldset:
+        legend:
+          text: What is your nationality?
+      hint:
+        text: Select all that apply
       items:
         - value: british
           text: British
@@ -178,36 +194,49 @@ examples:
           text: Citizen of another country
 
   - name: with pre-checked values
+    screenshot:
+      variants:
+        - default
+        - no-js
     options:
-      name: nationality
+      name: how-contacted-checked
+      idPrefix: how-contacted-checked
+      fieldset:
+        legend:
+          text: How do you want to be contacted?
+      values:
+        - email
+        - text
       items:
-        - value: british
-          text: British
-        - value: irish
-          text: Irish
-        - value: other
-          text: Citizen of another country
+        - value: email
+          text: Email
           conditional:
             html: |
-              <div class="govuk-form-group">
-                <label class="govuk-label" for="other-country">
-                  Country
-                </label>
-                <input class="govuk-input" id="other-country" name="other-country" type="text" value="Ravka">
-              </div>
-      values:
-        - british
-        - other
+              <label class="govuk-label" for="context-email">Email address</label>
+              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+        - value: phone
+          text: Phone
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-phone">Phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+        - value: text
+          text: Text message
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: with divider and None
-    screenshot: true
+    screenshot:
+      variants:
+        - default
+        - no-js
     options:
       name: with-divider-and-none
       fieldset:
         legend:
           text: Which types of waste do you transport regularly?
-          classes: govuk-fieldset__legend--l
-          isPageHeading: true
       items:
         - value: animal
           text: Waste from animal carcasses
@@ -226,8 +255,6 @@ examples:
       fieldset:
         legend:
           text: Do you have any access needs?
-          classes: govuk-fieldset__legend--l
-          isPageHeading: true
       items:
         - value: accessible-toilets
           text: Accessible toilets available
@@ -246,36 +273,12 @@ examples:
           text: None of these
           behaviour: exclusive
 
-  - name: with id and name
-    options:
-      name: with-id-and-name
-      fieldset:
-        legend:
-          text: What is your nationality?
-      hint:
-        text: If you have dual nationality, select all options that are relevant to you.
-      items:
-        - name: british
-          id: item_british
-          value: yes
-          text: British
-        - name: irish
-          id: item_irish
-          value: irish
-          text: Irish
-        - name: custom-name-scottish
-          text: Scottish
-          value: scottish
-
   - name: with hints on items
     options:
       name: with-hints-on-items
-      screenshot: true
       fieldset:
         legend:
           text: How do you want to sign in?
-          classes: govuk-fieldset__legend--l
-          isPageHeading: true
       items:
         - name: gateway
           id: government-gateway
@@ -289,29 +292,6 @@ examples:
           text: Sign in with GOV.UK Verify
           hint:
             text: You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
-
-  - name: with disabled item
-    options:
-      name: sign-in
-      fieldset:
-        legend:
-          text: How do you want to sign in?
-          classes: govuk-fieldset__legend--l
-          isPageHeading: true
-      items:
-        - name: gateway
-          id: government-gateway
-          value: gov-gateway
-          text: Sign in with Government Gateway
-          hint:
-            text: You'll have a user ID if you've registered for Self Assessment or filed a tax return online before.
-        - name: verify
-          id: govuk-verify
-          value: gov-verify
-          text: Sign in with GOV.UK Verify
-          hint:
-            text: You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
-          disabled: true
 
   - name: with legend as a page heading
     options:
@@ -331,89 +311,7 @@ examples:
         - value: farm
           text: Farm or agricultural waste
 
-  - name: with a medium legend
-    options:
-      name: waste
-      fieldset:
-        legend:
-          text: Which types of waste do you transport regularly?
-          classes: govuk-fieldset__legend--m
-      hint:
-        text: Select all that apply
-      errorMessage:
-        text: Select which types of waste you transport regularly
-      items:
-        - value: animal
-          text: Waste from animal carcasses
-        - value: mines
-          text: Waste from mines or quarries
-        - value: farm
-          text: Farm or agricultural waste
-
-  - name: without fieldset
-    options:
-      name: colours
-      items:
-        - value: red
-          text: Red
-        - value: green
-          text: Green
-        - value: blue
-          text: Blue
-
-  - name: with single option set 'aria-describedby' on input
-    options:
-      name: t-and-c
-      errorMessage:
-        text: Please accept the terms and conditions
-      items:
-        - value: yes
-          text: I agree to the terms and conditions
-
-  - name: with single option (and hint) set 'aria-describedby' on input
-    options:
-      name: t-and-c-with-hint
-      errorMessage:
-        text: Please accept the terms and conditions
-      items:
-        - value: yes
-          text: I agree to the terms and conditions
-          hint:
-            text: Go on, you know you want to!
-
-  - name: with fieldset and error message
-    options:
-      name: nationality
-      errorMessage:
-        text: Please accept the terms and conditions
-      fieldset:
-        legend:
-          text: What is your nationality?
-      items:
-        - value: british
-          text: British
-        - value: irish
-          text: Irish
-        - value: other
-          text: Citizen of another country
-
   - name: with error message
-    options:
-      name: waste
-      errorMessage:
-        text: Please select an option
-      fieldset:
-        legend:
-          text: Which types of waste do you transport regularly?
-      items:
-        - value: animal
-          text: Waste from animal carcasses
-        - value: mines
-          text: Waste from mines or quarries
-        - value: farm
-          text: Farm or agricultural waste
-
-  - name: with error message and hints on items
     options:
       name: waste
       errorMessage:
@@ -440,8 +338,6 @@ examples:
       name: waste
       hint:
         text: Nullam id dolor id nibh ultricies vehicula ut id elit.
-      errorMessage:
-        text: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       fieldset:
         legend:
           text: Maecenas faucibus mollis interdum?
@@ -480,62 +376,6 @@ examples:
       items:
         - value: email
           text: Email
-          conditional:
-            html: |
-              <label class="govuk-label" for="context-email">Email address</label>
-              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
-        - value: phone
-          text: Phone
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-phone">Phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
-        - value: text
-          text: Text message
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
-
-  - name: with conditional items with special characters
-    options:
-      name: contact-prefs
-      idPrefix: user.profile[contact-prefs]
-      fieldset:
-        legend:
-          text: How do you want to be contacted?
-      items:
-        - value: email
-          text: Email
-          conditional:
-            html: |
-              <label class="govuk-label" for="context-email">Email address</label>
-              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
-        - value: phone
-          text: Phone
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-phone">Phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
-        - value: text
-          text: Text message
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
-
-  - name: with conditional item checked
-    screenshot: true
-    options:
-      name: how-contacted-checked
-      idPrefix: how-contacted-checked
-      fieldset:
-        legend:
-          text: How do you want to be contacted?
-      items:
-        - value: email
-          text: Email
-          checked: true
           conditional:
             html: |
               <label class="govuk-label" for="context-email">Email address</label>
@@ -670,23 +510,6 @@ examples:
         - value: c
           text: this thing
 
-  - name: small with disabled
-    options:
-      idPrefix: nationality
-      name: nationality
-      classes: govuk-checkboxes--small
-      fieldset:
-        legend:
-          text: Filter by
-      items:
-        - value: a
-          text: a thing
-        - value: b
-          text: another thing
-        - value: c
-          text: this thing
-          disabled: true
-
   - name: small with conditional reveal
     options:
       name: how-contacted
@@ -706,7 +529,6 @@ examples:
           text: another thing
 
   - name: small with divider and None
-    screenshot: true
     options:
       name: small-with-divider-and-none
       classes: govuk-checkboxes--small
@@ -726,6 +548,50 @@ examples:
           behaviour: exclusive
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: with id and name
+    hidden: true
+    options:
+      name: with-id-and-name
+      fieldset:
+        legend:
+          text: What is your nationality?
+      hint:
+        text: If you have dual nationality, select all options that are relevant to you.
+      items:
+        - name: british
+          id: item_british
+          value: yes
+          text: British
+        - name: irish
+          id: item_irish
+          value: irish
+          text: Irish
+        - name: custom-name-scottish
+          text: Scottish
+          value: scottish
+  - name: with disabled item
+    hidden: true
+    options:
+      name: sign-in
+      fieldset:
+        legend:
+          text: How do you want to sign in?
+          classes: govuk-fieldset__legend--l
+          isPageHeading: true
+      items:
+        - name: gateway
+          id: government-gateway
+          value: gov-gateway
+          text: Sign in with Government Gateway
+          hint:
+            text: You'll have a user ID if you've registered for Self Assessment or filed a tax return online before.
+        - name: verify
+          id: govuk-verify
+          value: gov-verify
+          text: Sign in with GOV.UK Verify
+          hint:
+            text: You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+          disabled: true
   - name: with idPrefix
     hidden: true
     options:
@@ -848,6 +714,33 @@ examples:
           text: Citizen of another country
           hint:
             text: Hint for other option here
+  - name: with conditional items with special characters
+    hidden: true
+    options:
+      name: contact-prefs
+      idPrefix: user.profile[contact-prefs]
+      fieldset:
+        legend:
+          text: How do you want to be contacted?
+      items:
+        - value: email
+          text: Email
+          conditional:
+            html: |
+              <label class="govuk-label" for="context-email">Email address</label>
+              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+        - value: phone
+          text: Phone
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-phone">Phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+        - value: text
+          text: Text message
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
   - name: with error message and hint
     hidden: true
     options:
@@ -927,7 +820,7 @@ examples:
     options:
       describedBy: test-target-element
       name: t-and-c
-      errorMessage:
+      hint:
         text: Please accept the terms and conditions
       items:
         - value: yes
@@ -937,7 +830,7 @@ examples:
     options:
       describedBy: test-target-element
       name: t-and-c-with-hint
-      errorMessage:
+      hint:
         text: Please accept the terms and conditions
       items:
         - value: yes
@@ -969,7 +862,34 @@ examples:
           text: British
         - value: irish
           text: Irish
-
+  - name: with conditional item checked
+    hidden: true
+    options:
+      name: how-contacted-checked
+      idPrefix: how-contacted-checked
+      fieldset:
+        legend:
+          text: How do you want to be contacted?
+      items:
+        - value: email
+          text: Email
+          checked: true
+          conditional:
+            html: |
+              <label class="govuk-label" for="context-email">Email address</label>
+              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+        - value: phone
+          text: Phone
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-phone">Phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+        - value: text
+          text: Text message
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
   - name: item checked overrides values
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -220,11 +220,11 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['with pre-checked values'])
 
       const $component = $('.govuk-checkboxes')
-      const $british = $component.find('input[value="british"]')
-      expect($british.attr('checked')).toBe('checked')
+      const $email = $component.find('input[value="email"]')
+      expect($email.attr('checked')).toBe('checked')
 
-      const $other = $component.find('input[value="other"]')
-      expect($other.attr('checked')).toBe('checked')
+      const $text = $component.find('input[value="text"]')
+      expect($text.attr('checked')).toBe('checked')
     })
 
     it('allows item.checked to override values', () => {
@@ -297,7 +297,7 @@ describe('Checkboxes', () => {
       ).toBeTruthy()
     })
     it('visible by default when checked', () => {
-      const $ = render('checkboxes', examples['with conditional item checked'])
+      const $ = render('checkboxes', examples['with pre-checked values'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -318,7 +318,7 @@ describe('Checkboxes', () => {
       const $firstConditional = $component
         .find('.govuk-checkboxes__conditional')
         .first()
-      expect($firstConditional.text().trim()).toContain('Country')
+      expect($firstConditional.text().trim()).toContain('Email address')
       expect(
         $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
       ).toBeFalsy()
@@ -386,10 +386,7 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the error message', () => {
-      const $ = render(
-        'checkboxes',
-        examples['with fieldset and error message']
-      )
+      const $ = render('checkboxes', examples['with error message'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -540,12 +537,13 @@ describe('Checkboxes', () => {
 
   describe('single checkbox without a fieldset', () => {
     it('adds aria-describedby to input if there is an error', () => {
-      const exampleName = "with single option set 'aria-describedby' on input"
+      const exampleName =
+        "with single option set 'aria-describedby' on input, and describedBy"
 
       const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
 
-      expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
+      expect($input.attr('aria-describedby')).toMatch('t-and-c-hint')
     })
 
     it('adds aria-describedby to input if there is an error and parent fieldset', () => {
@@ -556,7 +554,7 @@ describe('Checkboxes', () => {
       const $input = $('input')
 
       expect($input.attr('aria-describedby')).toMatch(
-        'test-target-element t-and-c-error'
+        'test-target-element t-and-c-hint'
       )
     })
   })
@@ -564,13 +562,13 @@ describe('Checkboxes', () => {
   describe('single checkbox (with hint) without a fieldset', () => {
     it('adds aria-describedby to input if there is an error and a hint', () => {
       const exampleName =
-        "with single option (and hint) set 'aria-describedby' on input"
+        "with single option (and hint) set 'aria-describedby' on input, and describedBy"
 
       const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
 
       expect($input.attr('aria-describedby')).toMatch(
-        't-and-c-with-hint-error t-and-c-with-hint-item-hint'
+        't-and-c-with-hint-hint t-and-c-with-hint-item-hint'
       )
     })
 
@@ -582,7 +580,7 @@ describe('Checkboxes', () => {
       const $input = $('input')
 
       expect($input.attr('aria-describedby')).toMatch(
-        'test-target-element t-and-c-with-hint-error t-and-c-with-hint-item-hint'
+        'test-target-element t-and-c-with-hint-hint t-and-c-with-hint-item-hint'
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -112,22 +112,11 @@ examples:
     screenshot: true
     options:
       id: dob
-  - name: complete question
-    options:
-      id: dob
-      namePrefix: dob
       fieldset:
         legend:
           text: What is your date of birth?
       hint:
         text: For example, 31 3 1980
-      items:
-        - name: day
-          classes: govuk-input--width-2
-        - name: month
-          classes: govuk-input--width-2
-        - name: year
-          classes: govuk-input--width-4
   - name: day and month
     options:
       id: bday
@@ -242,67 +231,6 @@ examples:
           classes: govuk-input--width-2
         - name: year
           classes: govuk-input--width-4 govuk-input--error
-  - name: with default items
-    options:
-      id: dob
-      namePrefix: dob
-      fieldset:
-        legend:
-          text: What is your date of birth?
-      hint:
-        text: For example, 31 3 1980
-  - name: with optional form-group classes
-    options:
-      id: dob
-      namePrefix: dob
-      fieldset:
-        legend:
-          text: What is your date of birth?
-      hint:
-        text: For example, 31 3 1980
-      formGroup:
-        classes: extra-class
-  - name: with autocomplete values
-    options:
-      id: dob-with-autocomplete-attribute
-      namePrefix: dob-with-autocomplete
-      fieldset:
-        legend:
-          text: What is your date of birth?
-      hint:
-        text: For example, 31 3 1980
-      items:
-        - name: day
-          classes: govuk-input--width-2
-          autocomplete: bday-day
-        - name: month
-          classes: govuk-input--width-2
-          autocomplete: bday-month
-        - name: year
-          classes: govuk-input--width-4
-          autocomplete: bday-year
-  - name: with input attributes
-    options:
-      id: dob-with-input-attributes
-      namePrefix: dob-with-input-attributes
-      fieldset:
-        legend:
-          text: What is your date of birth?
-      hint:
-        text: For example, 31 3 1980
-      items:
-        - name: day
-          classes: govuk-input--width-2
-          attributes:
-            data-example-day: day
-        - name: month
-          classes: govuk-input--width-2
-          attributes:
-            data-example-month: month
-        - name: year
-          classes: govuk-input--width-4
-          attributes:
-            data-example-year: year
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes
@@ -316,6 +244,23 @@ examples:
       id: with-attributes
       attributes:
         data-attribute: my data value
+  - name: with items
+    hidden: false
+    options:
+      id: dob
+      namePrefix: dob
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      items:
+        - name: day
+          classes: govuk-input--width-2
+        - name: month
+          classes: govuk-input--width-2
+        - name: year
+          classes: govuk-input--width-4
   - name: with empty items
     hidden: true
     options:
@@ -421,3 +366,58 @@ examples:
         - name: day
         - name: month
         - name: year
+  - name: with optional form-group classes
+    hidden: true
+    options:
+      id: dob
+      namePrefix: dob
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      formGroup:
+        classes: extra-class
+  - name: with autocomplete values
+    hidden: true
+    options:
+      id: dob-with-autocomplete-attribute
+      namePrefix: dob-with-autocomplete
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      items:
+        - name: day
+          classes: govuk-input--width-2
+          autocomplete: bday-day
+        - name: month
+          classes: govuk-input--width-2
+          autocomplete: bday-month
+        - name: year
+          classes: govuk-input--width-4
+          autocomplete: bday-year
+  - name: with input attributes
+    hidden: true
+    options:
+      id: dob-with-input-attributes
+      namePrefix: dob-with-input-attributes
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      items:
+        - name: day
+          classes: govuk-input--width-2
+          attributes:
+            data-example-day: day
+        - name: month
+          classes: govuk-input--width-2
+          attributes:
+            data-example-month: month
+        - name: year
+          classes: govuk-input--width-4
+          attributes:
+            data-example-year: year

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -83,7 +83,7 @@ describe('Date input', () => {
 
       const $items = $('.govuk-date-input__item')
       const $firstItemInput = $(
-        '.govuk-date-input:first-child .govuk-date-input__input'
+        '.govuk-date-input__item:first-child .govuk-date-input__input'
       )
 
       expect($items).toHaveLength(3)
@@ -91,7 +91,7 @@ describe('Date input', () => {
     })
 
     it('renders item with suffixed name for input', () => {
-      const $ = render('date-input', examples['complete question'])
+      const $ = render('date-input', examples['with items'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('name')).toBe('dob-day')
@@ -182,12 +182,12 @@ describe('Date input', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = render('date-input', examples['complete question'])
+      const $ = render('date-input', examples.default)
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('date-input', examples['complete question'])
+      const $ = render('date-input', examples.default)
 
       const $fieldset = $('.govuk-fieldset')
       const hintId = $('.govuk-hint').attr('id')
@@ -294,7 +294,7 @@ describe('Date input', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('date-input', examples['complete question'])
+      const $ = render('date-input', examples.default)
 
       const $component = $(
         '.govuk-form-group > .govuk-fieldset > .govuk-date-input'
@@ -309,7 +309,7 @@ describe('Date input', () => {
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = render('date-input', examples['complete question'])
+      const $ = render('date-input', examples.default)
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -117,45 +117,12 @@ params:
 
 examples:
   - name: default
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       name: file-upload-1
       label:
         text: Upload a file
-  - name: allows multiple files
-    options:
-      id: file-upload-1
-      name: file-upload-1
-      label:
-        text: Upload a file
-      multiple: true
-  - name: allows image files only
-    options:
-      id: file-upload-1
-      name: file-upload-1
-      label:
-        text: Upload a file
-      attributes:
-        accept: 'image/*'
-  - name: allows direct media capture
-    description: Currently only works on mobile devices.
-    options:
-      id: file-upload-1
-      name: file-upload-1
-      label:
-        text: Upload a file
-      attributes:
-        capture: 'user'
-  - name: disabled
-    options:
-      id: file-upload-1
-      name: file-upload-1
-      label:
-        text: Upload a file
-      disabled: true
+
   - name: with hint text
     options:
       id: file-upload-2
@@ -164,6 +131,7 @@ examples:
         text: Upload your photo
       hint:
         text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+
   - name: with error message and hint
     options:
       id: file-upload-3
@@ -174,6 +142,7 @@ examples:
         text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       errorMessage:
         text: Error message goes here
+
   - name: with label as page heading
     options:
       id: file-upload-1
@@ -182,14 +151,7 @@ examples:
         text: Upload a file
         classes: govuk-label--l
         isPageHeading: true
-  - name: with optional form-group classes
-    options:
-      id: file-upload-1
-      name: file-upload-1
-      label:
-        text: Upload a file
-      formGroup:
-        classes: extra-class
+
   - name: enhanced
     screenshot:
       variants:
@@ -201,16 +163,7 @@ examples:
       label:
         text: Upload a file
       javascript: true
-  - name: enhanced, disabled
-    options:
-      javascript: true
-      disabled: true
-      id: file-upload-error
-      name: file-upload-error
-      label:
-        text: Upload a file
-      hint:
-        text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+
   - name: enhanced, with error message and hint
     options:
       javascript: true
@@ -222,22 +175,6 @@ examples:
         text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       errorMessage:
         text: Error message goes here
-  - name: translated
-    options:
-      id: file-upload-1
-      name: file-upload-1
-      label:
-        text: Llwythwch ffeil i fyny
-      multiple: true
-      javascript: true
-      chooseFilesButtonText: Dewiswch ffeil
-      dropInstructionText: neu ollwng ffeil
-      noFileChosenText: Dim ffeil wedi'i dewis
-      multipleFilesChosenText:
-        other: "%{count} ffeil wedi'u dewis"
-        one: "%{count} ffeil wedi'i dewis"
-      enteredDropZoneText: Wedi mynd i mewn i'r parth gollwng
-      leftDropZoneText: Parth gollwng i'r chwith
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value
@@ -329,6 +266,47 @@ examples:
       label:
         text: Llwythwch ffeil i fyny
       multiple: true
+      chooseFilesButtonText: Dewiswch ffeil
+      dropInstructionText: neu ollwng ffeil
+      noFileChosenText: Dim ffeil wedi'i dewis
+      multipleFilesChosenText:
+        other: "%{count} ffeil wedi'u dewis"
+        one: "%{count} ffeil wedi'i dewis"
+      enteredDropZoneText: Wedi mynd i mewn i'r parth gollwng
+      leftDropZoneText: Parth gollwng i'r chwith
+  - name: allows multiple files
+    hidden: true
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      multiple: true
+  - name: disabled
+    hidden: true
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      disabled: true
+  - name: with optional form-group classes
+    hidden: true
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Upload a file
+      formGroup:
+        classes: extra-class
+  - name: translated
+    options:
+      id: file-upload-1
+      name: file-upload-1
+      label:
+        text: Llwythwch ffeil i fyny
+      multiple: true
+      javascript: true
       chooseFilesButtonText: Dewiswch ffeil
       dropInstructionText: neu ollwng ffeil
       noFileChosenText: Dim ffeil wedi'i dewis

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -265,59 +265,6 @@ examples:
         isPageHeading: true
       id: input-with-page-heading
       name: test-name
-  - name: with optional form-group classes
-    options:
-      label:
-        text: National Insurance number
-      id: input-example
-      name: test-name
-      formGroup:
-        classes: extra-class
-  - name: with autocomplete attribute
-    options:
-      label:
-        text: Postcode
-      id: input-with-autocomplete-attribute
-      name: postcode
-      autocomplete: postal-code
-  - name: with pattern attribute
-    options:
-      label:
-        text: Numbers only
-      id: input-with-pattern-attribute
-      name: numbers-only
-      type: number
-      pattern: '[0-9]*'
-  - name: with spellcheck enabled
-    options:
-      label:
-        text: Spellcheck is enabled
-      id: input-with-spellcheck-enabled
-      name: spellcheck
-      type: text
-      spellcheck: true
-  - name: with spellcheck disabled
-    options:
-      label:
-        text: Spellcheck is disabled
-      id: input-with-spellcheck-disabled
-      name: spellcheck
-      type: text
-      spellcheck: false
-  - name: with autocapitalize turned off
-    options:
-      label:
-        text: Autocapitalize is turned off
-      id: input-with-autocapitalize-off
-      name: autocapitalize
-      type: text
-      autocapitalize: none
-  - name: disabled
-    options:
-      label:
-        text: Disabled input
-      id: disabled-input
-      disabled: true
 
   - name: with prefix
     options:
@@ -338,6 +285,7 @@ examples:
         text: kg
 
   - name: with prefix and suffix
+    screenshot: true
     options:
       label:
         text: Cost per item, in pounds
@@ -347,16 +295,7 @@ examples:
         text: £
       suffix:
         text: per item
-  - name: with prefix and long suffix
-    options:
-      label:
-        text: Cost per item, in pounds, per household member
-      id: input-with-prefix-suffix
-      name: cost
-      prefix:
-        text: £
-      suffix:
-        text: per household member
+
   - name: with prefix and suffix and error
     options:
       label:
@@ -369,6 +308,7 @@ examples:
         text: per item
       errorMessage:
         text: Error message goes here
+
   - name: with prefix and suffix and width modifier
     options:
       label:
@@ -381,6 +321,7 @@ examples:
       suffix:
         text: per item
   - name: with extra letter spacing
+    screenshot: true
     options:
       id: input-with-extra-letter-spacing
       label:
@@ -485,7 +426,6 @@ examples:
       label:
         text: With inputmode
       inputmode: decimal
-
   - name: with prefix with html as text
     hidden: true
     options:
@@ -525,7 +465,6 @@ examples:
         text: £
         attributes:
           data-attribute: value
-
   - name: with suffix with html as text
     hidden: true
     options:
@@ -580,3 +519,63 @@ examples:
         text: £
       suffix:
         text: per item
+  - name: with optional form-group classes
+    hidden: true
+    options:
+      label:
+        text: National Insurance number
+      id: input-example
+      name: test-name
+      formGroup:
+        classes: extra-class
+  - name: with autocomplete attribute
+    hidden: true
+    options:
+      label:
+        text: Postcode
+      id: input-with-autocomplete-attribute
+      name: postcode
+      autocomplete: postal-code
+  - name: with pattern attribute
+    hidden: true
+    options:
+      label:
+        text: Numbers only
+      id: input-with-pattern-attribute
+      name: numbers-only
+      type: number
+      pattern: '[0-9]*'
+  - name: with spellcheck enabled
+    hidden: true
+    options:
+      label:
+        text: Spellcheck is enabled
+      id: input-with-spellcheck-enabled
+      name: spellcheck
+      type: text
+      spellcheck: true
+  - name: with spellcheck disabled
+    hidden: true
+    options:
+      label:
+        text: Spellcheck is disabled
+      id: input-with-spellcheck-disabled
+      name: spellcheck
+      type: text
+      spellcheck: false
+  - name: with autocapitalize turned off
+    hidden: true
+    options:
+      label:
+        text: Autocapitalize is turned off
+      id: input-with-autocapitalize-off
+      name: autocapitalize
+      type: text
+      autocapitalize: none
+  - name: disabled
+    hidden: true
+    options:
+      label:
+        text: Disabled input
+      id: disabled-input
+      disabled: true

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -162,26 +162,6 @@ examples:
       id: password-input-width
       name: password
       classes: govuk-input--width-10
-  - name: with new-password autocomplete
-    description: Supporting browsers and password managers should prompt to generate a password.
-    options:
-      label:
-        text: Password
-      autocomplete: new-password
-      id: password-input-new-password
-      name: password
-  - name: with translations
-    options:
-      label:
-        text: Cyfrinair
-      id: password-translated
-      name: password-translated
-      showPasswordText: Datguddia
-      hidePasswordText: Cuddio
-      showPasswordAriaLabelText: Datgelu cyfrinair
-      hidePasswordAriaLabelText: Cuddio cyfrinair
-      passwordShownAnnouncementText: Mae eich cyfrinair yn weladwy.
-      passwordHiddenAnnouncementText: Mae eich cyfrinair wedi'i guddio.
 
   # Hidden examples
   - name: classes
@@ -225,3 +205,25 @@ examples:
       label:
         text: With describedBy
       describedBy: test-target-element
+  - name: with new-password autocomplete
+    hidden: true
+    description: Supporting browsers and password managers should prompt to generate a password.
+    options:
+      label:
+        text: Password
+      autocomplete: new-password
+      id: password-input-new-password
+      name: password
+  - name: with translations
+    hidden: true
+    options:
+      label:
+        text: Cyfrinair
+      id: password-translated
+      name: password-translated
+      showPasswordText: Datguddia
+      hidePasswordText: Cuddio
+      showPasswordAriaLabelText: Datgelu cyfrinair
+      hidePasswordAriaLabelText: Cuddio cyfrinair
+      passwordShownAnnouncementText: Mae eich cyfrinair yn weladwy.
+      passwordHiddenAnnouncementText: Mae eich cyfrinair wedi'i guddio.

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -151,12 +151,24 @@ accessibilityCriteria: |
 
 examples:
   - name: default
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       name: example-default
+      fieldset:
+        legend:
+          text: Have you changed your name?
+      items:
+        - value: yes
+          text: Yes
+        - value: no
+          text: No
+
+  - name: with hint
+    options:
+      name: example-with-hint
+      fieldset:
+        legend:
+          text: Have you changed your name?
       hint:
         text: This includes changing your last name or spelling your name differently.
       items:
@@ -166,6 +178,7 @@ examples:
           text: No
 
   - name: inline
+    screenshot: true
     options:
       idPrefix: example
       classes: govuk-radios--inline
@@ -182,28 +195,6 @@ examples:
           text: No
           checked: true
 
-  - name: with disabled
-    options:
-      idPrefix: gov
-      name: gov
-      fieldset:
-        legend:
-          text: How do you want to sign in?
-          classes: govuk-fieldset__legend--l
-          isPageHeading: true
-      items:
-        - value: gateway
-          text: Sign in with Government Gateway
-          id: gateway
-          hint:
-            text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
-        - value: verify
-          text: Sign in with GOV.UK Verify
-          id: verify
-          hint:
-            text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
-          disabled: true
-
   - name: with legend as page heading
     options:
       idPrefix: housing-act
@@ -213,26 +204,6 @@ examples:
           text: Which part of the Housing Act was your licence issued under?
           classes: govuk-fieldset__legend--l
           isPageHeading: true
-      hint:
-        text: Select one of the options below.
-      items:
-        - value: part-2
-          html:
-            <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 2 of the Housing Act 2004</span>
-            For properties that are 3 or more stories high and occupied by 5 or more people
-        - value: part-3
-          html:
-            <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 3 of the Housing Act 2004</span>
-            For properties that are within a geographical area defined by a local council
-
-  - name: with a medium legend
-    options:
-      idPrefix: housing-act
-      name: housing-act
-      fieldset:
-        legend:
-          text: Which part of the Housing Act was your licence issued under?
-          classes: govuk-fieldset__legend--m
       hint:
         text: Select one of the options below.
       items:
@@ -266,10 +237,6 @@ examples:
           text: Create an account
 
   - name: with hints on items
-    screenshot:
-      variants:
-        - default
-        - no-js
     options:
       idPrefix: gov
       name: gov
@@ -379,33 +346,6 @@ examples:
               <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
-  - name: with conditional items with special characters
-    options:
-      idPrefix: user.profile[contact-prefs]
-      name: contact-prefs
-      fieldset:
-        legend:
-          text: How do you want to be contacted?
-      items:
-        - value: email
-          text: Email
-          conditional:
-            html: |
-              <label class="govuk-label" for="context-email">Email address</label>
-              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
-        - value: phone
-          text: Phone
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-phone">Phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
-        - value: text
-          text: Text message
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
-
   - name: with conditional item checked
     screenshot:
       variants:
@@ -437,56 +377,6 @@ examples:
             html: |
               <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
-
-  - name: prechecked
-    options:
-      name: example-default
-      hint:
-        text: This includes changing your last name or spelling your name differently.
-      items:
-        - value: yes
-          text: Yes
-        - value: no
-          text: No
-          checked: true
-
-  - name: prechecked using value
-    options:
-      name: example-default
-      items:
-        - value: yes
-          text: Yes
-        - value: no
-          text: No
-      value: no
-
-  - name: with conditional items and pre-checked value
-    options:
-      idPrefix: 'how-contacted-checked'
-      name: 'how-contacted-checked'
-      fieldset:
-        legend:
-          text: How do you want to be contacted?
-      items:
-        - value: email
-          text: Email
-          conditional:
-            html: |
-              <label class="govuk-label" for="context-email">Email</label>
-              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
-        - value: phone
-          text: Phone
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-phone">Phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
-        - value: text
-          text: Text message
-          conditional:
-            html: |
-              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
-              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
-      value: text
 
   - name: with optional form-group classes showing group error
     options:
@@ -520,10 +410,7 @@ examples:
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: small
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       idPrefix: 'how-contacted-2'
       name: 'how-contacted-2'
@@ -611,24 +498,6 @@ examples:
         - value: text
           text: Text message
 
-  - name: small with disabled
-    options:
-      idPrefix: 'how-contacted-2'
-      name: 'how-contacted-2'
-      formGroup:
-        classes: 'govuk-radios--small'
-      fieldset:
-        legend:
-          text: How do you want to be contacted?
-      items:
-        - value: email
-          text: Email
-        - value: phone
-          text: Phone
-        - value: text
-          text: Text message
-          disabled: true
-
   - name: small with conditional reveal
     options:
       idPrefix: 'how-contacted-2'
@@ -666,41 +535,7 @@ examples:
         - value: created
           text: created
 
-  - name: small inline extreme
-    options:
-      idPrefix: sort
-      classes: govuk-radios--small govuk-radios--inline
-      name: example
-      fieldset:
-        legend:
-          text: Sort by
-      items:
-        - value: relevance
-          text: relevance
-        - value: title
-          text: title
-        - value: created
-          text: created
-        - value: modified
-          text: modified
-        - value: category
-          text: category
-        - value: votes
-          text: votes
-        - value: flavour
-          text: flavour
-        - value: hue
-          text: hue
-        - value: happiness
-          text: happiness
-        - value: funkiness
-          text: funkiness
-
   - name: small with a divider
-    screenshot:
-      variants:
-        - default
-        - no-js
     options:
       idPrefix: example-small-divider
       name: example
@@ -719,6 +554,7 @@ examples:
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with idPrefix
+    hidden: true
     options:
       name: example-radio
       idPrefix: example-id-prefix
@@ -954,7 +790,6 @@ examples:
         - value: no
           text: No
           checked: true
-
   - name: item checked overrides value
     hidden: true
     options:
@@ -981,3 +816,89 @@ examples:
               <textarea class="govuk-textarea govuk-!-width-one-third" name="conditional-textarea" id="conditional-textarea">
               test
               </textarea>
+  - name: with disabled
+    hidden: true
+    options:
+      idPrefix: gov
+      name: gov
+      fieldset:
+        legend:
+          text: How do you want to sign in?
+          classes: govuk-fieldset__legend--l
+          isPageHeading: true
+      items:
+        - value: gateway
+          text: Sign in with Government Gateway
+          id: gateway
+          hint:
+            text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
+        - value: verify
+          text: Sign in with GOV.UK Verify
+          id: verify
+          hint:
+            text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+          disabled: true
+  - name: prechecked using value
+    hidden: true
+    options:
+      name: example-default
+      items:
+        - value: yes
+          text: Yes
+        - value: no
+          text: No
+      value: no
+  - name: with conditional items with special characters
+    hidden: true
+    options:
+      idPrefix: user.profile[contact-prefs]
+      name: contact-prefs
+      fieldset:
+        legend:
+          text: How do you want to be contacted?
+      items:
+        - value: email
+          text: Email
+          conditional:
+            html: |
+              <label class="govuk-label" for="context-email">Email address</label>
+              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+        - value: phone
+          text: Phone
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-phone">Phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+        - value: text
+          text: Text message
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+  - name: with conditional items and pre-checked value
+    options:
+      idPrefix: 'how-contacted-checked'
+      name: 'how-contacted-checked'
+      fieldset:
+        legend:
+          text: How do you want to be contacted?
+      items:
+        - value: email
+          text: Email
+          conditional:
+            html: |
+              <label class="govuk-label" for="context-email">Email</label>
+              <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+        - value: phone
+          text: Phone
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-phone">Phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+        - value: text
+          text: Text message
+          conditional:
+            html: |
+              <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+              <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+      value: text

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -125,11 +125,13 @@ describe('Radios', () => {
     })
 
     it('render checked', () => {
-      const $ = render('radios', examples.prechecked)
+      const $ = render('radios', examples['with conditional item checked'])
 
       const $component = $('.govuk-radios')
-      const $lastInput = $component.find('.govuk-radios__item:last-child input')
-      expect($lastInput.attr('checked')).toBe('checked')
+      const $firstInput = $component.find(
+        '.govuk-radios__item:first-child input'
+      )
+      expect($firstInput.attr('checked')).toBe('checked')
     })
 
     it('checks the radio that matches value', () => {

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -123,35 +123,6 @@ examples:
         - value: 3
           text: GOV.UK frontend option 3
           disabled: true
-  - name: id
-    options:
-      id: select-id
-      name: test-name
-      label:
-        text: Horse with no name
-      items: []
-  - name: with no items
-    options:
-      id: select-1
-      name: select-1
-      label:
-        text: Horse with no name
-      items: []
-  - name: with selected value
-    options:
-      id: select-1
-      name: select-1
-      label:
-        text: Label text goes here
-      items:
-        - value: 1
-          text: GOV.UK frontend option 1
-        - value: 2
-          text: GOV.UK frontend option 2
-        - value: 3
-          text: GOV.UK frontend option 3
-          disabled: true
-      value: 2
   - name: with hint text and error message
     options:
       id: select-2
@@ -193,24 +164,6 @@ examples:
       classes: govuk-!-width-full
       label:
         text: Label text goes here
-      items:
-        - value: 1
-          text: GOV.UK frontend option 1
-        - value: 2
-          text: GOV.UK frontend option 2
-          selected: true
-        - value: 3
-          text: GOV.UK frontend option 3
-          disabled: true
-  - name: with optional form-group classes
-    options:
-      id: select-1
-      name: select-1
-      classes: govuk-!-width-full
-      label:
-        text: Label text goes here
-      formGroup:
-        classes: extra-class
       items:
         - value: 1
           text: GOV.UK frontend option 1
@@ -336,7 +289,6 @@ examples:
           text: GOV.UK frontend option 1
         - value: 2
           text: GOV.UK frontend option 2
-
   - name: without values
     hidden: true
     options:
@@ -348,7 +300,6 @@ examples:
         - text: Red
         - text: Green
         - text: Blue
-
   - name: without values with selected value
     hidden: true
     options:
@@ -361,7 +312,6 @@ examples:
         - text: Green
         - text: Blue
       value: Green
-
   - name: with falsy values
     hidden: true
     options:
@@ -376,7 +326,6 @@ examples:
           value: false
         - text: Number zero
           value: 0
-
   - name: item selected overrides value
     hidden: true
     options:
@@ -393,3 +342,46 @@ examples:
         - value: blue
           text: Blue
       value: green
+  - name: id
+    hidden: true
+    options:
+      id: select-id
+      name: test-name
+      label:
+        text: Horse with no name
+      items: []
+  - name: with selected value
+    hidden: true
+    options:
+      id: select-1
+      name: select-1
+      label:
+        text: Label text goes here
+      items:
+        - value: 1
+          text: GOV.UK frontend option 1
+        - value: 2
+          text: GOV.UK frontend option 2
+        - value: 3
+          text: GOV.UK frontend option 3
+          disabled: true
+      value: 2
+  - name: with optional form-group classes
+    hidden: true
+    options:
+      id: select-1
+      name: select-1
+      classes: govuk-!-width-full
+      label:
+        text: Label text goes here
+      formGroup:
+        classes: extra-class
+      items:
+        - value: 1
+          text: GOV.UK frontend option 1
+        - value: 2
+          text: GOV.UK frontend option 2
+          selected: true
+        - value: 3
+          text: GOV.UK frontend option 3
+          disabled: true

--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -101,6 +101,7 @@ examples:
       name: more-detail
       label:
         text: Can you provide more detail?
+
   - name: with hint
     options:
       name: more-detail
@@ -146,39 +147,6 @@ examples:
         text: Full address
         classes: govuk-label--l
         isPageHeading: true
-
-  - name: with optional form-group classes
-    options:
-      id: textarea-with-page-heading
-      name: address
-      label:
-        text: Full address
-      formGroup:
-        classes: extra-class
-
-  - name: with autocomplete attribute
-    options:
-      id: textarea-with-autocomplete-attribute
-      name: address
-      label:
-        text: Full address
-      autocomplete: street-address
-
-  - name: with spellcheck enabled
-    options:
-      label:
-        text: Spellcheck is enabled
-      id: textarea-with-spellcheck-enabled
-      name: spellcheck
-      spellcheck: true
-
-  - name: with spellcheck disabled
-    options:
-      label:
-        text: Spellcheck is disabled
-      id: textarea-with-spellcheck-disabled
-      name: spellcheck
-      spellcheck: false
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: id
@@ -256,3 +224,36 @@ examples:
         text: Error message
       hint:
         text: Hint
+  - name: with optional form-group classes
+    hidden: true
+    options:
+      id: textarea-with-page-heading
+      name: address
+      label:
+        text: Full address
+      formGroup:
+        classes: extra-class
+  - name: with autocomplete attribute
+    hidden: true
+    options:
+      id: textarea-with-autocomplete-attribute
+      name: address
+      label:
+        text: Full address
+      autocomplete: street-address
+  - name: with spellcheck enabled
+    hidden: true
+    options:
+      label:
+        text: Spellcheck is enabled
+      id: textarea-with-spellcheck-enabled
+      name: spellcheck
+      spellcheck: true
+  - name: with spellcheck disabled
+    hidden: true
+    options:
+      label:
+        text: Spellcheck is disabled
+      id: textarea-with-spellcheck-disabled
+      name: spellcheck
+      spellcheck: false


### PR DESCRIPTION
## Change

Updates the review app examples for the following components:

- Character count
- Checkboxes
- Date input
- Input
- File upload
- Password input
- Radios
- Select
- Textarea

This PR principally aims to:

- remove or hide examples that don't explicitly change the behaviour of the component that are better suited for API testing
- consolidate examples that are doing similar things or could serve multiple purposes
- identify which examples we should be including in VRT to provide decent coverage without breaking the bank

Resolves https://github.com/alphagov/govuk-frontend/issues/6074

## Notes

I've removed or hidden disabled examples. The intent with this was that it's not something we support 'officially' and so there's a question about how much coverage is useful for it to have. I'm not confident about this choice so am interested in thoughts. There's an open question around if we should have a separate example for common states like disabled or error.

Branched off of https://github.com/alphagov/govuk-frontend/pull/6073 so I can use full yaml config.