### PR TITLE
Add percent character back into filesize comparison

### DIFF
--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -152,14 +152,15 @@ function getFileSizeComparison(headFiles, baseFiles) {
       percentage = sizeDiff.toFixed(1).replace('.0', '')
 
       // Return null if there's no percentage difference
-      if (percentage === '0%') {
+      // Test as string because toFixed returns a string
+      if (percentage === '0') {
         return null
       }
     }
 
     return {
       ...file,
-      percentage
+      percentage: `${percentage}%`
     }
   })
 


### PR DESCRIPTION
Something we missed in https://github.com/alphagov/govuk-frontend/pull/6227 which leads to stuff like [this comment](https://github.com/alphagov/govuk-frontend/pull/6230#issuecomment-3308265382)