### PR TITLE
Add cooldown to all Dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,9 @@ updates:
       time: '10:30'
       timezone: 'Europe/London'
 
+    cooldown:
+      default-days: 7
+
     versioning-strategy: increase
 
     allow:
@@ -96,6 +99,9 @@ updates:
       time: '10:30'
       timezone: 'Europe/London'
 
+    cooldown:
+      default-days: 7
+
   # Update GitHub Actions (Build)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/build
@@ -104,6 +110,9 @@ updates:
       interval: monthly
       time: '10:30'
       timezone: 'Europe/London'
+
+    cooldown:
+      default-days: 7
 
   # Update GitHub Actions (Install dependencies)
   - package-ecosystem: github-actions
@@ -114,6 +123,9 @@ updates:
       time: '10:30'
       timezone: 'Europe/London'
 
+    cooldown:
+      default-days: 7
+
   # Update GitHub Actions (Setup Node.js)
   - package-ecosystem: github-actions
     directory: /.github/workflows/actions/setup-node
@@ -122,3 +134,6 @@ updates:
       interval: monthly
       time: '10:30'
       timezone: 'Europe/London'
+
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Take 2. `cooldown` is an object and I've set `default-days` to 7. See https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates