### PR TITLE
Hide feature flag interface from review app

### DIFF
--- a/packages/govuk-frontend-review/src/views/layouts/_generic.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/_generic.njk
@@ -9,7 +9,8 @@
 {% block bodyStart %}
   {% block banner %}
     {% include "../partials/banner.njk" %}
-    {% include "../partials/feature-flags.njk" %}
+    {# Uncomment to show feature flag options. #}
+    {#% include "../partials/feature-flags.njk" %#}
   {% endblock %}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/layouts/full-page-example.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/full-page-example.njk
@@ -2,5 +2,6 @@
 
 {% block banner %}
   {% include "../partials/exampleBanner.njk" %}
-  {% include "../partials/feature-flags.njk" %}
+  {# Uncomment to show feature flag options. #}
+  {#% include "../partials/feature-flags.njk" %#}
 {% endblock %}


### PR DESCRIPTION
Closes #6616.

## Changes

- Comments out feature flag interface in the review app.

This doesn't remove any of the existing functionality, as it was decided that keeping something like it available (in a probably more generic form) would be valuable to have as a general feature of the review app. Converting it to be generic isn't part of the scope of this PR, however. 

## Thoughts

When we decommission a feature flag we should probably have a process to additionally unset any cookies that it uses.