### PR TITLE
Fix long filenames in enhanced file upload not wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ We introduced this change in [pull request #5882: Rename ellipses html class to 
 ### Fixes
 
 - [#6223: Account for multiple attribute when enhancing a File Input](https://github.com/alphagov/govuk-frontend/pull/6223)
-- [#6297: Output deprecation warning if $govuk-show-breakpoints is true](https://github.com/alphagov/govuk-frontend/pull/6297)
+- [#6297: Output deprecation warning if `$govuk-show-breakpoints` is true](https://github.com/alphagov/govuk-frontend/pull/6297)
+- [#6304: Fix long filenames in enhanced file upload not wrapping](https://github.com/alphagov/govuk-frontend/pull/6304)
 
 ## v5.12.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -84,6 +84,7 @@
     padding: govuk-spacing(3) govuk-spacing(2);
     background-color: govuk-colour("white");
     text-align: left;
+    @include govuk-text-break-word;
   }
 
   // bugs documented with button using flex


### PR DESCRIPTION
Resolves #5774.

## Changes
- Adds the `govuk-text-break-word` mixin to the enhanced file upload's status element, which forcibly breaks words that are longer than the container width. 