### PR TITLE
v5 backport: #6445 Fix skip link outline being clipped in forced colours mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#6528: Fix hover state on focused small radios](https://github.com/alphagov/govuk-frontend/pull/6528)
 - [#6529: Fix rebranded header background being visible when printed](https://github.com/alphagov/govuk-frontend/pull/6529) - thanks to @lewis-softwire for reporting this issue
 - [#6462: Update HMRC brand colour](https://github.com/alphagov/govuk-frontend/pull/6462)
+- [#6539: Fix skip link outline being clipped in forced colours mode](https://github.com/alphagov/govuk-frontend/pull/6539)
 
 ## v5.13.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
@@ -24,6 +24,10 @@
       outline-offset: 0;
       background-color: $govuk-focus-colour;
 
+      @media (forced-colors: active) {
+        outline-offset: (0 - $govuk-focus-width);
+      }
+
       // Undo unwanted changes when global styles are enabled
       @if $govuk-global-styles {
         @include govuk-link-decoration;


### PR DESCRIPTION
v5 support branch port of https://github.com/alphagov/govuk-frontend/pull/6445