### PR TITLE
Rework the rebrand toggling system to be 'on' by default

### DIFF
--- a/docs/contributing/old-brand-feature-flag.md
+++ b/docs/contributing/old-brand-feature-flag.md
@@ -1,19 +1,19 @@
-# The 'rebrand' feature flag
+# The ' old brand' feature flag
 
-While we work on the rebrand of GOV.UK Frontend, you can use the feature flag toggling system to help with:
+While we continue to work on the rebrand of GOV.UK Frontend, you can use the feature flag toggling system to help with:
 
 - sharing and visualising changes
 - testing rebranded components
 
 ## How to use the UI
 
-You can see the feature flag toggling UI at the top of most pages in the review app as a Details element. It does not appear on component previews. When you open the toggling UI, you'll see a form with a checkbox labelled 'rebrand feature flag on'. By checking this box and clicking **Submit**, you'll reload the page. If you're looking at a page on the review app with components impacted by the rebrand, such as the header, you'll see the rebranded version of that component. Unchecking the box and resubmitting the form will turn the feature flag off.
+You can see the feature flag toggling UI at the top of most pages in the review app as a Details element. It does not appear on component previews. When you open the toggling UI, you'll see a form with a checkbox labelled 'Use the old brand'. By checking this box and clicking **Submit**, you'll reload the page. If you're looking at a page on the review app with components impacted by the rebrand, such as the header, you'll see the old brand version of that component. Unchecking the box and resubmitting the form will turn the feature flag off.
 
 Additionally, when on a component landing page, such as '/components/header', you can select the link just under the feature flag form labelled 'show all flag states'. You will then see two example iframes for each component example, one with the new brand and one with the old brand. You can turn this feature off by selecting the link again or navigating to a new page.
 
-## Things that change when the rebrand feature flag is on
+## Things that change when the old brand feature flag is on
 
-When the feature flag is turned on, the primary change is that the HTML class `govuk-template--rebranded` is added to the HTML tag of templates. This impacts the styling of the following components:
+When the feature flag is turned on, the primary change is that the HTML class `govuk-template--rebranded` is removed from the HTML tag of templates. This impacts the styling of the following components:
 
 - header
 - footer
@@ -22,19 +22,16 @@ When the feature flag is turned on, the primary change is that the HTML class `g
 
 This will also automatically update the logo in the header component and add the crown to the footer component.
 
-> [!NOTE]
-> Logo changes will not take effect in examples where we are changing the `header` block and recalling the header component macro. This is because we aren't setting the `rebrand` parameter to `true` in those header macro calls in those custom examples, whereas we do by default.
-
 ## How it works
 
 ### Feature flags middleware
 
 This feature is controlled by the app's feature flag middleware.
 
-1. When the feature flag form makes a post request to `/set-rebrand`, the middleware sets a `use_rebrand` cookie and redirects the user back to the page they were just on.
+1. When the feature flag form makes a post request to `/unset-rebrand`, the middleware sets a `use_old_brand` cookie and redirects the user back to the page they were just on.
 2. The middleware sets 3 local variables:
 
-- `useRebrand`, which is set based on the presence of either a `rebrandOverride` query parameter or the state of the `use_rebrand` cookie if the override parameter is not present
+- `useRebrand`, which is set based on the presence of either a `rebrandOverride` query parameter or the state of the `use_old_brand` cookie if the override parameter is not present. It is `true` by default
 - `ShowAllFlagStates`, which is set based on the presence of a `showAllFlagStates` query parameter - the link under the feature flag form sets this parameter
 - `exampleStates` which is either `[true, false]` if `showAllFlagStates` is `true`, or an array containing `useRebrand` as one item
 

--- a/packages/govuk-frontend-review/src/common/middleware/feature-flags.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/feature-flags.mjs
@@ -3,16 +3,16 @@ import express from 'express'
 const router = express.Router()
 
 const FEATURE_NAME = 'rebrand'
-const COOKIE_NAME = `use_${FEATURE_NAME}`
+const COOKIE_NAME = `use_old_brand`
 
 /**
- * Control rebrand cookie setting and unsetting
+ * Control old brand cookie setting and unsetting
  *
- * Sets the rebrand cookie if setRebrand is present in request body,
- * otherwise unsets the cookie, then redirect.
+ * Sets the old brand cookie if unsetRebrand is present in request body,
+ * otherwise unsets the cookie, then redirects.
  */
-router.post(`/set-${FEATURE_NAME}`, (req, res) => {
-  const queryName = `set${FEATURE_NAME.charAt(0).toUpperCase() + FEATURE_NAME.slice(1)}`
+router.post(`/unset-${FEATURE_NAME}`, (req, res) => {
+  const queryName = `unset${FEATURE_NAME.charAt(0).toUpperCase() + FEATURE_NAME.slice(1)}`
 
   if (queryName in req.body) {
     const maxAgeInDays = 28
@@ -42,7 +42,7 @@ router.use((req, res, next) => {
   res.locals[localVarName] =
     overrideQuery in req.query
       ? req.query[overrideQuery] === 'true'
-      : req.cookies?.[COOKIE_NAME] === 'true'
+      : req.cookies?.[COOKIE_NAME] !== 'true'
   res.locals.showAllFlagStates = 'showAllFlagStates' in req.query
 
   res.locals.exampleStates = res.locals.showAllFlagStates

--- a/packages/govuk-frontend-review/src/views/partials/feature-flags.njk
+++ b/packages/govuk-frontend-review/src/views/partials/feature-flags.njk
@@ -5,14 +5,14 @@
 {%- set featureFlagHtml -%}
   <h2 class="govuk-heading-m">Feature flag control</h2>
   <p class="govuk-body">This is an experimental feature for turning the 'rebrand' feature flag on and off only.</p>
-  <form method="post" action="/set-rebrand">
+  <form method="post" action="/unset-rebrand">
     {{ govukCheckboxes({
-      name: 'setRebrand',
+      name: 'unsetRebrand',
       items: [
         {
-          text: 'Rebrand feature flag on',
+          text: 'Use the old brand',
           value: 'true',
-          checked: useRebrand
+          checked: not useRebrand
         }
       ]
     }) }}

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -83,9 +83,11 @@ examples:
       items:
         - title:
             text: Company Directors
+            classes: ':hover'
           href: '#'
           status:
             text: Completed
+          classes: ':hover'
 
         - title:
             text: Registered company details


### PR DESCRIPTION
## What

Changes the toggling system in the review app so that now you have to opt in to see the _old_ brand rather than the other way around. Specifically, `/set-rebrand` is now `/unset-rebrand` which sets a `use_old_brand` cookie rather than a `use_rebrand` cookie which _negatively_ effects the setting of `useRebrand` rather than positively.

This also updates tests and the docs for the toggling system.

## Why

It's been out for a while now!

Imforned naturally as part of work on https://github.com/alphagov/govuk-frontend/issues/6247. It's easier on the designers doing the auditing to see the new brand over the old brand without having to turn it on and set their cookies.

## Notes

The only reason I've observed to keep the cookie which sets it to default old or default new is for checking the full page examples. Otherwise I wonder if we need to set cookies at all and can just rely on the 'show all states' functionality to see the old brand in action.

I wonder how useful that doc is and if any of the design system devs have referred to it over the course of the rebrand work rather than just checking the code + commit history.