### PR TITLE
Fix reference to base_ref

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -59,7 +59,7 @@ jobs:
               console.log('workflow_dispatch - running Percy')
               core.setOutput('relevant_changes', 'true')
             } else if (context.eventName === 'push') {
-              console.log('Merging to ${{github.base_ref}} - running Percy')
+              console.log(`Merging to ${context.ref} - running Percy`)
               core.setOutput('relevant_changes', 'true')
             } else {
               const changedFiles = JSON.parse('${{ steps.files.outputs.changed_files }}')


### PR DESCRIPTION
`github.base_ref` is not available on a push event.

Use the github-script `context`'s `ref` property instead.