### PR TITLE
Fix coverage for configuration.mjs being ignored

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -14,12 +14,7 @@ const { headless = 'new' } = jestPuppeteerConfig.launch
 const config = {
   cacheDirectory: '<rootDir>/.cache/jest/',
   clearMocks: true,
-  coveragePathIgnorePatterns: [
-    '.test.(js|mjs)',
-    '.eslintrc.js',
-    'config/*',
-    'vendor/*'
-  ],
+  coveragePathIgnorePatterns: ['.test.(js|mjs)'],
 
   modulePathIgnorePatterns: [
     '<rootDir>/dist/',


### PR DESCRIPTION
`coveragePathIgnorePatterns` expects [’an array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.’][1]

Because these are regular expressions and **not** globs, in this context this evaluates as the characters `config` literally, followed by _zero or more_ slashes.

`common/configuration.mjs` contains the the characters `config` literally, followed by _zero_ slashes, so matches the ignore pattern.

We already set `collectCoverageFrom` to only include coverage from `./packages/govuk-frontend/src/**/*.{js,mjs}`.

`/packages/govuk-frontend/src/` does not include:

- any files named `.eslintrc.js`
- any files ending `.js` or `.mjs` inside a folder called `vendor`
- any folders called `config`

As such the only thing we actually need to exclude from coverage are our test files, for which matching on the regular expression `.test.(js|mjs)` is sufficient.

[1]: https://jestjs.io/docs/configuration#coveragepathignorepatterns-arraystring