### PR TITLE
Security fix: @isaacs/brace-expansion and tar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15877,12 +15877,12 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
+      "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.1.2",
         "minipass": "^7.1.2",
         "path-scurry": "^2.0.0"
       },
@@ -16000,6 +16000,21 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob2base": {
@@ -27754,6 +27769,7 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
       "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -37926,9 +37942,9 @@
       "dependencies": {
         "@govuk-frontend/config": "*",
         "filesize": "^11.0.13",
-        "glob": "^13.0.0",
+        "glob": "^13.0.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.1.2",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "slash": "^3.0.0"
@@ -37936,6 +37952,21 @@
       "engines": {
         "node": "^24.11.0",
         "npm": "11.6.2"
+      }
+    },
+    "shared/lib/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "shared/lib/node_modules/slash": {

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "@govuk-frontend/config": "*",
     "filesize": "^11.0.13",
-    "glob": "^13.0.0",
+    "glob": "^13.0.1",
     "js-yaml": "^4.1.1",
-    "minimatch": "^10.1.1",
+    "minimatch": "^10.1.2",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "slash": "^3.0.0"


### PR DESCRIPTION
We have a [security alert on @isaacs/brace-expansion](https://github.com/alphagov/govuk-frontend/security/dependabot/181), but dependabot is unable to fix it automatically for some reason.

Run `npm audit fix` to fix it and a `tar` [vulnerability](https://github.com/alphagov/govuk-frontend/security/dependabot/176) manually. Also install the patch updates that `minimatch` and `glob` have released to address this (this isn't enough to fix the issue since `@npmcli/run-script` indirectly depends on a compromised version of `glob`).

`@isaacs/brace-expansion` is a dependency of `minimatch`, which we use directly in `shared/lib`, as well as indirectly via `glob`. It's potentially worth investigating moving to `micromatch`, which seems better supported/quicker.

```
npm ls @isaacs/brace-expansion

├─┬ @govuk-frontend/lib@ -> ./shared/lib
│ ├─┬ glob@13.0.1
│ │ └─┬ minimatch@10.1.2
│ │   └── @isaacs/brace-expansion@5.0.1 deduped
│ └─┬ minimatch@10.1.2
│   └── @isaacs/brace-expansion@5.0.1
└─┬ @govuk-frontend/tasks@ -> ./shared/tasks
  └─┬ @npmcli/run-script@10.0.3
    └─┬ @npmcli/package-json@7.0.1
      └─┬ glob@11.1.0
        └─┬ minimatch@10.1.1
          └── @isaacs/brace-expansion@5.0.1 deduped
```