### PR TITLE
Replace scaled colours with palette variants

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -119,7 +119,7 @@
   }
 
   &:hover {
-    color: scale-color($govuk-error-colour, $lightness: -30%);
+    color: govuk-colour("red", $variant: "shade-50");
   }
 
   &:active {
@@ -156,7 +156,7 @@
   }
 
   &:hover {
-    color: scale-color($govuk-success-colour, $lightness: -30%);
+    color: govuk-colour("green", $variant: "shade-50");
   }
 
   &:active {


### PR DESCRIPTION
We're trying to use direct palette colours across the codebase, but we missed changing these.

## Success link hover
<img width="1098" height="885" alt="Success notification banner hover link" src="https://github.com/user-attachments/assets/af68d0b2-b56c-4d41-be29-19094dcf7843" />

## Error link hover
<img width="1116" height="515" alt="Error summary link hover" src="https://github.com/user-attachments/assets/00b10c18-3f5b-48c7-8d3d-ca72266cd38f" />
