### PR TITLE
Make merged map of functional colours public

### DIFF
--- a/packages/govuk-frontend/src/govuk/core/_govuk-frontend-properties.scss
+++ b/packages/govuk-frontend/src/govuk/core/_govuk-frontend-properties.scss
@@ -18,7 +18,7 @@
       }
 
       // CSS custom properties for each functional colour
-      @each $name, $value in $_govuk-functional-colours {
+      @each $name, $value in $govuk-functional-colours {
         --_govuk-#{$name}-colour: #{$value};
       }
     }

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -97,12 +97,12 @@
     $colour: "#{$colour}";
   }
 
-  @if map-has-key($_govuk-functional-colours, $colour) {
-    $value: map-get($_govuk-functional-colours, $colour);
+  @if map-has-key($govuk-functional-colours, $colour) {
+    $value: map-get($govuk-functional-colours, $colour);
     @return var(--_govuk-#{$colour}-colour, #{$value});
   }
 
-  @error "Unknown colour `#{$colour}` (available colours: #{map-keys($_govuk-functional-colours)})";
+  @error "Unknown colour `#{$colour}` (available colours: #{map-keys($govuk-functional-colours)})";
 }
 
 @function _govuk-define-functional-colours($colours, $defaults) {

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -290,7 +290,7 @@ describe('@function govuk-functional-colour', () => {
 
   beforeEach(() => {
     sassBootstrap = `
-      $_govuk-functional-colours: (
+      $govuk-functional-colours: (
         "error": #ff0000,
         "success": #00ff00,
         "link": #0000ff,

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -13,7 +13,7 @@
 ///
 /// @access public
 $govuk-functional-colours: () !default;
-$_govuk-functional-colours: _govuk-define-functional-colours(
+$govuk-functional-colours: _govuk-define-functional-colours(
   $govuk-functional-colours,
   $defaults: (
     (

--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -246,7 +246,7 @@ describe('Organisation colours', () => {
       @import "sass-color-helpers/stylesheets/color-helpers";
 
       $minimum-contrast: 4.5;
-      $body-background-colour: map-get($_govuk-functional-colours, body-background);
+      $body-background-colour: map-get($govuk-functional-colours, body-background);
 
       @each $organisation in map-keys($govuk-colours-organisations) {
 


### PR DESCRIPTION
While users could set `$govuk-functional-colours` to override specific functional colours, those were merged into a `$_govuk-functional-colours` variable which was private when `@use`ing GOV.UK Frontend.

This was made to avoid users wiping the merged map if they redefined `$govuk-functional-colours` after importing. Given Sass will ensure GOV.UK Frontend keeps using the merged values, we're setting the map public, which will let users `map.get` from it if necessary [^1]

[^1]: https://sass-lang.com/documentation/at-rules/import/#configuring-modules-through-imports

> [!NOTE]
> The Sass doc for the `$govuk-functional-colours` map is not ideal, but given we'll be updating the data structure in #6634, we can update the documentation then.

Fixes #6633 