### PR TITLE
v5 backport: #6454 Prevent date inputs shifting alignment on iOS 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6351: Preserve already escaped `attributes` values to prevent double escaping](https://github.com/alphagov/govuk-frontend/pull/6351)
 - [#6438: Fix pagination outputting empty links when provided a null or empty value](https://github.com/alphagov/govuk-frontend/pull/6438) – thanks to @NikhilNanjappa for reporting this issue
+- [#6531: Prevent date inputs shifting alignment on iOS 18](https://github.com/alphagov/govuk-frontend/pull/6531) – thanks to @rowellx68 for reporting this issue and @colinrotherham for suggesting the fix.
 
 ## v5.13.0 (Feature release)
 
@@ -430,7 +431,7 @@ If you use GOV.UK Frontend in a Prototype Kit prototype, enable the refreshed br
 ```json
 "plugins": {
   "govuk-frontend": {
-	"rebrand": true
+    "rebrand": true
   }
 }
 ```

--- a/packages/govuk-frontend/src/govuk/components/date-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/date-input/_index.scss
@@ -14,6 +14,11 @@
     display: inline-block;
     margin-right: govuk-spacing(4);
     margin-bottom: 0;
+
+    // Prevents an issue in iOS Safari 18 where the items vertically
+    // shift when the value of inputs is changed.
+    // https://github.com/alphagov/reported-bugs/issues/90
+    vertical-align: bottom;
   }
 
   .govuk-date-input__label {


### PR DESCRIPTION
Due to an upstream issue in Safari on iOS 18 (and potentially 17), the box model calculations for these inputs go iffy when the value is deleted and re-typed.

The upstream issue was reported during the beta period of iOS 26 and fixed in the release of iOS 26 in September, however no fix for older versions seems to be coming, so we should prevent the issue in our own code in the meantime.

NHS.UK Frontend issue: https://github.com/nhsuk/nhsuk-frontend/issues/1227
Our bug report: https://github.com/alphagov/reported-bugs/issues/90