### PR TITLE
Allow examples to set page template options

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -215,20 +215,19 @@ export default async () => {
         fixture
       })
 
-      let bodyClasses = 'app-template__body'
+      const pageTemplateOptions = fixture.pageTemplateOptions ?? {}
 
-      for (const modifier of fixture.previewLayoutModifiers) {
-        bodyClasses += ` app-template__body--${modifier}`
-      }
+      let bodyClasses = `${pageTemplateOptions.bodyClasses ?? ''} app-template__body`
 
       if ('iframe' in req.query) {
         bodyClasses += ' app-template__body--component-preview'
       }
 
       res.render('component-preview', {
-        bodyClasses,
         componentView,
-        previewLayout: fixtures.previewLayout
+        previewLayout: fixtures.previewLayout,
+        ...pageTemplateOptions,
+        bodyClasses
       })
     }
   )

--- a/packages/govuk-frontend/src/govuk/components/back-link/back-link.yaml
+++ b/packages/govuk-frontend/src/govuk/components/back-link/back-link.yaml
@@ -26,8 +26,8 @@ examples:
     options: {}
   - name: inverse
     screenshot: true
-    previewLayoutModifiers:
-      - inverse
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
     options:
       classes: govuk-back-link--inverse
 

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -84,8 +84,8 @@ examples:
   - name: inverse
     screenshot: true
     description: Breadcrumbs that appear on dark backgrounds
-    previewLayoutModifiers:
-      - inverse
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
     options:
       classes: govuk-breadcrumbs--inverse
       items:

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -91,8 +91,8 @@ examples:
   - name: inverse
     screenshot: true
     description: A button that appears on dark backgrounds
-    previewLayoutModifiers:
-      - inverse
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
     options:
       name: Inverse
       text: Inverse button

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -202,8 +202,8 @@ examples:
           text: Navigation item 4
   - name: inverse
     description: Service navigation that appears between other areas of brand blue. Rebrand only.
-    previewLayoutModifiers:
-      - inverse
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
     options:
       classes: govuk-service-navigation--inverse
       serviceName: Apply for a juggling license

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -322,7 +322,7 @@ module.exports = {
  * @property {string} [description] - Example description
  * @property {boolean} [hidden] - Example hidden from review app
  * @property {boolean} [screenshot] - Screenshot and include in visual regression tests
- * @property {string[]} [previewLayoutModifiers] - Component preview layout class modifiers
+ * @property {PageTemplateOptions} [pageTemplateOptions] - Page template options for render
  * @property {MacroOptions} options - Nunjucks macro options (or params)
  */
 
@@ -330,6 +330,12 @@ module.exports = {
  * Nunjucks macro options
  *
  * @typedef {{ [param: string]: unknown }} MacroOptions
+ */
+
+/**
+ * Page template options
+ *
+ * @typedef {{ [param: string]: unknown }} PageTemplateOptions
  */
 
 /**

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -126,7 +126,7 @@ async function generateFixture(componentDataPath, options) {
 
         // Add defaults to optional fields
         description: example.description ?? '',
-        previewLayoutModifiers: example.previewLayoutModifiers ?? [],
+        pageTemplateOptions: example.pageTemplateOptions ?? {},
         screenshot: example.screenshot ?? false,
 
         // Add rendered Nunjucks example to fixture


### PR DESCRIPTION
We currently allow each example to set an array of `previewLayoutModifiers` which affect how the example is rendered in the review app (and thus in our visual regression tests).

This is limited because:

- it assumes that the modifier will exist as a modifier class of `app-template__body`
- it can only be used to add classes to the body

Replace with a generic way to set ‘context’ for the example, which is then passed to `env.render`.

This will allow us to set e.g. `htmlClasses` on the page template using the same approach, allowing us to add examples that use the rebrand.

Part of #5840.