### PR TITLE
Prevent date inputs shifting alignment on iOS 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
-- [#6351: Preserve already escaped `attributes` values to prevent double escaping](https://github.com/alphagov/govuk-frontend/pull/6351) thanks to @colinrotherham for fixing this issue
+- [#6351: Preserve already escaped `attributes` values to prevent double escaping](https://github.com/alphagov/govuk-frontend/pull/6351) – thanks to @colinrotherham for fixing this issue
 - [#6462: Update HMRC brand colour](https://github.com/alphagov/govuk-frontend/pull/6462)
+- [#6454: Prevent date inputs shifting alignment on iOS 18](https://github.com/alphagov/govuk-frontend/pull/6454) – thanks to @rowellx68 for reporting this issue and @colinrotherham for suggesting the fix.
 
 ## v6.0.0-beta.1 (Beta breaking release)
 

--- a/packages/govuk-frontend/src/govuk/components/date-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/date-input/_index.scss
@@ -14,6 +14,11 @@
     display: inline-block;
     margin-right: govuk-spacing(4);
     margin-bottom: 0;
+
+    // Prevents an issue in iOS Safari 18 where the items vertically
+    // shift when the value of inputs is changed.
+    // https://github.com/alphagov/reported-bugs/issues/90
+    vertical-align: bottom;
   }
 
   .govuk-date-input__label {


### PR DESCRIPTION
Due to [an upstream issue in Safari on iOS 18](https://github.com/alphagov/reported-bugs/issues/90) (and potentially iOS 17), the box model calculations for children of the Date input component go a bit wrong when an input's value is deleted and re-typed.

The issue was reported to the WebKit team during the beta period of iOS 26 and fixed before the final release of iOS 26 in September, however no fix for older versions of iOS has yet happened nor appears to be coming, so we should prevent the issue in our own code until iOS 18 has fallen out of browsers we support.

The specific fix is the one suggested by @colinrotherham in the NHS.UK Frontend issue: https://github.com/nhsuk/nhsuk-frontend/issues/1227#issuecomment-2796496825

Closes #5861.

## Changes
- Added `vertical-align` rule to items within the Date input component.