### PR TITLE
Proposal: Allow removal of Content Licence information in the GOV.UK footer component

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -123,8 +123,16 @@
     padding: 0;
   }
 
+  .govuk-footer__inline-list:last-child {
+    margin-bottom: 0;
+  }
+
   .govuk-footer__meta-custom {
     margin-bottom: govuk-spacing(4);
+  }
+
+  .govuk-footer__meta-custom:last-child {
+    margin-bottom: 0;
   }
 
   .govuk-footer__inline-list-item {

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -68,9 +68,9 @@ params:
             required: false
             description: HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.
   - name: contentLicence
-    type: object
+    type: object or boolean
     required: false
-    description: The content licence information within the footer component. Defaults to Open Government Licence (OGL) v3 licence.
+    description: The content licence information within the footer component. Is hidden when set to `false`. Defaults to Open Government Licence (OGL) v3 licence.
     params:
       - name: text
         type: string
@@ -162,6 +162,11 @@ examples:
         text: 'Mae’r holl gynnwys ar gael dan Drwydded y Llywodraeth Agored v3.0, ac eithrio lle nodir yn wahanol'
       copyright:
         text: '© Hawlfraint y Goron'
+
+  - name: with no content licence
+    description: Open Government Licence turned off
+    options:
+      contentLicence: false
 
   - name: with custom meta
     description: Custom meta section

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -174,6 +174,13 @@ examples:
       meta:
         text: GOV.UK Prototype Kit v7.0.1
 
+  - name: with only custom meta
+    description: custom meta without content licence
+    options:
+      meta:
+        text: GOV.UK Prototype Kit v7.0.1
+      contentLicence: false
+
   - name: with meta links and meta content
     description: Secondary navigation links and custom meta text
     options:
@@ -196,6 +203,29 @@ examples:
           - href: '#8'
             text: Ligula Nullam Ultricies
         html: Built by the <a href="#" class="govuk-footer__link">Department of Magical Law Enforcement</a>
+
+  - name: with only meta links
+    description: meta links without content licence
+    options:
+      meta:
+        items:
+          - href: '#1'
+            text: Bibendum Ornare
+          - href: '#2'
+            text: Nullam
+          - href: '#3'
+            text: Tortor Fringilla
+          - href: '#4'
+            text: Tellus
+          - href: '#5'
+            text: Egestas Nullam
+          - href: '#6'
+            text: Euismod Etiam
+          - href: '#7'
+            text: Fusce Sollicitudin
+          - href: '#8'
+            text: Ligula Nullam Ultricies
+      contentLicence: false
 
   - name: with default width navigation (one column)
     options:

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -60,35 +60,37 @@
         </div>
         {% endif %}
         {% endif %}
-        {# The SVG needs `focusable="false"` so that Internet Explorer does not
-          treat it as an interactive element - without this it will be
-          'focusable' when using the keyboard to navigate. -#}
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          class="govuk-footer__licence-logo"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 483.2 195.7"
-          height="17"
-          width="41"
-        >
-          <path
-            fill="currentColor"
-            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-          />
-        </svg>
-        <span class="govuk-footer__licence-description">
-        {% if params.contentLicence.html or params.contentLicence.text %}
-          {{ params.contentLicence.html | safe | trim | indent(10) if params.contentLicence.html else params.contentLicence.text }}
-        {% else %}
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
+        {% if params.contentLicence !== false %}
+          {# The SVG needs `focusable="false"` so that Internet Explorer does not
+            treat it as an interactive element - without this it will be
+            'focusable' when using the keyboard to navigate. -#}
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41"
+          >
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+          </svg>
+          <span class="govuk-footer__licence-description">
+          {% if params.contentLicence.html or params.contentLicence.text %}
+            {{ params.contentLicence.html | safe | trim | indent(12) if params.contentLicence.html else params.contentLicence.text }}
+          {% else %}
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          {% endif %}
+          </span>
         {% endif %}
-        </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -226,6 +226,15 @@ describe('footer', () => {
         '&lt;a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license"&gt;Drwydded y Llywodraeth Agored v3.0&lt;/a&gt;'
       )
     })
+
+    it('can be turned off by setting it to `false`', () => {
+      const $ = render('footer', examples['with no content licence'])
+
+      const $licenceLogo = $('.govuk-footer__licence-logo')
+      const $licenceMessage = $('.govuk-footer__licence-description')
+      expect($licenceLogo).toHaveLength(0)
+      expect($licenceMessage).toHaveLength(0)
+    })
   })
 
   describe('crown copyright', () => {


### PR DESCRIPTION
I have coded this up but I understand there may be a reason why this proposal is not accepted or wanted so no hard feelings if it is not accepted 😄 

At Companies House (https://find-and-update.company-information.service.gov.uk/) we do not use the OGL Licence:

![](https://github.com/user-attachments/assets/1a872343-03e9-4f57-944f-324a69e9fa70)

If we want to use the `govukFooter` Nunjucks macro we have to manually hide the OGL Licence by doing something like:
```css
.ch-footer {
    .govuk-footer__licence-logo,
    .govuk-footer__licence-description {
        display: none;
    }
    .govuk-footer__meta-custom {
        margin-bottom: 0;
    }
}
```

or by maintaining our own Nunjucks macro, where we then cant benefit from any markup changes for example when the crown logo was added recently.

This pull request introduces:
- a way to set `contentLicence` to `false` which then hides it.
- additional CSS to remove the space below any meta links or custom meta information if there's no content licence information.
- fixtures to visually check the above and to test the hiding behaviour
- updates to the documentation to make note this parameter now accepts a boolean false value

## Screenshots

### Companies House example

![GOV.UK footer with no OGL content licence and meta information lining up with crown logo correctly](https://github.com/user-attachments/assets/c9b74c0e-914c-4286-8b95-fab1c83f7914)

```nunjucks
{{ govukFooter({
  meta: {
    items: [
      {
        href: "http://resources.companieshouse.gov.uk/serviceInformation.shtml",
        text: "Policies"
      },
      {
        href: "https://beta.companieshouse.gov.uk/help/cookies",
        text: "Cookies"
      },
      {
        href: "https://www.gov.uk/government/organisations/companies-house#org-contacts",
        text: "Contact us",
        attributes: {
          target: "_blank"
        }
      },
      {
        href: "/help/accessibility-statement",
        text: "Accessibility statement"
      },
      {
        href: "https://developer.companieshouse.gov.uk/api/docs/",
        text: "Developers"
      }
    ],
    html: 'Built by <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/companies-house">Companies House</a>'
  },
  contentLicence: false
}) }}
```

### GOV.UK Design System guidance 

| Before | After | 
| - | - |
| ![Screenshot of footer macro options showing Name: contentLicence. Type: object. Description: The content licence information within the footer component. Defaults to Open Government Licence v3 licence. See macro options for contentLicence](https://github.com/user-attachments/assets/63b39560-12c5-411b-a635-d064d85d68da) | ![Screenshot of footer macro options showing Name: contentLicence. Type: object or boolean. Description: The content licence information within the footer component. Is hidden when set to false. Defaults to Open Government Licence v3 licence. See macro options for contentLicence.](https://github.com/user-attachments/assets/966ee4ca-edd6-42ea-927f-62ba7b61cda4) |
