### PR TITLE
Improve stats comment wording when there aren't any bundle changes

### DIFF
--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -108,7 +108,7 @@ export async function commentStats(
   let modulesText = ''
 
   if (!fileSizeData.length && !modulesData.length) {
-    bodyText = 'No changes to any file sizes!'
+    bodyText = 'No changes to any distributed file sizes!'
   } else {
     if (fileSizeData.length) {
       // File sizes


### PR DESCRIPTION
'No changes to any file sizes!' could be confusing given that files will obviously change in PRs, even if they don't impact our bundled, distributed files. This is an attempt to make the wording clearer.

Willing to split hairs over exact wording.