### PR TITLE
Remove brand switch from govukFooter

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -15,11 +15,7 @@
     border-top: 10px solid;
     border-top-color: govuk-functional-colour(brand);
     color: $govuk-footer-text;
-    @include _govuk-rebrand(
-      "background",
-      $from: $govuk-footer-background,
-      $to: $_govuk-rebrand-template-background-colour
-    );
+    background: $_govuk-rebrand-template-background-colour;
   }
 
   .govuk-footer__crown {
@@ -35,12 +31,7 @@
     margin: 0; // Reset `<hr>` default margins
     @include govuk-responsive-margin(8, "bottom");
     border: 0; // Reset `<hr>` default borders
-    border-bottom: 1px solid;
-    @include _govuk-rebrand(
-      "border-bottom-color",
-      $from: $govuk-footer-content-border,
-      $to: $_govuk-rebrand-border-colour-on-blue-tint-95
-    );
+    border-bottom: 1px solid $_govuk-rebrand-border-colour-on-blue-tint-95;
   }
 
   .govuk-footer__meta {
@@ -150,12 +141,7 @@
       padding-bottom: govuk-spacing(2);
     }
 
-    border-bottom: 1px solid;
-    @include _govuk-rebrand(
-      "border-bottom-color",
-      $from: $govuk-footer-content-border,
-      $to: $_govuk-rebrand-border-colour-on-blue-tint-95
-    );
+    border-bottom: 1px solid $_govuk-rebrand-border-colour-on-blue-tint-95;
   }
 
   .govuk-footer__navigation {

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -105,10 +105,6 @@ params:
     type: object
     required: false
     description: HTML attributes (for example data attributes) to add to the footer component container.
-  - name: rebrand
-    type: boolean
-    required: false
-    description: If `true`, use the redesigned footer with the GOV.UK crown. Default is `false`.
 
 previewLayout: full-width
 accessibilityCriteria: |
@@ -504,14 +500,3 @@ examples:
               attributes:
                 data-attribute: my-attribute
                 data-attribute-2: my-attribute-2
-
-  # this rebrand example is included in screenshots but hidden in the app because
-  # the interaction with the 'rebrand' feature flag is confusing.
-
-  - name: rebrand
-    hidden: true
-    screenshot: true
-    pageTemplateOptions:
-      htmlClasses: govuk-template--rebranded
-    options:
-      rebrand: true

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -1,18 +1,13 @@
 {% from "../../macros/attributes.njk" import govukAttributes -%}
 {% from "../../macros/logo.njk" import govukLogo -%}
 
-{%- set _rebrand = params.rebrand | default(govukRebrand() if govukRebrand is callable else govukRebrand) -%}
-
 <div class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   <div class="govuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
-    {% if _rebrand %}
-      {{- govukLogo({
-        classes: 'govuk-footer__crown',
-        rebrand: true,
-        useLogotype: false
-      }) }}
-    {% endif %}
+    {{- govukLogo({
+      classes: 'govuk-footer__crown',
+      useLogotype: false
+    }) }}
     {% if params.navigation | length %}
       <div class="govuk-footer__navigation">
         {% for nav in params.navigation %}

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('@govuk-frontend/helpers/nunjucks')
-const { nunjucksEnv, getExamples } = require('@govuk-frontend/lib/components')
+const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('footer', () => {
   let examples
@@ -30,6 +30,13 @@ describe('footer', () => {
     const $container = $component.find('.govuk-width-container')
 
     expect($container.hasClass('app-width-container')).toBeTruthy()
+  })
+
+  it('renders the crown in the footer by default', () => {
+    const $ = render('footer', examples.default)
+
+    const $crown = $('.govuk-footer__crown')
+    expect($crown).toHaveLength(1)
   })
 
   describe('meta', () => {
@@ -274,35 +281,6 @@ describe('footer', () => {
       expect($copyrightMessage.html()).toContain(
         '&lt;span&gt;Hawlfraint y Goron&lt;/span&gt;'
       )
-    })
-  })
-
-  describe('rebrand', () => {
-    it('Does not show the crown in the footer by default', () => {
-      const $ = render('footer', examples.default)
-
-      const $crown = $('.govuk-footer__crown')
-      expect($crown).toHaveLength(0)
-    })
-
-    it('Does render the crown if the `rebrand` option is set', () => {
-      const $ = render('footer', examples.rebrand)
-
-      const $crown = $('.govuk-footer__crown')
-      expect($crown).toHaveLength(1)
-    })
-
-    it('Does render the crown if the `govukRebrand` nunjucks global is set to true', () => {
-      const env = nunjucksEnv()
-      env.addGlobal('govukRebrand', true)
-
-      const $ = render('footer', {
-        ...examples.default,
-        env
-      })
-
-      const $crown = $('.govuk-footer__crown')
-      expect($crown).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
For #6613.

## Changes

- Removed rebrand flags from Footer component template.
  - This makes the crown icon visible by default and is non-removable. 
- Removed rebrand parameter docs and review app example.
- Updated previously rebrand-conditional styles to become the default.
- Added test ensuring that crown icon is rendered by default.
- Removed other rebrand related tests.

## Notes
This currently uses a hardcoded, private Sass variable for some of the colours (as opposed to a functional colour delivered via custom property). This is to be resolved separately. 