### PR TITLE
Output hexadecimal colours for `govuk-shade` and `govuk-tint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6047: Fix text within the inverse Service navigation variant not appearing in white](https://github.com/alphagov/govuk-frontend/pull/6047) – thanks to @peteryates for reporting this issue
+- [#6084: Output hexadecimal colours for `govuk-shade` and `govuk-tint`](https://github.com/alphagov/govuk-frontend/pull/6084)
 
 ## v5.11.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -121,7 +121,9 @@
 /// @access public
 
 @function govuk-shade($colour, $percentage) {
-  @return mix(#000000, $colour, $percentage);
+  // Ensure the output is a hex string so that Safari <12 can render the colour
+  // without issues from float values in `rgb()`
+  @return _as-hexadecimal(mix(#000000, $colour, $percentage));
 }
 
 /// Make a colour lighter by mixing it with white
@@ -132,5 +134,32 @@
 /// @access public
 
 @function govuk-tint($colour, $percentage) {
-  @return mix(govuk-colour("white"), $colour, $percentage);
+  // Ensure the output is a hex string so that Safari <12 can render the colour
+  // without issues from float values in `rgb()`
+  @return _as-hexadecimal(mix(govuk-colour("white"), $colour, $percentage));
+}
+
+/// Converts a colour with potential float values for its RGB channels
+/// into hexadecimal notation
+///
+/// This ensures the colour is rendered properly by Safari < 12
+///
+/// @param {Colour} $colour - The colour to convert
+/// @return {Colour}
+/// @access private
+@function _as-hexadecimal($colour) {
+  @if not function-exists(change-color) {
+    @return $colour;
+  }
+
+  // `red`,`green` and `blue` functions are limited to 'legacy' colour spaces
+  // ensuring we don't get floating computations on them
+  $parts: (
+    "red": red($colour),
+    "green": green($colour),
+    "blue": blue($colour),
+    "alpha": alpha($colour)
+  );
+
+  @return change-color($colour, $parts...);
 }

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -386,7 +386,7 @@ describe('@function govuk-shade', () => {
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
           .foo {
-            color: rgb(141.93, 170.15, 198.37);
+            color: #8eaac6;
           }
         `
     })
@@ -406,7 +406,7 @@ describe('@function govuk-tint', () => {
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
           .foo {
-            color: rgb(58.29, 86.51, 114.73);
+            color: #3a5773;
           }
         `
     })

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -372,3 +372,43 @@ describe('@function govuk-organisation-colour', () => {
     })
   })
 })
+
+describe('@function govuk-shade', () => {
+  it('outputs hexadecimal values', async () => {
+    const sass = `
+      @import "helpers/colour";
+
+      .foo {
+        color: govuk-shade(rgb(171, 205, 239), 17);
+      }
+    `
+
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
+          .foo {
+            color: rgb(141.93, 170.15, 198.37);
+          }
+        `
+    })
+  })
+})
+
+describe('@function govuk-tint', () => {
+  it('outputs hexadecimal values', async () => {
+    const sass = `
+      @import "helpers/colour";
+
+      .foo {
+        color: govuk-tint(rgb(18, 52, 86), 17);
+      }
+    `
+
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
+          .foo {
+            color: rgb(58.29, 86.51, 114.73);
+          }
+        `
+    })
+  })
+})


### PR DESCRIPTION
Converts output of the `mix` function used in `govuk-shade` and `govuk-tint` into a hexadecimal colour. This avoids getting an `rgb` colour with float values which Safari < 12 does not render properly.

Fixes #5988