### PR TITLE
Enable Express server to allow external connections

### DIFF
--- a/packages/govuk-frontend-review/src/start.mjs
+++ b/packages/govuk-frontend-review/src/start.mjs
@@ -5,6 +5,6 @@ import app from './app.mjs'
 const server = await app()
 
 server.listen({
-  host: 'localhost',
+  host: process.env.ALLOW_EXTERNAL_CONNECTIONS ? null : 'localhost',
   port: ports.app
 })


### PR DESCRIPTION
When deployed on Heroku, the server needs to listen on all interfaces, not just 'localhost', otherwise requests cannot reach it.