### PR TITLE
Remove fieldset indentation from checkboxes and radios

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -904,12 +904,15 @@ examples:
     hidden: true
     options:
       name: conditional
+      fieldset:
+        legend:
+          text: Test
       items:
         - value: other
           text: Other
           conditional:
             html: |
               <label class="govuk-label" for="conditional-textarea">textarea</label>
-              <textarea class="govuk-textarea govuk-!-width-one-third" name="conditional-textarea" id="conditional-textarea">
+              <textarea class="govuk-textarea" name="conditional-textarea" id="conditional-textarea">
               test
               </textarea>

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -115,7 +115,7 @@
     attributes: params.fieldset.attributes,
     legend: params.fieldset.legend,
     html: innerHtml | trim
-  }) | trim | indent(2) }}
+  }) | trim }}
 {% else %}
   {{ innerHtml | safe | trim }}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -804,13 +804,16 @@ examples:
     hidden: true
     options:
       name: conditional
+      fieldset:
+        legend:
+          text: Test
       items:
         - value: other
           text: Other
           conditional:
             html: |
               <label class="govuk-label" for="conditional-textarea">textarea</label>
-              <textarea class="govuk-textarea govuk-!-width-one-third" name="conditional-textarea" id="conditional-textarea">
+              <textarea class="govuk-textarea" name="conditional-textarea" id="conditional-textarea">
               test
               </textarea>
   - name: with disabled

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -108,7 +108,7 @@
     attributes: params.fieldset.attributes,
     legend: params.fieldset.legend,
     html: innerHtml | trim
-  }) | trim | indent(2) }}
+  }) | trim }}
 {% else %}
   {{ innerHtml | safe | trim }}
 {% endif %}


### PR DESCRIPTION
When conditionally revealing a textarea, indenting the HTML can alter the value of the textarea by including the indentation as leading spaces.

We tried to fix this in #4899 but we didn't spot the fact that the HTML was still indented if a `fieldset` was used.

Update the examples introduced in #4899 to include a fieldset, and remove the call to `indent` when calling `govukFieldset`.

Closes #4807 (again)