### PR TITLE
Remove reference to secret NPM_TOKEN

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -33,6 +33,4 @@ jobs:
         run: npm run build:package
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}


### PR DESCRIPTION
We're switching to OIDC (https://docs.npmjs.com/trusted-publishers) and will be removing the NPM_TOKEN secret in favour of it.