### PR TITLE
Fix filename for Dart Sass v1.79.0 output

### DIFF
--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v6.0.0
         if: ${{ !cancelled() }}
         with:
-          name: Dart Sass v1.0.0 output
+          name: Dart Sass v1.79.0 output
           path: .tmp/index.css
           if-no-files-found: ignore
 


### PR DESCRIPTION
We updated the minimum tested Dart Sass version from v1.0.0 to v1.79.0 in #6366 but the artefact filename was missed.

Update the filename to match the version actually being tested.