### PR TITLE
Uninstall @types/testing-library__jest-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@govuk-frontend/lib": "*",
         "@govuk-frontend/tasks": "*",
         "@testing-library/jest-dom": "^6.8.0",
-        "@types/testing-library__jest-dom": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.38.0",
         "concurrently": "^9.2.1",
@@ -8719,16 +8718,6 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/testing-library__jest-dom": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-6.0.0.tgz",
-      "integrity": "sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==",
-      "deprecated": "This is a stub types definition. @testing-library/jest-dom provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "@testing-library/jest-dom": "*"
       }
     },
     "node_modules/@types/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@govuk-frontend/lib": "*",
     "@govuk-frontend/tasks": "*",
     "@testing-library/jest-dom": "^6.8.0",
-    "@types/testing-library__jest-dom": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.38.0",
     "concurrently": "^9.2.1",


### PR DESCRIPTION
As flagged in a deprecation notice:

```
@types/testing-library__jest-dom@6.0.0: This is a stub types definition. @testing-library/jest-dom provides its own type definitions, so you do not need this installed.
```