### PR TITLE
Add labels to Percy snapshots

### DIFF
--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -166,7 +166,8 @@ export async function screenshotExample(browser, exampleName) {
 
   // Screenshot preview page
   await percySnapshot(page, `js: ${exampleName} (example)`, {
-    scope: '.govuk-main-wrapper'
+    scope: '.govuk-main-wrapper',
+    labels: 'Examples'
   })
 
   // Close page


### PR DESCRIPTION
Adds the following labels to our percy screenshots:

- The component name for each component
- 'No-JS' for no-js screenshots of components with js rendering
- 'Examples' for the relatively small number of example screenshots

Means that team members assessing VRT results can filter by tag using the search in Percy's review UI.

Closes https://github.com/alphagov/govuk-frontend/issues/6052