### PR TITLE
Add service navigation block to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,11 +83,17 @@ We made this change in [pull request #6537: Refactor footer to detach element fr
 
 ### New features
 
-#### Easily include service navigation on your page
+#### Easily include Service navigation on your page
 
 We've added new ways to include Service navigation components on a page when using GOV.UK Frontend's Nunjucks template.
 
-If a `serviceName` variable is set, a Service navigation will automatically appear populated by the service name.
+If you set the `serviceName` variable, the page template will add a Service Navigation component to the `<header>` element, displaying the service name. You can also set the `serviceUrl` variable to provide a link for the service name.
+
+```njk
+{% extends "govuk/template.njk" %}
+{% set serviceName = "YOUR_SERVICE_NAME" %}
+{% set serviceUrl = "YOUR_SERVICE_URL" %}
+```
 
 For further customisations, we've added a `govukServiceNavigation` Nunjucks block to override the default component.
 

--- a/packages/govuk-frontend/src/govuk/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/template.jsdom.test.js
@@ -641,6 +641,48 @@ describe('Template', () => {
           ).toEqual(testName)
         })
 
+        it('renders service navigation with link if `serviceName` and `serviceUrl` are set', () => {
+          const testName = 'Test Service Name'
+          const testUrl = 'https://gov.uk'
+
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                serviceName: testName,
+                serviceUrl: testUrl
+              }
+            })
+          )
+
+          expect(
+            document.querySelector('.govuk-service-navigation')
+          ).toBeInTheDocument()
+          expect(
+            document
+              .querySelector('.govuk-service-navigation__service-name')
+              .textContent.trim()
+          ).toEqual(testName)
+          expect(
+            document.querySelector('.govuk-service-navigation__link')
+          ).toHaveAttribute('href', testUrl)
+        })
+
+        it('does not render service navigation if only `serviceUrl` is set', () => {
+          const testUrl = 'https://gov.uk'
+
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                serviceUrl: testUrl
+              }
+            })
+          )
+
+          expect(
+            document.querySelector('.govuk-service-navigation')
+          ).not.toBeInTheDocument()
+        })
+
         it('allows content to be inserted using govukServiceNavigation', () => {
           replacePageWith(
             renderTemplate('govuk/template.njk', {

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -64,7 +64,8 @@
         {% block govukServiceNavigation %}
           {%- if serviceName %}
             {{ govukServiceNavigation({
-              serviceName: serviceName
+              serviceName: serviceName,
+              serviceUrl: serviceUrl
             }) }}
           {%- endif  %}
         {% endblock %}


### PR DESCRIPTION
Closes #6474.

## Changes
- Added a `govukServiceNavigation` block inside of the `header` block.
  - This block is pre-populated with a service navigation component that becomes visible if a `serviceName` variable is set.
  - A user may optionally set a `serviceUrl` variable to render the service name as a link.
- Added tests.