### PR TITLE
[Experiment] Added 4px corner radius to all buttons

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -84,6 +84,8 @@ $govuk-inverse-button-text-colour: $govuk-brand-colour !default;
 
     @include govuk-media-query($from: tablet) {
       width: auto;
+
+      border-radius: 4px;
     }
 
     // Ensure that any global link styles are overridden


### PR DESCRIPTION
> [!IMPORTANT]
> Just an experiment/ do not merge

As part of [Scope brand related design work ](https://github.com/alphagov/govuk-frontend/issues/6247) the team has decided to explore the idea of adding rounded corners to buttons.
### Deployment
https://govuk-frontend-pr-6315.herokuapp.com/

### Design considerations
I've used 4px as a starting point to explore this idea. Anything rounder begins to look cartoonish in my opinion, and we also need to remember that the more rounded the corner, the more padding around the text will be needed to prevent the text looking squeezed. 

The aim here is to make the buttons look more distinctive to improve their affordance, not to completely restyle them.

### Why rounded corners?
**Differentiation**
They provide a point of visual differentiation from the other blocky elements on the Design System, such as banners. The rest of the Design System uses sharp corners so by using rounded corners on one thing, we draw attention to that thing. 

<img width="321" height="301" alt="A collection of rectangles surrounding a circle" src="https://github.com/user-attachments/assets/8a1a41a6-612f-431e-93cc-f5416541f24b" />

**Affordance**
They specifically provide extra affordance to things like buttons, by aligning more closely with button styles used across the web and digital devices. At the moment our buttons rely on colour and a shadow to make them explicit.

<img width="769" height="200" alt="Two buttons, one with rounded corners and the other without" src="https://github.com/user-attachments/assets/dada0d9c-d463-4c18-bf85-d302265731c7" />

This is especially true when buttons have very long text, making the button appear more like a banner (and making it more likely to be ignored)

<img width="678" height="136" alt="A button with a long sentence" src="https://github.com/user-attachments/assets/39598d67-5905-4635-987e-6ccb8fe3c9c5" />

**Visual consistency**
They create a visual link between the typeface, New Transport, and the layout elements. New Transport uses rounded tails on the ‘T’, ‘L’ and ‘A’ letters, and rounded corners would echo these distinctive elements 

<img width="342" height="108" alt="The letters 't', 'l' and 'a' from the Transport typeface" src="https://github.com/user-attachments/assets/d1c92ee2-4630-45ee-9125-98b8b176e79b" />

**Space saving**
On tight layouts where space is at a premium, rounded corners allow users to gauge the gaps between blocks of content that would otherwise need to be spaced further apart

<img width="959" height="184" alt="Showing the difference made by adding rounded corners to tightly packed blocks" src="https://github.com/user-attachments/assets/d43b2e28-8990-440d-a143-22e4282446dc" />

**Friendliness**
Rounded corners are seen as being friendlier and could support the [GOV.UK](http://gov.uk/) brand's aim of appealing to users who were intimidated by the previous branding.

### Where we could use rounded corners
It was decided by the squad that we would only add rounded corners to buttons for now. 

This is to 
- Ensure maximum differentiation from other elements in the Design System 
- Minimise impact on our users
- Allow us to engage the community on a tightly scoped change 

----
**Before**
Buttons are square edged and do not stand out against elements such as the file upload 

<img width="685" height="438" alt="File upload with original buttons" src="https://github.com/user-attachments/assets/e9e795b3-f0d7-47ba-8602-1c03671c9902" />


**After**
Buttons are clearly differentiated from the file upload component

<img width="685" height="438" alt="File upload with new, rounded buttons" src="https://github.com/user-attachments/assets/36e74e77-d905-4c56-b439-2825958ec246" />
