### PR TITLE
Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/bundler-integrations.yml
+++ b/.github/workflows/bundler-integrations.yml
@@ -9,6 +9,9 @@ jobs:
     name: Test tree shaking
     runs-on: ubuntu-22.04
 
+    permissions:
+      contents: read
+
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
 

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -11,6 +11,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: sass-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -4,6 +4,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: screenshots-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/stats-comment.yml
+++ b/.github/workflows/stats-comment.yml
@@ -4,6 +4,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write # For writing comments
+
 jobs:
   generate-stats:
     name: Generate stats

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -313,6 +317,7 @@ jobs:
     needs: [install]
 
     permissions:
+      contents: read
       pull-requests: write
 
     # Run existing "Diff changes to npm package" workflow
@@ -324,6 +329,7 @@ jobs:
     needs: [install]
 
     permissions:
+      contents: read
       pull-requests: write
 
     # Run existing "Stats comment" workflow


### PR DESCRIPTION
Code scanning has flagged that we [don't set explicit permissions](https://github.com/alphagov/govuk-frontend/security/code-scanning) on our GitHub Actions workflows, so this does that.

I've started with `contents: read` then added permissions until workflows completed.