### PR TITLE
Add forced hover state example to task list

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -103,6 +103,32 @@ examples:
               text: Incomplete
               classes: govuk-tag--blue
 
+  - name: forced hover state
+    options:
+      items:
+        - title:
+            text: Company Directors
+          href: '#'
+          status:
+            text: Completed
+          classes: :hover
+
+        - title:
+            text: Registered company details
+          href: '#'
+          status:
+            tag:
+              text: Incomplete
+              classes: govuk-tag--blue
+
+        - title:
+            text: Business plan
+          href: '#'
+          status:
+            tag:
+              text: Incomplete
+              classes: govuk-tag--blue
+
   - name: with hint text and additional states
     screenshot: true
     options:


### PR DESCRIPTION
Makes it easier to see at a glance what the hover state colour of the task list is

Part of https://github.com/alphagov/govuk-frontend/issues/6257 although will not resolve it