### PR TITLE
Extract stylelint and its plugins in their own group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,12 @@ updates:
           - 'editorconfig-checker'
           - 'standard'
           - 'prettier'
+          - 'typescript'
+
+      stylelint:
+        patterns:
           - 'stylelint'
           - 'stylelint-*'
-          - 'typescript'
 
       percy:
         patterns:


### PR DESCRIPTION
This will prevent it from stopping other linting updates while we make stylelint-config-gds compatible with Stylelint 17. Keeping it as a group will avoid us forgetting to unpin it and give us a little reminder to tackle the upgrade of stylelint-config-gds.

See: https://github.com/alphagov/govuk-frontend/pull/6685