### PR TITLE
Run Percy only in certain circumstances

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -49,26 +49,31 @@ jobs:
 
       - name: Check for relevant changes
         id: changes
-        if: github.event_name != 'workflow_dispatch'
         uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             console.log('Checking if Percy needs to run.')
 
-            const { checkRelevantChanges } = await import('${{ github.workspace }}/.github/workflows/scripts/check-percy-files.mjs')
+            const changedFiles = JSON.parse('${{ steps.files.outputs.changed_files }}')
+            if ('${{ github.event_name }}' === 'workflow_dispatch') {
+              console.log('workflow_dispatch - running Percy')
+              core.setOutput('relevant_changes', 'true')
+            } else {
+              const { checkRelevantChanges } = await import('${{ github.workspace }}/.github/workflows/scripts/check-percy-files.mjs')
 
-            const relevantChanges = checkRelevantChanges(JSON.parse('${{ steps.files.outputs.changed_files }}'))
+              const relevantChanges = checkRelevantChanges(changedFiles)
+              core.setOutput('relevant_changes', relevantChanges)
 
-            core.setOutput('relevant_changes', relevantChanges.toString())
-            console.log('Relevant changes detected:', relevantChanges)
+              console.log('Relevant changes detected:', relevantChanges)
+            }
 
       - name: Install dependencies
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache browser download
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: actions/cache@v4.2.3
         with:
           # Use faster GNU tar for all runners
@@ -77,13 +82,13 @@ jobs:
           path: .cache/puppeteer
 
       - name: Build
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: ./.github/workflows/actions/build
 
       - name: Start review app
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: npm start --workspace @govuk-frontend/review &
 
       - name: Send screenshots to Percy
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: npx --workspace @govuk-frontend/review percy exec -- npm run test:screenshots

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -28,11 +28,51 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: files
+        run: |
+          BASE_REF="${{ github.base_ref || 'main' }}"
+          echo "Comparing with base branch: $BASE_REF"
+
+          git fetch origin $BASE_REF:$BASE_REF 2>/dev/null || true
+          CHANGED_FILES=$(git diff --name-only origin/$BASE_REF..HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          CHANGED_FILES_JSON=$(echo "$CHANGED_FILES" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT
+
+      - name: Check for relevant changes
+        id: changes
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            console.log('Checking if Percy needs to run.')
+
+            if ('${{ github.event_name }}' === 'workflow_dispatch') {
+              core.setOutput('relevant_changes', 'true')
+              console.log('Workflow dispatch - skipping file check')
+              return
+            }
+
+            const { checkRelevantChanges } = await import('${{ github.workspace }}/.github/workflows/scripts/check-percy-files.mjs')
+
+            const relevantChanges = checkRelevantChanges(JSON.parse('${{ steps.files.outputs.changed_files }}'))
+
+            core.setOutput('relevant_changes', relevantChanges.toString())
+            console.log('Relevant changes detected:', relevantChanges)
 
       - name: Install dependencies
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache browser download
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: actions/cache@v4.2.3
         with:
           # Use faster GNU tar for all runners
@@ -41,10 +81,13 @@ jobs:
           path: .cache/puppeteer
 
       - name: Build
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: ./.github/workflows/actions/build
 
       - name: Start review app
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: npm start --workspace @govuk-frontend/review &
 
       - name: Send screenshots to Percy
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: npx --workspace @govuk-frontend/review percy exec -- npm run test:screenshots

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Get changed files
         id: files
+        if: github.event_name != 'workflow_dispatch'
         run: |
           BASE_REF="${{ github.base_ref || 'main' }}"
           echo "Comparing with base branch: $BASE_REF"
@@ -48,17 +49,12 @@ jobs:
 
       - name: Check for relevant changes
         id: changes
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             console.log('Checking if Percy needs to run.')
-
-            if ('${{ github.event_name }}' === 'workflow_dispatch') {
-              core.setOutput('relevant_changes', 'true')
-              console.log('Workflow dispatch - skipping file check')
-              return
-            }
 
             const { checkRelevantChanges } = await import('${{ github.workspace }}/.github/workflows/scripts/check-percy-files.mjs')
 
@@ -68,11 +64,11 @@ jobs:
             console.log('Relevant changes detected:', relevantChanges)
 
       - name: Install dependencies
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache browser download
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
         uses: actions/cache@v4.2.3
         with:
           # Use faster GNU tar for all runners
@@ -81,13 +77,13 @@ jobs:
           path: .cache/puppeteer
 
       - name: Build
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
         uses: ./.github/workflows/actions/build
 
       - name: Start review app
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
         run: npm start --workspace @govuk-frontend/review &
 
       - name: Send screenshots to Percy
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant_changes == 'true'
         run: npx --workspace @govuk-frontend/review percy exec -- npm run test:screenshots

--- a/.github/workflows/scripts/check-percy-files.mjs
+++ b/.github/workflows/scripts/check-percy-files.mjs
@@ -1,0 +1,47 @@
+const EXTENSIONS = ['.css', '.scss', '.js', '.mjs', '.njk', '.yaml', '.yml']
+
+/**
+ * Check if there are relevant changes for Percy screenshots
+ *
+ * @param {string[]} changedFiles - Array of file paths that have changed
+ * @returns {boolean} True if relevant changes are detected
+ */
+export function checkRelevantChanges(changedFiles) {
+  for (const file of changedFiles) {
+    if (isRelevantFile(file)) {
+      return true
+    }
+  }
+
+  return false
+}
+/**
+ * Check if a file is relevant for Percy screenshots
+ *
+ * @param {string} file - File path to check
+ * @returns {boolean} True if the file is relevant
+ */
+function isRelevantFile(file) {
+  if (!file || file.includes('.test.')) {
+    return false
+  }
+
+  // Asset changes always trigger screenshots
+  if (
+    file.startsWith('packages/govuk-frontend/src/govuk/assets/') ||
+    file.startsWith('dist/assets/')
+  ) {
+    return true
+  }
+
+  // Check for frontend source files (CSS, SCSS, JS, MJS, Nunjucks)
+  if (
+    file.startsWith('packages/govuk-frontend/src/govuk/') ||
+    file.startsWith('packages/govuk-frontend-review/src/') ||
+    file.startsWith('dist')
+  ) {
+    return EXTENSIONS.some((ext) => file.endsWith(ext))
+  }
+
+  return false
+}

--- a/.github/workflows/scripts/check-percy-files.test.mjs
+++ b/.github/workflows/scripts/check-percy-files.test.mjs
@@ -1,0 +1,83 @@
+import { checkRelevantChanges } from './check-percy-files.mjs'
+
+const govukFrontendSrcPath = 'packages/govuk-frontend/src/govuk'
+const govukReviewSrcPath = 'packages/govuk-frontend-review/src'
+
+describe('checkRelevantChanges', () => {
+  describe('govuk-frontend file extensions', () => {
+    test.each([
+      ['.scss', [`${govukFrontendSrcPath}/components/button/button.scss`]],
+      ['.js', [`${govukFrontendSrcPath}/components/accordion/accordion.js`]],
+      ['.mjs', [`${govukFrontendSrcPath}/components/header/header.mjs`]],
+      ['.njk', [`${govukFrontendSrcPath}/components/button/template.njk`]],
+      ['.yaml', [`${govukFrontendSrcPath}/components/button/button.yaml`]],
+      ['.yml', [`${govukFrontendSrcPath}/components/button/button.yml`]]
+    ])('returns true for %s', (description, changedFiles) => {
+      expect(checkRelevantChanges(changedFiles)).toBe(true)
+    })
+  })
+
+  describe('review app file extensions', () => {
+    test.each([
+      ['.scss', [`${govukReviewSrcPath}/stylesheets/app.scss`]],
+      ['.js', [`${govukReviewSrcPath}/app.js`]],
+      ['.mjs', [`${govukReviewSrcPath}/app.mjs`]],
+      ['.njk', [`${govukReviewSrcPath}/views/component.njk`]],
+      ['.yaml', [`${govukReviewSrcPath}/views/examples/example.yaml`]],
+      ['.yml', [`${govukReviewSrcPath}/views/examples/example.yml`]]
+    ])('returns true for %s', (description, changedFiles) => {
+      expect(checkRelevantChanges(changedFiles)).toBe(true)
+    })
+  })
+
+  describe('dist file extensions', () => {
+    test.each([
+      ['.js', [`dist/govuk-frontend.min.js`]],
+      ['.css', [`dist/govuk-frontend.min.css`]]
+    ])('returns true for %s', (description, changedFiles) => {
+      expect(checkRelevantChanges(changedFiles)).toBe(true)
+    })
+  })
+
+  describe('asset files', () => {
+    test.each([
+      [
+        'govuk-frontend src',
+        ['packages/govuk-frontend/src/govuk/assets/manifest.json']
+      ],
+      ['dist', ['dist/assets/manifest.json']]
+    ])('returns true for %s', (description, changedFiles) => {
+      expect(checkRelevantChanges(changedFiles)).toBe(true)
+    })
+  })
+
+  describe('with irrelevant files', () => {
+    it('returns true when relevant files mixed with irrelevant files', () => {
+      const changedFiles = [
+        'README.md',
+        `${govukFrontendSrcPath}/components/button/button.scss`,
+        'docs/contributing/testing.md'
+      ]
+      expect(checkRelevantChanges(changedFiles)).toBe(true)
+    })
+
+    it('returns false for irrelevant files', () => {
+      const changedFiles = [
+        'jest.config.mjs', // Root file
+        '.github/workflows/test.yml', // GitHub files
+        'bin/build-release.sh', // bin files
+        'docs/contributing/testing.md', // doc files
+        'packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs', // Test files, even if correct extension and location
+        'packages/govuk-frontend/src/govuk/components/accordion/README.md', // Wrong extension, right location
+        'packages/govuk-frontend/tasks/index.mjs', // Right extension in the package, but not relevant
+        'packages/govuk-frontend-review/tasks/index.mjs', // Right extension in the package, but not relevant
+        'shared/config/index.js' // Shared files
+      ]
+      expect(checkRelevantChanges(changedFiles)).toBe(false)
+    })
+
+    it('returns false for empty file list', () => {
+      expect(checkRelevantChanges([])).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Introduces two steps to the `screenshots` workflow:

### Get changed files
Here we diff the commit and the base branch, getting the file names of files that have changed.

### Check for relevant changes
Here we check whether we should actually run Percy. We run the `checkRelevantChanges` function which takes the list of file names and checks for the following to kick off the Percy build:

- Any file in the govuk-frontend and dist `assets` folders is changed
- Any CSS, SCSS, JS, MJS, NJK, YAML or YML file is changed within the package src folders, or the `dist` folder

This check ignores all test files.

I _think_ this covers anything that might affect visuals, but I've probably missed something.

## Considerations

### workflow_dispatch calls
I think if we run a workflow_dispatch, we expect Percy to run, so I've added some conditionals to skip the checks if the event is a `workflow_dispatch`. I'm not sure about this approach - we could check the `event_name` in both of the new steps instead, and output a default value.

### Comparing recent commits instead of the base branch
We currently only compare to the base branch, so if we push a change to a PR that doesn't change any relevant file, we still run Percy. I think this is desirable - I imagine not running it could a) confuse the contributor and b) inevitably cause some funkiness with our CI automation.

However, in theory we could compare against previous commits in certain conditions, so we'd only check pushes which changed relevant files.

### Only running certain screenshots depending on which files have changed
We currently run the entire screenshot suite every time we run Percy, but given we know which files have changed, we could use labels/grouping and run only certain shots. I decided that was too fiddly to be in scope for this PR.

I think the way we'd do this is to:

- check for any changed files within the `components` folder
- add any affected component folder name to an array (eg: "accordion", "back-link")
- pass this array to to the send screenshots step
- Add each item in the array as a label in the Percy call

I think running specific component snapshots as well as the non-component examples should be enough coverage, but of course I worry about weird interactions between components, so maybe this is a step too far.