### PR TITLE
v5 backport: #6462 - Update HMRC brand colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#6531: Prevent date inputs shifting alignment on iOS 18](https://github.com/alphagov/govuk-frontend/pull/6531) – thanks to @rowellx68 for reporting this issue and @colinrotherham for suggesting the fix.
 - [#6528: Fix hover state on focused small radios](https://github.com/alphagov/govuk-frontend/pull/6528)
 - [#6529: Fix rebranded header background being visible when printed](https://github.com/alphagov/govuk-frontend/pull/6529) - thanks to @lewis-softwire for reporting this issue
+- [#6462: Update HMRC brand colour](https://github.com/alphagov/govuk-frontend/pull/6462)
 
 ## v5.13.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -142,7 +142,7 @@ $_govuk-organisation-colours: (
     colour: #266ebc
   ),
   "hm-revenue-customs": (
-    colour: #008476
+    colour: #008670
   ),
   "hm-treasury": (
     colour: #b2292e


### PR DESCRIPTION
The colour listed by brand.gov.uk has been updated.