### PR TITLE
Fix null scope issues in `createAll()` and `initAll()`

### DIFF
--- a/packages/govuk-frontend-review/tsconfig.json
+++ b/packages/govuk-frontend-review/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./src/**/*.mjs"],
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
+    "strictNullChecks": false,
     "types": ["express", "node", "nunjucks", "slug", "typed-query-selector"]
   }
 }

--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -200,19 +200,19 @@ export function normaliseDataset(Component, dataset) {
  * Normalise options passed to `initAll` or `createAll`
  *
  * @template {CompatibleClass} ComponentClass
- * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
+ * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document | null} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
  * @returns {CreateAllOptions<ComponentClass>} Normalised options
  */
 export function normaliseOptions(scopeOrOptions) {
-  let /** @type {Element | Document} */ $scope = document
+  let /** @type {Element | Document | null} */ $scope = document
   let /** @type {OnErrorCallback<ComponentClass> | undefined} */ onError
 
   // Handle options object
   if (isObject(scopeOrOptions)) {
     const options = scopeOrOptions
 
-    // Scope must be valid
-    if (isScope(options.scope)) {
+    // Scope must be valid or null
+    if (isScope(options.scope) || options.scope === null) {
       $scope = options.scope
     }
 
@@ -224,6 +224,8 @@ export function normaliseOptions(scopeOrOptions) {
 
   if (isScope(scopeOrOptions)) {
     $scope = scopeOrOptions
+  } else if (scopeOrOptions === null) {
+    $scope = null
   } else if (typeof scopeOrOptions === 'function') {
     onError = scopeOrOptions
   }

--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -200,7 +200,7 @@ export function normaliseDataset(Component, dataset) {
  * Normalise options passed to `initAll` or `createAll`
  *
  * @template {CompatibleClass} ComponentClass
- * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
+ * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
  * @returns {CreateAllOptions<ComponentClass>} Normalised options
  */
 export function normaliseOptions(scopeOrOptions) {

--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -199,6 +199,7 @@ export function normaliseDataset(Component, dataset) {
 /**
  * Normalise options passed to `initAll` or `createAll`
  *
+ * @internal
  * @template {CompatibleClass} ComponentClass
  * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document | null} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
  * @returns {CreateAllOptions<ComponentClass>} Normalised options

--- a/packages/govuk-frontend/src/govuk/common/configuration.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration.mjs
@@ -1,7 +1,7 @@
 import { Component } from '../component.mjs'
 import { ConfigError } from '../errors/index.mjs'
 
-import { isObject, formatErrorMessage } from './index.mjs'
+import { isObject, isScope, formatErrorMessage } from './index.mjs'
 
 export const configOverride = Symbol.for('configOverride')
 
@@ -197,6 +197,44 @@ export function normaliseDataset(Component, dataset) {
 }
 
 /**
+ * Normalise options passed to `initAll` or `createAll`
+ *
+ * @template {CompatibleClass} ComponentClass
+ * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
+ * @returns {CreateAllOptions<ComponentClass>} Normalised options
+ */
+export function normaliseOptions(scopeOrOptions) {
+  let /** @type {Element | Document} */ $scope = document
+  let /** @type {OnErrorCallback<ComponentClass> | undefined} */ onError
+
+  // Handle options object
+  if (isObject(scopeOrOptions)) {
+    const options = scopeOrOptions
+
+    // Scope must be valid
+    if (isScope(options.scope)) {
+      $scope = options.scope
+    }
+
+    // Error handler must be a function
+    if (typeof options.onError === 'function') {
+      onError = options.onError
+    }
+  }
+
+  if (isScope(scopeOrOptions)) {
+    $scope = scopeOrOptions
+  } else if (typeof scopeOrOptions === 'function') {
+    onError = scopeOrOptions
+  }
+
+  return {
+    scope: $scope,
+    onError
+  }
+}
+
+/**
  * Config merging function
  *
  * Takes any number of objects and combines them together, with
@@ -372,4 +410,8 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
 /**
  * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
  * @typedef {typeof Component & ChildClass<ConfigurationType>} ChildClassConstructor<ConfigurationType>
+ */
+
+/**
+ * @import { CompatibleClass, Config, CreateAllOptions, OnErrorCallback } from '../init.mjs'
  */

--- a/packages/govuk-frontend/src/govuk/common/configuration/normalise-options.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/normalise-options.jsdom.test.mjs
@@ -17,6 +17,14 @@ describe('normaliseOptions', () => {
     {
       name: 'article element',
       $scope: document.createElement('article')
+    },
+    {
+      name: 'null selector',
+      $scope: document.querySelector('.unknown-scope')
+    },
+    {
+      name: 'null',
+      $scope: null
     }
   ]
 
@@ -82,6 +90,18 @@ describe('normaliseOptions', () => {
       })
     ).toMatchObject({
       scope: document,
+      onError: undefined
+    })
+  })
+
+  it("preserves 'null' scope", () => {
+    expect(normaliseOptions(null)).toMatchObject({
+      scope: null,
+      onError: undefined
+    })
+
+    expect(normaliseOptions({ scope: null })).toMatchObject({
+      scope: null,
       onError: undefined
     })
   })

--- a/packages/govuk-frontend/src/govuk/common/configuration/normalise-options.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/normalise-options.jsdom.test.mjs
@@ -3,6 +3,14 @@ import { normaliseOptions } from '../configuration.mjs'
 describe('normaliseOptions', () => {
   const scopes = [
     {
+      name: 'document',
+      $scope: document
+    },
+    {
+      name: 'document (new)',
+      $scope: document.implementation.createHTMLDocument()
+    },
+    {
       name: 'div element',
       $scope: document.createElement('div')
     },

--- a/packages/govuk-frontend/src/govuk/common/configuration/normalise-options.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/configuration/normalise-options.jsdom.test.mjs
@@ -1,0 +1,125 @@
+import { normaliseOptions } from '../configuration.mjs'
+
+describe('normaliseOptions', () => {
+  const scopes = [
+    {
+      name: 'div element',
+      $scope: document.createElement('div')
+    },
+    {
+      name: 'article element',
+      $scope: document.createElement('article')
+    }
+  ]
+
+  const handlers = [
+    {
+      name: 'plain function',
+      handler: function errorCallback() {}
+    },
+    {
+      name: 'anonymous function',
+      handler: function () {}
+    },
+    {
+      name: 'shorthand function',
+      handler() {}
+    },
+    {
+      name: 'arrow function',
+      handler: () => {}
+    }
+  ]
+
+  it('returns defaults', () => {
+    expect(normaliseOptions()).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it('returns defaults for empty object', () => {
+    expect(normaliseOptions({})).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("returns defaults for 'undefined' scope option", () => {
+    expect(
+      normaliseOptions({
+        scope: undefined
+      })
+    ).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("returns defaults for 'undefined' error handler option", () => {
+    expect(
+      normaliseOptions({
+        onError: undefined
+      })
+    ).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("returns defaults for 'null' error handler option", () => {
+    expect(
+      normaliseOptions({
+        onError: null
+      })
+    ).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  describe('with $scope option', () => {
+    it.each(scopes)("normalises '$name' option into object", ({ $scope }) => {
+      expect(normaliseOptions({ scope: $scope })).toMatchObject({
+        scope: $scope,
+        onError: undefined
+      })
+    })
+  })
+
+  describe('with $scope parameter', () => {
+    it.each(scopes)(
+      "normalises '$name' parameter into object",
+      ({ $scope }) => {
+        expect(normaliseOptions($scope)).toMatchObject({
+          scope: $scope,
+          onError: undefined
+        })
+      }
+    )
+  })
+
+  describe('with error handler option', () => {
+    it.each(handlers)(
+      "normalises '$name' option into object",
+      ({ handler }) => {
+        expect(normaliseOptions({ onError: handler })).toMatchObject({
+          scope: document,
+          onError: handler
+        })
+      }
+    )
+  })
+
+  describe('with error handler parameter', () => {
+    it.each(handlers)(
+      "normalises '$name' parameter into object",
+      ({ handler }) => {
+        expect(normaliseOptions(handler)).toMatchObject({
+          scope: document,
+          onError: handler
+        })
+      }
+    )
+  })
+})

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -132,12 +132,12 @@ export function isObject(option) {
  * Check for valid scope
  *
  * @internal
- * @template {Element} ScopeType
+ * @template {Element | Document} ScopeType
  * @param {unknown | ScopeType} $scope - Scope of the document to search within
  * @returns {$scope is ScopeType} Whether the scope can be queried
  */
 export function isScope($scope) {
-  return !!$scope && $scope instanceof Element
+  return !!$scope && ($scope instanceof Element || $scope instanceof Document)
 }
 
 /**

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -120,7 +120,7 @@ function isArray(option) {
  * Check for an object
  *
  * @internal
- * @template {Partial<Record<keyof ObjectType, unknown>>} [ObjectType=ObjectNested]
+ * @template {Partial<Record<keyof ObjectType, unknown>>} ObjectType
  * @param {unknown | ObjectType} option - Option to check
  * @returns {option is ObjectType} Whether the option is an object
  */
@@ -152,7 +152,3 @@ export function formatErrorMessage(Component, message) {
  */
 
 /* eslint-enable jsdoc/valid-types */
-
-/**
- * @import { ObjectNested } from './configuration.mjs'
- */

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -129,6 +129,18 @@ export function isObject(option) {
 }
 
 /**
+ * Check for valid scope
+ *
+ * @internal
+ * @template {Element} ScopeType
+ * @param {unknown | ScopeType} $scope - Scope of the document to search within
+ * @returns {$scope is ScopeType} Whether the scope can be queried
+ */
+export function isScope($scope) {
+  return !!$scope && $scope instanceof Element
+}
+
+/**
  * Format error message
  *
  * @internal

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -79,66 +79,79 @@ describe('errors', () => {
       expect(
         new ElementError({
           component: Accordion,
-          identifier: 'variableName'
+          identifier: 'Element name'
         })
       ).toBeInstanceOf(GOVUKFrontendError)
     })
+
     it('has its own name set', () => {
       expect(
         new ElementError({
           component: Accordion,
-          identifier: 'variableName'
+          identifier: 'Element name'
         }).name
       ).toBe('ElementError')
     })
-    it('has name set by Component', () => {
-      expect(
-        new ElementError({
-          component: Accordion,
-          identifier: 'variableName'
-        }).name
-      ).toBe('ElementError')
-    })
+
     it('accepts a string and does not process it in any way', () => {
       expect(new ElementError('Complex custom error message').message).toBe(
         'Complex custom error message'
       )
     })
-    it('formats the message when the element is not found', () => {
-      expect(
-        new ElementError({
-          component: Accordion,
-          identifier: 'variableName'
-        }).message
-      ).toBe(`${Accordion.moduleName}: variableName not found`)
-    })
-    it('formats the message when the element is not the right type', () => {
-      const $element = document.createElement('div')
 
-      expect(
-        new ElementError({
+    describe('with component', () => {
+      it('formats the message when the element is not found', () => {
+        const error = new ElementError({
           component: Accordion,
-          element: $element,
-          expectedType: 'HTMLAnchorElement',
-          identifier: 'variableName'
-        }).message
-      ).toBe(
-        `${Accordion.moduleName}: variableName is not of type HTMLAnchorElement`
-      )
-    })
-    it('formats the message when the element is not the right type and Component in config', () => {
-      const $element = document.createElement('div')
+          identifier: 'Element name'
+        })
 
-      expect(
-        new ElementError({
-          component: Accordion,
+        expect(error).toHaveProperty(
+          'message',
+          `${Accordion.moduleName}: Element name not found`
+        )
+      })
+
+      it('formats the message when the element is not the right type', () => {
+        const $element = document.createElement('div')
+
+        const error = new ElementError({
           element: $element,
-          expectedType: 'HTMLAnchorElement',
-          identifier: 'variableName'
-        }).message
-      ).toBe(
-        `${Accordion.moduleName}: variableName is not of type HTMLAnchorElement`
-      )
+          component: Accordion,
+          identifier: 'Element name',
+          expectedType: 'HTMLAnchorElement'
+        })
+
+        expect(error).toHaveProperty(
+          'message',
+          `${Accordion.moduleName}: Element name is not of type HTMLAnchorElement`
+        )
+      })
+    })
+
+    describe('without component', () => {
+      it('formats the message when the element is not found', () => {
+        const error = new ElementError({
+          identifier: 'Element name'
+        })
+
+        expect(error).toHaveProperty('message', 'Element name not found')
+      })
+
+      it('formats the message when the element is not the right type', () => {
+        const $element = document.createElement('div')
+
+        const error = new ElementError({
+          element: $element,
+          identifier: 'Element name',
+          expectedType: 'HTMLAnchorElement'
+        })
+
+        expect(error).toHaveProperty(
+          'message',
+          'Element name is not of type HTMLAnchorElement'
+        )
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -92,7 +92,10 @@ export class ElementError extends GOVUKFrontendError {
         ? ` is not of type ${expectedType ?? 'HTMLElement'}`
         : ' not found'
 
-      message = formatErrorMessage(component, message)
+      // Prepend with module name (optional)
+      if (component) {
+        message = formatErrorMessage(component, message)
+      }
     }
 
     super(message)
@@ -127,10 +130,10 @@ export class InitError extends GOVUKFrontendError {
  *
  * @internal
  * @typedef {object} ElementErrorOptions
+ * @property {Element | Document | null} [element] - The element in error (optional)
+ * @property {ComponentWithModuleName} [component] - Component throwing the error (optional)
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
- * @property {Element | Document | null} [element] - The element in error
- * @property {string} [expectedType] - The type that was expected for the identifier
- * @property {ComponentWithModuleName} component - Component throwing the error
+ * @property {string} [expectedType] - The type that was expected for the identifier (optional)
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -128,7 +128,7 @@ export class InitError extends GOVUKFrontendError {
  * @internal
  * @typedef {object} ElementErrorOptions
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
- * @property {Element | null} [element] - The element in error
+ * @property {Element | Document | null} [element] - The element in error
  * @property {string} [expectedType] - The type that was expected for the identifier
  * @property {ComponentWithModuleName} component - Component throwing the error
  */

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -1,4 +1,4 @@
-import { formatErrorMessage } from '../common/index.mjs'
+import { formatErrorMessage, isObject } from '../common/index.mjs'
 
 /**
  * GOV.UK Frontend error
@@ -82,7 +82,7 @@ export class ElementError extends GOVUKFrontendError {
     let message = typeof messageOrOptions === 'string' ? messageOrOptions : ''
 
     // Build message from options
-    if (typeof messageOrOptions === 'object') {
+    if (isObject(messageOrOptions)) {
       const { component, identifier, element, expectedType } = messageOrOptions
 
       message = identifier

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -1,3 +1,5 @@
+import { isObject } from './common/index.mjs'
+
 /**
  * Internal support for selecting messages to render, with placeholder
  * interpolation and locale-aware number formatting and pluralisation
@@ -45,7 +47,7 @@ export class I18n {
     // If the `count` option is set, determine which plural suffix is needed and
     // change the lookupKey to match. We check to see if it's numeric instead of
     // falsy, as this could legitimately be 0.
-    if (typeof options?.count === 'number' && typeof translation === 'object') {
+    if (typeof options?.count === 'number' && isObject(translation)) {
       const translationPluralForm =
         translation[this.getPluralSuffix(lookupKey, options.count)]
 
@@ -189,7 +191,7 @@ export class I18n {
       : this.selectPluralFormUsingFallbackRules(count)
 
     // Use the correct plural form if provided
-    if (typeof translation === 'object') {
+    if (isObject(translation)) {
       if (preferredForm in translation) {
         return preferredForm
         // Fall back to `other` if the plural form is missing, but log a warning

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -141,7 +141,27 @@ describe('initAll', () => {
     })
   })
 
-  it('only initialises components within a given scope', () => {
+  it('only initialises components within a given scope parameter', () => {
+    document.body.classList.add('govuk-frontend-supported')
+    document.body.innerHTML = `
+      <div data-module="govuk-accordion"></div>
+      <div class="not-in-scope">
+        <div data-module="govuk-accordion"></div>
+      </div>'
+      <div class="my-scope">
+        <div data-module="govuk-accordion"></div>
+      </div>`
+
+    initAll(document.querySelector('.my-scope'))
+
+    // Expect to have been called exactly once with the accordion in .my-scope
+    expect(GOVUKFrontend.Accordion).toHaveBeenCalledTimes(1)
+    expect(GOVUKFrontend.Accordion).toHaveBeenCalledWith(
+      document.querySelector('.my-scope [data-module="govuk-accordion"]')
+    )
+  })
+
+  it('only initialises components within a given scope option', () => {
     document.body.classList.add('govuk-frontend-supported')
     document.body.innerHTML = `
       <div data-module="govuk-accordion"></div>

--- a/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/init.jsdom.test.mjs
@@ -45,6 +45,11 @@ describe('initAll', () => {
     'password-input'
   ]
 
+  beforeEach(() => {
+    // Silence warnings in test output, and allow us to 'expect' them
+    jest.spyOn(console, 'log').mockImplementation()
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     document.body.className = ''
@@ -86,11 +91,6 @@ describe('initAll', () => {
   )
 
   describe('govuk-frontend-supported not present', () => {
-    beforeAll(() => {
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-    })
-
     it('returns early', () => {
       document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
 
@@ -103,7 +103,7 @@ describe('initAll', () => {
       initAll()
 
       // Only validate the message as it's the important part for the user
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'SupportError',
           message: 'GOV.UK Frontend is not supported in this browser'
@@ -121,7 +121,7 @@ describe('initAll', () => {
         onError: errorCallback
       })
 
-      expect(global.console.log).not.toHaveBeenCalled()
+      expect(console.log).not.toHaveBeenCalled()
 
       expect(errorCallback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -173,16 +173,13 @@ describe('initAll', () => {
         <div data-module="govuk-accordion"></div>
       </div>`
 
-    // Silence warnings in test output, and allow us to 'expect' them
-    jest.spyOn(global.console, 'log').mockImplementation()
-
     expect(() => {
       initAll({
         scope: document.querySelector('.unknown-scope')
       })
     }).not.toThrow()
 
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'ElementError',
         message: 'GOV.UK Frontend scope element (`$scope`) not found'
@@ -200,15 +197,12 @@ describe('initAll', () => {
       throw new Error('Error thrown from accordion')
     })
 
-    // Silence warnings in test output, and allow us to 'expect' them
-    jest.spyOn(global.console, 'log').mockImplementation()
-
     expect(() => {
       initAll()
     }).not.toThrow()
 
-    expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+    expect(console.log).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Error thrown from accordion'
       })
@@ -236,7 +230,7 @@ describe('initAll', () => {
       }
     })
 
-    expect(global.console.log).not.toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
 
     expect(errorCallback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -256,6 +250,9 @@ describe('initAll', () => {
 describe('createAll', () => {
   beforeEach(() => {
     document.body.classList.add('govuk-frontend-supported')
+
+    // Silence warnings in test output, and allow us to 'expect' them
+    jest.spyOn(console, 'log').mockImplementation()
   })
 
   afterEach(() => {
@@ -298,7 +295,7 @@ describe('createAll', () => {
 
     const result = createAll(MockComponent)
 
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'SupportError',
         message: 'GOV.UK Frontend is not supported in this browser'
@@ -319,7 +316,7 @@ describe('createAll', () => {
       { onError: errorCallback }
     )
 
-    expect(global.console.log).not.toHaveBeenCalled()
+    expect(console.log).not.toHaveBeenCalled()
 
     expect(errorCallback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -353,9 +350,6 @@ describe('createAll', () => {
     componentRoot.setAttribute('data-module', 'mock-component')
     document.body.appendChild(componentRoot)
 
-    // Silence warnings in test output, and allow us to 'expect' them
-    jest.spyOn(global.console, 'log').mockImplementation()
-
     const checkSupportMock = jest.fn(() => {
       throw Error('Mock error')
     })
@@ -369,7 +363,7 @@ describe('createAll', () => {
     const result = createAll(MockComponentWithCheckSupport)
     expect(checkSupportMock).toHaveBeenCalled()
     expect(result).toStrictEqual([])
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Mock error'
       })
@@ -482,17 +476,14 @@ describe('createAll', () => {
           <div data-module="mock-component"></div>
         </div>`
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       const result = createAll(
         MockComponent,
         undefined,
         document.querySelector('.unknown-scope')
       )
 
-      expect(global.console.log).toHaveBeenCalledWith(expect.any(ElementError))
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(expect.any(ElementError))
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'ElementError',
           message: `${MockComponent.moduleName}: Scope element (\`$scope\`) not found`
@@ -512,14 +503,11 @@ describe('createAll', () => {
           <div data-module="mock-component"></div>
         </div>`
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       const result = createAll(MockComponent, undefined, {
         scope: document.querySelector('.unknown-scope')
       })
 
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'ElementError',
           message: `${MockComponent.moduleName}: Scope element (\`$scope\`) not found`
@@ -541,9 +529,6 @@ describe('createAll', () => {
 
       const errorCallback = jest.fn((_error, _context) => {})
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       const result = createAll(
         MockComponent,
         { attribute: 'random' },
@@ -553,7 +538,7 @@ describe('createAll', () => {
         }
       )
 
-      expect(global.console.log).not.toHaveBeenCalled()
+      expect(console.log).not.toHaveBeenCalled()
 
       expect(errorCallback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -588,9 +573,6 @@ describe('createAll', () => {
         console.log(context)
       })
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       expect(() => {
         createAll(
           MockComponentThatErrors,
@@ -601,8 +583,8 @@ describe('createAll', () => {
 
       expect(errorCallback).toHaveBeenCalled()
 
-      expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           component: MockComponentThatErrors,
           config: { attribute: 'random' },
@@ -619,9 +601,6 @@ describe('createAll', () => {
         console.log(context)
       })
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       expect(() => {
         createAll(
           MockComponentThatErrors,
@@ -632,8 +611,8 @@ describe('createAll', () => {
 
       expect(errorCallback).toHaveBeenCalled()
 
-      expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           component: MockComponentThatErrors,
           config: { attribute: 'random' },
@@ -645,15 +624,12 @@ describe('createAll', () => {
     it('catches errors thrown by components and logs them to the console', () => {
       document.body.innerHTML = `<div data-module="mock-component" data-boom></div>`
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       expect(() => {
         createAll(MockComponentThatErrors)
       }).not.toThrow()
 
-      expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'Error thrown from constructor'
         })
@@ -670,9 +646,6 @@ describe('createAll', () => {
           <div data-module="mock-component" data-boom></div>
         </div>`
 
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       expect(() => {
         createAll(
           MockComponentThatErrors,
@@ -681,8 +654,8 @@ describe('createAll', () => {
         )
       }).not.toThrow()
 
-      expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
-      expect(global.console.log).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'Error thrown from constructor'
         })

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -1,4 +1,4 @@
-import { isSupported } from './common/index.mjs'
+import { isObject, isSupported } from './common/index.mjs'
 import { Accordion } from './components/accordion/accordion.mjs'
 import { Button } from './components/button/button.mjs'
 import { CharacterCount } from './components/character-count/character-count.mjs'
@@ -88,12 +88,7 @@ function createAll(Component, config, createAllOptions) {
   let /** @type {Element | Document} */ $scope = document
   let /** @type {OnErrorCallback<ComponentClass> | undefined} */ onError
 
-  if (typeof createAllOptions === 'object') {
-    createAllOptions = /** @type {CreateAllOptions<ComponentClass>} */ (
-      // eslint-disable-next-line no-self-assign
-      createAllOptions
-    )
-
+  if (isObject(createAllOptions)) {
     $scope = createAllOptions.scope ?? $scope
     onError = createAllOptions.onError
   }

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -26,15 +26,20 @@ import { SupportError } from './errors/index.mjs'
 function initAll(config) {
   config = typeof config !== 'undefined' ? config : {}
 
-  // Skip initialisation when GOV.UK Frontend is not supported
-  if (!isSupported()) {
+  try {
+    // Skip initialisation when GOV.UK Frontend is not supported
+    if (!isSupported()) {
+      throw new SupportError()
+    }
+  } catch (error) {
     if (config.onError) {
-      config.onError(new SupportError(), {
+      config.onError(error, {
         config
       })
     } else {
-      console.log(new SupportError())
+      console.log(error)
     }
+
     return
   }
 
@@ -105,16 +110,21 @@ function createAll(Component, config, createAllOptions) {
     `[data-module="${Component.moduleName}"]`
   )
 
-  // Skip initialisation when GOV.UK Frontend is not supported
-  if (!isSupported()) {
+  try {
+    // Skip initialisation when GOV.UK Frontend is not supported
+    if (!isSupported()) {
+      throw new SupportError()
+    }
+  } catch (error) {
     if (onError) {
-      onError(new SupportError(), {
+      onError(error, {
         component: Component,
         config
       })
     } else {
-      console.log(new SupportError())
+      console.log(error)
     }
+
     return []
   }
 

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -21,7 +21,7 @@ import { SupportError } from './errors/index.mjs'
  * Use the `data-module` attributes to find, instantiate and init all of the
  * components provided as part of GOV.UK Frontend.
  *
- * @param {Config & { scope?: Element, onError?: OnErrorCallback<CompatibleClass> }} [config] - Config for all components (with optional scope)
+ * @param {Config} [config] - Config for all components (with optional scope)
  */
 function initAll(config) {
   config = typeof config !== 'undefined' ? config : {}
@@ -173,6 +173,8 @@ export { initAll, createAll }
  * Config for all components via `initAll()`
  *
  * @typedef {object} Config
+ * @property {Element | Document | null} [scope] - Scope of the document to search within
+ * @property {OnErrorCallback<CompatibleClass>} [onError] - Initialisation error callback
  * @property {AccordionConfig} [accordion] - Accordion config
  * @property {ButtonConfig} [button] - Button config
  * @property {CharacterCountConfig} [characterCount] - Character Count config
@@ -199,7 +201,7 @@ export { initAll, createAll }
 /**
  * Component config keys, e.g. `accordion` and `characterCount`
  *
- * @typedef {keyof Config} ConfigKey
+ * @typedef {keyof Omit<Config, 'scope' | 'onError'>} ConfigKey
  */
 
 /**
@@ -212,7 +214,7 @@ export { initAll, createAll }
  * @typedef {object} ErrorContext
  * @property {Element} [element] - Element used for component module initialisation
  * @property {ComponentClass} [component] - Class of component
- * @property {ComponentConfig<ComponentClass>} config - Config supplied to component
+ * @property {Config | ComponentConfig<ComponentClass>} [config] - Config supplied to components
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -78,7 +78,7 @@ function initAll(config = {}) {
  * @template {CompatibleClass} ComponentClass
  * @param {ComponentClass} Component - class of the component to create
  * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
- * @param {OnErrorCallback<ComponentClass> | Element | Document | CreateAllOptions<ComponentClass> } [createAllOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
+ * @param {OnErrorCallback<ComponentClass> | Element | Document | null | CreateAllOptions<ComponentClass>} [createAllOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
  * @returns {Array<InstanceType<ComponentClass>>} - array of instantiated components
  */
 function createAll(Component, config, createAllOptions) {
@@ -210,6 +210,6 @@ export { initAll, createAll }
 /**
  * @template {CompatibleClass} ComponentClass
  * @typedef {object} CreateAllOptions
- * @property {Element | Document} [scope] - scope of the document to search within
+ * @property {Element | Document | null} [scope] - scope of the document to search within
  * @property {OnErrorCallback<ComponentClass>} [onError] - callback function if error throw by component on init
  */

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -1,4 +1,4 @@
-import { isObject, isSupported } from './common/index.mjs'
+import { isObject, isScope, isSupported } from './common/index.mjs'
 import { Accordion } from './components/accordion/accordion.mjs'
 import { Button } from './components/button/button.mjs'
 import { CharacterCount } from './components/character-count/character-count.mjs'
@@ -102,7 +102,7 @@ function createAll(Component, config, createAllOptions) {
     onError = createAllOptions
   }
 
-  if (createAllOptions instanceof HTMLElement) {
+  if (isScope(createAllOptions)) {
     $scope = createAllOptions
   }
 

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -86,10 +86,10 @@ function initAll(config) {
  */
 function createAll(Component, config, createAllOptions) {
   let /** @type {Element | Document} */ $scope = document
-  let /** @type {OnErrorCallback<Component> | undefined} */ onError
+  let /** @type {OnErrorCallback<ComponentClass> | undefined} */ onError
 
   if (typeof createAllOptions === 'object') {
-    createAllOptions = /** @type {CreateAllOptions<Component>} */ (
+    createAllOptions = /** @type {CreateAllOptions<ComponentClass>} */ (
       // eslint-disable-next-line no-self-assign
       createAllOptions
     )

--- a/packages/govuk-frontend/src/govuk/init.mjs
+++ b/packages/govuk-frontend/src/govuk/init.mjs
@@ -1,5 +1,5 @@
 import { normaliseOptions } from './common/configuration.mjs'
-import { isSupported } from './common/index.mjs'
+import { isObject, isSupported } from './common/index.mjs'
 import { Accordion } from './components/accordion/accordion.mjs'
 import { Button } from './components/button/button.mjs'
 import { CharacterCount } from './components/character-count/character-count.mjs'
@@ -22,10 +22,13 @@ import { ElementError, SupportError } from './errors/index.mjs'
  * Use the `data-module` attributes to find, instantiate and init all of the
  * components provided as part of GOV.UK Frontend.
  *
- * @param {Config} [config] - Config for all components (with optional scope)
+ * @param {Config | Element | Document | null} [scopeOrConfig] - Scope of the document to search within or config for all components (with optional scope)
  */
-function initAll(config = {}) {
-  const options = normaliseOptions(config)
+function initAll(scopeOrConfig = {}) {
+  const config = isObject(scopeOrConfig) ? scopeOrConfig : {}
+
+  // Extract initialisation options
+  const options = normaliseOptions(scopeOrConfig)
 
   try {
     // Skip initialisation when GOV.UK Frontend is not supported
@@ -87,14 +90,14 @@ function initAll(config = {}) {
  * @template {CompatibleClass} ComponentClass
  * @param {ComponentClass} Component - class of the component to create
  * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
- * @param {OnErrorCallback<ComponentClass> | Element | Document | null | CreateAllOptions<ComponentClass>} [createAllOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
+ * @param {OnErrorCallback<ComponentClass> | Element | Document | null | CreateAllOptions<ComponentClass>} [scopeOrOptions] - options for createAll including scope of the document to search within and callback function if error throw by component on init
  * @returns {Array<InstanceType<ComponentClass>>} - array of instantiated components
  */
-function createAll(Component, config, createAllOptions) {
+function createAll(Component, config, scopeOrOptions) {
   let /** @type {NodeListOf<Element> | undefined} */ $elements
 
   // Extract initialisation options
-  const options = normaliseOptions(createAllOptions)
+  const options = normaliseOptions(scopeOrOptions)
 
   try {
     // Skip initialisation when GOV.UK Frontend is not supported

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["**/*.js", "**/*.mjs"],
   "exclude": ["**/dist", "**/node_modules", "**/*.test.*"],
   "compilerOptions": {
+    "strictNullChecks": false,
     "types": ["node", "typed-query-selector"]
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
     "strict": false,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
+    "strictNullChecks": true,
     "target": "ESNext",
     "types": [],
     "paths": {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "strictNullChecks": false,
     "types": [
       "jest",
       "jest-axe",


### PR DESCRIPTION
Hello from the NHS digital service manual team 👋

We've been doing lots of testing of `createAll()` and `initAll()` on optional or dynamically created HTML

This PR fixes a couple of issues affecting scoped initialisation I raised earlier today:

* https://github.com/alphagov/govuk-frontend/issues/6161
* https://github.com/alphagov/govuk-frontend/issues/6162

We also noticed that `createAll()` passes configs to non-configurable components so we've fixed this, updated some tests, and I've had a go at the [stretch task](https://github.com/alphagov/govuk-frontend/issues/5469) from @romaricpascal so the compiler can spot this in future in:

* https://github.com/alphagov/govuk-frontend/issues/5469

Happy to tweak things, adjust naming conventions, or talk you through anything 😊