### PR TITLE
Explicitly set box-shadow colour for focused inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#6730: Fix `if-function` Sass deprecation](https://github.com/alphagov/govuk-frontend/pull/6730)
 - [#6731: Fix `global-builtin` Sass deprecation](https://github.com/alphagov/govuk-frontend/pull/6731)
 - [#6679: Fix summary list cells becoming vertically misaligned when a multi-line inline-block element is present](https://github.com/alphagov/govuk-frontend/pull/6679) - thanks to @DannyPayne-CH for raising the issue
+- [#6678: Explicitly set box-shadow colour for focused inputs](https://github.com/alphagov/govuk-frontend/pull/6678) - thanks to @colinrotherham for raising the issue
 
 ## v6.0.0 (Breaking release)
 

--- a/packages/govuk-frontend/src/govuk/helpers/_focused.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_focused.scss
@@ -87,5 +87,5 @@
   // components such as textarea where we avoid changing `border-width` as
   // it will change the element size. Also, `outline` cannot be utilised
   // here as it is already used for the yellow focus state.
-  box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element govuk-functional-colour(input-border);
 }


### PR DESCRIPTION
Focused inputs have never previously set a `box-shadow` colour, causing browsers to default to pure black (`#000000`). This appears to have gone unnoticed for several years due to the visual similarity to the input border colour (`#0b0c0c`).

Our checkbox and radio button focus styles do explicitly set a `box-shadow` colour, so it seems like it should be set here as well.

Closes #6433.

## Changes
- Added explicit colour definition (using the `input-border` functional colour) to the `box-shadow` in the `govuk-focused-form-input` mixin.