### PR TITLE
Add error, success and template background variants to the links example page

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -5,8 +5,9 @@ $govuk-suppressed-warnings: ("organisation-colours");
 
 @import "govuk";
 @import "partials/app";
-@import "partials/code";
 @import "partials/banner";
+@import "partials/code";
 @import "partials/feature-flag-banner";
+@import "partials/links";
 @import "partials/organisation-swatch";
 @import "partials/prose";

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_links.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_links.scss
@@ -1,0 +1,10 @@
+// Custom links specifically for the links page to test our error and success
+// link styles, since we don't provide these as link classes
+
+.app-link--error {
+  @include govuk-link-style-error;
+}
+
+.app-link--success {
+  @include govuk-link-style-success;
+}

--- a/packages/govuk-frontend-review/src/views/examples/links/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/links/index.njk
@@ -15,7 +15,10 @@
   'Link with no visited state': 'govuk-link--no-visited-state',
   'Text link': 'govuk-link--text-colour',
   'Muted link': 'govuk-link--muted',
-  'Inverse': 'govuk-link--inverse'
+  'Error': 'app-link--error',
+  'Success': 'app-link--success',
+  'Inverse': 'govuk-link--inverse',
+  'On template background': ''
 } %}
 
 {% set states = {
@@ -50,7 +53,7 @@
 
     {% for variant_description, variant_class in variants %}
 
-      <section class="govuk-!-margin-top-8"{% if variant_class == "govuk-link--inverse"%} style="background: #1d70b8; padding: 15px; margin: -15px;"{% endif %}>
+      <section class="govuk-!-margin-top-8"{% if variant_class == "govuk-link--inverse"%} style="background: #1d70b8; padding: 15px; margin: -15px;"{% endif %}{% if variant_description == "On template background"%} style="background: #f4f8fb; padding: 15px; margin: -15px;"{% endif %}>
         <h2 class="govuk-heading-l"{% if variant_class == "govuk-link--inverse"%} style="color: #fff;"{% endif %}>{{ variant_description }}</h2>
 
       {% for state_description, state_class in states %}


### PR DESCRIPTION
What it says.

Part of https://github.com/alphagov/govuk-frontend/issues/6257 to help with the wider colour audit, though won't resolve that issue.