### PR TITLE
Bump typedoc to 0.28.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3261,16 +3261,16 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.2.tgz",
-      "integrity": "sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.8.1.tgz",
+      "integrity": "sha512-HVZW+8pxoOExr5ZMPK15U79jQAZTO/S6i5byQyyZGjtNj+qaYd82cizTncwFzTQgiLo8uUBym6vh+/1tfJklTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.2.1",
-        "@shikijs/langs": "^3.2.1",
-        "@shikijs/themes": "^3.2.1",
-        "@shikijs/types": "^3.2.1",
+        "@shikijs/engine-oniguruma": "^3.8.1",
+        "@shikijs/langs": "^3.8.1",
+        "@shikijs/themes": "^3.8.1",
+        "@shikijs/types": "^3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -8426,40 +8426,40 @@
       ]
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
-      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.8.1.tgz",
+      "integrity": "sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
-      "integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.8.1.tgz",
+      "integrity": "sha512-TjOFg2Wp1w07oKnXjs0AUMb4kJvujML+fJ1C5cmEj45lhjbUXtziT1x2bPQb9Db6kmPhkG5NI2tgYW1/DzhUuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
-      "integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.8.1.tgz",
+      "integrity": "sha512-Vu3t3BBLifc0GB0UPg2Pox1naTemrrvyZv2lkiSw3QayVV60me1ujFQwPZGgUTmwXl1yhCPW8Lieesm0CYruLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
-      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34629,18 +34629,17 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
-      "integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.7.tgz",
+      "integrity": "sha512-lpz0Oxl6aidFkmS90VQDQjk/Qf2iw0IUvFqirdONBdj7jPSN9mGXhy66BcGNDxx5ZMyKKiBVAREvPEzT6Uxipw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.1",
+        "@gerrit0/mini-shiki": "^3.7.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.7.0 "
+        "yaml": "^2.8.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -34668,7 +34667,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -36732,7 +36730,7 @@
         "rollup": "^4.19.1",
         "sassdoc": "^2.7.4",
         "supertest": "^7.1.3",
-        "typedoc": "^0.28.4",
+        "typedoc": "^0.28.7",
         "typedoc-plugin-missing-exports": "^4.0.0"
       },
       "engines": {
@@ -36743,65 +36741,12 @@
         "nunjucks": "^3.2.4"
       }
     },
-    "packages/govuk-frontend-review/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/govuk-frontend-review/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/govuk-frontend-review/node_modules/typedoc": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.4.tgz",
-      "integrity": "sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.2",
-        "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.7.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 18",
-        "pnpm": ">= 10"
-      },
-      "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
-      }
-    },
-    "packages/govuk-frontend-review/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "shared/bundler-integrations": {

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -59,7 +59,7 @@
     "rollup": "^4.19.1",
     "sassdoc": "^2.7.4",
     "supertest": "^7.1.3",
-    "typedoc": "^0.28.4",
+    "typedoc": "^0.28.7",
     "typedoc-plugin-missing-exports": "^4.0.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
[Dependabot is struggling with this one](https://github.com/alphagov/govuk-frontend/pull/6126).

It's updating the package in the root node_modules folder (where's it's a transitive dependency of `typedoc-plugin-missing-exports`), but missing the package in the govuk-frontend-review folder (where it's a direct dependency). And something wacky is going on with the branch it's created - if I manually set `0.28.7` in the govuk-frontend-review package.json, then `npm install`, it resets to 0.28.4, which is obviously no good (though I have no idea why this is happening).

So it was easier just to spin up a new branch to fix.

I've simplified things by matching versions, which moves the package into the root node_modules folder only.

I investigated the "nuclear" approach of recreating the package-lock file here: https://github.com/alphagov/govuk-frontend/pull/6143

I'd sort of prefer to do that if there's appetite, but here's the simpler fix in the meantime.