### PR TITLE
Configure non-component examples to screenshot

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/form-controls-states/form-controls-states.yaml
+++ b/packages/govuk-frontend-review/src/views/examples/form-controls-states/form-controls-states.yaml
@@ -1,0 +1,1 @@
+screenshot: true

--- a/packages/govuk-frontend-review/src/views/examples/labels-legends-and-headings/labels-legends-and-headings.yaml
+++ b/packages/govuk-frontend-review/src/views/examples/labels-legends-and-headings/labels-legends-and-headings.yaml
@@ -1,0 +1,1 @@
+screenshot: true

--- a/packages/govuk-frontend-review/src/views/examples/small-form-controls/small-form-controls.yaml
+++ b/packages/govuk-frontend-review/src/views/examples/small-form-controls/small-form-controls.yaml
@@ -1,0 +1,1 @@
+screenshot: true

--- a/packages/govuk-frontend-review/src/views/examples/text-alignment/text-alignment.yaml
+++ b/packages/govuk-frontend-review/src/views/examples/text-alignment/text-alignment.yaml
@@ -1,0 +1,1 @@
+screenshot: true

--- a/packages/govuk-frontend-review/src/views/examples/typography/typography.yaml
+++ b/packages/govuk-frontend-review/src/views/examples/typography/typography.yaml
@@ -1,0 +1,1 @@
+screenshot: true

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -1,6 +1,10 @@
+import { join } from 'path'
+
+import { paths } from '@govuk-frontend/config'
 import { download } from '@govuk-frontend/helpers/jest/browser/download.mjs'
 import { goToComponent, goToExample } from '@govuk-frontend/helpers/puppeteer'
 import { getComponentNames, getExamples } from '@govuk-frontend/lib/components'
+import { getListing, getYaml } from '@govuk-frontend/lib/files'
 import percySnapshot from '@percy/puppeteer'
 import puppeteer from 'puppeteer'
 
@@ -40,9 +44,20 @@ export async function screenshots() {
     }
   }
 
-  // Screenshot specific example pages
-  for (const exampleName of ['text-alignment', 'typography']) {
-    await screenshotExample(browser, exampleName)
+  // Screenshot non component examples
+  const nonComponentExamples = await getListing(
+    join(paths.app, 'src/views/examples/**/*.yaml')
+  )
+
+  for (const examplePath of nonComponentExamples) {
+    const exampleConfig = await getYaml(join(paths.root, examplePath))
+    const exampleName = examplePath
+      .split('/')
+      .pop()
+      .replace(/\.yaml$/, '')
+    if (exampleConfig.screenshot) {
+      await screenshotExample(browser, exampleName)
+    }
   }
 
   // Close browser


### PR DESCRIPTION
## What
Adds a YAML config file to each relevant example. This should at least contain a `screenshot: true` property. This property is then checked and the example is added to the screenshot suite if relevant.

We could possibly add a `name` property to give the test a user-friendly name and/or a `description` property to detail what the example brings to the test suite.