### PR TITLE
Replace links to the website get-in-touch page to contact

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Get in touch another way
-    url: https://design-system.service.gov.uk/get-in-touch/
+    url: https://design-system.service.gov.uk/contact/
     about: Find out how to get in touch via email or Slack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1742,7 +1742,7 @@ We've renamed the Sass mixin `govuk-typography-responsive` to `govuk-font-size` 
 
 This is an experimental change to see if the name `govuk-font-size` better communicates the Sass mixin's intended use than the name `govuk-typography-responsive`.
 
-We're interested in feedback from the community on this name change, so please let us know what you think [through our usual channels](https://design-system.service.gov.uk/get-in-touch/).
+We're interested in feedback from the community on this name change, so please let us know what you think [through our usual channels](https://design-system.service.gov.uk/contact/).
 
 This change was introduced in [pull request #4291: Rename `govuk-typography-responsive` to `govuk-font-size`](https://github.com/alphagov/govuk-frontend/pull/4291).
 
@@ -4389,7 +4389,7 @@ This will add the correct amount of padding depending on if there are elements a
 
 If you need to control the spacing manually, use the `.govuk-main-wrapper--l` modifier instead.
 
-The `govuk-main-wrapper` and `govuk-main-wrapper--l` Sass mixins are now deprecated. [Contact us](https://design-system.service.gov.uk/get-in-touch/) if you need to continue using these mixins.
+The `govuk-main-wrapper` and `govuk-main-wrapper--l` Sass mixins are now deprecated. [Contact us](https://design-system.service.gov.uk/contact/) if you need to continue using these mixins.
 
 [Pull request #1493: Add automatic vertical spacing modifier for main wrapper](https://github.com/alphagov/govuk-frontend/pull/1493)
 

--- a/docs/contributing/coding-standards/components.md
+++ b/docs/contributing/coding-standards/components.md
@@ -30,4 +30,4 @@ To help you build and initialise your own JavaScript components, GOV.UK Frontend
 
 Learn more about styling components in our [CSS style guide](./css.md). Our [JavaScript style guide](./js.md) has more information on coding components.
 
-If you need help building a component, [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) and we'll support you.
+If you need help building a component, [contact the Design System team](https://design-system.service.gov.uk/contact/) and we'll support you.

--- a/docs/releasing/publishing-a-preview.md
+++ b/docs/releasing/publishing-a-preview.md
@@ -1,6 +1,6 @@
 # Publishing a preview of GOV.UK Frontend
 
-This preview guidance is aimed at Design System team members. If you're an external contributor who needs to create a preview, please [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) and we'll do it for you.
+This preview guidance is aimed at Design System team members. If you're an external contributor who needs to create a preview, please [contact the Design System team](https://design-system.service.gov.uk/contact/) and we'll do it for you.
 
 Before you publish a preview, you need to have committed a code change to GOV.UK Frontend. Then follow these instructions.
 

--- a/packages/govuk-frontend-review/src/views/errors/404.njk
+++ b/packages/govuk-frontend-review/src/views/errors/404.njk
@@ -31,7 +31,7 @@
       <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
 
       <p class="govuk-body">
-        <a class="govuk-link" href="https://design-system.service.gov.uk/get-in-touch/" rel="noreferrer noopener" target="_blank">Contact the Design System team (opens in new tab)</a> if you believe you are seeing this message in error.
+        <a class="govuk-link" href="https://design-system.service.gov.uk/contact/" rel="noreferrer noopener" target="_blank">Contact the Design System team (opens in new tab)</a> if you believe you are seeing this message in error.
       </p>
     </div>
   </div>

--- a/packages/govuk-frontend-review/src/views/errors/500.njk
+++ b/packages/govuk-frontend-review/src/views/errors/500.njk
@@ -26,7 +26,7 @@
       <p class="govuk-body">Try again later.</p>
 
       <p class="govuk-body">
-        <a class="govuk-link" href="https://design-system.service.gov.uk/get-in-touch/" rel="noreferrer noopener" target="_blank">Contact the Design System team (opens in new tab)</a> if you believe you are seeing this message in error.
+        <a class="govuk-link" href="https://design-system.service.gov.uk/contact/" rel="noreferrer noopener" target="_blank">Contact the Design System team (opens in new tab)</a> if you believe you are seeing this message in error.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## What/Why

Replaces links to `https://design-system.service.gov.uk/get-in-touch/` with `https://design-system.service.gov.uk/contact/`

Doing in response to https://github.com/alphagov/govuk-design-system/pull/5068. This isn't the biggest deal since we redirect but is the neater option.

## Notes

There are 2 instances of the old link in the changelog. I don't know if it's the right call to change these since they're historical content so I've played it safe and left them alone. Interested in perspectives on this.