### PR TITLE
Remove use of pkg import from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,7 +279,7 @@ If you were redefining a custom value for the functional colour before importing
 $govuk-functional-colours: (
   brand: rebeccapurple
 );
-@import 'pkg:govuk-frontend';
+@import "node_modules/govuk-frontend/dist/govuk/index";
 ```
 
 Note that you can only redefine existing functional colours, not add new functional colours. This is to make sure there's a clear separation between colours from GOV.UK Frontend and colours from your own project.


### PR DESCRIPTION
We've [got work to do to properly support `pkg` imports][1]. Until we're confident they work well, align the way that we suggest users import Frontend with [what's in our docs][2].

[1]: https://github.com/alphagov/govuk-frontend/issues/6530
[2]: https://frontend.design-system.service.gov.uk/import-css/#import-using-sass