### PR TITLE
Fix which map is used to generate the applied colours properties

### DIFF
--- a/packages/govuk-frontend/src/govuk/core/_govuk-frontend-properties.scss
+++ b/packages/govuk-frontend/src/govuk/core/_govuk-frontend-properties.scss
@@ -12,7 +12,7 @@
     }
 
     // CSS custom properties for each applied colour
-    @each $name, $value in $govuk-applied-colours {
+    @each $name, $value in $_govuk-applied-colours {
       --_govuk-#{$name}-colour: #{$value};
     }
   }

--- a/packages/govuk-frontend/src/govuk/core/govuk-frontend-properties.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/core/govuk-frontend-properties.unit.test.mjs
@@ -49,10 +49,6 @@ describe('GOV.UK Frontend custom properties', () => {
     it('outputs one custom property for each applied colour', async () => {
       const sass = `
         @import "base";
-        $govuk-applied-colours: (
-          brand: govuk-colour('blue'),
-          text: govuk-colour('black')
-        );
 
         @import "core/govuk-frontend-properties";
       `


### PR DESCRIPTION
Because the test was mocking the `$govuk-applied-colours` variable with a reduced list of properties, we missed `govuk-frontend-properties` wasn't updated to use the private `$_govuk-applied-colours` map containing the merge of user values with our defaults.

This PR fixes that and updates the test to avoid mocking.