### PR TITLE
[5.14] Use null rather than false to hide the content licence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,18 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 If your service does not provide information under the Open Government Licence (OGL), you can now remove it from the GOV.UK footer.
 
-If you're using Nunjucks, set the `contentLicence` parameter to `false`:
+If you're using Nunjucks, set the `contentLicence` parameter to `null`:
 
 ```nunjucks
 {{ govukFooter({
-  contentLicence: false
+  contentLicence: null
 }) }}
 ```
 
-This change was introduced in [#6527: Allow false value to turn off contentLicence in GOV.UK Footer](https://github.com/alphagov/govuk-frontend/pull/6527). Thanks to @NickColley for making this change.
+We introduced this feature in the following pull requests:
+
+- [#6527: Allow false value to turn off contentLicence in GOV.UK Footer](https://github.com/alphagov/govuk-frontend/pull/6527). Thanks to @NickColley for making this change.
+- [#6586: Use null rather than false to hide the content licence](https://github.com/alphagov/govuk-frontend/pull/6586). Thanks to @gunndabad for reporting the issue.
 
 ### Fixes
 

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -68,9 +68,9 @@ params:
             required: false
             description: HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.
   - name: contentLicence
-    type: object or boolean
+    type: object
     required: false
-    description: The content licence information within the footer component. If your service provides its information under a different license than OGL, use `false` to hide the OGL logo and licence text. Defaults to Open Government Licence (OGL) v3 licence.
+    description: The content licence information within the footer component. If your service provides its information under a different license than OGL, use `null` to hide both the OGL logo and licence text. Defaults to Open Government Licence (OGL) v3 licence.
     params:
       - name: text
         type: string
@@ -166,7 +166,7 @@ examples:
   - name: with no content licence
     description: Open Government Licence turned off
     options:
-      contentLicence: false
+      contentLicence: null
 
   - name: with custom meta
     description: Custom meta section
@@ -179,7 +179,7 @@ examples:
     options:
       meta:
         text: GOV.UK Prototype Kit v7.0.1
-      contentLicence: false
+      contentLicence: null
 
   - name: with meta links and meta content
     description: Secondary navigation links and custom meta text
@@ -225,7 +225,7 @@ examples:
             text: Fusce Sollicitudin
           - href: '#8'
             text: Ligula Nullam Ultricies
-      contentLicence: false
+      contentLicence: null
 
   - name: with default width navigation (one column)
     options:

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -60,7 +60,7 @@
         </div>
         {% endif %}
         {% endif %}
-        {% if params.contentLicence !== false %}
+        {% if params.contentLicence !== null %}
           {# The SVG needs `focusable="false"` so that Internet Explorer does not
             treat it as an interactive element - without this it will be
             'focusable' when using the keyboard to navigate. -#}

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -227,7 +227,7 @@ describe('footer', () => {
       )
     })
 
-    it('can be turned off by setting it to `false`', () => {
+    it('can be turned off by setting it to `null`', () => {
       const $ = render('footer', examples['with no content licence'])
 
       const $licenceLogo = $('.govuk-footer__licence-logo')


### PR DESCRIPTION
This simplifies the type of the `contentLicence` option, making it easier to port to languages with static typing.

Fixes #6553