### PR TITLE
Add Dart Sass version changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The Sass developers have provided guides for:
 
 This change was introduced in [pull request #6311: Remove support for Ruby Sass and LibSass](https://github.com/alphagov/govuk-frontend/pull/6311).
 
+#### We've set our minimum Dart Sass version to 1.79
+
+GOV.UK Frontend will no longer support services using Dart Sass versions earlier than 1.79. If you're using an earlier version of Dart Sass, your service's Sass may break, as GOV.UK Frontend may use features in Dart Sass that are not available in earlier versions.
+
+If you're using an earlier version of Dart Sass than 1.79, see [the Dart Sass releases](https://github.com/sass/dart-sass/releases) and follow their release notes to upgrade to version 1.79 or later to continue using GOV.UK Frontend.
+
+This change was introduced in [pull request #6366: Update Dart Sass tests minimum version to 1.79.0](https://github.com/alphagov/govuk-frontend/pull/6366)
+
 ## v6.0.0-beta.0 (Beta breaking release)
 
 To install this version with npm, run `npm install govuk-frontend@6.0.0-beta.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.


### PR DESCRIPTION
Does 2 things:

1. Moves the changelog entry for drop LibSass and Ruby Sass into the 'Unreleased' section
2. Adds a changelog entry for setting our Dart Sass minimum support version, using https://github.com/alphagov/govuk-frontend/pull/6366 as a reference PR like we did for the LibSass/Ruby Sass policy change