### PR TITLE
Refactor how we get element IDs from URL hashes and remove the `getFragmentForUrl` helper

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -1,6 +1,6 @@
 import { outdent } from 'outdent'
 
-import { isSupported, getFragmentFromUrl, getBreakpoint } from './index.mjs'
+import { isSupported, getBreakpoint } from './index.mjs'
 
 describe('Common JS utilities', () => {
   describe('isSupported', () => {
@@ -24,49 +24,6 @@ describe('Common JS utilities', () => {
       // For example, running `initAll()` in `<head>` without `type="module"`
       // will see support checks run when document.body is still `null`
       expect(isSupported(null)).toBe(false)
-    })
-  })
-
-  describe('getFragmentFromUrl', () => {
-    it.each([
-      {
-        url: 'https://www.gov.uk/#content',
-        fragment: 'content'
-      },
-      {
-        url: 'https://www.gov.uk/example/#content',
-        fragment: 'content'
-      },
-      {
-        url: 'https://www.gov.uk/example/?keywords=123#content',
-        fragment: 'content'
-      },
-      {
-        url: '/#content',
-        fragment: 'content'
-      },
-      {
-        url: '/example/#content',
-        fragment: 'content'
-      },
-      {
-        url: '/?keywords=123#content',
-        fragment: 'content'
-      },
-      {
-        url: '#content',
-        fragment: 'content'
-      },
-      {
-        url: '/',
-        fragment: undefined
-      },
-      {
-        url: '',
-        fragment: undefined
-      }
-    ])("returns '$fragment' for '$url'", ({ url, fragment }) => {
-      expect(getFragmentFromUrl(url)).toBe(fragment)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -7,24 +7,6 @@
  */
 
 /**
- * Get hash fragment from URL
- *
- * Extract the hash fragment (everything after the hash) from a URL,
- * but not including the hash symbol
- *
- * @private
- * @param {string} url - URL
- * @returns {string | undefined} Fragment from URL, without the hash
- */
-export function getFragmentFromUrl(url) {
-  if (!url.includes('#')) {
-    return undefined
-  }
-
-  return url.split('#').pop()
-}
-
-/**
  * Get GOV.UK Frontend breakpoint value from CSS custom property
  *
  * @private

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -1,5 +1,5 @@
 import { ConfigurableComponent } from '../../common/configuration.mjs'
-import { getFragmentFromUrl, setFocus } from '../../common/index.mjs'
+import { setFocus } from '../../common/index.mjs'
 
 /**
  * Error summary component
@@ -66,7 +66,7 @@ export class ErrorSummary extends ConfigurableComponent {
       return false
     }
 
-    const inputId = getFragmentFromUrl($target.href)
+    const inputId = $target.hash.replace('#', '')
     if (!inputId) {
       return false
     }

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,4 +1,4 @@
-import { getFragmentFromUrl, setFocus } from '../../common/index.mjs'
+import { setFocus } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
@@ -23,33 +23,15 @@ export class SkipLink extends Component {
     const hash = this.$root.hash
     const href = this.$root.getAttribute('href') ?? ''
 
-    /** @type {URL | undefined} */
-    let url
-
-    /**
-     * Check for valid link URL
-     *
-     * {@link https://caniuse.com/url}
-     * {@link https://url.spec.whatwg.org}
-     *
-     */
-    try {
-      url = new window.URL(this.$root.href)
-    } catch (error) {
-      throw new ElementError(
-        `Skip link: Target link (\`href="${href}"\`) is invalid`
-      )
-    }
-
     // Return early for external URLs or links to other pages
     if (
-      url.origin !== window.location.origin ||
-      url.pathname !== window.location.pathname
+      this.$root.origin !== window.location.origin ||
+      this.$root.pathname !== window.location.pathname
     ) {
       return
     }
 
-    const linkedElementId = getFragmentFromUrl(hash)
+    const linkedElementId = hash.replace('#', '')
 
     // Check link path matching current page
     if (!linkedElementId) {

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -1,4 +1,4 @@
-import { getBreakpoint, getFragmentFromUrl } from '../../common/index.mjs'
+import { getBreakpoint } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
@@ -256,7 +256,7 @@ export class Tabs extends Component {
    * @param {HTMLAnchorElement} $tab - Tab link
    */
   setAttributes($tab) {
-    const panelId = getFragmentFromUrl($tab.href)
+    const panelId = $tab.hash.replace('#', '')
     if (!panelId) {
       return
     }
@@ -438,7 +438,7 @@ export class Tabs extends Component {
    * @returns {Element | null} Tab panel
    */
   getPanel($tab) {
-    const panelId = getFragmentFromUrl($tab.href)
+    const panelId = $tab.hash.replace('#', '')
     if (!panelId) {
       return null
     }


### PR DESCRIPTION
Everywhere we’re currently using this helper we’re taking the URL from an `HTMLAnchorElement`.

Rather than pass the URL to `getFragmentForUrl` as a string and splitting on `#`, we can get the hash of the target URL using `HTMLAnchorElement.prototype.hash`.

The only thing that then needs to be done is to remove the leading `#`, which we can do with a simple replace that I don’t think is worth abstracting.