### PR TITLE
Remove OS version suffix from check names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ concurrency:
 
 jobs:
   install:
-    name: Install
-    runs-on: ${{ matrix.runner }}
+    name: Install (${{ matrix.runner.name }})
+    runs-on: ${{ matrix.runner.os }}
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
@@ -32,8 +32,10 @@ jobs:
 
       matrix:
         runner:
-          - ubuntu-22.04
-          - windows-latest
+          - name: Ubuntu
+            os: ubuntu-22.04
+          - name: Windows
+            os: windows-latest
 
     steps:
       - name: Checkout code
@@ -43,8 +45,8 @@ jobs:
         uses: ./.github/workflows/actions/install-node
 
   build:
-    name: Build
-    runs-on: ${{ matrix.runner }}
+    name: Build (${{ matrix.runner.name }})
+    runs-on: ${{ matrix.runner.os }}
     needs: [install]
 
     strategy:
@@ -52,8 +54,10 @@ jobs:
 
       matrix:
         runner:
-          - ubuntu-22.04
-          - windows-latest
+          - name: Ubuntu
+            os: ubuntu-22.04
+          - name: Windows
+            os: windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/5581

Reworks the `matrix.runner` object to be an array of objects with the format:

```
- name: [name of OS being tested eg: WIndows]
  os: [actual os version eg: windows-latest]
```

...and then applies that to tests where we include the OS name in the test eg: 'Lint ([OS name])' so that '[OS name]' becomes the name rather than os version.

The maybe slightly controversial addition is to also add that same OS name and os version to the Install and Build jobs. We run 2 versions of these so it feels like it makes sense to be consistent with naming and how we structure the `runner` object per job.