### PR TITLE
Add media query functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### New features
+
+#### Use Sass functions to create custom media queries
+
+We've added new Sass functions to help write `@media` and `@container` queries, mixins and functions whilst still using GOV.UK Frontend's `$govuk-breakpoints` setting.
+
+You can create `min-width` and `max-width` queries using the `govuk-from-breakpoint` and `govuk-until-breakpoint` functions:
+
+```scss
+.element {
+  color: red;
+
+  @media #{govuk-from-breakpoint(mobile)} and #{govuk-until-breakpoint(desktop)} {
+    color: blue;
+  }
+}
+```
+
+You can get the configured value of a breakpoint using `govuk-breakpoint-value`:
+
+```scss
+@function wider-than-tablet($width) {
+  @return $width > govuk-breakpoint-value(tablet);
+}
+```
+
+Each of these functions allows for passing a custom breakpoint map. This can be useful if a particular component needs to change layout at different dimensions to the rest of the site and for authoring `@container` queries.
+
+```scss
+$component-breakpoints: (
+  small: 300px,
+  medium: 500px,
+  large: 750px
+);
+
+.element {
+  color: red;
+
+  @container #{govuk-from-breakpoint(small, $component-breakpoints)} {
+    color: blue;
+  }
+}
+```
+
+We made this change in [pull request #6264: Add media query functions](https://github.com/alphagov/govuk-frontend/pull/6264).
+
 ## v5.12.0 (Feature release)
 
 ### New features

--- a/packages/govuk-frontend/src/govuk/helpers/_media-queries.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_media-queries.scss
@@ -40,16 +40,37 @@ $sass-mq-already-included: true;
 /// Get the value of a breakpoint by name.
 ///
 /// @param {String | Number} $value - If a string, the name of a breakpoint
-///   in $breakpoints. If a number, it will use that number directly.
-/// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $name.
+///   in $breakpoints. If a number without units, it will convert to px. If a
+///   number with units, it will return the value unaltered.
+/// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $value.
 /// @returns {Number} - The set (minimum) value of the breakpoint
+///
+/// @example scss
+///  .element {
+///    width: govuk-breakpoint-value(tablet);
+///    @media (min-width: #{govuk-breakpoint-value(desktop)}) {
+///      color: red;
+///    }
+///    @media (min-width: #{govuk-breakpoint-value(400px)}) {
+///      color: green;
+///    }
+///    $custom-breakpoint-map: (
+///      small: 350px,
+///      medium: 769px,
+///      large: 1100px,
+///      extra-large: 1600px
+///    );
+///    @media (orientation: landscape) and (min-width: #{govuk-breakpoint-value(extra-large, $custom-breakpoint-map)}) {
+///      color: blue;
+///    }
+///  }
 ///
 /// @access public
 
 @function govuk-breakpoint-value($value, $breakpoints: $govuk-breakpoints) {
-  // If $breakpoint is a number
+  // If $value is a number
   @if type-of($value) == "number" {
-    // If $breakpoint is unitless, cast it to a pixel value
+    // If the number is unitless, coerce it into a pixel value
     @if unitless($value) {
       $value: $value * 1px;
     }
@@ -57,7 +78,8 @@ $sass-mq-already-included: true;
     @return $value;
   }
 
-  // If $breakpoint is a string, look it up in the map
+  // If $value is a string and exists as a key in in $breakpoints,
+  // look up and use the value of it
   @if type-of($value) == "string" and map-has-key($breakpoints, $value) {
     @return map-get($breakpoints, $value);
   }
@@ -76,6 +98,28 @@ $sass-mq-already-included: true;
 /// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $from.
 /// @returns {String} - A `min-width` media query segment
 ///
+/// @example scss
+///  .example {
+///    @media #{govuk-from-breakpoint(tablet)} {
+///      color: red;
+///    }
+///    @media #{govuk-from-breakpoint(30em)} {
+///      color: green;
+///    }
+///    @media #{govuk-from-breakpoint(tablet)} and (orientation: landscape) {
+///      color: blue;
+///    }
+///    $custom-breakpoint-map: (
+///      small: 350px,
+///      medium: 769px,
+///      large: 1100px,
+///      extra-large: 1600px
+///    );
+///    @media #{govuk-from-breakpoint(extra-large, $custom-breakpoint-map)} {
+///      color: cyan;
+///    }
+///  }
+///
 /// @access public
 
 @function govuk-from-breakpoint($from, $breakpoints: $govuk-breakpoints) {
@@ -91,13 +135,35 @@ $sass-mq-already-included: true;
 /// Generate the `max-width` segment of a media query given a breakpoint key
 ///
 /// sass-mq converted pixel values to ems, and only performed subtractions on
-/// on named breakpoints. These have been retained for backwards compatibility,
+/// named breakpoints. These have been retained for backwards compatibility,
 /// though unlike sass-mq, this also supports using non-px and em values.
 ///
 /// @param {String | Number} $until - If a string, expects the name of a
 ///   breakpoint in $breakpoints. If a number, it will use that number.
 /// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $until.
 /// @returns {String} - A `max-width` media query segment
+///
+/// @example scss
+///  .example {
+///    @media #{govuk-until-breakpoint(desktop)} {
+///      color: red;
+///    }
+///    @media #{govuk-until-breakpoint(40em)} {
+///      color: green;
+///    }
+///    @media #{govuk-until-breakpoint(tablet)} and (orientation: landscape) {
+///      color: blue;
+///    }
+///    $custom-breakpoint-map: (
+///      small: 350px,
+///      medium: 769px,
+///      large: 1100px,
+///      extra-large: 1600px
+///    );
+///    @media #{govuk-until-breakpoint(extra-large, $custom-breakpoint-map)} {
+///      color: cyan;
+///    }
+///  }
 ///
 /// @access public
 
@@ -109,7 +175,7 @@ $sass-mq-already-included: true;
     $value: govuk-em($value);
   }
 
-  // If the value derives from a named breakpoint, additionally subtract .01em
+  // If $value derives from a named breakpoint, additionally subtract .01em
   @if type-of($until) != "number" and unit($value) == "em" {
     $value: $value - 0.01em;
   }
@@ -150,7 +216,7 @@ $sass-mq-already-included: true;
 ///      color: hotpink;
 ///    }
 ///    @include govuk-media-query(tablet, $media-type: screen) {
-///      color: hotpink;
+///      color: rebeccapurple;
 ///    }
 ///  }
 ///

--- a/packages/govuk-frontend/src/govuk/helpers/_media-queries.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_media-queries.scss
@@ -30,9 +30,92 @@ $sass-mq-already-included: false !default;
 
 $sass-mq-already-included: true;
 
+@import "../settings/media-queries";
+@import "../tools/px-to-em";
+
 // =========================================================
 // Helpers
 // =========================================================
+
+/// Get the value of a breakpoint by name.
+///
+/// @param {String | Number} $value - If a string, the name of a breakpoint
+///   in $breakpoints. If a number, it will use that number directly.
+/// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $name.
+/// @returns {Number} - The set (minimum) value of the breakpoint
+///
+/// @access public
+
+@function govuk-breakpoint-value($value, $breakpoints: $govuk-breakpoints) {
+  // If $breakpoint is a number
+  @if type-of($value) == "number" {
+    // If $breakpoint is unitless, cast it to a pixel value
+    @if unitless($value) {
+      $value: $value * 1px;
+    }
+
+    @return $value;
+  }
+
+  // If $breakpoint is a string, look it up in the map
+  @if type-of($value) == "string" and map-has-key($breakpoints, $value) {
+    @return map-get($breakpoints, $value);
+  }
+
+  // If we get this far, we can't use the value, so return an error
+  @error "Could not find a breakpoint given `#{$value}`.";
+}
+
+/// Generate the `min-width` segment of a media query given a breakpoint key
+///
+/// Pixel values are converted to ems for backwards compatibility with
+/// sass-mq. Unlike sass-mq, non-px and em values can be used as well.
+///
+/// @param {String | Number} $from - If a string, expects the name of a
+///   breakpoint in $breakpoints. If a number, it will use that number.
+/// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $from.
+/// @returns {String} - A `min-width` media query segment
+///
+/// @access public
+
+@function govuk-from-breakpoint($from, $breakpoints: $govuk-breakpoints) {
+  $value: govuk-breakpoint-value($from, $breakpoints);
+
+  @if type-of($value) == "number" and unit($value) == "px" {
+    $value: govuk-em($value);
+  }
+
+  @return "(min-width: #{$value})";
+}
+
+/// Generate the `max-width` segment of a media query given a breakpoint key
+///
+/// sass-mq converted pixel values to ems, and only performed subtractions on
+/// on named breakpoints. These have been retained for backwards compatibility,
+/// though unlike sass-mq, this also supports using non-px and em values.
+///
+/// @param {String | Number} $until - If a string, expects the name of a
+///   breakpoint in $breakpoints. If a number, it will use that number.
+/// @param {Map} $breakpoints [$govuk-breakpoints] - The map to look for $until.
+/// @returns {String} - A `max-width` media query segment
+///
+/// @access public
+
+@function govuk-until-breakpoint($until, $breakpoints: $govuk-breakpoints) {
+  $value: govuk-breakpoint-value($until, $breakpoints);
+
+  @if type-of($value) == "number" and unit($value) == "px" {
+    // If it's a pixel value, convert it to ems.
+    $value: govuk-em($value);
+  }
+
+  // If the value derives from a named breakpoint, additionally subtract .01em
+  @if type-of($until) != "number" and unit($value) == "em" {
+    $value: $value - 0.01em;
+  }
+
+  @return "(max-width: #{$value})";
+}
 
 /// Media Query
 ///

--- a/packages/govuk-frontend/src/govuk/tools/_px-to-em.scss
+++ b/packages/govuk-frontend/src/govuk/tools/_px-to-em.scss
@@ -2,14 +2,16 @@
 /// @group tools/unit-conversion
 ////
 
+@import "../settings/typography-responsive";
+
 /// Convert pixels to em
 ///
 /// @param {Number} $value - Length in pixels
-/// @param {Number} $context-font-size - Font size of element
+/// @param {Number} $context-font-size [$govuk-root-font-size] - Font size of element
 /// @return {Number} Length in ems
 /// @access public
 
-@function govuk-em($value, $context-font-size) {
+@function govuk-em($value, $context-font-size: $govuk-root-font-size) {
   @if unitless($value) {
     $value: $value * 1px;
   }


### PR DESCRIPTION
Closes #6235. Tests for this work are being written in #6292. 

## Changes
Introduces three new functions: 
- `govuk-breakpoint-value`, which gets the raw value of a breakpoint given its name.
  - If passed a number with units, the function returns the value immediately and does not attempt to look it up.
  - If passed a unitless number, converts it to a pixel value and returns it.
  - If passed a string, it attempts to locate it within the breakpoint map and returns a value if one is found.
  - If none of the above conditions were successful, it returns an error. 
- `govuk-from-breakpoint`, which generates a `(min-width)` segment of media query using the value from `govuk-breakpoint-value`. 
  - If the given value is in pixels, it passes the value through `govuk-em`. This is for backwards compatibility with `sass-mq`.
  - Otherwise, the value is used directly and not manipulated.
- `govuk-until-breakpoint`, which generates a `(max-width)` segment of media query using `govuk-breakpoint-value`. 
  - If the given value is in pixels, it passes the value through `govuk-em`.
  - If the value originated from a named breakpoint, and is now in em units, subtract 0.01em from it. This behaviour, and the value being subtracted, is for backwards compatibility with `sass-mq`.

Because the conversion to, and subtraction from, em units is now gated behind type and unit checks, the new functions theoretically now support use with other units (rem, ch, etc.) which they didn't previously.

For ease of use, this PR also updates the `govuk-em` function to use `$govuk-root-font-size` as the default contextual font size, instead of requiring it to be defined on every use. 

## Thoughts
Originally, I intended `govuk-until-breakpoint` to subtract 0.02px prior to converting the value to em units. It now subtracts 0.01em after conversion, consistent with how `sass-mq` worked.

because of [a bug in Safari 10 and older](https://bugs.webkit.org/show_bug.cgi?id=178261), where subtracting 0.01px invoked a rounding error in the browser and allowed media queries to overlap (e.g. 599.99px and 600px were treated the same).

