### PR TITLE
Run Percy on package file changes

### DIFF
--- a/shared/github-scripts/check-percy-files.mjs
+++ b/shared/github-scripts/check-percy-files.mjs
@@ -26,6 +26,11 @@ function isRelevantFile(file) {
     return false
   }
 
+  // Package file changes always trigger screenshots
+  if (file.endsWith('package.json') || file.endsWith('package-lock.json')) {
+    return true
+  }
+
   // Asset changes always trigger screenshots
   if (
     file.startsWith('packages/govuk-frontend/src/govuk/assets/') ||

--- a/shared/github-scripts/check-percy-files.unit.test.mjs
+++ b/shared/github-scripts/check-percy-files.unit.test.mjs
@@ -51,6 +51,16 @@ describe('checkRelevantChanges', () => {
     })
   })
 
+  describe('package files', () => {
+    test.each([
+      ['govuk-frontend package file', ['packages/govuk-frontend/package.json']],
+      ['root package.json', ['package.json']],
+      ['root package-lock', ['package-lock.json']]
+    ])('returns true for %s', (description, changedFiles) => {
+      expect(checkRelevantChanges(changedFiles)).toBe(true)
+    })
+  })
+
   describe('with irrelevant files', () => {
     it('returns true when relevant files mixed with irrelevant files', () => {
       const changedFiles = [


### PR DESCRIPTION
Installing new packages might cause unexpected changes, so we really want to run Percy automatically (though we are able to run it manually via the workflow_dispatch as well)