### PR TITLE
[SPIKE] Detach `<header>` and `<footer>` elements from components

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -3,7 +3,7 @@
 
 {%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
-<footer class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
+<div class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
     {% if _rebrand %}
@@ -106,4 +106,4 @@
       </div>
     </div>
   </div>
-</footer>
+</div>

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -3,7 +3,7 @@
 
 {%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
-<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
+<div class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default("//gov.uk", true) }}" class="govuk-header__homepage-link">
@@ -20,4 +20,4 @@
       </a>
     </div>
   </div>
-</header>
+</div>

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -43,11 +43,13 @@
       }) }}
     {% endblock %}
 
+    <header>
     {% block header %}
       {{ govukHeader({
         rebrand: _rebrand
       }) }}
     {% endblock %}
+    </header>
 
     {% block main %}
       <div class="govuk-width-container {%- if containerClasses %} {{ containerClasses }}{% endif %}">
@@ -58,11 +60,13 @@
       </div>
     {% endblock %}
 
+    <footer>
     {% block footer %}
       {{ govukFooter({
         rebrand: _rebrand
       }) }}
     {% endblock %}
+    </footer>
 
     {% block bodyEnd %}{% endblock %}
   </body>


### PR DESCRIPTION
Spike for #6458. An MVP that moves the `<header>` and `<footer>` elements to the template and nothing else.

## Changes
- Changed GOV.UK Header and Footer components to use `<div>` elements.
- Moved `<header>` and `<footer>` elements to the template.

## Thoughts

### Pros

- **Backwards compatible.** Simple customisations of the `header` or `footer` blocks will be retained and are unlikely to be misrepresented.

### Cons

- **Elements are not customisable.** Teams cannot remove or change the `<header>` and `<footer>` elements. This means that they will always be present on the page, even if there is no content within them.
- **Potential for undesired landmarks.** Teams that previously removed the header or footer by providing blank `header` and `footer` blocks will now have header and footer landmarks again.
- **Potential for duplicated landmarks.** Teams that previously overrode the header or footer with entirely new elements that are not the Design System components will now have duplicated `<header>` and `<footer>` elements. 