### PR TITLE
Check for push event on screenshots workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -2,11 +2,6 @@ name: Percy screenshots
 
 on:
   workflow_call:
-    inputs:
-      trigger_event:
-        description: 'The event that the tests workflow was triggered by (push, pull_request, workflow_dispatch)'
-        required: true
-        type: string
   workflow_dispatch:
 
 concurrency:
@@ -60,10 +55,10 @@ jobs:
           script: |
             console.log('Checking if Percy needs to run.')
 
-            if ('${{ github.event_name }}' === 'workflow_dispatch') {
+            if (context.eventName === 'workflow_dispatch') {
               console.log('workflow_dispatch - running Percy')
               core.setOutput('relevant_changes', 'true')
-            } else if ('${{ github.event_name }}' === 'workflow_call' && '${{ inputs.trigger_event }}' === 'push') {
+            } else if (context.eventName === 'push') {
               console.log('Merging to ${{github.base_ref}} - running Percy')
               core.setOutput('relevant_changes', 'true')
             } else {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -303,8 +303,6 @@ jobs:
     # Run existing "Percy screenshots" workflow
     # (after install and build have been cached)
     uses: ./.github/workflows/screenshots.yml
-    with:
-      trigger_event: ${{ github.event_name }}
     secrets: inherit
 
   generate-diff-package:


### PR DESCRIPTION
In #6214, we'd assumed the event name would be 'workflow_call', but it turns out the calling workflow's event is used.

So we can use that directly, as well as make use of the built-in context object available in github-scripts

_Actually_ fixes #6210 (probably)