### PR TITLE
[SPIKE] Detach `<header>` and `<footer>` elements from components, rename existing template blocks

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -3,7 +3,7 @@
 
 {%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
-<footer class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
+<div class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
     {% if _rebrand %}
@@ -106,4 +106,4 @@
       </div>
     </div>
   </div>
-</footer>
+</div>

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -3,7 +3,7 @@
 
 {%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
 
-<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
+<div class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
   <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default("//gov.uk", true) }}" class="govuk-header__homepage-link">
@@ -20,4 +20,4 @@
       </a>
     </div>
   </div>
-</header>
+</div>

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -44,9 +44,15 @@
     {% endblock %}
 
     {% block header %}
-      {{ govukHeader({
-        rebrand: _rebrand
-      }) }}
+      <header class="govuk-template__header">
+      {% block headerStart %}{% endblock %}
+      {% block headerContent %}
+        {{ govukHeader({
+          rebrand: _rebrand
+        }) }}
+      {% endblock %}
+      {% block headerEnd %}{% endblock %}
+      </header>
     {% endblock %}
 
     {% block main %}
@@ -59,9 +65,15 @@
     {% endblock %}
 
     {% block footer %}
-      {{ govukFooter({
-        rebrand: _rebrand
-      }) }}
+      <footer class="govuk-template__footer">
+      {% block footerStart %}{% endblock %}
+      {% block footerContent %}
+        {{ govukFooter({
+          rebrand: _rebrand
+        }) }}
+      {% endblock %}
+      {% block footerEnd %}{% endblock %}
+      </footer>
     {% endblock %}
 
     {% block bodyEnd %}{% endblock %}


### PR DESCRIPTION
Spike for #6458. A more full-on version that moves the `<header>` and `<footer>` elements to the template and introduces multiple new blocks to allow customisation of the elements and surrounding parts of the page.

## Changes
- Changed GOV.UK Header and Footer components to use `<div>` elements.
- Moved `<header>` and `<footer>` elements to the template.
- Added new `headerStart`, `headerEnd`, `footerStart` and `footerEnd` blocks. 
- Added `govuk-template__header` and `govuk-template__footer` classes to the `<header>` and `<footer>` elements, to make future customisations easier.
- Moved the existent `header` and `footer` blocks to surround the new blocks and elements.
- Renamed the prior blocks to `headerContent` and `footerContent`. 

## Thoughts

### Pros

- **Elements remain customisable.** Teams can still add, remove, or change the presence and attributes of the `<header>` and `<footer>` elements using the newly provided blocks. 
- **Easier customisation.** The addition of new blocks and classes make it easier for teams to tweak the header and footer and inject content into them, without having to override Nunjucks blocks and re-implement the `govukHeader` and `govukFooter` components.
- **Consistent naming.** The names of the blocks are consistently 'namespaced', with `header` as the parent and `header*` being children of it. 
- **Removed landmarks stay removed.** If a team has previously removed the header or footer by providing a blank block, then the removal will stay consistent.

### Cons

- **Breaking change.** Users not using our header and footer Nunjucks components _must_ make manual changes to their code to not have a header and footer that are lacking `<header>` and `<footer>` elements, or have duplicates of those elements. This change not being visual makes it more likely for it to slip through the cracks.
- **Potential for duplicated landmarks.** Teams that previously overrode the header or footer with entirely new elements that are not the Design System components will now have duplicated `<header>` and `<footer>` elements. 
- **Unnecessary overlap in intended use of blocks.** The new header/footer start and end blocks don't provide any functionality that doesn't already exist from customising the existing `header` and `footer` blocks.