### PR TITLE
Add documentation on minimum Sass version

### DIFF
--- a/docs/contributing/sass-support.md
+++ b/docs/contributing/sass-support.md
@@ -10,12 +10,10 @@ The developers of Sass discontinued Ruby Sass in 2019. LibSass was subsequently 
 
 ## How we determine the minimum Dart Sass version we support
 
-We will update the minimum supported version of Dart Sass with each major release of GOV.UK Frontend, starting from version 6.0.0.
-
-When doing so, we will:
+We'll update the minimum supported version of Dart Sass with each major release of GOV.UK Frontend, starting from version 6.0.0. We plan to do this by following the steps below.
 
 1. Select a version of Dart Sass that was released at least 12 months before the planned release date of the major GOV.UK Frontend version.
 2. Request feedback from the community to find any issues preventing the use of that version of Dart Sass.
-3. If no major problems are identified, update Frontend's documentation and automated tests to use the selected version of Dart Sass.
+3. If no major problems are identified, update GOV.UK Frontend's documentation and automated tests to use the selected version of Dart Sass.
 
-The version of Dart Sass chosen is at the team's discretion, but will take into account factors such as major feature additions, deprecations, or bugfixes included in the version.
+The version of Dart Sass chosen is at the team's discretion, but will take into account factors such as major feature additions, deprecations, or bug fixes included in the version.


### PR DESCRIPTION
Adds documentation about how we're determining our minimum supported version of Dart Sass.

Related to:
- https://github.com/alphagov/govuk-frontend/issues/6234
- https://github.com/alphagov/govuk-frontend-docs/issues/558

## Thoughts

I've not included anything specific about how we might deal with breaking releases of Sass itself (Dart Sass 2.x will remove support for various deprecated things that, at current, we still use). 

I think we're partially covered by our "at least 12 months" guide to stick to older Sass versions for a while, if we want to do so, whilst being able to say we don't support Dart Sass 2.x is something we can figure out when it's closer to releasing.