### PR TITLE
Log remaining `govuk-<SOMETHING>()` calls when test fails

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.unit.test.mjs
@@ -94,9 +94,12 @@ describe('GOV.UK Frontend', () => {
   it('does not contain any unexpected govuk- function calls', async () => {
     const sass = '@import "index"'
 
-    await expect(compileSassString(sass)).resolves.toMatchObject({
-      css: expect.not.stringMatching(/_?govuk-[\w-]+\(.*?\)/g)
-    })
+    const { css } = await compileSassString(sass)
+    const matches = css.matchAll(/_?govuk-[\w-]+\(.*?\)/g)
+
+    // `matchAll` does not return an actual `Array` so we need
+    // a little conversion before we can check its length
+    expect(Array.from(matches)).toHaveLength(0)
   })
 
   describe('Sass documentation', () => {


### PR DESCRIPTION
The test detecting if any `govuk-<SOMETHING>()` calls make it to the CSS output was only telling you a function made it through (likely through a typo). That's very little information to go by to find  which function made it through and where.

This new test checks the length of the regex matches, allowing Jest to output the list of matches if the test fails:

```
    Expected length: 0
    Received length: 1
    Received array:  [["govuk-color(\"black\")"]]
```

This should then allow to search the codebase for the misspelt call and fix it.