### PR TITLE
Silence `color-function` deprecation warnings

### DIFF
--- a/shared/config/sass.js
+++ b/shared/config/sass.js
@@ -2,7 +2,13 @@
  * @type {import('sass-embedded').Options<"async">}
  */
 const deprecationOptions = {
-  silenceDeprecations: ['slash-div', 'mixed-decls', 'import', 'global-builtin'],
+  silenceDeprecations: [
+    'color-functions',
+    'global-builtin',
+    'import',
+    'mixed-decls',
+    'slash-div'
+  ],
   quietDeps: true
 }
 


### PR DESCRIPTION
We started using the `red`, `green` and `blue` functions in #6084 but we’re now seeing deprecation warnings in the console:

```
Deprecation Warning [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
158 │     "red": red($colour),
    │            ^^^^^^^^^^^^
    ╵
    ../../../../packages/govuk-frontend/src/govuk/helpers/_colour.scss 158:12            -as-hexadecimal()
    ../../../../packages/govuk-frontend/src/govuk/helpers/_colour.scss 139:11            govuk-tint()
    ../../../../packages/govuk-frontend/src/govuk/settings/_colours-applied.scss 187:45  @import
    ../../../../packages/govuk-frontend/src/govuk/settings/_index.scss 13:9              @import
    ../../../../packages/govuk-frontend/src/govuk/_base.scss 1:9                         @import
    ../../../../packages/govuk-frontend/src/govuk/index.scss 1:9                         root stylesheet

Deprecation Warning [color-functions]: green() is deprecated. Suggestion:

color.channel($color, "green", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
159 │     "green": green($colour),
    │              ^^^^^^^^^^^^^^
    ╵
    ../../../../packages/govuk-frontend/src/govuk/helpers/_colour.scss 159:14            -as-hexadecimal()
    ../../../../packages/govuk-frontend/src/govuk/helpers/_colour.scss 139:11            govuk-tint()
    ../../../../packages/govuk-frontend/src/govuk/settings/_colours-applied.scss 187:45  @import
    ../../../../packages/govuk-frontend/src/govuk/settings/_index.scss 13:9              @import
    ../../../../packages/govuk-frontend/src/govuk/_base.scss 1:9                         @import
    ../../../../packages/govuk-frontend/src/govuk/index.scss 1:9                         root stylesheet

Deprecation Warning [color-functions]: blue() is deprecated. Suggestion:

color.channel($color, "blue", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
160 │     "blue": blue($colour),
    │             ^^^^^^^^^^^^^
    ╵
    ../../../../packages/govuk-frontend/src/govuk/helpers/_colour.scss 160:13            -as-hexadecimal()
    ../../../../packages/govuk-frontend/src/govuk/helpers/_colour.scss 139:11            govuk-tint()
    ../../../../packages/govuk-frontend/src/govuk/settings/_colours-applied.scss 187:45  @import
    ../../../../packages/govuk-frontend/src/govuk/settings/_index.scss 13:9              @import
    ../../../../packages/govuk-frontend/src/govuk/_base.scss 1:9                         @import
    ../../../../packages/govuk-frontend/src/govuk/index.scss 1:9                         root stylesheet
```

We’re intentionally using these functions alongside `change-color` because they force Sass to use legacy colour spaces, so we can’t fix these dependencies for now. Instead, silence deprecation warnings relating to color functions.

Once we’ve dropped support for other Sass compilers we’ll be able to switch to `color.to-space` which only exists in Dart Sass.