### PR TITLE
Update error summary examples

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.yaml
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.yaml
@@ -82,6 +82,7 @@ examples:
       titleText: There is a problem
       descriptionText: The file couldn't be loaded. Try again later.
   - name: with everything
+    screenshot: true
     options:
       titleText: There is a problem
       descriptionText: Please fix the errors below.


### PR DESCRIPTION
Additionally screenshot the ‘with everything’ example which shows the description as well as an error that is not a link.

Part of #6075 