### PR TITLE
[SPIKE] Detach `<header>` and `<footer>` elements from components, add new template blocks

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -3,7 +3,7 @@
 
 {%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
-<footer class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
+<div class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
     {% if _rebrand %}
@@ -106,4 +106,4 @@
       </div>
     </div>
   </div>
-</footer>
+</div>

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -3,7 +3,7 @@
 
 {%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
-<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
+<div class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default("//gov.uk", true) }}" class="govuk-header__homepage-link">
@@ -20,4 +20,4 @@
       </a>
     </div>
   </div>
-</header>
+</div>

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -43,10 +43,14 @@
       }) }}
     {% endblock %}
 
-    {% block header %}
-      {{ govukHeader({
-        rebrand: _rebrand
-      }) }}
+    {% block templateHeader %}
+      <header>
+      {% block header %}
+        {{ govukHeader({
+          rebrand: _rebrand
+        }) }}
+      {% endblock %}
+      </header>
     {% endblock %}
 
     {% block main %}
@@ -58,10 +62,14 @@
       </div>
     {% endblock %}
 
-    {% block footer %}
-      {{ govukFooter({
-        rebrand: _rebrand
-      }) }}
+    {% block templateFooter %}
+      <footer>
+      {% block footer %}
+        {{ govukFooter({
+          rebrand: _rebrand
+        }) }}
+      {% endblock %}
+      </footer>
     {% endblock %}
 
     {% block bodyEnd %}{% endblock %}


### PR DESCRIPTION
Spike for #6458. An "MVP+" that moves the `<header>` and `<footer>` elements to the template and introduces a new wrapping block to allow customisation of the elements.

## Changes
- Changed GOV.UK Header and Footer components to use `<div>` elements.
- Moved `<header>` and `<footer>` elements to the template.
- Wrapped the `<header>` and `<footer>` in new `templateHeader` and `templateFooter` blocks.

## Thoughts

### Pros

- **Backwards compatible.** Simple customisations of the `header` or `footer` blocks will be retained and are unlikely to be misrepresented.
- **Elements remain customisable.** Teams can still add, remove, or change the presence and attributes of the `<header>` and `<footer>` elements using the newly provided blocks. 

### Cons

- **Potential for undesired landmarks.** Teams that previously removed the header or footer by providing blank `header` and `footer` blocks will now have header and footer landmarks again.
- **Potential for duplicated landmarks.** Teams that previously overrode the header or footer with entirely new elements that are not the Design System components will now have duplicated `<header>` and `<footer>` elements. 