### PR TITLE
Remove template background colour private variable

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
@@ -13,7 +13,7 @@
     // changes colours in their browser.
     border-bottom: $border-bottom-width solid transparent;
 
-    background-color: $_govuk-rebrand-template-background-colour;
+    background-color: govuk-functional-colour(template-background);
   }
 
   // Support older browsers which don't hide elements with the `hidden` attribute

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -15,7 +15,7 @@
     border-top: 10px solid;
     border-top-color: govuk-functional-colour(brand);
     color: $govuk-footer-text;
-    background: $_govuk-rebrand-template-background-colour;
+    background: govuk-functional-colour(template-background);
   }
 
   .govuk-footer__crown {

--- a/packages/govuk-frontend/src/govuk/objects/_template.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.scss
@@ -5,7 +5,7 @@
   .govuk-template {
     // Set the overall page background colour to the same colour as used by the
     // footer to give the illusion of a long footer.
-    background-color: $_govuk-rebrand-template-background-colour;
+    background-color: govuk-functional-colour(template-background);
 
     // Prevent automatic text sizing, as we already cater for small devices and
     // would like the browser to stay on 100% text zoom by default.

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -21,7 +21,7 @@ $govuk-functional-colours: _govuk-define-functional-colours(
       "text": govuk-colour("black"),
       // Used by components that want to give the illusion of extending
       // the template background (such as the footer and cookie banner).
-      "template-background": govuk-colour("black", $variant: "tint-95"),
+      "template-background": govuk-colour("blue", $variant: "tint-95"),
       "body-background": govuk-colour("white"),
       // Use 'true black' to avoid printers using colour ink to print body text
       "print-text": #000000,
@@ -275,12 +275,6 @@ $govuk-link-active-colour: govuk-functional-colour(link-active);
 // =============================================================================
 // Brand refresh
 // =============================================================================
-
-/// Updated template background colour
-///
-/// @type Colour
-/// @access private
-$_govuk-rebrand-template-background-colour: govuk-colour("blue", "tint-95");
 
 /// Border colour for areas on a light-blue background
 ///


### PR DESCRIPTION
Closes #6640.

This does not cover the variable for the related border colour, which has a separate issue: #6642.

## Changes

- Changed colour of `template-background` functional colour to 95% tint blue.
- Removed `$_govuk-rebrand-template-background-colour`.
- Updated references to `$_govuk-rebrand-template-background-colour` to use the `template-background` functional colour.

