### PR TITLE
Remove stray `it.only`

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/components.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.unit.test.js
@@ -30,7 +30,7 @@ describe('Components', () => {
         })
       })
 
-      it.only('does not use custom properties in shorthand properties', async () => {
+      it('does not use custom properties in shorthand properties', async () => {
         const { css } = sassCompilationResult
 
         // Use a list of allowed properties rather than disallowed ones


### PR DESCRIPTION
Accidentally leftover in https://github.com/alphagov/govuk-frontend/pull/6590