### PR TITLE
Fix file upload being invisible when using the ✨ 'JavaScript enhanced' ✨ version with an empty label

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -68,7 +68,6 @@ export class FileUpload extends ConfigurableComponent {
     }
 
     this.$input = /** @type {HTMLFileInputElement} */ ($input)
-    this.$input.setAttribute('hidden', 'true')
 
     if (!this.$input.id) {
       throw new ElementError({
@@ -95,6 +94,9 @@ export class FileUpload extends ConfigurableComponent {
     // to the new button replacement element
     // so that focus will work in the error summary
     this.$input.id = `${this.id}-input`
+
+    // Hide the native input
+    this.$input.setAttribute('hidden', 'true')
 
     // Create the file selection button
     const $button = document.createElement('button')

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -720,6 +720,9 @@ describe('/components/file-upload', () => {
                   'govuk-file-upload: Field label (`<label for=file-upload-1>`) not found'
               }
             })
+
+            // Expect the input to still be visible
+            await page.waitForSelector('input', { visible: true, timeout: 100 })
           })
         })
       })


### PR DESCRIPTION
When using the JavaScript ‘enhanced’ version of the file upload component, we currently have a failure state where the native input is hidden _before_ we throw an error if no label is present, resulting in neither the input nor the enhanced version being rendered.

Defer hiding the native input until after we’re done with these checks.

Fixes #6104 