### PR TITLE
Finish applying the new brand to percy

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -314,3 +314,27 @@ examples:
           actions:
             - text: Hide cookie message
               type: button
+
+  # this rebrand example is included in screenshots but hidden in the app because
+  # the interaction with the 'rebrand' feature flag is confusing.
+
+  - name: rebrand
+    hidden: true
+    screenshot: true
+    pageTemplateOptions:
+      htmlClasses: govuk-template--rebranded
+    options:
+      messages:
+        - headingText: Cookies on this government service
+          text: We use analytics cookies to help understand how users use our service.
+          actions:
+            - text: Accept analytics cookies
+              type: submit
+              name: cookies
+              value: accept
+            - text: Reject analytics cookies
+              type: submit
+              name: cookies
+              value: reject
+            - text: View cookie preferences
+              href: /cookie-preferences

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -469,7 +469,14 @@ examples:
               attributes:
                 data-attribute: my-attribute
                 data-attribute-2: my-attribute-2
+
+  # this rebrand example is included in screenshots but hidden in the app because
+  # the interaction with the 'rebrand' feature flag is confusing.
+
   - name: rebrand
     hidden: true
+    screenshot: true
+    pageTemplateOptions:
+      htmlClasses: govuk-template--rebranded
     options:
       rebrand: true

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -382,3 +382,22 @@ examples:
         end: '<div>[end]</div>'
         navigationStart: '<li>[navigation start]</li>'
         navigationEnd: '<li>[navigation end]</li>'
+
+  # this rebrand example is included in screenshots but hidden in the app because
+  # the interaction with the 'rebrand' feature flag is confusing.
+
+  - name: rebrand
+    hidden: true
+    screenshot: true
+    pageTemplateOptions:
+      htmlClasses: govuk-template--rebranded
+    options:
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+        - href: '#/2'
+          text: Navigation item 2
+        - href: '#/3'
+          text: Navigation item 3
+        - href: '#/4'
+          text: Navigation item 4


### PR DESCRIPTION
This follows on from https://github.com/alphagov/govuk-frontend/pull/6105 and then https://github.com/alphagov/govuk-frontend/pull/6106 to get rebrand percy snapshots for the other components impacted by the brand updates and the `govuk-template--rebranded` class:

- Footer
- Cookie banner
- Service nav

Resolves https://github.com/alphagov/govuk-frontend/issues/5840