### PR TITLE
Deprecate turquoise and pink tag colour modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,19 @@ We've now removed the Header component's `useTudorCrown` parameter and assets re
 
 This change was introduced in [pull request #6414: Remove `useTudorCrown` parameter and St. Edwards crown assets](https://github.com/alphagov/govuk-frontend/pull/6414)
 
+### Recommended changes
+
+#### Rename turquoise and pink coloured tags
+
+We've renamed 2 of the Tag component's colour modifier classes to be in line with GOV.UK Frontend's new colour palette:
+
+- `govuk-tag--turquoise` is now `govuk-tag--teal`
+- `govuk-tag--pink` is now `govuk-tag--magenta`
+
+Rename your tags to reflect these changes, as we'll be removing `govuk-tag--turquoise` and `govuk-tag--pink` in a future breaking release.
+
+This change was introduced in [pull request #6416: Deprecate turquoise and pink tag colour modifiers](https://github.com/alphagov/govuk-frontend/pull/6416)
+
 ### Fixes
 
 #### Tags now have borders for improved legibility

--- a/packages/govuk-frontend/src/govuk/components/tag/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tag/_index.scss
@@ -98,12 +98,22 @@
     @include _govuk-tag-colours("yellow");
   }
 
-  // Turquoise and pink use consistent tag colour rules but a different colour
-  // name; teal for turquoise and magenta for pink
+  .govuk-tag--teal {
+    @include _govuk-tag-colours("teal");
+  }
+
+  .govuk-tag--magenta {
+    @include _govuk-tag-colours("magenta");
+  }
+
+  // Turquoise and pink are deprecated over teal and magenta respectively
+
+  // @deprecated
   .govuk-tag--turquoise {
     @include _govuk-tag-colours("teal");
   }
 
+  // @deprecated
   .govuk-tag--pink {
     @include _govuk-tag-colours("magenta");
   }

--- a/packages/govuk-frontend/src/govuk/components/tag/tag.yaml
+++ b/packages/govuk-frontend/src/govuk/components/tag/tag.yaml
@@ -31,8 +31,8 @@ examples:
       classes: govuk-tag--light-blue
   - name: turquoise
     options:
-      text: Turquoise
-      classes: govuk-tag--turquoise
+      text: Teal
+      classes: govuk-tag--teal
   - name: green
     options:
       text: Green
@@ -43,8 +43,8 @@ examples:
       classes: govuk-tag--purple
   - name: pink
     options:
-      text: Pink
-      classes: govuk-tag--pink
+      text: Magenta
+      classes: govuk-tag--magenta
   - name: red
     options:
       text: Red

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -153,7 +153,7 @@ examples:
           status:
             tag:
               text: Review
-              classes: govuk-tag--pink
+              classes: govuk-tag--magenta
         - title:
             text: Documentation
           href: '#'
@@ -216,8 +216,8 @@ examples:
           href: '#'
           status:
             tag:
-              text: Turquoise
-              classes: govuk-tag--turquoise
+              text: Teal
+              classes: govuk-tag--teal
         - title:
             text: Task G
           href: '#'
@@ -237,8 +237,8 @@ examples:
           href: '#'
           status:
             tag:
-              text: Pink
-              classes: govuk-tag--pink
+              text: Magenta
+              classes: govuk-tag--magenta
         - title:
             text: Task J
           href: '#'


### PR DESCRIPTION
Replaces `govuk-tag--turquoise` with `govuk-tag--teal` and vice verca for `pink` and `magenta`, plus updates to our examples. Resolves https://github.com/alphagov/govuk-frontend/issues/6388