### PR TITLE
[PROPOSITION] Add new `afterContent` block to the template

### DIFF
--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -55,6 +55,7 @@
         <main class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}" id="main-content" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
           {% block content %}{% endblock %}
         </main>
+        {% block afterContent %}{% endblock %}
       </div>
     {% endblock %}
 


### PR DESCRIPTION
A new `afterContent` block after`</main>` would allow to inject content more flexibly around the `<main>` tag. 

Particularly, it would avoid having to redeclaire the whole `main` block and copy GOV.UK Frontend's initial structure when needing to implement a 1/3 - 2/3 (or 2/3 - 1/3) layout where the content of the 1/3 is not part of `<main>`.

At the moment, to add a `<nav>` before the `<main>` in a 1/3 column, we can easily inject the following in `beforeContent`:

```njk
<div class="govuk-grid-row">
   <nav class="govuk-column-one-third" aria-label="...">
      <!-- .... -->
   </nav>
```

Thankfully, because the `govuk-grid-row` is a `<div>`, we can add an extra closing `<div>` in the `footer` block with

```njk
{% block footer %}
    </div>
    {{super()}}
{% endblock %}
```

However, this wouldn't work so well if we wanted to inject an `<aside>` after the `<main>` as the `govuk-grid-row` would have been closed already by the `</div>` closing the `main` block.