### PR TITLE
Use plain media queries if there's no condition on `width`

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -117,7 +117,7 @@
     fill: #00ffe0;
 
     // Override Dot colour when printing
-    @include govuk-media-query($media-type: print) {
+    @media print {
       fill: currentcolor;
     }
 
@@ -502,7 +502,7 @@
 
       // When printing, use the normal blue as this contrasts better with the
       // white printing header
-      @include govuk-media-query($media-type: print) {
+      @media print {
         color: $govuk-brand-colour;
       }
 
@@ -523,7 +523,7 @@
     border-bottom: 0;
   }
 
-  @include govuk-media-query($media-type: print) {
+  @media print {
     .govuk-header {
       border-bottom-width: 0;
       color: govuk-colour("black");

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -36,7 +36,7 @@
     color: govuk-colour("white");
     background: govuk-colour("green");
 
-    @include govuk-media-query($media-type: print) {
+    @media print {
       border-color: currentcolor;
       color: $govuk-print-text-colour;
       background: none;

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -346,7 +346,7 @@
 /// @access public
 
 @mixin govuk-link-print-friendly {
-  @include govuk-media-query($media-type: print) {
+  @media print {
     &[href^="/"],
     &[href^="http://"],
     &[href^="https://"]

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -23,7 +23,7 @@
     @include _govuk-font-face-gds-transport;
   }
 
-  @include govuk-media-query($media-type: print) {
+  @media print {
     font-family: $govuk-font-family-print;
   }
 }
@@ -37,7 +37,7 @@
 @mixin govuk-text-colour {
   color: $govuk-text-colour;
 
-  @include govuk-media-query($media-type: print) {
+  @media print {
     color: $govuk-print-text-colour;
   }
 }
@@ -240,7 +240,7 @@
       font-size: $font-size-rem;
       line-height: $calculated-line-height;
     } @else if $breakpoint == "print" {
-      @include govuk-media-query($media-type: print) {
+      @media print {
         font-size: $font-size;
         line-height: $calculated-line-height;
       }

--- a/packages/govuk-frontend/src/govuk/objects/_template.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.scss
@@ -37,7 +37,7 @@
 
     // Force the scrollbar to always display in IE, to prevent horizontal page
     // jumps as content height changes (e.g. autocomplete results open).
-    @include govuk-media-query($media-type: screen) {
+    @media screen {
       overflow-y: scroll;
     }
   }

--- a/packages/govuk-frontend/src/govuk/objects/_width-container.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_width-container.scss
@@ -55,7 +55,7 @@
 
   // As soon as the viewport is greater than the width of the page plus the
   // gutters, just centre the content instead of adding gutters.
-  @include govuk-media-query($and: "(min-width: #{($width + $govuk-gutter * 2)})") {
+  @media (min-width: #{($width + $govuk-gutter * 2)}) {
     margin-right: auto;
     margin-left: auto;
 

--- a/packages/govuk-frontend/src/govuk/overrides/_display.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_display.scss
@@ -16,7 +16,7 @@
     display: none !important;
   }
 
-  @include govuk-media-query($media-type: print) {
+  @media print {
     .govuk-\!-display-none-print {
       display: none !important;
     }


### PR DESCRIPTION
Removes calls to `govuk-media-query` which only use the `$media-type` or `$and` parameters as those can be expressed with plain `@media` at-rule.

Fixes #6237 