### PR TITLE
Tweak changelog wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
-#### Style focus states for form inputs with the `govuk-focused-form-input` mixin
+#### Use the `govuk-focused-form-input` mixin to style focus states for form inputs
 
 You can now use the `govuk-focused-form-input` mixin to style the focus state in your own form input components.
 


### PR DESCRIPTION
Tweak the wording of some unreleased changelog entries based on our content doc for v5.12.0: https://docs.google.com/document/d/1yxX5wzMNC51sPPtmnn2fRa4Dc2LScAJSuozbvix7Wbc/edit?tab=t.oi2fwcsgi4a9