### PR TITLE
Update govuk-frontend's `package.json` repository info

### DIFF
--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/alphagov/govuk-frontend.git"
+    "url": "git+https://github.com/alphagov/govuk-frontend.git",
+    "directory": "packages/govuk-frontend"
   },
   "bugs": {
     "url": "https://github.com/alphagov/govuk-frontend/issues"

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -19,7 +19,7 @@ export default async () => {
 
   // GitHub URL without `.git` suffix
   const { href } = new URL(pkg.repository.url)
-  const githubURL = new URL(href.replace(/\.git$/, ''))
+  const githubURL = new URL(href.replace(/^git\+/, '').replace(/\.git$/, ''))
 
   // Locate component names and macros
   const componentNames = await getComponentNames()


### PR DESCRIPTION
Fixes the little warning about package file formatting we get when releasing to npm.

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/alphagov/govuk-frontend.git"
```

Whilst I was doing that, I noticed there's a `directory` property that can point to which folder within a repository the package lives, which seems handy for us given we have multiple 'packages' living alongside each other in our repo.

Related documentation: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository

## Changes
- Changed repository URL to prefix it with `git+`.
- Updated config check made by the Prototype Kit configuration to remove the `git+` prefix, as it already does with the `.git` suffix.
- Added `directory` property pointing to the root of the `govuk-frontend` package (the one that's actually deployed to npm)