### PR TITLE
Account for `multiple` attribute when enhancing a File Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ We introduced this change in [pull request #5882: Rename ellipses html class to 
 
 ### Fixes
 
+- [#6223: Account for multiple attribute when enhancing a File Input](https://github.com/alphagov/govuk-frontend/pull/6223)
 - [#6297: Output deprecation warning if $govuk-show-breakpoints is true](https://github.com/alphagov/govuk-frontend/pull/6297)
 
 ## v5.12.0 (Feature release)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -176,6 +176,15 @@ examples:
       errorMessage:
         text: Error message goes here
 
+  - name: enhanced, multiple files
+    options:
+      javascript: true
+      id: file-upload-3
+      name: file-upload-3
+      label:
+        text: Upload files
+      multiple: true
+
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value
     hidden: true


### PR DESCRIPTION
Updates the checks done when dragging and dropping over the enhanced file upload attribute to account for the presence of the `multiple` attribute on the enhanced `<input>`. When absent, the enhanced file upload will only accept drops of a single file. The component will also check the number of files being dragged when it can (more on that right after) to decide whether to change state when the user drags over it.

Handling the `drop` event and the `dragenter` event need to be done slightly differently.

During the `drop`, the `files` property of the event's [`dataTransfer`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer) contains the list of files so we can just count that before allowing to copy into the input's `files` property. That's the easy part.

Before the `drop`, when deciding to change state or not:
- the `files` property is not filled (that'd be a bit creepy if any webpage had access to the files content when you passed over it while dragging 😬 
- the event's `dataTransfer` offers an`items` property with more limited information, but a useful [`kind` property](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem#instance_properties) for each item, set to `file` when the item is a file. [It isn't filled in by Safari](https://github.com/mdn/browser-compat-data/issues/24898), but as Chrome and Firefox provide it we can use it if present to count the items whose `kind` is `file` (at the cost of a good old `for` loop as [`DataTransferItemList`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList) is not an array or iterable)
- in the absence of `items`, we at least have a list of the types of things being dragged inside the `dataTransfer`'s `types` property, which we can check for the presence of a `Files`
- except we've seen it missing at times in Safari, so if we have no information, we'll assume users can drop and let the `drop` event take care of deciding whether the input can be filled or not

### Implementation considerations

The implementation adds two new methods to the component: `canFillInput` at the point of `drop` and `canDrop` for before that. Those are currently private could be offered for extension in the future, allowing teams to implement further logic for accepting or rejecting files (for example meeting the criteria of the `accept` attribute) with something like the following untested code:

```js
class AppFileInput extends FileInput {
   canDrop(dataTransfer) {
   	return super(dataTransfer) && dataTransfer.items.length && accepts(dataTransfer.items)
   }
   
   canFillInput(dataTransfer) {
   	return super(dataTransfer) && accepts(dataTransfer.files)
   }
   
   accepts(itemsOrFiles) {
	 for (let i = 0; i < itemsOrFiles.length; i++) {
		if (!this.isAcceptableType(itemsOrFiles[i].type)) {
			return false;
		}
	 }
     return true;
   } 
}
```

Fixes #5791