### PR TITLE
Add whoever triggered the build release workflow to generated PR description

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -56,7 +56,7 @@ jobs:
           script: |
             const { generateReleaseNotes } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
 
-            generateReleaseNotes('${{ inputs.version }}')
+            generateReleaseNotes('${{ inputs.version }}', { actor: '${{ github.actor }}', runId: '${{ github.run_id }}' })
 
       - name: Build release
         run: npm run build:release

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -122,8 +122,11 @@ export function updateChangelog(newVersion, previousVersion) {
  * following release heading if newVersion is tagged as internal
  *
  * @param {string} newVersion - Version used to find start point for release notes
+ * @param {object} [options] - Release notes options
+ * @param {string} [options.actor] - Github username of user who ran workflow
+ * @param {string} [options.runId] - ID of Build release workflow to reference
  */
-export function generateReleaseNotes(newVersion) {
+export function generateReleaseNotes(newVersion, options) {
   // Get the identifier from the version if there is one as we'll use this to
   // change what we pass to getChangelogLineIndexes if the version has an
   // 'internal' tag
@@ -143,6 +146,13 @@ export function generateReleaseNotes(newVersion) {
         ? line.replace(/^\s+/, '').substring(1)
         : line
     )
+
+  if (options && options.actor && options.runId) {
+    releaseNotes.push('')
+    releaseNotes.push(
+      `Pull request generated on behalf of @${options.actor} by [run ${options.runId}](https://github.com/alphagov/govuk-frontend/actions/runs/${options.runId}) of the [Build release workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/build-release.yml)`
+    )
+  }
 
   writeFileSync('./release-notes-body', releaseNotes.join('\n'))
 }

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -189,5 +189,18 @@ describe('Changelog release helper', () => {
         expect.not.stringContaining('### Fixes')
       )
     })
+
+    it('adds a note on the generation workflow if options param provided', () => {
+      generateReleaseNotes('3.1.0-internal.0', {
+        actor: 'bingbong',
+        runId: '12345'
+      })
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining(
+          'Pull request generated on behalf of @bingbong by [run 12345](https://github.com/alphagov/govuk-frontend/actions/runs/12345) of the [Build release workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/build-release.yml)'
+        )
+      )
+    })
   })
 })


### PR DESCRIPTION
Resolves https://github.com/alphagov/govuk-frontend/issues/5673

Passes `github.actor` during the build release workflow to `generateReleaseNotes`, which adds a line at the bottom of the generated PR desc if `actor` is present. We don't want to do this for every instance that we run `generateReleaseNotes` eg: when it's generating the action release notes for the github release.

Results from testing on this branch: https://github.com/alphagov/govuk-frontend/pull/6585