### PR TITLE
Remove leading `_` from colour custom properties

### DIFF
--- a/packages/govuk-frontend/src/govuk/custom-properties/_functional-colours.scss
+++ b/packages/govuk-frontend/src/govuk/custom-properties/_functional-colours.scss
@@ -8,7 +8,7 @@
   :root {
     @if $govuk-output-custom-properties {
       @each $name, $value in $govuk-functional-colours {
-        --_govuk-#{$name}-colour: #{_govuk-resolve-colour($value)};
+        --govuk-#{$name}-colour: #{_govuk-resolve-colour($value)};
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/custom-properties/custom-properties.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/custom-properties/custom-properties.unit.test.mjs
@@ -10,6 +10,6 @@ describe('GOV.UK Frontend custom properties', () => {
 
     await expect(css).toContain('--govuk-frontend-version')
     await expect(css).toContain('--govuk-breakpoint-mobile')
-    await expect(css).toContain('--_govuk-brand-colour')
+    await expect(css).toContain('--govuk-brand-colour')
   })
 })

--- a/packages/govuk-frontend/src/govuk/custom-properties/functional-colours.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/custom-properties/functional-colours.unit.test.mjs
@@ -8,8 +8,8 @@ describe('custom-properties/functional-colours', () => {
 
     const { css } = await compileSassString(sass)
 
-    await expect(css).toContain('--_govuk-brand-colour: #1d70b8;')
-    await expect(css).toContain('--_govuk-text-colour: #0b0c0c;')
+    await expect(css).toContain('--govuk-brand-colour: #1d70b8;')
+    await expect(css).toContain('--govuk-text-colour: #0b0c0c;')
   })
 
   it('outputs the properties only once when included multiple times', async () => {
@@ -20,7 +20,7 @@ describe('custom-properties/functional-colours', () => {
 
     const { css } = await compileSassString(sass)
 
-    const occurrences = css.matchAll(/--_govuk-brand-colour/g)
+    const occurrences = css.matchAll(/--govuk-brand-colour/g)
 
     expect(Array.from(occurrences)).toHaveLength(1)
   })
@@ -34,7 +34,7 @@ describe('custom-properties/functional-colours', () => {
 
       const { css } = await compileSassString(sass)
 
-      await expect(css).toContain('--_govuk-brand-colour')
+      await expect(css).toContain('--govuk-brand-colour')
     })
 
     it('does not output core custom properties if `false`', async () => {
@@ -45,7 +45,7 @@ describe('custom-properties/functional-colours', () => {
 
       const { css } = await compileSassString(sass)
 
-      await expect(css).not.toContain('--_govuk-brand-colour')
+      await expect(css).not.toContain('--govuk-brand-colour')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -112,7 +112,7 @@
 /// @example css - Output from getting a functional colour
 ///   .branded-element {
 ///     /* Assuming the 'brand' colour is hotpink */
-///     color: var(--_govuk-brand-colour, hotpink);
+///     color: var(--govuk-brand-colour, hotpink);
 ///   }
 ///
 /// @throw if `$colour` is not an functional colour of GOV.UK Frontend
@@ -129,7 +129,7 @@
   @if map-has-key($govuk-functional-colours, $colour) {
     $value: _govuk-resolve-colour(map-get($govuk-functional-colours, $colour));
 
-    @return var(--_govuk-#{$colour}-colour, #{$value});
+    @return var(--govuk-#{$colour}-colour, #{$value});
   }
 
   @error "Unknown colour `#{$colour}` (available colours: #{map-keys($govuk-functional-colours)})";

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -318,7 +318,7 @@ describe('@function govuk-functional-colour', () => {
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
         .foo {
-          color: var(--_govuk-error-colour, #ff0000);
+          color: var(--govuk-error-colour, #ff0000);
         }
       `
     })
@@ -336,7 +336,7 @@ describe('@function govuk-functional-colour', () => {
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
         .foo {
-          color: var(--_govuk-rebeccapurple-colour, #663399);
+          color: var(--govuk-rebeccapurple-colour, #663399);
         }
       `
     })
@@ -355,7 +355,7 @@ describe('@function govuk-functional-colour', () => {
       await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
         css: expect.stringContaining(outdent`
           .foo {
-            color: var(--_govuk-palette-reference-with-variant-colour, #50a1a5);
+            color: var(--govuk-palette-reference-with-variant-colour, #50a1a5);
           }
         `)
       })
@@ -373,7 +373,7 @@ describe('@function govuk-functional-colour', () => {
       await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
         css: expect.stringContaining(outdent`
           .foo {
-            color: var(--_govuk-palette-reference-colour, #ca357c);
+            color: var(--govuk-palette-reference-colour, #ca357c);
           }
         `)
       })


### PR DESCRIPTION
A leading `_` usually signals private variables, but [services should be alright referencing the custom properties using `var()`](https://github.com/alphagov/govuk-frontend-docs/issues/589#issuecomment-3806192767). We'll document that they shouldn't try updating them until we [designed a proper public API for that](https://github.com/alphagov/govuk-frontend/issues/6489), though.