### PR TITLE
Add interruption panel

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/interruption-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/interruption-page/index.njk
@@ -1,0 +1,39 @@
+---
+title: Is your age correct?
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ example.title }} - GOV.UK{% endblock %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    href: "/",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% call govukPanel({
+        classes: "govuk-panel--interruption",
+        titleText: "Is your age correct?"
+      }) %}
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+        <div class="govuk-button-group">
+          {{ govukButton({
+            classes: "govuk-button--inverse",
+            text: "Yes, this is correct"
+          }) }}
+          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+        </div>
+      {% endcall %}
+    </div>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/interruption-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/interruption-page/index.njk
@@ -23,16 +23,22 @@ title: Is your age correct?
     <div class="govuk-grid-column-two-thirds">
       {% call govukPanel({
         classes: "govuk-panel--interruption",
-        titleText: "Is your age correct?"
+        titleText: "Is your age correct?",
+        actions: {
+          items: [
+            {
+              text: "Yes, this is correct",
+              type: "button",
+              href: "#submit"
+            },
+            {
+              text: "Change my age",
+              href: "#change"
+            }
+          ]
+        }
       }) %}
         <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
-        <div class="govuk-button-group">
-          {{ govukButton({
-            classes: "govuk-button--inverse",
-            text: "Yes, this is correct"
-          }) }}
-          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
-        </div>
       {% endcall %}
     </div>
   </div>

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -2,4 +2,3 @@
 @use "mixin";
 
 @include mixin.styles;
-

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -2,3 +2,4 @@
 @use "mixin";
 
 @include mixin.styles;
+

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -62,7 +62,5 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background: base.govuk-functional-colour(brand);
     text-align: left;
-
-    @include base.govuk-font($size: 19);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -43,11 +43,27 @@
     margin-bottom: base.govuk-spacing(6);
   }
 
-  // Remove bottom spacing from anything at the end of the Panel's body
+  // Remove bottom spacing from anything at the end of the Panel's content
   // to stop the Panel's padding spacing from becoming too large.
   .govuk-panel__title:last-child,
-  .govuk-panel__body > :last-child {
+  .govuk-panel__body > :last-child,
+  .govuk-panel__actions > :last-child {
     margin-bottom: 0;
+  }
+
+  // On larger screens if the Panel actions have a button group,
+  // then we want to adjust the spacing a bit to avoid the button group
+  // making the Panel's padding spacing being too large.
+  @media #{base.govuk-from-breakpoint(tablet)} {
+    .govuk-panel__actions > .govuk-button-group:last-child {
+      margin-bottom: -1 * base.govuk-spacing(2);
+    }
+  }
+
+  // When the panel shows some actions, make sure they have some spacing
+  // from the panel's content
+  .govuk-panel__body:not(:last-child) {
+    margin-bottom: base.govuk-spacing(7);
   }
 
   .govuk-panel--confirmation {
@@ -64,21 +80,6 @@
     .govuk-panel__title {
       @include base.govuk-font-size($size: 36);
       margin-bottom: base.govuk-spacing(3);
-    }
-
-    // When the Button group is at the end of the Panel's body then,
-    // make sure it has some spacing away from the other body content.
-    .govuk-panel__body > .govuk-button-group:last-child {
-      margin-top: base.govuk-spacing(7);
-    }
-
-    // On larger screens if the Interruption panel has a Button group at the end of the Panel's body,
-    // then we want to adjust the spacing a bit to avoid the Button group
-    // making the Panel's padding spacing being too large.
-    @media #{base.govuk-from-breakpoint(tablet)} {
-      &:has(.govuk-panel__body > .govuk-button-group:last-child) {
-        padding-bottom: base.govuk-spacing(5);
-      }
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -34,12 +34,6 @@
       // it but the the text remains legible.
       overflow-wrap: break-word;
     }
-
-    @media print {
-      --govuk-text-colour: inherit;
-      border-color: currentcolor;
-      background: none;
-    }
   }
 
   .govuk-panel__title {
@@ -62,5 +56,13 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background: base.govuk-functional-colour(brand);
     text-align: left;
+  }
+
+  @media print {
+    .govuk-panel {
+      --govuk-text-colour: inherit;
+      border-color: currentcolor;
+      background: none;
+    }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -43,7 +43,10 @@
     margin-bottom: base.govuk-spacing(6);
   }
 
-  .govuk-panel__title:last-child {
+  // Remove bottom spacing from anything at the end of the Panel's body
+  // to stop the Panel's padding spacing from becoming too large.
+  .govuk-panel__title:last-child,
+  .govuk-panel__body > :last-child {
     margin-bottom: 0;
   }
 
@@ -56,6 +59,27 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background: base.govuk-functional-colour(brand);
     text-align: left;
+
+    // Smaller title to go alongside smaller body text.
+    .govuk-panel__title {
+      @include base.govuk-font-size($size: 36);
+      margin-bottom: base.govuk-spacing(3);
+    }
+
+    // When the Button group is at the end of the Panel's body then,
+    // make sure it has some spacing away from the other body content.
+    .govuk-panel__body > .govuk-button-group:last-child {
+      margin-top: base.govuk-spacing(7);
+    }
+
+    // On larger screens if the Interruption panel has a Button group at the end of the Panel's body,
+    // then we want to adjust the spacing a bit to avoid the Button group
+    // making the Panel's padding spacing being too large.
+    @media #{base.govuk-from-breakpoint(tablet)} {
+      &:has(.govuk-panel__body > .govuk-button-group:last-child) {
+        padding-bottom: base.govuk-spacing(5);
+      }
+    }
   }
 
   @media print {

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -33,18 +33,18 @@
       // it but the the text remains legible.
       overflow-wrap: break-word;
     }
-  }
-
-  .govuk-panel--confirmation {
-    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
-    color: base.govuk-functional-colour(text);
-    background: base.govuk-functional-colour(success);
 
     @media print {
       --govuk-text-colour: inherit;
       border-color: currentcolor;
       background: none;
     }
+  }
+
+  .govuk-panel--confirmation {
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
+    color: base.govuk-functional-colour(text);
+    background: base.govuk-functional-colour(success);
   }
 
   .govuk-panel__title {
@@ -56,5 +56,13 @@
 
   .govuk-panel__title:last-child {
     margin-bottom: 0;
+  }
+
+  .govuk-panel--interruption {
+    color: govuk-colour("white");
+    background-color: $govuk-brand-colour;
+    text-align: left;
+
+    @include govuk-font($size: 19);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -59,10 +59,10 @@
   }
 
   .govuk-panel--interruption {
-    color: govuk-colour("white");
-    background-color: $govuk-brand-colour;
+    color: base.govuk-colour("white");
+    background-color: base.govuk-functional-colour(brand);
     text-align: left;
 
-    @include govuk-font($size: 19);
+    @include base.govuk-font($size: 19);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -11,6 +11,7 @@
     padding: base.govuk-spacing(7) - base.$govuk-border-width;
 
     border: base.$govuk-border-width solid transparent;
+    color: base.govuk-functional-colour(text);
 
     text-align: center;
 
@@ -41,12 +42,6 @@
     }
   }
 
-  .govuk-panel--confirmation {
-    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
-    color: base.govuk-functional-colour(text);
-    background: base.govuk-functional-colour(success);
-  }
-
   .govuk-panel__title {
     @include base.govuk-font-size($size: 48);
     @include base.govuk-typography-weight-bold;
@@ -58,9 +53,14 @@
     margin-bottom: 0;
   }
 
+  .govuk-panel--confirmation {
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
+    background: base.govuk-functional-colour(success);
+  }
+
   .govuk-panel--interruption {
-    color: base.govuk-colour("white");
-    background-color: base.govuk-functional-colour(brand);
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
+    background: base.govuk-functional-colour(brand);
     text-align: left;
 
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
@@ -2,13 +2,25 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/panel', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects regular size text on the green and blue panels
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('panel')
 
       for (const exampleName in examples) {
         await render(page, 'panel', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -45,7 +45,7 @@ examples:
       text: 'Your reference number: HDJ2123F'
   - name: interruption
     options:
-      titleText: Is your weight correct?
+      titleText: Is your age correct?
       html: |
         <p>You entered your age as <strong>109</strong>.</p>
         <div class="govuk-button-group">

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -38,6 +38,23 @@ examples:
     options:
       titleHtml: Application complete
       text: 'Your reference number: HDJ2123F'
+  - name: custom heading level
+    options:
+      titleText: Application complete
+      headingLevel: 2
+      text: 'Your reference number: HDJ2123F'
+  - name: interruption
+    options:
+      titleText: Is your weight correct?
+      html: |
+        <p>You entered your age as <strong>109</strong>.</p>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Yes, this is correct
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+        </div>
+      classes: govuk-panel--interruption
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: title html as text

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -37,12 +37,7 @@ examples:
     screenshot: true
     options:
       titleHtml: Application complete
-      text: 'Your reference number: HDJ2123F'
-  - name: custom heading level
-    options:
-      titleText: Application complete
-      headingLevel: 2
-      text: 'Your reference number: HDJ2123F'
+      html: Your reference number<br><strong>HDJ2123F</strong>
   - name: interruption
     options:
       titleText: Is your age correct?

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -31,6 +31,44 @@ params:
     type: object
     required: false
     description: HTML attributes (for example data attributes) to add to the panel container.
+  - name: actions
+    type: object
+    required: false
+    description: Can be used when creating an [interruption panel](https://design-system.service.gov.uk/components/panel/#interruption-panel) which will add a button or link. Default is `button` unless you set `href` which will show the action as a link.
+    params:
+      - name: items
+        type: array
+        required: false
+        description: The list of buttons or links to display at the end of an Interruption panel.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: The button or link text.
+          - name: type
+            type: string
+            required: false
+            description: The type of button – `"button"` or `"submit"`. If `href` is provided, set `type` to `"button"` render a link styled as a button.
+          - name: href
+            type: string
+            required: false
+            description: The `href` for a link. Set `type` to `"button"` and set `href` to render a link styled as a button.
+          - name: classes
+            type: string
+            required: false
+            description: The additional classes that you want to add to the button or link.
+          - name: attributes
+            type: object
+            required: false
+            description: The additional attributes that you want to add to the button or link. For example, data attributes.
+      - name: classes
+        type: string
+        required: false
+        description: The additional classes that you want to add to the `govuk-panel__actions` element that wraps the buttons or links.
+      - name: attributes
+        type: object
+        required: false
+        description: The additional attributes that you want to add to the `govuk-panel__actions` element that wraps the buttons or links. For example, data attributes.
 
 examples:
   - name: default
@@ -44,12 +82,12 @@ examples:
       titleText: Is your age correct?
       html: |
         <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
-        <div class="govuk-button-group">
-          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-            Yes, this is correct
-          </button>
-          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
-        </div>
+      actions:
+        items:
+          - text: Yes, this is correct
+            type: button
+          - text: No, change my age
+            href: '#'
   - name: interruption-with-content-with-long-line-length
     options:
       classes: govuk-panel--interruption
@@ -59,14 +97,14 @@ examples:
         <p class="govuk-body">Previous home address: 1 Willow Lane, Newchurch, Kington, HR5 3QF</p>
         <p class="govuk-body">New home address: 9 Elm Street, Whitney-on-Wye, Hereford, HR3 6EH</p>
         <p class="govuk-body">You can go back to undo this change.</p>
-        <div class="govuk-button-group">
-          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-            Are you sure you want to change this?
-          </button>
-          <a href="#" class="govuk-link govuk-link--inverse">
-            Go back to application
-          </a>
-        </div>
+      actions:
+        items:
+          - text: Are you sure you want to change this?
+            type: submit
+            attributes:
+              form: the-form-id
+          - text: Go back to application
+            href: '#'
   - name: interruption-with-headings-content-and-lists
     options:
       classes: govuk-panel--interruption
@@ -82,15 +120,11 @@ examples:
           <li>enter their custody information</li>
           <li>update the licence conditions section</li>
         </ul>
-        <div class="govuk-button-group">
-          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
-            Continue to other sections
-          </button>
-          <a href="#" class="govuk-link govuk-link--inverse">
-            Go back to application
-          </a>
-        </div>
-
+      actions:
+        - text: Continue to other sections
+          type: submit
+        - text: Go back to application
+          href: '#'
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: title html as text
     hidden: true
@@ -142,3 +176,82 @@ examples:
       classes: govuk-panel--interruption extra-class one-more-class
       titleText: Are you sure you want to change this?
       html: <p class="govuk-body">You've changed the person's address from Wales to England. This means that the referral needs to be cancelled.</p>
+  - name: confirmation, with actions
+    hidden: true
+    options:
+      titleText: Is your age correct?
+      actions:
+        items:
+          - type: button
+            text: Yes, this is correct
+          - href: '#'
+            text: No, change my age
+  - name: interruption, with actions classes and attributes
+    hidden: true
+    options:
+      classes: govuk-panel--interruption
+      titleText: Is your age correct?
+      html: |
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+      actions:
+        classes: extra-class one-more-class
+        attributes:
+          'data-test': 1
+          'data-other-test': 'yes'
+        items:
+          - type: button
+            text: Yes, this is correct
+          - href: '#'
+            text: No, change my age
+  - name: interruption, submit action
+    hidden: true
+    options:
+      classes: govuk-panel--interruption
+      titleText: Is your age correct?
+      html: |
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+      actions:
+        items:
+          - type: submit
+            text: Yes, this is correct
+            attributes:
+              form: test-target-element
+              name: 'acknowledged'
+              value: ''
+            classes: 'extra-class one-more-class'
+          - href: '#'
+            text: No, change my age
+  - name: interruption, button link
+    hidden: true
+    options:
+      classes: govuk-panel--interruption
+      titleText: Is your age correct?
+      html: |
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+      actions:
+        classes: extra-class one-more-class
+        attributes:
+          'data-test': 1
+          'data-other-test': 'yes'
+        items:
+          - type: button
+            text: Yes, this is correct
+            href: '?acknowledged=true'
+          - href: '#'
+            text: No, change my age
+  - name: interruption, no actions
+    hidden: true
+    options:
+      classes: govuk-panel--interruption
+      titleText: Is your age correct?
+      html: |
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+  - name: interruption, no actions items
+    hidden: true
+    options:
+      classes: govuk-panel--interruption
+      titleText: Is your age correct?
+      html: |
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+      actions:
+        classes: 'extra-class'

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -40,16 +40,56 @@ examples:
       html: Your reference number<br><strong>HDJ2123F</strong>
   - name: interruption
     options:
+      classes: govuk-panel--interruption
       titleText: Is your age correct?
       html: |
-        <p>You entered your age as <strong>109</strong>.</p>
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
             Yes, this is correct
           </button>
           <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
         </div>
+  - name: interruption-with-content-with-long-line-length
+    options:
       classes: govuk-panel--interruption
+      titleText: Are you sure you want to change this?
+      html: |
+        <p class="govuk-body">You've changed the person's address from Wales to England. This means that the referral needs to be cancelled.</p>
+        <p class="govuk-body">Previous home address: 1 Willow Lane, Newchurch, Kington, HR5 3QF</p>
+        <p class="govuk-body">New home address: 9 Elm Street, Whitney-on-Wye, Hereford, HR3 6EH</p>
+        <p class="govuk-body">You can go back to undo this change.</p>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Are you sure you want to change this?
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">
+            Go back to application
+          </a>
+        </div>
+  - name: interruption-with-headings-content-and-lists
+    options:
+      classes: govuk-panel--interruption
+      titleText: Your new answer affects other sections of this application
+      html: |
+        <h2 class="govuk-heading-m">Question: Where is Andy Cooke located?</h2>
+        <p class="govuk-body">
+          Previous answer: Custody<br>
+          New answer: Released
+        </p>
+        <p class="govuk-body govuk-!-margin-bottom-2">You need to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>enter their custody information</li>
+          <li>update the licence conditions section</li>
+        </ul>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Continue to other sections
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">
+            Go back to application
+          </a>
+        </div>
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: title html as text

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -136,3 +136,9 @@ examples:
       titleText: Application complete
       headingLevel: 2
       text: 'Your reference number: HDJ2123F'
+  - name: interruption with custom classes
+    hidden: true
+    options:
+      classes: govuk-panel--interruption extra-class one-more-class
+      titleText: Are you sure you want to change this?
+      html: <p class="govuk-body">You've changed the person's address from Wales to England. This means that the referral needs to be cancelled.</p>

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -2,8 +2,17 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
-<div class="govuk-panel govuk-panel--confirmation
-  {%- if params.classes %} {{ params.classes }}{% endif %}"
+{%- set classNames = "govuk-panel" -%}
+
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{%- if (not params.classes) or (not "govuk-panel--interruption" in params.classes) %}
+  {% set classNames = classNames + " govuk-panel--confirmation" -%}
+{% endif %}
+
+<div class="{{ classNames }}"
   {{- govukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -2,17 +2,14 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
-{%- set classNames = "govuk-panel" -%}
+{%- set isInterruption = params.classes and ("govuk-panel--interruption" in params.classes) -%}
 
-{%- if params.classes %}
-  {% set classNames = classNames + " " + params.classes %}
-{% endif %}
+{#- The Panel component defaults to the Confirmation variant -#}
+{%- set defaultModifierClassName = "govuk-panel--confirmation" if not isInterruption -%}
 
-{%- if (not params.classes) or (not "govuk-panel--interruption" in params.classes) %}
-  {% set classNames = classNames + " govuk-panel--confirmation" -%}
-{% endif %}
-
-<div class="{{ classNames }}"
+<div class="govuk-panel
+  {%- if defaultModifierClassName %} {{ defaultModifierClassName }}{% endif %}
+  {%- if params.classes %} {{ params.classes }}{% endif -%}"
   {{- govukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -1,4 +1,5 @@
 {% from "../../macros/attributes.njk" import govukAttributes -%}
+{% from "../button/macro.njk" import govukButton -%}
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
@@ -6,6 +7,23 @@
 
 {#- The Panel component defaults to the Confirmation variant -#}
 {%- set defaultModifierClassName = "govuk-panel--confirmation" if not isInterruption -%}
+
+{%- macro _panelAction(action) -%}
+  {%- if not action.href or action.type == "button" -%}
+    {{ govukButton({
+      "text": action.text,
+      "type": action.type if action.type else "button",
+      "classes": "govuk-button--inverse" + (" " + action.classes if action.classes),
+      "href": action.href,
+      "attributes": action.attributes
+    }) }}
+  {%- else -%}
+    <a class="govuk-link govuk-link--inverse {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}"
+      {{- govukAttributes(action.attributes) }}>
+      {{- action.text -}}
+    </a>
+  {%- endif -%}
+{%- endmacro -%}
 
 <div class="govuk-panel
   {%- if defaultModifierClassName %} {{ defaultModifierClassName }}{% endif %}
@@ -17,6 +35,22 @@
   {% if caller or params.html or params.text %}
   <div class="govuk-panel__body">
     {{ caller() if caller else (params.html | safe | trim | indent(4) if params.html else params.text) }}
+  </div>
+  {% endif %}
+  {% if isInterruption and params.actions %}
+  {% set actions = params.actions %}
+  <div class="govuk-panel__actions
+    {%- if actions.classes %} {{ actions.classes }}{% endif -%}"
+    {{- govukAttributes(actions.attributes) }}>
+
+    {%- if actions.items.length -%}
+    <div class="govuk-button-group">
+    {% for action in actions.items %}
+      {{ _panelAction(action) | safe | trim | indent(6) }}
+    {% endfor %}
+    </div>
+    {%- endif -%}
+
   </div>
   {% endif %}
 </div>

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -25,9 +25,11 @@ describe('Panel', () => {
 
     it('renders body text', () => {
       const $ = render('panel', examples.default)
-      const panelBodyText = $('.govuk-panel__body').text().trim()
+      const panelBodyText = $('.govuk-panel__body').html().trim()
 
-      expect(panelBodyText).toBe('Your reference number: HDJ2123F')
+      expect(panelBodyText).toBe(
+        'Your reference number<br><strong>HDJ2123F</strong>'
+      )
     })
 
     it('doesnt render panel body if no body text is passed', () => {

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -105,4 +105,39 @@ describe('Panel', () => {
       expect($component.attr('second-attribute')).toBe('bar')
     })
   })
+
+  describe('classes', () => {
+    it('has confirmation modifier class by default', () => {
+      const $ = render('panel')
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel govuk-panel--confirmation'
+      )
+    })
+    it('keeps confirmation modifier class if additional classes used', () => {
+      const $ = render('panel', examples.classes)
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel extra-class one-more-class govuk-panel--confirmation'
+      )
+    })
+    it('has no confirmation modifier class if interruption modifier class is used', () => {
+      const $ = render('panel', examples.interruption)
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel govuk-panel--interruption'
+      )
+    })
+    it('keeps interruption modifier class if additional classes used', () => {
+      const $ = render('panel', examples['interruption with custom classes'])
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel govuk-panel--interruption extra-class one-more-class'
+      )
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -120,7 +120,7 @@ describe('Panel', () => {
 
       const $component = $('.govuk-panel')
       expect($component.attr('class')).toBe(
-        'govuk-panel extra-class one-more-class govuk-panel--confirmation'
+        'govuk-panel govuk-panel--confirmation extra-class one-more-class'
       )
     })
     it('has no confirmation modifier class if interruption modifier class is used', () => {

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -140,4 +140,129 @@ describe('Panel', () => {
       )
     })
   })
+
+  describe('actions', () => {
+    describe('as confirmation panel', () => {
+      it('does not render the actions', () => {
+        const $ = render('panel', examples['confirmation, with actions'])
+
+        const $actions = $('.govuk-panel__actions')
+        expect($actions).toHaveLength(0)
+      })
+    })
+
+    describe('as interruption panel', () => {
+      describe('the actions container', () => {
+        it('renders with a `govuk-button-group` wrapping the actions', () => {
+          const $ = render('panel', examples.interruption)
+
+          const $actions = $(
+            '.govuk-panel__body + .govuk-panel__actions .govuk-button-group > *'
+          )
+          expect($actions).toHaveLength(2)
+        })
+
+        it('accepts `classes` on `.govuk-panel__actions`', () => {
+          const $ = render(
+            'panel',
+            examples['interruption, with actions classes and attributes']
+          )
+
+          const $actions = $('.govuk-panel__actions')
+          expect($actions.attr('class')).toContain(
+            ' extra-class one-more-class'
+          )
+        })
+
+        it('accepts `attributes` on `.govuk-panel__actions', () => {
+          const $ = render(
+            'panel',
+            examples['interruption, with actions classes and attributes']
+          )
+
+          const $actions = $('.govuk-panel__actions')
+          expect($actions.data()).toMatchObject({
+            test: 1,
+            otherTest: 'yes'
+          })
+        })
+
+        it('does not render if no `actions` are present', () => {
+          const $ = render('panel', examples['interruption, no actions'])
+
+          const $actions = $('.govuk-panel__actions')
+          expect($actions).toHaveLength(0)
+        })
+
+        it('does not render the button group if no `actions.items` are present', () => {
+          const $ = render('panel', examples['interruption, no actions items'])
+
+          const $actions = $('.govuk-panel__actions')
+          expect($actions).toHaveLength(1)
+
+          const $buttonGroup = $actions.find('.govuk-button-group')
+          expect($buttonGroup).toHaveLength(0)
+        })
+      })
+
+      describe('the actions', () => {
+        it('render as buttons when action type is `button`', () => {
+          const $ = render('panel', examples.interruption)
+
+          const $actions = $(
+            '.govuk-panel__actions .govuk-button-group > button.govuk-button.govuk-button--inverse'
+          )
+          expect($actions.text()).toContain('Yes, this is correct')
+        })
+
+        it('render as links when action has an `href` and no type', () => {
+          const $ = render('panel', examples.interruption)
+
+          const $actions = $(
+            '.govuk-panel__actions .govuk-button-group > a.govuk-link.govuk-link--inverse'
+          )
+          expect($actions.text()).toContain('No, change my age')
+        })
+
+        it('render as submit buttons when action has a type: "submit"', () => {
+          const $ = render('panel', examples['interruption, submit action'])
+
+          const $actions = $(
+            '.govuk-panel__actions .govuk-button-group > button[type="submit"]'
+          )
+          expect($actions.text()).toContain('Yes, this is correct')
+        })
+
+        it('render as button links when action has an `href` and `type: "button"`', () => {
+          const $ = render('panel', examples.interruption)
+
+          const $actions = $(
+            '.govuk-panel__actions .govuk-button-group > a.govuk-link.govuk-link--inverse'
+          )
+          expect($actions.text()).toContain('No, change my age')
+        })
+
+        it('accept extra `attributes`', () => {
+          const $ = render('panel', examples['interruption, submit action'])
+
+          const $actions = $(
+            '.govuk-panel__actions .govuk-button-group > button[type="submit"]'
+          )
+          expect($actions.attr('name')).toBe('acknowledged')
+          expect($actions.attr('value')).toBe('')
+        })
+
+        it('accept extra `classes`', () => {
+          const $ = render('panel', examples['interruption, submit action'])
+
+          const $actions = $(
+            '.govuk-panel__actions .govuk-button-group > button[type="submit"]'
+          )
+          expect($actions.attr('class')).toContain(
+            ' extra-class one-more-class'
+          )
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
At the NHS we’ve just published the [Interruption panel](https://service-manual.nhs.uk/design-system/components/panel#interruption-panel) variant, to support the [Interruption page pattern](https://service-manual.nhs.uk/design-system/patterns/interruption-page).

This is based on the longstanding pattern used across GOVUK services (see [backlog thread](https://github.com/alphagov/govuk-design-system-backlog/issues/27)), and the excellent guidance from Ministry of Justice [Interruption card component](https://design-patterns.service.justice.gov.uk/components/interruption-card/).

This pull request proposes adding the same pattern to the GOV.UK Design System.

Like the NHS one, it uses a variant of the Panel component rather than creating a new component. Unlike the NHS one, as well as setting the background colour to blue, it also sets the text as left-aligned (this is because the default green one is centre-aligned, unlike the NHS version).

Links and buttons currently require `govuk-button--inverse` or `govuk-link--inverse` modifiers, however these could default to white instead, when used within the panel.