### PR TITLE
Update cycle brief template on govuk-frontend

### DIFF
--- a/.github/ISSUE_TEMPLATE/cycle-brief.md
+++ b/.github/ISSUE_TEMPLATE/cycle-brief.md
@@ -8,12 +8,12 @@ assignees: ""
 
 ## Brief
 
-<!-- Use this format if it helps: [Action + Outcome/Output + For User Type + To Solve User Problem] e.g. reinstate the Friday call for contributors to provide an opportunity to engage with the team -->
-
-## Epic lead
+<!-- Describe the outcome we expect to achieve working on this brief. It should also include why we are doing this work, and the expected tasks -->
 
 ## Squad
 
+<!-- Using @ feature to tag your fellow squad members. You can discover everyone's GitHub usernames pinned to our team Slack channel -->
+
 ## Further detail
 
-<!-- Any extra context that might help – can include things that are out of scope, things to consider, related work, references -->
+<!-- Any extra context that might help – can include things that are out of scope, useful links, things to consider, related work, references -->

--- a/.github/ISSUE_TEMPLATE/cycle-brief.md
+++ b/.github/ISSUE_TEMPLATE/cycle-brief.md
@@ -12,7 +12,7 @@ assignees: ""
 
 ## Squad
 
-<!-- Using @ feature to tag your fellow squad members. You can discover everyone's GitHub usernames pinned to our team Slack channel -->
+<!-- Use the @ feature to tag your fellow squad members. You can discover everyone's GitHub usernames pinned to our team Slack channel -->
 
 ## Further detail
 


### PR DESCRIPTION
Make this template consistent with [#4854](https://github.com/alphagov/govuk-design-system/pull/4854)

- removes epic lead role
- adds more information on what to include
- adds guidance on how to find colleague's GitHub usernames