### PR TITLE
Remove duplicated Sass compilation test

### DIFF
--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -167,15 +167,6 @@ describe('packages/govuk-frontend/dist/', () => {
         await expect(compileSassFile(file)).resolves.not.toThrow()
       })
     })
-
-    // all.scss is deprecated but we still want to make sure it works when used
-    // as the root for compilation
-    describe('all.scss', () => {
-      it('should compile without throwing an exception', async () => {
-        const file = join(paths.package, 'dist/govuk/index.scss')
-        await expect(compileSassFile(file)).resolves.not.toThrow()
-      })
-    })
   })
 
   describe('ECMAScript (ES) modules', () => {


### PR DESCRIPTION
We removed the deprecated `all.scss` entrypoints in #6412. We previously had two tests for Sass compilation – one for `index.scss` and one for `all.scss`.

Rather than removing the `all.scss` test in that PR we updated the filename, which means we now have two identical tests.

Remove the second test instead.