### PR TITLE
Remove GitHub tasklists from release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -45,13 +45,13 @@ Technical writers, Developers
 
 ### Design System site
 
-- [ ] [Run dependabot](https://github.com/alphagov/govuk-design-system/network/updates/194539/jobs) to bump the version of `govuk-frontend`
+- [ ] Bump the version of `govuk-frontend`
 - [ ] Update [the "What's new" section on the homepage](https://github.com/alphagov/govuk-design-system/blob/main/views/partials/_whats-new.njk)
 - [ ] Update [the "Recently shipped" section of the roadmap](https://github.com/alphagov/govuk-design-system/blob/main/src/community/roadmap/index.md#recently-shipped)
 
 ### Frontend docs
 
-- [ ] [Run dependabot](https://github.com/alphagov/govuk-frontend-docs/network/updates/4008122/jobs) to bump the version of `govuk-frontend`
+- [ ] Bump the version of `govuk-frontend`
 
 ### Comms
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -34,41 +34,35 @@ Technical writers, Developers
 
 ## Done when
 
-```[tasklist]
-## Comms preparation
+### Comms preparation
+
 - [ ] Draft release notes
 - [ ] Draft comms
-```
 
-```[tasklist]
-## GOV.UK Frontend
+### GOV.UK Frontend
+
 - [ ] Follow [our process to release GOV.UK Frontend to npm and GitHub](https://github.com/alphagov/govuk-frontend/blob/main/docs/releasing/publishing.md)
-```
 
-```[tasklist]
-## Design System site
+### Design System site
+
 - [ ] [Run dependabot](https://github.com/alphagov/govuk-design-system/network/updates/194539/jobs) to bump the version of `govuk-frontend`
 - [ ] Update [the "What's new" section on the homepage](https://github.com/alphagov/govuk-design-system/blob/main/views/partials/_whats-new.njk)
 - [ ] Update [the "Recently shipped" section of the roadmap](https://github.com/alphagov/govuk-design-system/blob/main/src/community/roadmap/index.md#recently-shipped)
-```
 
-```[tasklist]
-## Frontend docs
+### Frontend docs
+
 - [ ] [Run dependabot](https://github.com/alphagov/govuk-frontend-docs/network/updates/4008122/jobs) to bump the version of `govuk-frontend`
-```
 
-```[tasklist]
-## Comms
+### Comms
+
 - [ ] Send comms on Slack channels
 - [ ] Send comms to mailing list
-```
 
-```[tasklist]
-## Logistics
+### Logistics
+
 - [ ] Ensure issues published in the release are gathered in a [GitHub milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones)
 - [ ] 🔑 Ensure that [relevant access tokens are up to date](https://github.com/alphagov/govuk-frontend/blob/main/docs/releasing/before-publishing-a-release.md#make-sure-access-tokens-are-up-to-date)
 - [ ] Verify that decisions are appropriately documented (in code/issues/pull request comments or in separate documents linked from issues/pull requests)
 - [ ] Update state of published issues on project board
 - [ ] Close published issues when appropriate
 - [ ] Open any follow-up issues if necessary
-```


### PR DESCRIPTION
Pretty much what it says in the title, with an addition of removing the use of Dependabot for updating GOV.UK Frontend on our websites due the trouble we're having with it lately.