### PR TITLE
Remove rebrand flag from cookie banner

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
@@ -13,11 +13,7 @@
     // changes colours in their browser.
     border-bottom: $border-bottom-width solid transparent;
 
-    @include _govuk-rebrand(
-      "background-color",
-      govuk-functional-colour(template-background),
-      $_govuk-rebrand-template-background-colour
-    );
+    background-color: $_govuk-rebrand-template-background-colour;
   }
 
   // Support older browsers which don't hide elements with the `hidden` attribute

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -314,27 +314,3 @@ examples:
           actions:
             - text: Hide cookie message
               type: button
-
-  # this rebrand example is included in screenshots but hidden in the app because
-  # the interaction with the 'rebrand' feature flag is confusing.
-
-  - name: rebrand
-    hidden: true
-    screenshot: true
-    pageTemplateOptions:
-      htmlClasses: govuk-template--rebranded
-    options:
-      messages:
-        - headingText: Cookies on this government service
-          text: We use analytics cookies to help understand how users use our service.
-          actions:
-            - text: Accept analytics cookies
-              type: submit
-              name: cookies
-              value: accept
-            - text: Reject analytics cookies
-              type: submit
-              name: cookies
-              value: reject
-            - text: View cookie preferences
-              href: /cookie-preferences


### PR DESCRIPTION
Just a small tweak for this one - one use of the mixin, and one irrelevant example.

Closes #6614 