### PR TITLE
Remove redirect to Frontend docs when accessing Sass docs

### DIFF
--- a/packages/govuk-frontend-review/src/common/middleware/docs.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/docs.mjs
@@ -13,22 +13,6 @@ router.get('/', (req, res) => {
 })
 
 /**
- * Sass docs latest release (when deployed)
- */
-router.use('/sass', ({ app }, res, next) => {
-  const { isDevelopment } =
-    /** @type {import('../../app.mjs').FeatureFlags} */ (app.get('flags'))
-
-  if (!isDevelopment) {
-    return res.redirect(
-      'https://frontend.design-system.service.gov.uk/sass-api-reference/'
-    )
-  }
-
-  next()
-})
-
-/**
  * Add middleware
  */
 router.use('/sass', express.static(join(paths.app, 'dist/docs/sassdoc')))


### PR DESCRIPTION
There's already a link to explicitely access the Frontend docs on the review app's homepage and having that redirect prevents from [previewing the Sass docs changes from a PR](https://govuk-frontend-pr-6656.herokuapp.com/docs/sass/).