### PR TITLE
Update Service navigation link colour

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_index.scss
@@ -5,7 +5,7 @@
 
   // We make the link colour a little darker than normal here so that it has
   // better perceptual contrast with the navigation background.
-  $govuk-service-navigation-link-colour: govuk-colour("blue", "shade-25");
+  $govuk-service-navigation-link-colour: govuk-colour("blue", "shade-10");
 
   .govuk-service-navigation {
     border-bottom: 1px solid $_govuk-rebrand-border-colour-on-blue-tint-95;

--- a/packages/govuk-frontend/src/govuk/settings/_colours-palette.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-palette.scss
@@ -19,7 +19,9 @@ $_govuk-palette: (
     "tint-80": #d2e2f1,
     "tint-95": #f4f8fb,
     "shade-25": #16548a,
-    "shade-50": #0f385c
+    "shade-50": #0f385c,
+    // Listed last as tests expect colours to be in a given order
+    "shade-10": #1a65a6
   ),
   "green": (
     "primary": #11875a,

--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -24,7 +24,7 @@ const allVariants = [
 
 describe('Colour palette', () => {
   it.each([
-    ['blue', allVariants],
+    ['blue', [...allVariants, 'shade-10']],
     ['green', allVariants],
     ['teal', [...allVariants, 'accent']],
     ['purple', allVariants],


### PR DESCRIPTION
For #6647.

## Changes
- Added a 10% blue shade to the colour palette. 
  - This was calculated by mixing 10% black with the brand blue, using [the colour mixing Sass code](https://sass-lang.com/playground/#eJyVU9tu4jAQfecrRgGkZBso6S4tDS8s7V4e9mm1+wFOMkksgoNsB1hV+fcdX6BUQpX6EMf2nHPmzNhOklWnEALFlErztmllsBxcbG2Zrt/uKC25qGhvcHsLT6zJu4ZpVKBrBImqazS0JWz5kVCwZ5K3nYKMEd/Id1IZ3oHrGhRq2KHMUWhWkQLRDjXXCEwUkDUs38Qg204URonkt4bJhW6hxuMkb7c7pnnWIGVpOlRTChvEX0plzAR43JESFgFolkHZSmAgeI7Q7lHuOR6g4UpP33CMKlWhLlkmQBnPaQxhfVnQyDZOpRAOAIKMUEEKw+T5YbZexIPIteoXr2qNElTNCip2TDRNxRjW3TyG+SyGBX2Pc49/ZnJzglu0IxI8IZijGOiq7ESueStcr37/WIfOTwQvZGckUygw/9P+xGNoTnNqYaGFTPOaCYGNZ8QQSCo8hpHasRxTkFUWRZSEZKoPyVQSUVwXyj4kZJt5TWclUXdSwHD4MpI9DZUZsn456C97ck41opnrCHmg00whmCV3n7/M7x8Wj1/XT8/fvgdLFy25VDoFa67g+9ByYQL2N4bkPorNcJN4vMK8FQUdzCvgFDu5dI9mqhq6fqFJH/s0p38EN1dBTvs8iWx1yPIaRhv8R/u2UfQq/EzZEqfUCgr3vl6/Sj3GW3Mq5g5aur2MnkBF0QNGqskdCy3CYVmWp3yx532CZBwtPcVnmZjIhBbmTzlfb6WV9PD+0oO748aEfxzvuJjNZhcuHPOqDRsyPuzkXSM9dfU/R/SHoA==) used to determine other tints and shades. 
- Updated the Service navigation component's link colour to the new shade.
- Updated test for output colours.