### PR TITLE
Update HMRC brand colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6351: Preserve already escaped `attributes` values to prevent double escaping](https://github.com/alphagov/govuk-frontend/pull/6351) thanks to @colinrotherham for fixing this issue
+- [#6462: Update HMRC brand colour](https://github.com/alphagov/govuk-frontend/pull/6462)
 
 ## v6.0.0-beta.1 (Beta breaking release)
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -70,7 +70,7 @@ $govuk-colours-organisations: (
     colour: #266ebc
   ),
   "hm-revenue-customs": (
-    colour: #008476
+    colour: #008670
   ),
   "hm-treasury": (
     colour: #b2292e


### PR DESCRIPTION
The colour listed by brand.gov.uk has been updated.

## Changes
- Updates the colour for HM Revenue & Customs in the organisation palette. 
  - As this colour already meets 4.5:1 minimum contrast against white, it does not need a contrast-safe alternative. 