### PR TITLE
Remove redundant ‘no-JS’ Percy snapshots

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -228,10 +228,7 @@ examples:
               <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
   - name: with divider and None
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       name: with-divider-and-none
       fieldset:

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.yaml
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.yaml
@@ -58,10 +58,7 @@ accessibilityCriteria: |
 
 examples:
   - name: default
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       titleText: There is a problem
       errorList:

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -217,10 +217,7 @@ examples:
             For properties that are within a geographical area defined by a local council
 
   - name: with a divider
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       idPrefix: example-divider
       name: example

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.yaml
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.yaml
@@ -22,10 +22,7 @@ params:
 
 examples:
   - name: default
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     options:
       text: Skip to main content
       href: '#test-target-element'


### PR DESCRIPTION
A second pass of #6071 to tidy up a few extra screenshots I don't think we need:

- Checkboxes ‘with divider and None’ looks identical with and without JavaScript
- The error summary only differs by focus state, but this doesn’t display in Percy anyway
- Radios ‘with a divider’ looks identical with and without JavaScript
- Skip link looks identical with and without JavaScript