### PR TITLE
Fix skip link outline being clipped in forced colours mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#6351: Preserve already escaped `attributes` values to prevent double escaping](https://github.com/alphagov/govuk-frontend/pull/6351) – thanks to @colinrotherham for fixing this issue
 - [#6462: Update HMRC brand colour](https://github.com/alphagov/govuk-frontend/pull/6462)
 - [#6454: Prevent date inputs shifting alignment on iOS 18](https://github.com/alphagov/govuk-frontend/pull/6454) – thanks to @rowellx68 for reporting this issue and @colinrotherham for suggesting the fix.
+- [#6445: Fix skip link outline being clipped in forced colours mode](https://github.com/alphagov/govuk-frontend/pull/6445)
 
 ## v6.0.0-beta.1 (Beta breaking release)
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
@@ -24,6 +24,10 @@
       outline-offset: 0;
       background-color: govuk-functional-colour(focus);
 
+      @media (forced-colors: active) {
+        outline-offset: (0 - $govuk-focus-width);
+      }
+
       // Undo unwanted changes when global styles are enabled
       @if $govuk-global-styles {
         @include govuk-link-decoration;


### PR DESCRIPTION
As skiplinks are typically displayed at the top of the viewport and at full width, the outline style we apply to links in forced-colors mode is clipped on all sides except for the bottom, making it more difficult to see that the link is currently focused.

Fixes #4100.

## Changes

- Adds a negative `outline-offset` when forced-colors mode is active, so that the outline is visibly rendered within the bounds of the skip link. 

## Screenshots

|Before|After|
|:-:|:-:|
|<img width="878" height="230" alt="Screenshot of the top of a GOV.UK page in dark forced colours mode, with the skiplink focused, showing the outline on the bottom only." src="https://github.com/user-attachments/assets/2a0f354f-c77f-4283-a435-f7d25a9ebd2a" />|<img width="878" height="230" alt="Screenshot of the top of a GOV.UK page in dark forced colours mode, with the skiplink focused, showing the outline on all four sides." src="https://github.com/user-attachments/assets/550dba8e-dec6-4566-86e7-e1401834779c" />|