### PR TITLE
Remove release step to check for tokens validity

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -61,7 +61,6 @@ Technical writers, Developers
 ### Logistics
 
 - [ ] Ensure issues published in the release are gathered in a [GitHub milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones)
-- [ ] 🔑 Ensure that [relevant access tokens are up to date](https://github.com/alphagov/govuk-frontend/blob/main/docs/releasing/before-publishing-a-release.md#make-sure-access-tokens-are-up-to-date)
 - [ ] Verify that decisions are appropriately documented (in code/issues/pull request comments or in separate documents linked from issues/pull requests)
 - [ ] Update state of published issues on project board
 - [ ] Close published issues when appropriate

--- a/docs/releasing/before-publishing-a-release.md
+++ b/docs/releasing/before-publishing-a-release.md
@@ -44,7 +44,3 @@ At this stage, the person leading the release should agree the publishing date. 
 - developers for changes to GOV.UK Frontend
 - technical writer for release notes
 - content designer, community manager and technical writer for announcements and engagement activities
-
-## Make sure access tokens are up to date
-
-Before each release, we need to make sure our GitHub access token is up to date. Sign into the `govuk-design-system-ci` GitHub account and follow the instructions in the team's password management tool to check and/or update the access token.


### PR DESCRIPTION
We're using [trusted publishing](https://docs.npmjs.com/trusted-publishers) to publish to npm so we no longer need to manage tokens.