### PR TITLE
Remove quietDeps from Sass config

### DIFF
--- a/shared/config/sass.js
+++ b/shared/config/sass.js
@@ -8,8 +8,7 @@ const deprecationOptions = {
     'import',
     'mixed-decls',
     'slash-div'
-  ],
-  quietDeps: true
+  ]
 }
 
 module.exports = {


### PR DESCRIPTION
GOV.UK Frontend doesn’t have any dependencies, but using `quietDeps` here means that where we treat the package as a dependency in tests we don’t get any deprecation warnings (other than for the `import` deprecation where our Sass tests use `@import`).

We’re silencing all of the deprecations that we know exist in the codebase anyway, so it should be safe for us to remove this option.

With this change, uncommenting the silenced deprecations causes the ‘compiles without deprecation warnings’ test in packages/govuk-frontend/src/govuk/all.unit.test.mjs to fail as expected (but with quite a lot of noise from where we are compiling Sass and not stubbing out the logger).