### PR TITLE
Add missing 'Restore dependecies' test to Export test jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -273,6 +273,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
       - name: Restore build
         uses: ./.github/workflows/actions/build
 


### PR DESCRIPTION
The job only had the 'Restore build' step. However, if a cache with the build is missing, the build will need to run again. For this, we need the dependencies installed.

> [!NOTE]
> We could look at combining the two actions in a single one, with an option to [trigger the caching of browser downloads](https://github.com/alphagov/govuk-frontend/blob/main/.github/workflows/screenshots.yml#L78-L85) used for the screenshot workflow.