### PR TITLE
Bump webpack to v5.102.0

### DIFF
--- a/docs/examples/webpack/package.json
+++ b/docs/examples/webpack/package.json
@@ -27,7 +27,7 @@
     "sass-embedded": "^1.89.2",
     "sass-loader": "^16.0.5",
     "terser-webpack-plugin": "^5.3.10",
-    "webpack": "^5.101.0",
+    "webpack": "^5.102.0",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "sass-embedded": "^1.89.2",
         "sass-loader": "^16.0.5",
         "terser-webpack-plugin": "^5.3.10",
-        "webpack": "^5.101.0",
+        "webpack": "^5.102.0",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
       },
@@ -168,10 +168,38 @@
         "node": ">= 0.6"
       }
     },
+    "docs/examples/webpack/node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "docs/examples/webpack/node_modules/watchpack": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "docs/examples/webpack/node_modules/webpack": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
-      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
+      "version": "5.102.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.0.tgz",
+      "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -183,9 +211,9 @@
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.15.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.24.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
+        "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -196,9 +224,9 @@
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
+        "tapable": "^2.2.3",
         "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
+        "watchpack": "^2.4.4",
         "webpack-sources": "^3.3.3"
       },
       "bin": {
@@ -36713,6 +36741,7 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
       "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -37894,7 +37923,7 @@
         "rollup": "^4.52.3",
         "terser-webpack-plugin": "^5.3.14",
         "vite": "^7.0.7",
-        "webpack": "^5.101.0"
+        "webpack": "^5.102.0"
       },
       "engines": {
         "node": "^22.11.0",
@@ -37938,10 +37967,38 @@
         "node": ">= 0.6"
       }
     },
+    "shared/bundler-integrations/node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "shared/bundler-integrations/node_modules/watchpack": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "shared/bundler-integrations/node_modules/webpack": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
-      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
+      "version": "5.102.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.0.tgz",
+      "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -37953,9 +38010,9 @@
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.15.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.24.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
+        "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -37966,9 +38023,9 @@
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
+        "tapable": "^2.2.3",
         "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
+        "watchpack": "^2.4.4",
         "webpack-sources": "^3.3.3"
       },
       "bin": {

--- a/shared/bundler-integrations/package.json
+++ b/shared/bundler-integrations/package.json
@@ -25,6 +25,6 @@
     "rollup": "^4.52.3",
     "terser-webpack-plugin": "^5.3.14",
     "vite": "^7.0.7",
-    "webpack": "^5.101.0"
+    "webpack": "^5.102.0"
   }
 }


### PR DESCRIPTION
Dependabot [gets its wires crossed](https://github.com/alphagov/govuk-frontend/pull/6283) sometimes, and maintains old versions in the package-lock.

So Dependabot will:

1. Bump package.json files to v5.102.0
2. Install v5.102.0 to the root directory
3. Not update the v5.101.0 packages in the package-lock file within the workspace subfolders

So v5.101.0 gets installed within the relevant workspace subfolder `node_modules` folder because that's what the package-lock has defined.

Then, npm will find the 5.102.0 dependency in the package.json file, but will find 5.101.0 installed in the nearest `node_modules` folder, and error.

Updating these manually (as this PR does) is trivial, so definitely dependabot getting confused.