### PR TITLE
Do not log express URL to console

### DIFF
--- a/packages/govuk-frontend-review/src/start.mjs
+++ b/packages/govuk-frontend-review/src/start.mjs
@@ -1,9 +1,7 @@
-import { ports, urls } from '@govuk-frontend/config'
+import { ports } from '@govuk-frontend/config'
 
 import app from './app.mjs'
 
 const server = await app()
 
-server.listen(ports.app, () => {
-  console.log(`Server started at ${urls.app}`)
-})
+server.listen(ports.app)


### PR DESCRIPTION
The review app’s Express instance runs on port 8080, and then we run Browsersync on port 3000 which is the primary port we expect users to use when using the review app.

However at the minute we log the Express URL last in the terminal:

```
[app] [Browsersync] Access URLs:
[app]  ---------------------------------------
[app]        Local: http://localhost:3000
[app]     External: http://192.168.68.119:3000
[app]  ---------------------------------------
[app]           UI: http://localhost:3001
[app]  UI External: http://192.168.68.119:3001
[app]  ---------------------------------------
[app] [Browsersync] Watching files...
[app] Server started at http://localhost:8080
```

We’re showing the user 5 different URLs here, and putting the onus on them to work out which one they need to use.

Reduce the confusion by not logging the Express URL, and only outputting the BrowerSync URLs.