### PR TITLE
Update guidance on using serviceName instead of productName

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -6,7 +6,7 @@ params:
   - name: productName
     type: string
     required: false
-    description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use `serviceName`.
+    description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use `serviceName` in the [service navigation component](/components/service-navigation/).
   - name: serviceName
     type: string
     required: false


### PR DESCRIPTION
While answering [this question on Slack](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1759923612193709) I noticed the macro guidance for `productName` in the header hasn't been updated to reflect the fact that the service name should now go in the service navigation rather than in the header.

Questions:

- Is the absolute path in the link ok or should it have the domain name?
- Is the lowercase capitalisation of 'service navigation' in the link text ok or should it be 'Service navigation'?
- As mentioned on Slack, the distinction between product name and service name is quite buried, and you might not find it if you're not using the Nunjucks templates. Is it worth considering some guidance on this in the main page content? I guess this would need an issue in the Design System rather than Frontend