### PR TITLE
Fixed summary card title wrap issue from #6513

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -207,7 +207,11 @@
     @include govuk-text-colour;
     margin: govuk-spacing(1) govuk-spacing(4) govuk-spacing(2) 0;
 
+    word-wrap: break-word; // Fallback for older browsers only
+    overflow-wrap: break-word;
+
     @media #{govuk-from-breakpoint(tablet)} {
+      min-width: 0;
       margin-bottom: govuk-spacing(1);
     }
   }


### PR DESCRIPTION
1) Added css property "min-width: 0" to ".govuk-summary-card__title" in the tablet media query.


2) Added css property "word-wrap: break-word" and "overflow-wrap: break-word" for text wrapping.