### PR TITLE
Fix thickness of underlines on previous and next pagination links in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6138: Fix file upload being invisible when using the 'JavaScript enhanced' version with an empty label](https://github.com/alphagov/govuk-frontend/pull/6138) – thanks to @JoPintoPaul for reporting this issue
+- [#6184: Fix thickness of underlines on previous and next pagination links in Safari](https://github.com/alphagov/govuk-frontend/pull/6184) – thanks to @frankieroberto for reporting this issue
 
 ## v5.11.1 (Fix release)
 

--- a/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
@@ -147,6 +147,10 @@
     }
   }
 
+  .govuk-pagination__link-title {
+    text-decoration-thickness: inherit;
+  }
+
   .govuk-pagination__link-label {
     @include govuk-typography-weight-regular;
     @include govuk-link-decoration;


### PR DESCRIPTION
The previous and next links within the pagination component include a nested span with the ‘Previous’ or ‘Next’ text in it, alongside the svg for the appropriate arrow.

In Safari, the span is not inheriting the `text-decoration-thickness` property from the parent link (correctly, we believe [^1]), so we need to explicitly set `text-decoration-thickness: inherit;` on the span so that it displays correctly.

| State | Before | After |
| -- | -- | -- |
| Default | <img width="393" height="93" alt="Before, with default underline thickness" src="https://github.com/user-attachments/assets/71cd6f68-f704-447b-9f81-d36a4dfd687d" /> | <img width="393" height="93" alt="Before, with underline thickness matching other links" src="https://github.com/user-attachments/assets/5a6d6e09-9ffe-45bb-bdfc-02001ed6fdc1" /> |
| Hover | <img width="393" height="93" alt="Hover state before, with no change to underline thickness" src="https://github.com/user-attachments/assets/1e9e01b1-500b-4127-86a7-437e43ee98b1" /> | <img width="393" height="93" alt="Hover after, with expected increase in underline thickness matching other links" src="https://github.com/user-attachments/assets/7055f631-4cb3-4dbf-b8a9-27436053b934" /> |

Fixes #5335.

[^1]: https://github.com/alphagov/govuk-frontend/issues/5335#issuecomment-2361533572