### PR TITLE
Update tag colours to use govuk_palette

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/tag/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tag/_index.scss
@@ -25,8 +25,8 @@
     padding-right: 8px;
     padding-bottom: 3px;
     padding-left: 8px;
-    color: govuk-shade(govuk-colour("blue"), 60%);
-    background-color: govuk-tint(govuk-colour("blue"), 70%);
+    color: govuk-colour("black");
+    background-color: govuk-colour("blue", $variant: "tint-80");
     text-decoration: none;
     overflow-wrap: break-word;
 
@@ -44,52 +44,52 @@
   }
 
   .govuk-tag--grey {
-    color: govuk-shade(govuk-colour("black", $variant: "tint-25"), 50%);
-    background-color: govuk-tint(govuk-colour("black", $variant: "tint-25"), 85%);
+    color: govuk-colour("black", $variant: "tint-25");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 
   .govuk-tag--purple {
-    color: govuk-shade(govuk-colour("magenta", $variant: "shade-25"), 50%);
-    background-color: govuk-tint(govuk-colour("magenta", $variant: "shade-25"), 85%);
+    color: govuk-colour("purple", $variant: "shade-50");
+    background-color: govuk-colour("purple", $variant: "tint-80");
   }
 
   .govuk-tag--turquoise {
-    color: govuk-shade(govuk-colour("blue", $variant: "tint-25"), 60%);
-    background-color: govuk-tint(govuk-colour("blue", $variant: "tint-25"), 80%);
+    color: govuk-colour("teal", $variant: "shade-50");
+    background-color: govuk-colour("teal", $variant: "tint-80");
   }
 
   .govuk-tag--blue {
-    color: govuk-shade(govuk-colour("blue"), 60%);
-    background-color: govuk-tint(govuk-colour("blue"), 70%);
+    color: govuk-colour("black");
+    background-color: govuk-colour("blue", $variant: "tint-80");
   }
 
   .govuk-tag--light-blue {
-    color: govuk-shade(govuk-colour("blue"), 60%);
-    background-color: govuk-tint(govuk-colour("blue"), 90%);
+    color: govuk-colour("blue", $variant: "shade-50");
+    background-color: govuk-colour("blue", $variant: "tint-95");
   }
 
   .govuk-tag--yellow {
-    color: govuk-shade(govuk-colour("yellow"), 65%);
-    background-color: govuk-tint(govuk-colour("yellow"), 75%);
+    color: govuk-colour("yellow", $variant: "shade-50");
+    background-color: govuk-colour("yellow", $variant: "tint-80");
   }
 
   .govuk-tag--orange {
-    color: govuk-shade(govuk-colour("orange"), 55%);
-    background-color: govuk-tint(govuk-colour("orange"), 70%);
+    color: govuk-colour("orange", $variant: "shade-50");
+    background-color: govuk-colour("orange", $variant: "tint-80");
   }
 
   .govuk-tag--red {
-    color: govuk-shade(govuk-colour("red"), 80%);
-    background-color: govuk-tint(govuk-colour("red"), 75%);
+    color: govuk-colour("red", $variant: "shade-50");
+    background-color: govuk-colour("red", $variant: "tint-80");
   }
 
   .govuk-tag--pink {
-    color: govuk-shade(govuk-colour("magenta", $variant: "primary"), 50%);
-    background-color: govuk-tint(govuk-colour("magenta", $variant: "primary"), 85%);
+    color: govuk-colour("magenta", $variant: "shade-50");
+    background-color: govuk-colour("magenta", $variant: "tint-80");
   }
 
   .govuk-tag--green {
-    color: govuk-shade(govuk-colour("green"), 20%);
-    background-color: govuk-tint(govuk-colour("green"), 80%);
+    color: govuk-colour("green", $variant: "shade-50");
+    background-color: govuk-colour("green", $variant: "tint-80");
   }
 }


### PR DESCRIPTION
Update the tag component with mapped colours from the new palette.

Functionally identical to https://github.com/alphagov/govuk-frontend/pull/6310 but creating a new PR for github info architecture purity. Details of colours picked can be found in the comments of https://github.com/alphagov/govuk-frontend/issues/6267.

Closes https://github.com/alphagov/govuk-frontend/issues/6329