### PR TITLE
Use optional catch binding for accordion

### DIFF
--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -49,6 +49,9 @@ module.exports = {
         // Babel transpiles ES2022 class static fields
         'es-x/no-class-static-fields': 'off',
 
+        // Babel transpiles optional catch binding
+        'es-x/no-optional-catch-binding': 'off',
+
         // ES modules include ES2016 '[].includes()' coverage
         // https://browsersl.ist/#q=supports+es6-module+and+not+supports+array-includes
         'es-x/no-array-prototype-includes': 'off',

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -518,8 +518,7 @@ export class Accordion extends ConfigurableComponent {
     if (id) {
       try {
         window.sessionStorage.setItem(id, isExpanded.toString())
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (exception) {}
+      } catch {}
     }
   }
 
@@ -543,8 +542,7 @@ export class Accordion extends ConfigurableComponent {
         if (state !== null) {
           this.setExpanded(state === 'true', $section)
         }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (exception) {}
+      } catch {}
     }
   }
 


### PR DESCRIPTION
We ‘don’t care’ if setting or reading from session storage in the Accordion throws an error (which it can do if e.g. [the user has configured the browsers to prevent the page from persisting data][1]).

As such we don’t do anything with the error passed into the catch block, which means we have an unused variable currently being flagged by the `@typescript-eslint/no-unused-vars` eslint rule.

I’ve checked that Babel transpiles optional catch binding based on our target browserslist, so we can safely disable the `es-x/no-optional-catch-binding` rule and use [optional catch binding](https://github.com/tc39/proposal-optional-catch-binding) to omit the binding for the try / catch blocks in the Accordion’s javascript.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage#exceptions