### PR TITLE
Add cooldown to dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,8 @@ updates:
       time: '10:30'
       timezone: 'Europe/London'
 
+    cooldown: 7
+
     versioning-strategy: increase
 
     allow:
@@ -105,6 +107,8 @@ updates:
       time: '10:30'
       timezone: 'Europe/London'
 
+    cooldown: 7
+
   # Update GitHub Actions (Install dependencies)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/install-node
@@ -114,9 +118,13 @@ updates:
       time: '10:30'
       timezone: 'Europe/London'
 
+    cooldown: 7
+
   # Update GitHub Actions (Setup Node.js)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/setup-node
+
+    cooldown: 7
 
     schedule:
       interval: monthly


### PR DESCRIPTION
Add a cooldown of 7 days to our dependabot checks. This allows time for any bugs and vulnerabilities from new releases to get found and sorted before we consider merging them.