### PR TITLE
Remove "Squad" heading from Cycle brief issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cycle-brief.md
+++ b/.github/ISSUE_TEMPLATE/cycle-brief.md
@@ -6,13 +6,11 @@ labels: "epic"
 assignees: ""
 ---
 
+<!-- List the squad members as "Assignees" on the issue. You can discover everyone's GitHub usernames pinned to our team Slack channel -->
+
 ## Brief
 
 <!-- Describe the outcome we expect to achieve working on this brief. It should also include why we are doing this work, and the expected tasks -->
-
-## Squad
-
-<!-- Use the @ feature to tag your fellow squad members. You can discover everyone's GitHub usernames pinned to our team Slack channel -->
 
 ## Further detail
 


### PR DESCRIPTION
It duplicates information with the "Assignees" list on the issue, and adds a risk of mentioning people with their actual name rather than their GitHub handle.