### PR TITLE
Fix visually hidden link text in review app

### DIFF
--- a/packages/govuk-frontend-review/src/views/macros/showExamples.njk
+++ b/packages/govuk-frontend-review/src/views/macros/showExamples.njk
@@ -37,7 +37,7 @@
         <div class="govuk-width-container">
           <p class="govuk-body">
             <a href="{{ path }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-              Open this example in a new tab<span class="govuk-visually-hidden">: {{ heading + (', rebrand flag ' + 'on' if state else 'off') | safe | lower }}</span>
+              Open this example in a new tab<span class="govuk-visually-hidden">: {{ heading + ', rebrand flag ' + ('on' if state else 'off') | safe }}</span>
             </a>
           </p>
         </div>


### PR DESCRIPTION
Fixes the malformed 'off' text in the visually hidden link text that open examples in the review app.

Fixes #6226.

## Changes

- Tweaked Nunjucks logic to fix output text.
- Removed `lower` Nunjucks filter, as this didn't appear to be doing anything. 

With rebrand flag off:
- Before: Open this example in a new tab: Header with product nameoff
- After: Open this example in a new tab: Header with product name, rebrand flag off

With rebrand flag on:
- Before: Open this example in a new tab: Header with product name, rebrand flag on
- After: Open this example in a new tab: Header with product name, rebrand flag on