### PR TITLE
Use `govuk-font` in skip link

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
@@ -1,10 +1,9 @@
 @include govuk-exports("govuk/component/skip-link") {
   .govuk-skip-link {
     @include govuk-visually-hidden-focusable;
-    @include govuk-typography-common;
     @include govuk-link-decoration;
     @include govuk-link-style-text;
-    @include govuk-font-size($size: 16);
+    @include govuk-font($size: 16);
 
     display: block;
     padding: govuk-spacing(2) govuk-spacing(3);


### PR DESCRIPTION
This is the only place in the codebase where we call `govuk-typography-common` directly rather than use `govuk-font`.

For consistency, switch to using `govuk-font`.