### PR TITLE
Force skip link to be focused for screenshot

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.yaml
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.yaml
@@ -22,8 +22,14 @@ params:
 
 examples:
   - name: default
-    screenshot: true
     options:
+      text: Skip to main content
+      href: '#test-target-element'
+  - name: with focus
+    screenshot: true
+    description: Simulate triggering the :focus CSS pseudo-class, not available in the production build.
+    options:
+      classes: :focus
       text: Skip to main content
       href: '#test-target-element'
 
@@ -61,10 +67,3 @@ examples:
       attributes:
         data-test: attribute
         aria-label: Skip to content
-  - name: with focus
-    hidden: true
-    description: Simulate triggering the :focus CSS pseudo-class, not available in the production build.
-    options:
-      classes: :focus
-      text: Skip to main content
-      href: '#test-target-element'

--- a/packages/govuk-frontend/src/govuk/helpers/_visually-hidden.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_visually-hidden.scss
@@ -74,7 +74,10 @@
 
 @mixin govuk-visually-hidden-focusable($important: true) {
   // IE 11 doesn't support the combined `:not(:active, :focus)` syntax.
-  &:not(:active):not(:focus) {
+  // Also allows for ':focus' companion classes from postcss-pseudo-classes
+  // which the plugin unfortunately doesn't handle automatically.
+  // stylelint-disable-next-line selector-class-pattern
+  &:not(:active):not(:focus):not(.\:focus) {
     @include _govuk-visually-hide-content($important: $important);
   }
 }


### PR DESCRIPTION
Make the ‘with focus’ example of the skip link visible in the review app and use it for screenshots.

This example uses the `:focus` ‘companion class’ we get from postcss-pseudo-classes.

Unfortunately the `govuk-visually-hidden-focusable` mixin uses a `&:not(:active):not(:focus)` which isn’t correctly handled by the postcss-pseudo-classes plugin, so we need to modify the rule slightly to prevent it from hiding the skip link.