### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,7 +270,7 @@ If you were redefining a custom value for the functional colour before importing
 ```scss
 // This will be merged with the default functional colours of GOV.UK Frontend
 // redefining the 'brand' colour to `rebeccapurple`
-$govuk-functional-colour: (
+$govuk-functional-colours: (
   brand: rebeccapurple
 );
 @import 'pkg:govuk-frontend';


### PR DESCRIPTION
The example provided for redefining `$govuk-functional-colours` uses the singular `$govuk-functional-colour`.