### PR TITLE
Simplify regular expressions in i18n.t to make them non-polynomial

### DIFF
--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -33,7 +33,7 @@ export class I18n {
    * @param {{ [key: string]: unknown }} [options] - Any options passed with the translation string, e.g: for string interpolation.
    * @returns {string} The appropriate translation string.
    * @throws {Error} Lookup key required
-   * @throws {Error} Options required for `${}` placeholders
+   * @throws {Error} Options required for `%{}` placeholders
    */
   t(lookupKey, options) {
     if (!lookupKey) {
@@ -58,7 +58,7 @@ export class I18n {
     }
 
     if (typeof translation === 'string') {
-      // Check for ${} placeholders in the translation string
+      // Check for %{} placeholders in the translation string
       // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
       if (translation.match(/%{(.\S+)}/)) {
         if (!options) {

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -59,8 +59,7 @@ export class I18n {
 
     if (typeof translation === 'string') {
       // Check for %{} placeholders in the translation string
-      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-      if (translation.match(/%{(\S+)}/)) {
+      if (/%{(\S+)}/.test(translation)) {
         if (!options) {
           throw new Error(
             'i18n: cannot replace placeholders in string if no option data provided'

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -60,7 +60,7 @@ export class I18n {
     if (typeof translation === 'string') {
       // Check for %{} placeholders in the translation string
       // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-      if (translation.match(/%{(.\S+)}/)) {
+      if (translation.match(/%{(\S+)}/)) {
         if (!options) {
           throw new Error(
             'i18n: cannot replace placeholders in string if no option data provided'
@@ -93,7 +93,7 @@ export class I18n {
       : undefined
 
     return translationString.replace(
-      /%{(.\S+)}/g,
+      /%{(\S+)}/g,
 
       /**
        * Replace translation string placeholders


### PR DESCRIPTION
This addresses a couple of GitHub Code Scanning alerts relating to [the regular expressions we use being polynomial](https://codeql.github.com/codeql-query-help/javascript/js-polynomial-redos/).

We're not particularly concerned about these alerts as the regexes should not be used against user-controlled data, but they're worth addressing anyway.

Thanks to @chrisns who explained:

> “You do not need both `.` and `\S+`. The ambiguity comes from their combination, which makes overlapping matching possible.”

This change does alter the behaviour of the function.

The use of `.\S+` in the current regex allows for a single leading space within the placeholder name (e.g. `%{ foo}`) because:

- `.` matches ANY character except newline, *including* a space
- `\S+` matches one or more *non-whitespace* characters (letters, digits, symbols, etc.)

By removing the `.` in the regular expression a leading space is no longer permitted as part of the placeholder name.

I don’t believe this was an intentional feature, and given the i18n library remains private and I think we can safely make this change as we know how it is used internally.

I've also fixed a couple of comments that incorrectly used `${}` for the placeholder format, and switched to using `Regexp.prototype.test` over `String.prototype.match` where we just want to know if the translation string matches the regex or not.