### PR TITLE
Move `head` block before `headIcons`

### DIFF
--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -17,6 +17,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="{{ themeColor }}">
 
+    {% block head %}{% endblock %}
+
     {% block headIcons %}
       <link rel="icon" sizes="48x48" href="{{ assetPath }}/images/favicon.ico">
       <link rel="icon" sizes="any" href="{{ assetPath }}/images/favicon.svg" type="image/svg+xml">
@@ -24,8 +26,6 @@
       <link rel="apple-touch-icon" href="{{ assetPath }}/images/govuk-icon-180.png">
       <link rel="manifest" href="{{ assetPath }}/manifest.json">
     {% endblock %}
-
-    {% block head %}{% endblock %}
 
     {#- OpenGraph images needs to be absolute, so we need either a URL for the image or for assetUrl to be set #}
     {% if opengraphImageUrl or assetUrl %}


### PR DESCRIPTION
This provides a more performant default. Having `head` before `headIcons` allows critical resources, particularly CSS,
 to start being downloaded before the favicons and to implement the [optimal order for elements inside the `<head>` tag](https://speakerdeck.com/csswizardry/get-your-head-straight?slide=39).

## Thoughts

I don't think this change warrants a CHANGELOG entry as it'll be transparent to users.
 
 Fixes #6477.
