### PR TITLE
fixed summary card title wrap issue

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -207,7 +207,11 @@
     @include govuk-text-colour;
     margin: govuk-spacing(1) govuk-spacing(4) govuk-spacing(2) 0;
 
+    word-wrap: break-word; // Fallback for older browsers only
+    overflow-wrap: break-word;
+
     @media #{govuk-from-breakpoint(tablet)} {
+      min-width: 0;
       margin-bottom: govuk-spacing(1);
     }
   }


### PR DESCRIPTION
## **Description of the task**

This PR fixes an issue #6513 where the `govuk-!-text-break-word` utility class doesn't work with summary card titles when text contains long strings without spaces.

## **Solution**

- Added `word-wrap: break-word` and `overflow-wrap: break-word` to `.govuk-summary-card__title` for automatic wrapping of unbreakable text
- Added `min-width: 0` to `.govuk-summary-card__title` within the tablet media query to allow flex items to shrink and enable text wrapping