### PR TITLE
Remove unnecessary tsconfig file

### DIFF
--- a/shared/github-scripts/tsconfig.json
+++ b/shared/github-scripts/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../../tsconfig.base.json",
-  "include": ["**/*.mjs"],
-  "compilerOptions": {
-    "strict": true,
-    "types": ["@actions/github", "@octokit/rest", "node", "jest"]
-  }
-}


### PR DESCRIPTION
This one slipped through the cracks, and is not needed now that shared/tsconfig.json exists.

Small tweak based off #6179