### PR TITLE
Fix summary list cells becoming vertically misaligned when a multi-line inline-block element is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#6727: Fix `slash-div` Sass deprecation](https://github.com/alphagov/govuk-frontend/pull/6727) - thanks to @colinrotherham for raising the issue
 - [#6730: Fix `if-function` Sass deprecation](https://github.com/alphagov/govuk-frontend/pull/6730)
 - [#6731: Fix `global-builtin` Sass deprecation](https://github.com/alphagov/govuk-frontend/pull/6731)
+- [#6679: Fix summary list cells becoming vertically misaligned when a multi-line inline-block element is present](https://github.com/alphagov/govuk-frontend/pull/6679) - thanks to @DannyPayne-CH for raising the issue
 
 ## v6.0.0 (Breaking release)
 

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -51,6 +51,11 @@
       padding-top: govuk-spacing(2);
       padding-right: govuk-spacing(4);
       padding-bottom: govuk-spacing(2);
+
+      // Make sure that any multi-line inline-blocks inside of the summary
+      // list (e.g. Tag components) don't cause the text baseline to shift,
+      // causing other cells in the row to be misaligned.
+      vertical-align: top;
     }
   }
 


### PR DESCRIPTION
Multi-line inline-block elements inside of the summary list cause the row's text baseline to shift to the lowest line of the inline-block, pushing down the starting baseline of text in other cells on the same row.

Closes #6117.

## Changes

- Set an explicit `vertical-align: top` on cells inside of summary lists.

## Screenshots

|Before|After|
|:-:|:-:|
|<img width="640" height="264" alt="Screenshot of a summary list with a multi-line key name, a multi-line tag in the second column, and a single line link in the third column. The first and third columns have their first lines of text pushed downwards to the same level as the second column's second line of text." src="https://github.com/user-attachments/assets/6fe8f7fd-c044-4ee3-ba70-a3ea9bd08a58" />|<img width="640" height="264" alt="Screenshot of a summary list with a multi-line key name, a multi-line tag in the second column, and a single line link in the third column. All three columns have their content aligned at the top." src="https://github.com/user-attachments/assets/ddd9d98e-7d5f-4a9b-b6e3-673aab56e812" />|

