### PR TITLE
Run percy on merges to relevant branches.

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -2,6 +2,11 @@ name: Percy screenshots
 
 on:
   workflow_call:
+    inputs:
+      trigger_event:
+        description: 'The event that the tests workflow was triggered by (push, pull_request, workflow_dispatch)'
+        required: true
+        type: string
   workflow_dispatch:
 
 concurrency:
@@ -57,6 +62,9 @@ jobs:
 
             if ('${{ github.event_name }}' === 'workflow_dispatch') {
               console.log('workflow_dispatch - running Percy')
+              core.setOutput('relevant_changes', 'true')
+            } else if ('${{ github.event_name }}' === 'workflow_call' && '${{ inputs.trigger_event }}' === 'push') {
+              console.log('Merging to ${{github.base_ref}} - running Percy')
               core.setOutput('relevant_changes', 'true')
             } else {
               const changedFiles = JSON.parse('${{ steps.files.outputs.changed_files }}')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -303,6 +303,8 @@ jobs:
     # Run existing "Percy screenshots" workflow
     # (after install and build have been cached)
     uses: ./.github/workflows/screenshots.yml
+    with:
+      trigger_event: ${{ github.event_name }}
     secrets: inherit
 
   generate-diff-package:


### PR DESCRIPTION
In #6119 we introduced a change so that Percy is only run in certain situations, either:

- if it's manually triggered via a workflow dispatch event
- if certain files have changed
  - any file in the govuk-frontend and dist assets folders
  - any CSS, SCSS, JS, MJS, NJK, YAML or YML file is changed within the package src folders, or the dist folder

However, we missed the fact that we also need to run Percy on _merges_ so that the baseline screenshots against which Percy compares get updated.

## Changes

The tests workflow triggers on `pull_request`, `push` (to main, support and feature branches), and `workflow dispatch`. It then runs the screenshot workflow via `workflow_call`.

If we've manually dispatched the screenshot workflow outside of the tests workflow, we already run Percy by default.

Now we also pass a `trigger_event` to the workflow and run Percy on a push - which will always be to one of the relevant branches as that's when the tests workflow triggers.

This felt cleaner than checking the branches within the screenshot workflow's script.

Fixes #6210 