### PR TITLE
Percentage changes on PR file sizes

### DIFF
--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -1,8 +1,7 @@
 import { readFile } from 'node:fs/promises'
-import { basename, join, parse } from 'path'
+import { basename, parse } from 'path'
 
-import { getFileSizes } from '@govuk-frontend/lib/files'
-import { getStats, modulePaths } from '@govuk-frontend/stats'
+import { getReadableFileSizes } from '@govuk-frontend/lib/files'
 import { outdent } from 'outdent'
 
 /**
@@ -90,53 +89,116 @@ export async function commentDiff(
 /**
  * Generates comment for stats
  *
+ * @param {FileSizeWithPercentage[]} fileSizeData
+ * @param {FileSizeWithPercentage[]} modulesData
  * @param {GithubActionContext} githubActionContext
  * @param {number} issueNumber
  * @param {DiffComment} statComment
  */
 export async function commentStats(
+  fileSizeData,
+  modulesData,
   githubActionContext,
   issueNumber,
-  { path, titleText, markerText }
+  { titleText, markerText }
 ) {
   const reviewAppURL = getReviewAppUrl(issueNumber)
+  let bodyText = ''
+  let fileSizeText = ''
+  let modulesText = ''
 
-  const distPath = join(path, 'dist')
-  const packagePath = join(path, 'packages/govuk-frontend/dist/govuk')
+  if (!fileSizeData.length && !modulesData.length) {
+    bodyText = 'No changes to any file sizes!'
+  } else {
+    if (fileSizeData.length) {
+      // File sizes
+      const fileSizeTitle = '### File sizes'
+      // We cast the type to both specify explicitly that getReadableFileSizes
+      // is FileSizeWithPercentage and it's size attribute is a string to appease
+      // typescript when calling renderTable
+      const fileSizeRows =
+        /** @type {(FileSizeWithPercentage & {size: string})[]} */ (
+          getReadableFileSizes(fileSizeData)
+        ).map((fileSize) => Object.values(fileSize))
 
-  // File sizes
-  const fileSizeTitle = '### File sizes'
-  const fileSizeRows = [
-    ...(await getFileSizes(join(distPath, '**/*.{css,js,mjs}'))),
-    ...(await getFileSizes(join(packagePath, '*.{css,js,mjs}')))
-  ]
-
-  const fileSizeHeaders = ['File', 'Size']
-  const fileSizeTable = renderTable(fileSizeHeaders, fileSizeRows)
-  const fileSizeText = [fileSizeTitle, fileSizeTable].join('\n')
-
-  // Module sizes
-  const modulesTitle = '### Modules'
-  const modulesRows = (await Promise.all(modulePaths.map(getStats))).map(
-    ([modulePath, moduleSize]) => {
-      const { base, dir, name } = parse(modulePath)
-
-      const statsPath = `docs/stats/${dir}/${name}.html`
-      const statsURL = new URL(statsPath, reviewAppURL)
-
-      return [`[${base}](${statsURL})`, moduleSize.bundled, moduleSize.minified]
+      const fileSizeHeaders = ['File', 'Size', 'Percentage change']
+      const fileSizeTable = renderTable(fileSizeHeaders, fileSizeRows)
+      fileSizeText = [fileSizeTitle, fileSizeTable].join('\n')
+    } else {
+      fileSizeText = 'No changes to asset file sizes.'
     }
-  )
 
-  const modulesHeaders = ['File', 'Size (bundled)', 'Size (minified)']
-  const modulesTable = renderTable(modulesHeaders, modulesRows)
-  const modulesFooter = `[View stats and visualisations on the review app](${reviewAppURL})`
-  const modulesText = [modulesTitle, modulesTable, modulesFooter].join('\n')
+    if (modulesData.length) {
+      // Module sizes
+      const modulesTitle = '### Modules'
+
+      // Group modules data by path
+      // This could use Object.groupBy, however this will be run within the stats
+      // comment github-script which currently uses it's own node env which is
+      // tied to node v20. Object.groupBy is only available from node 21.
+      // Therefore we use a reduce to replicate Object.groupBy.
+      //
+      // We cast the type to both specify explicitly that getReadableFileSizes
+      // is FileSizeWithPercentage and it's size attribute is a string to appease
+      // typescript when calling renderTable
+      const modulesDataByPath =
+        /** @type {(FileSizeWithPercentage & {size: string})[]} */ (
+          getReadableFileSizes(modulesData)
+        ).reduce((pathData, module) => {
+          if (!pathData[module.path]) {
+            pathData[module.path] = [module]
+          } else {
+            pathData[module.path] = [...pathData[module.path], module]
+          }
+
+          return pathData
+        }, /** @type {{[index: string]: (FileSizeWithPercentage & {size: string})[]}} */ ({}))
+
+      // ...then iterate through it to get table rows
+      const modulesRows = Object.keys(modulesDataByPath).map((path) => {
+        const { base, dir, name } = parse(path)
+        const statsPath = `docs/stats/${dir}/${name}.html`
+        const statsURL = new URL(statsPath, reviewAppURL)
+        const pathData = modulesDataByPath[path]
+
+        // Check that there isn't a mismatch between Object.keys and the path
+        // group and that they could find the grouped object by type, just in case
+        // (also to appease JSDoc)
+        const bundled =
+          pathData && pathData.find((bundle) => bundle.type === 'bundled')
+        const minified =
+          pathData && pathData.find((bundle) => bundle.type === 'minified')
+
+        return [
+          `[${base}](${statsURL})`,
+          bundled ? bundled.size : 'Could not find bundle size',
+          bundled ? bundled.percentage : 'Could not find bundle percentage',
+          minified ? minified.size : 'Could not find bundle size',
+          minified ? minified.percentage : 'Could not find bundle percentage'
+        ]
+      })
+
+      const modulesHeaders = [
+        'File',
+        'Size (bundled)',
+        'Percentage change (bundled)',
+        'Size (minified)',
+        'Percentage change (bundled)'
+      ]
+      const modulesTable = renderTable(modulesHeaders, modulesRows)
+      const modulesFooter = `[View stats and visualisations on the review app](${reviewAppURL})`
+      modulesText = [modulesTitle, modulesTable, modulesFooter].join('\n')
+    } else {
+      modulesText = 'No changes to module sizes.'
+    }
+
+    bodyText = [fileSizeText, modulesText].join('\n')
+  }
 
   await comment(githubActionContext, issueNumber, {
     markerText,
     titleText,
-    bodyText: [fileSizeText, modulesText].join('\n')
+    bodyText
   })
 }
 
@@ -201,7 +263,7 @@ function renderCommentFooter({ context, commit }) {
  * Renders a GitHub Markdown table.
  *
  * @param {string[]} headers - An array containing the table headers.
- * @param {string[][]} rows - An array of arrays containing the row data for the table.
+ * @param {(string)[][]} rows - An array of arrays containing the row data for the table.
  * @returns {string} The GitHub Markdown table as a string.
  */
 function renderTable(headers, rows) {
@@ -337,4 +399,8 @@ function getReviewAppUrl(prNumber, path = '/') {
  * @typedef {RestEndpointMethodTypes["issues"]} IssuesEndpoint
  * @typedef {IssuesEndpoint["listComments"]["parameters"]} IssueCommentsListParams
  * @typedef {IssuesEndpoint["getComment"]["response"]["data"]} IssueCommentData
+ */
+
+/**
+ * @import {FileSizeWithPercentage} from '@govuk-frontend/stats'
  */

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -402,5 +402,5 @@ function getReviewAppUrl(prNumber, path = '/') {
  */
 
 /**
- * @import {FileSizeWithPercentage} from '@govuk-frontend/stats'
+ * @import {FileSizeWithPercentage} from '@govuk-frontend/lib/files'
  */

--- a/.github/workflows/stats-comment.yml
+++ b/.github/workflows/stats-comment.yml
@@ -14,21 +14,41 @@ jobs:
     if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork }}
 
     steps:
+      - name: Cache stats
+        uses: actions/cache@v4.2.3
+        id: stats-cache
+        with:
+          # Restore build cache, unless commit SHA or base ref changes
+          key: build-stats-${{ github.base_ref }}-${{ github.sha }}
+          path: |
+            ./file-sizes-base.json
+            ./modules-sizes-base.json
+            ./file-sizes-head.json
+            ./modules-sizes-head.json
+
       - name: Checkout base branch
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4.2.2
 
         with:
           ref: ${{ github.base_ref }}
 
       - name: Restore base dependencies
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: ./.github/workflows/actions/install-node
 
       - name: Build npm package and GitHub release for base
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         run: |
           npm run build:package --workspace govuk-frontend
           npm run build:release --workspace govuk-frontend
 
       - name: Get base file stats
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v7.0.1
         with:
           script: |
@@ -42,20 +62,28 @@ jobs:
             writeFileSync('./modules-sizes-base.json', JSON.stringify(modulesSizes))
 
       - name: Checkout head
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref }}
           clean: false # So that we retain the stats generated from base
 
       - name: Restore head dependencies
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: ./.github/workflows/actions/install-node
 
       - name: Build npm package and GitHub release for head
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         run: |
           npm run build:package --workspace govuk-frontend
           npm run build:release --workspace govuk-frontend
 
       - name: Get head file stats
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v7.0.1
         with:
           script: |
@@ -69,6 +97,8 @@ jobs:
             writeFileSync('./modules-sizes-head.json', JSON.stringify(modulesSizes))
 
       - name: Compare base and head and add comment to PR
+        # Skip build when we’ve built this SHA before
+        if: steps.stats-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stats-comment.yml
+++ b/.github/workflows/stats-comment.yml
@@ -14,32 +14,85 @@ jobs:
     if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout base branch
         uses: actions/checkout@v4.2.2
 
-      - name: Restore dependencies
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Restore base dependencies
         uses: ./.github/workflows/actions/install-node
 
-      - name: Build npm package and GitHub release
+      - name: Build npm package and GitHub release for base
         run: |
           npm run build:package --workspace govuk-frontend
           npm run build:release --workspace govuk-frontend
 
-      - name: Add comment to PR
+      - name: Get base file stats
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { writeFileSync } = await import('fs')
+            const { getModuleFileSizes, getAllFileSizes } = await import('${{ github.workspace }}/shared/stats/src/index.mjs')
+
+            const fileSizes = await getAllFileSizes('${{ github.workspace }}')
+            const modulesSizes = await getModuleFileSizes()
+
+            writeFileSync('./file-sizes-base.json', JSON.stringify(fileSizes))
+            writeFileSync('./modules-sizes-base.json', JSON.stringify(modulesSizes))
+
+      - name: Checkout head
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.head_ref }}
+          clean: false # So that we retain the stats generated from base
+
+      - name: Restore head dependencies
+        uses: ./.github/workflows/actions/install-node
+
+      - name: Build npm package and GitHub release for head
+        run: |
+          npm run build:package --workspace govuk-frontend
+          npm run build:release --workspace govuk-frontend
+
+      - name: Get head file stats
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { writeFileSync } = await import('fs')
+            const { getModuleFileSizes, getAllFileSizes } = await import('${{ github.workspace }}/shared/stats/src/index.mjs')
+
+            const fileSizes = await getAllFileSizes('${{ github.workspace }}')
+            const modulesSizes = await getModuleFileSizes()
+
+            writeFileSync('./file-sizes-head.json', JSON.stringify(fileSizes))
+            writeFileSync('./modules-sizes-head.json', JSON.stringify(modulesSizes))
+
+      - name: Compare base and head and add comment to PR
         uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const { readFileSync } = await import('fs')
             const { commentStats } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
+            const { getFileSizeComparison } = await import('${{ github.workspace }}/shared/lib/files.js')
+
+            // Get base and head temp files and compare
+            const baseFileSizes = JSON.parse(readFileSync('./file-sizes-base.json', 'utf8'))
+            const baseModulesSizes = JSON.parse(readFileSync('./modules-sizes-base.json', 'utf8'))
+            const headFileSizes = JSON.parse(readFileSync('./file-sizes-head.json', 'utf8'))
+            const headModulesSizes = JSON.parse(readFileSync('./modules-sizes-head.json', 'utf8'))
+
+            const comparedFileSizes = getFileSizeComparison(headFileSizes, baseFileSizes)
+            const comparedModulesSizes = getFileSizeComparison(headModulesSizes, baseModulesSizes)
 
             // PR information
             const issueNumber = ${{ github.event.pull_request.number }}
             const commit = '${{ github.event.pull_request.head.sha }}'
 
             const options = {
-              path: '${{ github.workspace }}',
               titleText: ':clipboard: Stats',
               markerText: 'stats'
             }
 
-            await commentStats({ github, context, commit }, issueNumber, options)
+            await commentStats(comparedFileSizes, comparedModulesSizes, { github, context, commit }, issueNumber, options)

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -7,8 +7,13 @@ import {
   getComponentNamesFiltered,
   render
 } from '@govuk-frontend/lib/components'
-import { filterPath, getDirectories, hasPath } from '@govuk-frontend/lib/files'
-import { getStats, modulePaths } from '@govuk-frontend/stats'
+import {
+  filterPath,
+  getDirectories,
+  getReadableFileSizes,
+  hasPath
+} from '@govuk-frontend/lib/files'
+import { getModuleFileSizes } from '@govuk-frontend/stats'
 import express from 'express'
 
 import { getFullPageExamples } from './common/lib/files.mjs'
@@ -70,8 +75,9 @@ export default async () => {
   app.use(middleware.featureFlags)
 
   // Add build stats
-  app.locals.stats = Object.fromEntries(
-    await Promise.all(modulePaths.map(getStats))
+  app.locals.stats = Object.groupBy(
+    getReadableFileSizes(await getModuleFileSizes()),
+    ({ path }) => path
   )
 
   // Configure nunjucks

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -117,6 +117,12 @@
         <a href="/docs/stats/{{ bundleKey }}.html" class="govuk-body-s govuk-link govuk-!-font-weight-regular"><code>{{ bundleKey }}.mjs</code></a>
       {% endset %}
 
+      {% set bundleSizeHtml %}
+        {% for bundle in bundleSize %}
+          {{ bundle.size }} ({{ bundle.type }})<br>
+        {% endfor %}
+      {% endset %}
+
       {{ govukSummaryList({
         classes: "govuk-summary-list--no-border",
         rows: [
@@ -133,9 +139,7 @@
               text: "Total file size"
             },
             value: {
-              html:
-                bundleSize.bundled + " (bundled) <br>" +
-                bundleSize.minified + " (minified)"
+              html: bundleSizeHtml
             }
           }
         ]
@@ -144,6 +148,12 @@
       {% for componentName in componentNamesWithJavaScript | sort %}
         {% set componentKey = "components/" + componentName + "/" + componentName %}
         {% set componentSize = stats[componentKey + ".mjs"] %}
+
+        {% set componentSizeHtml %}
+          {% for bundle in componentSize %}
+            {{ bundle.size }} ({{ bundle.type }})<br>
+          {% endfor %}
+        {% endset %}
 
         {% set componentHtml %}
           <a href="/docs/stats/{{ componentKey }}.html" class="govuk-body-s govuk-link govuk-!-font-weight-regular"><code>{{ componentName }}.mjs</code></a>
@@ -170,9 +180,7 @@
                 text: "File size"
               },
               value: {
-                html:
-                  componentSize.bundled + " (bundled) <br>" +
-                  componentSize.minified + " (minified)"
+                html: componentSizeHtml
               }
             }
           ]

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -2,7 +2,6 @@ const { readFile, stat } = require('fs/promises')
 const { parse, relative, basename } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
-const { filesize } = require('filesize')
 const { glob } = require('glob')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
@@ -66,7 +65,7 @@ async function getDirectories(directoryPath) {
  *
  * @param {string} directoryPath - Minimatch pattern to directory
  * @param {import('glob').GlobOptionsWithFileTypesUnset} [options] - Glob options
- * @returns {Promise<[string, string][]>} - File entries with name and size
+ * @returns {Promise<FileSize[]>} - File entries with name and size
  */
 async function getFileSizes(directoryPath, options = {}) {
   const filesForAnalysis = await getListing(directoryPath, options)
@@ -77,11 +76,14 @@ async function getFileSizes(directoryPath, options = {}) {
  * Get file size entry
  *
  * @param {string} filePath - File path
- * @returns {Promise<[string, string]>} - File entry with name and size
+ * @returns {Promise<FileSize>} - File entry with name and size
  */
 async function getFileSize(filePath) {
   const { size } = await stat(filePath)
-  return [filePath, `${filesize(size, { base: 2 })}`]
+  return {
+    path: filePath,
+    size
+  }
 }
 
 /**
@@ -130,3 +132,7 @@ module.exports = {
   getYaml,
   mapPathTo
 }
+
+/**
+ * @import { FileSize } from '@govuk-frontend/stats'
+ */

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -2,6 +2,7 @@ const { readFile, stat } = require('fs/promises')
 const { parse, relative, basename } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
+const { filesize } = require('filesize')
 const { glob } = require('glob')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
@@ -188,6 +189,21 @@ function findFileSizeRow(fileSizes, searchFileSize) {
     return fileSize.path === searchFileSize.path
   })
 }
+
+/**
+ * Convert the number values of the size param on FileSize types to readable file
+ * size strings with filesize.
+ *
+ * @param {(FileSize|FileSizeWithPercentage)[]} filesizeData
+ * @returns {(FileSize|FileSizeWithPercentage)[]} FileSize array with readable file size strings on size attributes
+ */
+function getReadableFileSizes(filesizeData) {
+  return filesizeData.map((file) => ({
+    ...file,
+    size: `${filesize(file.size, { base: 2 })}`
+  }))
+}
+
 module.exports = {
   filterPath,
   hasPath,
@@ -196,6 +212,7 @@ module.exports = {
   getFileSize,
   getFileSizeComparison,
   getListing,
+  getReadableFileSizes,
   getYaml,
   mapPathTo
 }

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -218,5 +218,9 @@ module.exports = {
 }
 
 /**
- * @import {FileSize, FileSizeWithPercentage} from '@govuk-frontend/stats'
+ * @typedef {object} FileSize
+ * @property {string} path - File path
+ * @property {number|string} size - File size, as a raw number or human-readable string
+ * @property {('bundled'|'minified')} [type] - Type of file size. Only used by module sizes
+ * @typedef {FileSize & {percentage: string}} FileSizeWithPercentage - The FileSize type with an extra attribute representing increase or decrease in percentage
  */

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -122,17 +122,84 @@ async function getYaml(configPath) {
   return yaml.load(await readFile(configPath, 'utf8'), { json: true })
 }
 
+/**
+ * Compare arrays of FileSize types from the base and the head branch and add a
+ * percentage difference to the object.
+ *
+ * If there's no percentage difference, return a blank row.
+ *
+ * If a file is present in head or base but not the other, mark it as a new file
+ * or a deletion.
+ *
+ * @param {(FileSize & {size: number})[]} headFiles
+ * @param {(FileSize & {size: number})[]} baseFiles
+ * @returns {(FileSizeWithPercentage|null)[]} FileSize array with a percentage attribute, potentially reduced, or an empty array
+ */
+function getFileSizeComparison(headFiles, baseFiles) {
+  // Get initial percentage differences and check for deletions
+  const comparedFileSizes = baseFiles.map((file) => {
+    const headFile = findFileSizeRow(headFiles, file)
+    const percentage = headFile
+      ? `${Math.round((headFile.size / file.size) * 100 - 100)}%`
+      : 'Deleted'
+
+    // Return null if there's no percentage difference
+    if (percentage === '0%') {
+      return null
+    }
+
+    return {
+      ...file,
+      percentage
+    }
+  })
+
+  // Look for additions
+  headFiles.forEach((file) => {
+    if (!findFileSizeRow(baseFiles, file)) {
+      comparedFileSizes.push({
+        ...file,
+        percentage: 'New file'
+      })
+    }
+  })
+
+  // remove null rows before returning
+  return comparedFileSizes.filter((file) => file)
+}
+
+/**
+ * Private function used by getFileSizeComparison to find the same FileSize
+ * between two arrays of FileSizes.
+ *
+ * @param {(FileSize & {size: number})[]} fileSizes
+ * @param {(FileSize & {size: number})} searchFileSize
+ * @returns {(FileSize & {size: number})|undefined} The located FileSize in the compare array, or undefined if not present
+ */
+function findFileSizeRow(fileSizes, searchFileSize) {
+  return fileSizes.find((fileSize) => {
+    if (fileSize.type) {
+      return (
+        fileSize.path === searchFileSize.path &&
+        fileSize.type === searchFileSize.type
+      )
+    }
+
+    return fileSize.path === searchFileSize.path
+  })
+}
 module.exports = {
   filterPath,
   hasPath,
   getDirectories,
   getFileSizes,
   getFileSize,
+  getFileSizeComparison,
   getListing,
   getYaml,
   mapPathTo
 }
 
 /**
- * @import { FileSize } from '@govuk-frontend/stats'
+ * @import {FileSize, FileSizeWithPercentage} from '@govuk-frontend/stats'
  */

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -3,7 +3,6 @@ import { join, parse } from 'path'
 import { paths } from '@govuk-frontend/config'
 import { getComponentNamesFiltered } from '@govuk-frontend/lib/components'
 import { filterPath, getFileSizes, getYaml } from '@govuk-frontend/lib/files'
-import { filesize } from 'filesize'
 
 /**
  * Components with JavaScript
@@ -35,43 +34,29 @@ export const modulePaths = [packageOptions.modulePath].concat(
 )
 
 /**
- * Rollup module stats by path
- *
- * @param {string} modulePath - Rollup input path
- * @returns {Promise<[string, { bundled: string; minified: string }]>} Rollup module stats
- */
-export async function getStats(modulePath) {
-  const { dir, name } = parse(modulePath)
-
-  // Totals from Rollup `npm run build:stats` YAML output
-  const [bundled, minified] = await Promise.all([
-    getStatsByYaml(modulePath, `${dir}/${name}.yaml`),
-    getStatsByYaml(modulePath, `${dir}/${name}.min.yaml`)
-  ])
-
-  return [modulePath, { bundled, minified }]
-}
-
-/**
  * Rollup module stats by YAML path
  *
  * @param {string} modulePath - Rollup input path
- * @param {string} statsPath - Rollup stats output path
- * @returns {Promise<string>} Total size (formatted)
+ * @param {('bundled'|'minified')} type - Rollup stats output path
+ * @returns {Promise<FileSize>} Total size (formatted)
  */
-async function getStatsByYaml(modulePath, statsPath) {
-  const { base } = parse(modulePath)
-
+async function getStatsByYaml(modulePath, type) {
+  const { base, dir, name } = parse(modulePath)
+  const statsPath = `${dir}/${name}${type === 'minified' ? '.min' : ''}.yaml`
   const stats = /** @type {Record<string, ModulesList> | undefined} */ (
     await getYaml(join(paths.stats, `dist/${statsPath}`)).catch(() => undefined)
   )
 
   // Modules total size
-  const total = Object.values(stats?.[base] ?? {})
+  const size = Object.values(stats?.[base] ?? {})
     .map(({ rendered }) => rendered)
     .reduce((total, rendered) => total + rendered, 0)
 
-  return `${filesize(total, { base: 2 })}`
+  return {
+    path: modulePath,
+    size,
+    type
+  }
 }
 
 /**

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -99,4 +99,5 @@ export async function getAllFileSizes(path) {
  * @property {string} path - File path
  * @property {number|string} size - File size, as a raw number or human-readable string
  * @property {('bundled'|'minified')} [type] - Type of file size. Only used by module sizes
+ * @typedef {FileSize & {percentage: string}} FileSizeWithPercentage - The FileSize type with an extra attribute representing increase or decrease in percentage
  */

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -2,7 +2,7 @@ import { join, parse } from 'path'
 
 import { paths } from '@govuk-frontend/config'
 import { getComponentNamesFiltered } from '@govuk-frontend/lib/components'
-import { filterPath, getYaml } from '@govuk-frontend/lib/files'
+import { filterPath, getFileSizes, getYaml } from '@govuk-frontend/lib/files'
 import { filesize } from 'filesize'
 
 /**
@@ -86,6 +86,21 @@ export async function getModuleFileSizes() {
     )),
     ...(await Promise.all(
       modulePaths.map((path) => getStatsByYaml(path, 'minified'))
+    ))
+  ]
+}
+
+/**
+ * Get all distributed file sizes
+ *
+ * @param {string} path - Root path of project to retrieve files from
+ * @returns {Promise<FileSize[]>} Array of file size objects
+ */
+export async function getAllFileSizes(path) {
+  return [
+    ...(await getFileSizes(join(join(path, 'dist'), '**/*.{css,js,mjs}'))),
+    ...(await getFileSizes(
+      join(join(path, 'packages/govuk-frontend/dist/govuk'), '*.{css,js,mjs}')
     ))
   ]
 }

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -95,9 +95,5 @@ export async function getAllFileSizes(path) {
  */
 
 /**
- * @typedef {object} FileSize
- * @property {string} path - File path
- * @property {number|string} size - File size, as a raw number or human-readable string
- * @property {('bundled'|'minified')} [type] - Type of file size. Only used by module sizes
- * @typedef {FileSize & {percentage: string}} FileSizeWithPercentage - The FileSize type with an extra attribute representing increase or decrease in percentage
+ * @import {FileSize} from '@govuk-frontend/lib/files'
  */

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -75,5 +75,28 @@ async function getStatsByYaml(modulePath, statsPath) {
 }
 
 /**
+ * Get both bundled and minified module file sizes
+ *
+ * @returns {Promise<FileSize[]>} Array of file size objects
+ */
+export async function getModuleFileSizes() {
+  return [
+    ...(await Promise.all(
+      modulePaths.map((path) => getStatsByYaml(path, 'bundled'))
+    )),
+    ...(await Promise.all(
+      modulePaths.map((path) => getStatsByYaml(path, 'minified'))
+    ))
+  ]
+}
+
+/**
  * @typedef {{ [modulePath: string]: { rendered: number } }} ModulesList
+ */
+
+/**
+ * @typedef {object} FileSize
+ * @property {string} path - File path
+ * @property {number|string} size - File size, as a raw number or human-readable string
+ * @property {('bundled'|'minified')} [type] - Type of file size. Only used by module sizes
  */


### PR DESCRIPTION
## Change

Extends the `stats-comment` workflow and its associated script (`commentStats`) to display a percentage change between the PR base and the PR branch.

Resolves https://github.com/alphagov/govuk-frontend/issues/6057 AND Resolves https://github.com/alphagov/govuk-frontend/issues/6058

### Specific changes

- Added `FileSize` and `FileSizeWithPercentage` typedefs to manage the structure of the modules stats and dist file size objects
- Changed the structure of modules objects to no longer include sub-objects under `bundled` or `minified` but instead add them a separate rows with different 'types'
- Separated out making the filesize readable into it's own helper: `getReadableFileSize`
- Added a helper to compare `FileSize` objects: `getFileSizeComparison`. This compares two objects and adds a `percentage` attribute to each row with the change as a percentage value, unless the value is zero, in which case it removes the row
- Refactored `commentStats` to be solely focused on foramtting the compared data and returning either a constructed table of file sizes or a message saying there aren't any size changes
- Appled the data structure changes to the review app homepage where we display module stats

## Notes

Ideally we would've gone further in refactoring this to get both the module stats and dist and package stats the exact same way eg: a single method we pass filesizes to for both datasets. What makes this tricky is that the module stats especiall is very tightly coupled to the stats workspace and the stats rollup job and decoupling would mean this work would take forever to do in one go. Something we could do in future is go the other way and extend stats to also handle dist and package. I nthe mean time, the new typedefs are intended as a step towards that ideal.

We're doing a lot of type management here, especially in `commentStats`, which makes me worry that this is becoming overly complex. I welcome any suggestions to make it simpler.

I would've liked to use [`Object.groupBy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy) instead of `reduce` in `commentStats` when transforming the modules data into table rows. Because we're using github-script to run `commentStats`, we're at the mercy of github-script's node env which is pinned to v20, where `groupBy` isn't available. Hopefully we can revisit this in https://github.com/alphagov/govuk-frontend/issues/6114

The stats comment workflow will always fail on this PR because it's referencing the base ref which is `main` which doesn't have these changes yet. You can see this working in https://github.com/alphagov/govuk-frontend/pull/6113, specifically [this comment](https://github.com/alphagov/govuk-frontend/pull/6113#issuecomment-3088545484), which I ran with this branch as a base to test.