### PR TITLE
Restore logging of review app startup

### DIFF
--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "dev": "gulp dev --color",
+    "dev": "cross-env-shell REVIEW_APP_SILENT_START=true gulp dev --color",
     "prebuild": "npm run clean",
     "build": "gulp build --color",
     "build:sassdoc": "sassdoc --config sassdoc.config.yaml ../govuk-frontend/src/govuk",

--- a/packages/govuk-frontend-review/src/start.mjs
+++ b/packages/govuk-frontend-review/src/start.mjs
@@ -1,10 +1,19 @@
-import { ports } from '@govuk-frontend/config'
+import { ports, urls } from '@govuk-frontend/config'
 
 import app from './app.mjs'
 
 const server = await app()
 
-server.listen({
-  host: process.env.ALLOW_EXTERNAL_CONNECTIONS ? null : 'localhost',
-  port: ports.app
-})
+server.listen(
+  {
+    host: process.env.ALLOW_EXTERNAL_CONNECTIONS ? null : 'localhost',
+    port: ports.app
+  },
+  () => {
+    // Allow to disable the startup logs to avoid confusing users
+    // if other URLs are showed on screen (Browsersync's URLs, for ex.)
+    if (!process.env.REVIEW_APP_SILENT_START) {
+      console.log(`Review app started at ${urls.app}`)
+    }
+  }
+)


### PR DESCRIPTION
It was removed by https://github.com/alphagov/govuk-frontend/pull/6320, but it's the only sign that we have on Heroku that the app has started.

To prevent the logs from showing locally, ties the `console.log` call to the presence of a new REVIEW_APP_SILENT_START environment variable.