### PR TITLE
Fix hover and focus states for cookie banner links

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_index.scss
@@ -20,10 +20,7 @@
   // Override the colour of links in the cookie banner to ensure good contrast
   // against `template-background`.
   .govuk-cookie-banner .govuk-link {
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
+    &:not(:hover):not(:focus) {
       color: govuk-functional-colour(surface-link);
     }
   }


### PR DESCRIPTION
The surface-link colour is being applied incorrectly to the hover and focus states for links in the cookie banner.

Fix this by adopting the same approach used in the service navigation component, where we set the colour on all states except hover and focus.

This does mean that links within the cookie banner will not have a visited state (like service navigation).

| State | Before | After |
| -- | -- | -- |
| Link | <img width="217" height="43" alt="Before link" src="https://github.com/user-attachments/assets/d4470e6f-6b7d-4607-8cb0-ee2fc20d1c51" /> | <img width="217" height="43" alt="After link" src="https://github.com/user-attachments/assets/2d4c0cf6-c221-4cc3-a89a-aefe0d65905e" /> |
| Visited | <img width="217" height="43" alt="Before visited" src="https://github.com/user-attachments/assets/d1132f9d-2e43-483b-aaa4-4b7cfb7e37a7" /> | <img width="217" height="43" alt="After visited" src="https://github.com/user-attachments/assets/0ad0e2dc-778e-4b84-835e-89c02e2add4e" /> |
| Hover | <img width="217" height="43" alt="Before hover" src="https://github.com/user-attachments/assets/e2f4ebb2-2800-4a95-aac3-c0d89036a671" /> | <img width="217" height="43" alt="After hover" src="https://github.com/user-attachments/assets/5b551938-7a1e-4866-b0a6-6b2b65af906c" /> |
| Focus | <img width="217" height="43" alt="Before focus" src="https://github.com/user-attachments/assets/15de237e-ca02-49bb-a669-5a0aa315a1d4" /> | <img width="217" height="43" alt="After focus" src="https://github.com/user-attachments/assets/4964d04f-4ffa-4f09-a868-b2fae3fe1bfd" /> |