### PR TITLE
Update how Git ref of base branch is accessed in actions

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -32,9 +32,11 @@ jobs:
 
       - name: Generate diff
         run: |
-          # Using `origin/$GITHUB_BASE_REF` to avoid actually checking out the branch
+          # Using `origin/<BASE_REF>` to avoid actually checking out the branch
           # as all we need is to let Git diff the two references
-          bin/dist-diff.sh origin/$GITHUB_BASE_REF $GITHUB_WORKSPACE
+          # Using the even to get a more accurate reference when the base changes
+          # as $GITHUB_BASE_REF seems to keep referencing the old base
+          bin/dist-diff.sh origin/${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE
 
       - name: Save GitHub release diffs
         uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/diff-change-to-package.yaml
+++ b/.github/workflows/diff-change-to-package.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          bin/package-diff.sh $GITHUB_BASE_REF $GITHUB_WORKSPACE
+          bin/package-diff.sh ${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE
 
       - name: Save npm package diffs
         uses: actions/upload-artifact@v4.6.2


### PR DESCRIPTION
`$GITHUB_BASE_REF` keeps referencing the old base branch name after the base of a PR changes (eg. if the base branch gets merged on another branch).

Using the event that triggered the PR gives us more up to date information.