### PR TITLE
Update warning if applied colour variables are set

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -154,10 +154,14 @@ $govuk-functional-colours: _govuk-define-functional-colours(
 // the legacy variable and warn when they shouldn't so we need to track those
 $_govuk-deprecated-applied-colour-variables: () !default;
 
-@mixin deprecate-applied-colour-variable($functional-colour-name) {
+/// Warn if a given legacy applied colour variable is set
+///
+/// @param {String} Name of variable to check
+/// @access private
+@mixin _warn-if-applied-colour-variable-set($functional-colour-name) {
   @if not index($_govuk-deprecated-applied-colour-variables, $functional-colour-name) {
     @if variable-exists("govuk-#{$functional-colour-name}-colour") {
-      $deprecation-message: "Using the \`$govuk-#{$functional-colour-name}-colour\` variable to configure a new value is deprecated. Please use \`$govuk-functional-colours: (#{$functional-colour-name}: <NEW_COLOUR_VALUE>);\`.";
+      $deprecation-message: "Setting \`$govuk-#{$functional-colour-name}-colour\` no longer has any effect. Use \`$govuk-functional-colours: (#{$functional-colour-name}: <NEW_COLOUR_VALUE>);\` instead.";
 
       @include _warning("applied-colour-variables", $deprecation-message);
     }
@@ -169,7 +173,7 @@ $_govuk-deprecated-applied-colour-variables: () !default;
   }
 }
 
-@include deprecate-applied-colour-variable(brand);
+@include _warn-if-applied-colour-variable-set(brand);
 /// Brand colour
 ///
 /// @type Colour
@@ -179,7 +183,7 @@ $_govuk-deprecated-applied-colour-variables: () !default;
 ///   function instead: `govuk-functional-colour(brand)`.
 $govuk-brand-colour: govuk-functional-colour(brand);
 
-@include deprecate-applied-colour-variable(text);
+@include _warn-if-applied-colour-variable-set(text);
 /// Text colour
 ///
 /// @type Colour
@@ -189,7 +193,7 @@ $govuk-brand-colour: govuk-functional-colour(brand);
 ///   function instead: `govuk-functional-colour(text)`.
 $govuk-text-colour: govuk-functional-colour(text);
 
-@include deprecate-applied-colour-variable(template-background);
+@include _warn-if-applied-colour-variable-set(template-background);
 /// Template background colour
 ///
 /// Used by components that want to give the illusion of extending
@@ -202,7 +206,7 @@ $govuk-text-colour: govuk-functional-colour(text);
 ///   function instead: `govuk-functional-colour(template-background)`.
 $govuk-template-background-colour: govuk-functional-colour(template-background);
 
-@include deprecate-applied-colour-variable(body-background);
+@include _warn-if-applied-colour-variable-set(body-background);
 /// Body background colour
 ///
 /// @type Colour
@@ -212,7 +216,7 @@ $govuk-template-background-colour: govuk-functional-colour(template-background);
 ///   function instead: `govuk-functional-colour(body-background)`.
 $govuk-body-background-colour: govuk-functional-colour(body-background);
 
-@include deprecate-applied-colour-variable(print-text);
+@include _warn-if-applied-colour-variable-set(print-text);
 /// Text colour for print media
 ///
 /// Use 'true black' to avoid printers using colour ink to print body text
@@ -224,7 +228,7 @@ $govuk-body-background-colour: govuk-functional-colour(body-background);
 ///   function instead: `govuk-functional-colour(print-text)`.
 $govuk-print-text-colour: govuk-functional-colour(print-text);
 
-@include deprecate-applied-colour-variable(secondary-text);
+@include _warn-if-applied-colour-variable-set(secondary-text);
 /// Secondary text colour
 ///
 /// Used in for example 'muted' text and help text.
@@ -236,7 +240,7 @@ $govuk-print-text-colour: govuk-functional-colour(print-text);
 ///   function instead: `govuk-functional-colour(secondary-text)`.
 $govuk-secondary-text-colour: govuk-functional-colour(secondary-text);
 
-@include deprecate-applied-colour-variable(focus);
+@include _warn-if-applied-colour-variable-set(focus);
 /// Focus colour
 ///
 /// Used for outline (and background, where appropriate) when interactive
@@ -249,7 +253,7 @@ $govuk-secondary-text-colour: govuk-functional-colour(secondary-text);
 ///   function instead: `govuk-functional-colour(focus)`.
 $govuk-focus-colour: govuk-functional-colour(focus);
 
-@include deprecate-applied-colour-variable(focus-text);
+@include _warn-if-applied-colour-variable-set(focus-text);
 /// Focused text colour
 ///
 /// Ensure that the contrast between the text and background colour passes
@@ -262,7 +266,7 @@ $govuk-focus-colour: govuk-functional-colour(focus);
 ///   function instead: `govuk-functional-colour(focus-text)`.
 $govuk-focus-text-colour: govuk-functional-colour(focus-text);
 
-@include deprecate-applied-colour-variable(error);
+@include _warn-if-applied-colour-variable-set(error);
 /// Error colour
 ///
 /// Used to highlight error messages and form controls in an error state
@@ -274,7 +278,7 @@ $govuk-focus-text-colour: govuk-functional-colour(focus-text);
 ///   function instead: `govuk-functional-colour(error)`.
 $govuk-error-colour: govuk-functional-colour(error);
 
-@include deprecate-applied-colour-variable(success);
+@include _warn-if-applied-colour-variable-set(success);
 /// Success colour
 ///
 /// Used to highlight success messages and banners
@@ -286,7 +290,7 @@ $govuk-error-colour: govuk-functional-colour(error);
 ///   function instead: `govuk-functional-colour(error)`.
 $govuk-success-colour: govuk-functional-colour(success);
 
-@include deprecate-applied-colour-variable(border);
+@include _warn-if-applied-colour-variable-set(border);
 /// Border colour
 ///
 /// Used in for example borders, separators, rules and keylines.
@@ -298,7 +302,7 @@ $govuk-success-colour: govuk-functional-colour(success);
 ///   function instead: `govuk-functional-colour(border)`.
 $govuk-border-colour: govuk-functional-colour(border);
 
-@include deprecate-applied-colour-variable(input-border);
+@include _warn-if-applied-colour-variable-set(input-border);
 /// Input border colour
 ///
 /// Used for form inputs and controls
@@ -310,7 +314,7 @@ $govuk-border-colour: govuk-functional-colour(border);
 ///   function instead: `govuk-functional-colour(input-border)`.
 $govuk-input-border-colour: govuk-functional-colour(input-border);
 
-@include deprecate-applied-colour-variable(hover);
+@include _warn-if-applied-colour-variable-set(hover);
 /// Input hover colour
 ///
 /// Used for hover states on form controls
@@ -322,7 +326,7 @@ $govuk-input-border-colour: govuk-functional-colour(input-border);
 ///   function instead: `govuk-functional-colour(hover)`.
 $govuk-hover-colour: govuk-functional-colour(hover);
 
-@include deprecate-applied-colour-variable(link);
+@include _warn-if-applied-colour-variable-set(link);
 /// Link colour
 ///
 /// @type Colour
@@ -332,7 +336,7 @@ $govuk-hover-colour: govuk-functional-colour(hover);
 ///   function instead: `govuk-functional-colour(link)`.
 $govuk-link-colour: govuk-functional-colour(link);
 
-@include deprecate-applied-colour-variable(link-visited);
+@include _warn-if-applied-colour-variable-set(link-visited);
 /// Visited link colour
 ///
 /// @type Colour
@@ -342,7 +346,7 @@ $govuk-link-colour: govuk-functional-colour(link);
 ///   function instead: `govuk-functional-colour(link-visited)`.
 $govuk-link-visited-colour: govuk-functional-colour(link-visited);
 
-@include deprecate-applied-colour-variable(link-hover);
+@include _warn-if-applied-colour-variable-set(link-hover);
 /// Link hover colour
 ///
 /// @type Colour
@@ -352,7 +356,7 @@ $govuk-link-visited-colour: govuk-functional-colour(link-visited);
 ///   function instead: `govuk-functional-colour(link-hover)`.
 $govuk-link-hover-colour: govuk-functional-colour(link-hover);
 
-@include deprecate-applied-colour-variable(link-active);
+@include _warn-if-applied-colour-variable-set(link-active);
 /// Active link colour
 ///
 /// @type Colour

--- a/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/colours.unit.test.js
@@ -184,12 +184,7 @@ describe('Functional colours', () => {
 
         const { css } = await compileSassString(sass, sassConfig)
 
-        expect(mockWarnFunction).not.toHaveBeenCalledWith(
-          `Using the \`$govuk-${functionalColourName}-colour\` variable to configure a new value is deprecated.` +
-            ` Please use \`$govuk-functional-colours: (${functionalColourName}: <NEW_COLOUR_VALUE>);\`.` +
-            ' To silence this warning, update $govuk-suppressed-warnings with key: "applied-colour-variables"',
-          expect.anything()
-        )
+        expect(mockWarnFunction).not.toHaveBeenCalled()
 
         expect(css).toContain(`result: true;`)
       })
@@ -205,8 +200,8 @@ describe('Functional colours', () => {
         // Expect our mocked @warn function to have been called once with a single
         // argument, which should be the deprecation notice
         expect(mockWarnFunction).toHaveBeenCalledWith(
-          `Using the \`$govuk-${functionalColourName}-colour\` variable to configure a new value is deprecated.` +
-            ` Please use \`$govuk-functional-colours: (${functionalColourName}: <NEW_COLOUR_VALUE>);\`.` +
+          `Setting \`$govuk-${functionalColourName}-colour\` no longer has any effect.` +
+            ` Use \`$govuk-functional-colours: (${functionalColourName}: <NEW_COLOUR_VALUE>);\` instead.` +
             ' To silence this warning, update $govuk-suppressed-warnings with key: "applied-colour-variables"',
           expect.anything()
         )
@@ -225,12 +220,7 @@ describe('Functional colours', () => {
 
         // Expect our mocked @warn function to have been called once with a single
         // argument, which should be the deprecation notice
-        expect(mockWarnFunction).not.toHaveBeenCalledWith(
-          `Using the \`$govuk-${functionalColourName}-colour\` variable to configure a new value is deprecated.` +
-            ` Please use \`$govuk-functional-colours: (${functionalColourName}: <NEW_COLOUR_VALUE>);\`.` +
-            ' To silence this warning, update $govuk-suppressed-warnings with key: "applied-colour-variables"',
-          expect.anything()
-        )
+        expect(mockWarnFunction).not.toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
The warning currently says these settings are _deprecated_, but this suggests that setting them should still work.

Update the warning message to make it clear that these settings no longer do anything.

Rename the mixin to better reflect what it’s doing, add add Sassdoc to make it clear the mixin is private.