### PR TITLE
Disable BrowserSync UI by default

### DIFF
--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -48,6 +48,18 @@ By default, the local server will only accept connections from the same machine.
 ALLOW_EXTERNAL_CONNECTIONS=true npm start
 ```
 
+The review app uses BrowserSync, which allows you to:
+
+- sync interactions across multiple browsers
+- add outlines and grids to the page to aid debugging
+- throttle the network speed
+
+The user interface for this is disabled by default. To enable it, set the `ENABLE_BROWSERSYNC_UI` environment variable to true:
+
+```shell
+ENABLE_BROWSERSYNC_UI=true npm start
+```
+
 ## Deploying
 
 You can deploy your project straight to a Heroku instance.

--- a/packages/govuk-frontend-review/browsersync.config.js
+++ b/packages/govuk-frontend-review/browsersync.config.js
@@ -29,6 +29,9 @@ module.exports = {
   // Prevent browser opening
   open: false,
 
+  // Disable BrowserSync UI
+  ...(process.env.ENABLE_BROWSERSYNC_UI === 'true' ? {} : { ui: false }),
+
   // Allow for Express.js restart
   reloadDelay: 1000,
 


### PR DESCRIPTION
We don’t use it.

Disabling it saves a few resources and takes us down to only one URL listed in the BrowserSync ‘Access URLs’ in the console, reducing confusion for users.