### PR TITLE
Round percentage change in filesize script to one decimal point

### DIFF
--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -140,13 +140,21 @@ function getFileSizeComparison(headFiles, baseFiles) {
   // Get initial percentage differences and check for deletions
   const comparedFileSizes = baseFiles.map((file) => {
     const headFile = findFileSizeRow(headFiles, file)
-    const percentage = headFile
-      ? `${Math.round((headFile.size / file.size) * 100 - 100)}%`
-      : 'Deleted'
+    let percentage
 
-    // Return null if there's no percentage difference
-    if (percentage === '0%') {
-      return null
+    if (!headFile) {
+      percentage = 'Deleted'
+    } else {
+      const sizeDiff = ((headFile.size - file.size) / file.size) * 100
+
+      // Remove '.0' here rather than check for it in the proceeding if to strip
+      // out instances of '4.0%'
+      percentage = sizeDiff.toFixed(1).replace('.0', '')
+
+      // Return null if there's no percentage difference
+      if (percentage === '0%') {
+        return null
+      }
     }
 
     return {


### PR DESCRIPTION
Sets the percentage in the filesize percentage difference script to round to one decimal point, meaning things that changes to js or css that are less than 1% will still show as changes.

This has been validated by some testing where I removed some sass from the back link, resulting in a 1.6% change where before it would've just read 1%.

It wouldn't be hard to increase the decimal place if we want by adjusting `toFixed` and what we replace after processing the string.