### PR TITLE
[SPIKE] Separate blocks around `govuk-width-container` and `main` elements

### DIFF
--- a/packages/govuk-frontend/src/govuk/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/template.jsdom.test.js
@@ -697,16 +697,52 @@ describe('Template', () => {
     })
 
     describe('<main>', () => {
-      it('can have custom classes added using mainClasses', () => {
-        replacePageWith(
-          renderTemplate('govuk/template.njk', {
-            context: {
-              mainClasses: 'custom-main-class'
-            }
-          })
-        )
+      describe('classes', () => {
+        it('can have custom classes added using `mainClasses`', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                mainClasses: 'custom-main-class'
+              }
+            })
+          )
 
-        expect(document.querySelector('main')).toHaveClass('custom-main-class')
+          expect(document.querySelector('main')).toHaveClass(
+            'custom-main-class'
+          )
+        })
+
+        it('can have custom classes added using `pageMainClasses`', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                pageMainClasses: 'custom-page-main-class'
+              }
+            })
+          )
+
+          expect(document.querySelector('main')).toHaveClass(
+            'custom-page-main-class'
+          )
+        })
+
+        it('gives precedence to `pageMainClasses` over `mainClasses`', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                mainClasses: 'custom-main-class',
+                pageMainClasses: 'custom-page-main-class'
+              }
+            })
+          )
+
+          expect(document.querySelector('main')).toHaveClass(
+            'custom-page-main-class'
+          )
+          expect(document.querySelector('main')).not.toHaveClass(
+            'custom-main-class'
+          )
+        })
       })
 
       describe('lang attribute', () => {

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -55,8 +55,9 @@
         <div class="govuk-width-container {%- if widthContainerClasses %} {{ widthContainerClasses }}{% endif %}">
           {% block widthContainerStart %}{% block beforeContent %}{% endblock %}{% endblock %}
           {% set pageMainLang = pageMainLang | default(mainLang) %}
+          {% set pageMainClasses = pageMainClasses | default(mainClasses) %}
           {% block pageMain %}
-          <main class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}" id="main-content" {%- if pageMainLang %} lang="{{ pageMainLang }}"{% endif %}>
+          <main class="govuk-main-wrapper {%- if pageMainClasses %} {{ pageMainClasses }}{% endif %}" id="main-content" {%- if pageMainLang %} lang="{{ pageMainLang }}"{% endif %}>
             {% block content %}{% endblock %}
           </main>
           {% endblock %}


### PR DESCRIPTION
Add new blocks and variables to be more granular when injecting content in or around the `.govuk-width-container` tag or the `main` element.

## Issues addressed

This PR adresses the following issues with our existing blocks and variables

### `main` block overrides too much

The `main` block not only overrides the `<main>` tag, as you'd expect, but also the `<div class="govuk-width-container">` that wraps it. For a clearer API, this PR introduces:
- a `widthContainer` block to override the whole `<div class="govuk-width-container">` tag
- a `pageMain` (in line with `pageHeader` and `pageFooter` proposed in https://github.com/alphagov/govuk-frontend/pull/6465) to override only the `<main>` tag.

The naming of the `widthContainer` block follows a similar pattern to the blocks around the `govuk<COMPONENT_NAME>` components, where the block is named by dropping the "govuk" part of the component macro. It's also less generic than only "container".

To facilitate migration, the `main` block can still be used. It is deprecated and will be removed in the next major release after this change is shipped.

### `beforeContent` block name is misleading

With its name, you'd expect any HTML set in the `beforeContent` block to appear right before the `content` block. However, it will be injected before the `<main>` tag. Aligning with the `bodyStart` and `bodyEnd` conventions, this PR adds:
- a `widthContainerStart` block to inject content at the start of the `<div class="govuk-width-container">` tag
- a `widthContainerEnd` block to inject content at the end of the `<div class="govuk-width-container">` tag. 

Beyon a consistent naming, having the two blocks allows to wrap the `<main>` tag in a `<div class="govuk-grid-row">`, opening the tag in `widthContainerStart` and closing it in `widthContainerEnd` (and having an `<aside>` in either block for the other column.

The `...Start` and `...End` convention not only matches the `bodyStart` and `bodyEnd` blocks, but seemed more approachable to less dev-savvy users than a single `widthContainerContent` block that users could override, using `super()` to inject the `<main>` element in their desired position.

To facilitate the migration, the `beforeContent` block can still be used. It is deprecated and will be removed in the next major release after this change is shipped.

### `containerClasses` does not follow the new naming around `<div class="govuk-width-container">`

By naming the block around `<div class="govuk-width-container">` `widthContainer`, the `containerClasses` variable setting extra classes in the tag is now inconsistent.

This PR add as new `widthContainerClasses` variable for the same purpose, ensuring a consistent naming.

To facilitate the migration, the `containerClasses` variable can still be used. It is deprecated and will be removed in the next major release after this change is shipped.

## Other thoughts

* Following the `...Start` and `...End` conventions, we could add a `pageMainStart` and `pageMainEnd` block. This can be done in a non-breaking way later on though, and the `content` block already allows to inject content at the start and end of the main tag.
* `widthContainer` sounds a good name for the block around `<div class="govuk-width-container">`. `pageMain` sounds a little wonky though. `mainLandmark` may be more suitable, but diverges from `pageHeader` and `pageFooter` but require users to think of main as a landmark. `mainTag` may be a better option, which also translates well to the header and footer, as well as any kind of tag we may inject in the template in the future
* Do we need to confirm `...Start` and `...End` options are better suited than `...Content` + `super()`? Both approaches can work together with something like the following code, but feels a bit over the top:
	```njk
	{% block widthContainer %}
      {% block main %}
        {% set widthContainerClasses = widthContainerClasses | default(containerClasses) %}
        <div class="govuk-width-container {%- if widthContainerClasses %} {{ widthContainerClasses }}{% endif %}">
			{% block widthContainerContent %}
	          {% block widthContainerStart %}{% block beforeContent %}{% endblock %}{% endblock %}
	          {% block pageMain %}
	          <main class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}" id="main-content" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
	            {% block content %}{% endblock %}
	          </main>
	          {% endblock %}
	          {% block widthContainerEnd %}{% endblock %}
            {% endblock %}
        </div>
      {% endblock %}
    {% endblock %}
	```