### PR TITLE
Refine header visual regression tests and add rebranded examples

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -112,10 +112,7 @@ accessibilityCriteria: |
 
 examples:
   - name: default
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     description: The standard header as used on information pages on GOV.UK
     options: {}
 
@@ -158,7 +155,10 @@ examples:
           text: Eitem llywio 4
 
   - name: with service name and navigation
-    screenshot: true
+    screenshot:
+      variants:
+        - default
+        - no-js
     description: If you need to include basic navigation, contact or account management links.
     options:
       serviceName: Service Name
@@ -363,10 +363,7 @@ examples:
   - name: rebrand
     description: The standard header as used on information pages on GOV.UK
     hidden: true
-    screenshot:
-      variants:
-        - default
-        - no-js
+    screenshot: true
     pageTemplateOptions:
       htmlClasses: govuk-template--rebranded
     options:
@@ -375,7 +372,10 @@ examples:
   - name: with service name and navigation and rebrand
     description: If you need to include basic navigation, contact or account management links.
     hidden: true
-    screenshot: true
+    screenshot:
+      variants:
+        - default
+        - no-js
     pageTemplateOptions:
       htmlClasses: govuk-template--rebranded
     options:


### PR DESCRIPTION
Add two additional header examples to be included in screenshots:

- header with service name and navigation
- header with product name

And then add versions of all three examples that are screenshotted with the rebrand enabled.

Also:

- hide an example that was intended to be hidden ('Header with custom menu button label')
- take the no-js screenshot of the 'header with service name and navigation' instead of the default header example, as it's the navigation that changes depending on whether JS is enabled
- remove redundant navigationClasses from an example that doesn't have any navigation

Part of #5840.