### PR TITLE
Add button examples for hover and focus states of variants

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -53,6 +53,18 @@ examples:
     screenshot: true
     options:
       text: Save and continue
+  - name: default hover state
+    options:
+      text: Save and continue
+      classes: :hover
+  - name: default active state
+    options:
+      text: Save and continue
+      classes: :active
+  - name: default focus state
+    options:
+      text: Save and continue
+      classes: :focus
   - name: disabled
     options:
       text: Disabled button
@@ -72,12 +84,54 @@ examples:
       name: secondary
       text: Secondary button
       classes: govuk-button--secondary
+  - name: secondary hover state
+    options:
+      name: secondary
+      text: Secondary button
+      classes: govuk-button--secondary :hover
+  - name: secondary active state
+    options:
+      name: secondary
+      text: Secondary button
+      classes: govuk-button--secondary :active
+  - name: secondary focus state
+    options:
+      name: secondary
+      text: Secondary button
+      classes: govuk-button--secondary :focus
+  - name: secondary disabled
+    options:
+      name: secondary
+      text: Secondary button disabled
+      classes: govuk-button--secondary
+      disabled: true
   - name: warning
     description: A button for actions that need a warning
     options:
       name: Warning
       text: Warning button
       classes: govuk-button--warning
+  - name: warning hover state
+    options:
+      name: Warning
+      text: Warning button
+      classes: govuk-button--warning :hover
+  - name: warning active state
+    options:
+      name: Warning
+      text: Warning button
+      classes: govuk-button--warning :active
+  - name: warning focus state
+    options:
+      name: Warning
+      text: Warning button
+      classes: govuk-button--warning :focus
+  - name: warning disabled
+    options:
+      name: warning
+      text: Warning button disabled
+      classes: govuk-button--warning
+      disabled: true
   - name: inverse
     screenshot: true
     description: A button that appears on dark backgrounds
@@ -87,6 +141,35 @@ examples:
       name: Inverse
       text: Inverse button
       classes: govuk-button--inverse
+  - name: inverse hover state
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      name: Inverse
+      text: Inverse button
+      classes: govuk-button--inverse :hover
+  - name: inverse active state
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      name: Inverse
+      text: Inverse button
+      classes: govuk-button--inverse :active
+  - name: inverse focus state
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      name: Inverse
+      text: Inverse button
+      classes: govuk-button--inverse :focus
+  - name: inverse disabled
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      name: Inverse
+      text: Inverse button
+      classes: govuk-button--inverse
+      disabled: true
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes


### PR DESCRIPTION
Adds examples to button for:

- forced hover state of all variants
- disabled state of all variants
- forced focus state, only of the default button since it's the same for all variants

Part of https://github.com/alphagov/govuk-frontend/issues/6257 although will not resolve it

We previously removed a lot of these examples in https://github.com/alphagov/govuk-frontend/pull/6091 however the design system designers expressed that it'd be useful to see these examples at a glance, in particular the different colours.

This could be remedied more completely by some sort of states API as detailed in https://github.com/alphagov/govuk-frontend/issues/6257#issuecomment-3362142102, but this PR does the job for now