### PR TITLE
Bump npm version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Used only for the development of GOV.UK Frontend, see `packages/govuk-frontend/package.json` for the published `package.json`",
   "engines": {
     "node": "^22.11.0",
-    "npm": "^10.1.0"
+    "npm": "^10.5.0"
   },
   "license": "MIT",
   "workspaces": [


### PR DESCRIPTION
We’re currently having issues with Dependabot updates timing out.

GitHub support have advised us that specifying a version of npm >= 10.5.0 might help with the timeouts:

> Fortunately, I've received an update from the Dependabot Updates Software Engineering Team today.
>
> They have pointed out that this issue appears to be related to the corepack npm install handling of requests to registry.npmjs.org.
>
> This is a known npm issue that affects npm version 10 up to 10.5.0.
>
> In your package.json you are specifying npm version 10.1.0 or greater. They've suggest explicitly specifying version 10.5.0 or greater instead.

We’ve [already tried this in alphagov/govuk-design-system][1] where it seems to have done the trick, so let’s make the same change here – bump the version of npm to 10.5.0 in our engines config.

[1]: https://github.com/alphagov/govuk-design-system/pull/4806