### PR TITLE
Tighten node requirements

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,4 +1,4 @@
-24.13.0
+24.13.1
 # When updating this version, remember to update:
 # - the 'engines' fields in the various `package.json` files of the project
 # - `package-lock.json` by running `npm install`

--- a/docs/examples/webpack/package.json
+++ b/docs/examples/webpack/package.json
@@ -3,8 +3,8 @@
   "name": "@govuk-frontend/webpack-boilerplate",
   "description": "Boilerplate example for govuk-frontend using webpack",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "scripts": {
     "dev": "webpack serve --progress --mode development",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,8 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       },
       "optionalDependencies": {
         "@actions/github": "^9.0.0",
@@ -127,8 +127,8 @@
         "webpack-dev-server": "^5.2.3"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -238,7 +238,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2051,7 +2050,6 @@
       "integrity": "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2161,7 +2159,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2204,7 +2201,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5417,6 +5413,25 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@octokit/endpoint": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
@@ -6068,7 +6083,6 @@
       "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -6173,7 +6187,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6864,7 +6877,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7524,7 +7536,6 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -8258,7 +8269,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8302,7 +8312,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9862,7 +9871,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12203,8 +12211,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
       "devOptional": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -13005,7 +13012,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13260,7 +13266,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13627,7 +13632,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -13643,7 +13647,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
       "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -16490,7 +16493,6 @@
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -22148,7 +22150,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -25181,7 +25182,6 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
       "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -26138,7 +26138,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -26195,7 +26194,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -27186,7 +27184,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
       "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -29156,7 +29153,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -29957,7 +29953,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -30182,7 +30177,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.0",
         "chromium-bidi": "12.0.1",
@@ -30204,7 +30198,6 @@
       "integrity": "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.0",
         "chromium-bidi": "12.0.1",
@@ -31052,7 +31045,6 @@
       "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -31463,7 +31455,6 @@
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.89.2.tgz",
       "integrity": "sha512-Ack2K8rc57kCFcYlf3HXpZEJFNUX8xd8DILldksREmYXQkRHI879yy8q4mRDJgrojkySMZqmmmW1NxrFxMsYaA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "buffer-builder": "^0.2.0",
@@ -33468,7 +33459,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -33832,7 +33822,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -34315,7 +34304,6 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -34566,7 +34554,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -34770,8 +34757,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -35013,7 +34999,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -36364,7 +36349,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -36457,7 +36441,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -36506,7 +36489,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -36659,7 +36641,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -37591,8 +37572,8 @@
         "typedoc-plugin-missing-exports": "^4.1.2"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       },
       "optionalDependencies": {
         "nunjucks": "^3.2.4"
@@ -37620,8 +37601,8 @@
         "webpack": "^5.104.1"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     },
     "shared/config": {
@@ -37631,8 +37612,8 @@
         "govuk-frontend": "*"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     },
     "shared/github-scripts": {
@@ -37645,8 +37626,8 @@
         "semver": "^7.7.3"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     },
     "shared/helpers": {
@@ -37671,8 +37652,8 @@
         "slug": "^9.1.0"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       },
       "peerDependencies": {
         "@puppeteer/browsers": "^2.1.0",
@@ -37701,8 +37682,8 @@
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     },
     "shared/lib/node_modules/minimatch": {
@@ -37744,8 +37725,8 @@
         "rollup-plugin-visualizer": "^6.0.5"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     },
     "shared/tasks": {
@@ -37770,8 +37751,8 @@
         "slug": "^9.1.0"
       },
       "engines": {
-        "node": "24.13.0",
-        "npm": "11.6.2"
+        "node": "24.13.1",
+        "npm": "11.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "name": "@govuk-frontend/repository",
   "description": "Used only for the development of GOV.UK Frontend, see `packages/govuk-frontend/package.json` for the published `package.json`",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "workspaces": [

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -4,8 +4,8 @@
   "description": "GOV.UK Frontend review app",
   "main": "src/start.mjs",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "scripts": {

--- a/shared/bundler-integrations/package.json
+++ b/shared/bundler-integrations/package.json
@@ -2,8 +2,8 @@
   "name": "@govuk-frontend/bundler-integrations",
   "description": "Boilerplate to verify that GOV.UK Frontend works OK with main bundlers",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "private": true,
   "scripts": {

--- a/shared/config/package.json
+++ b/shared/config/package.json
@@ -4,8 +4,8 @@
   "description": "GOV.UK Frontend shared config",
   "main": "index.js",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/shared/github-scripts/package.json
+++ b/shared/github-scripts/package.json
@@ -3,8 +3,8 @@
   "name": "@govuk-frontend/workflow-scripts",
   "description": "GOV.UK Frontend GitHub Actions workflow scripts",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -9,8 +9,8 @@
     "./*": "./*.js"
   },
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -8,8 +8,8 @@
     "./*": "./*.js"
   },
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/shared/stats/package.json
+++ b/shared/stats/package.json
@@ -4,8 +4,8 @@
   "description": "GOV.UK Frontend build stats",
   "main": "src/index.mjs",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "scripts": {

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -4,8 +4,8 @@
   "description": "GOV.UK Frontend shared tasks",
   "main": "index.mjs",
   "engines": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.13.1",
+    "npm": "11.8.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Tightens our requirements on Node version to an exact version and updates to the latest Node and npm version (that second part can be extracted in its own PR or left).

This has been prefered over loosening our requirements on the `npm` version as running `11.8.0` on a `package-lock.json` generated with `11.6.2` [errored from missing dependencies in the `package-lock` file](https://github.com/alphagov/govuk-frontend/actions/runs/22219310618?pr=6757).

## Why

We had a couple of CI fails from Dependabot updates:

- https://github.com/alphagov/govuk-frontend/actions/runs/22199182869/job/64207330184?pr=6756
- https://github.com/alphagov/govuk-frontend/actions/runs/22193376028/job/64187136429?pr=6755

These updates try to install our project using `npm@11.8.0` where our `engines` field
in `package.json` specifies `npm@11.6.2` (as an exact version).

PRs not updating `package.json` and `package-lock.json` seem unaffected (for now), so benefit from [the cached dependencies](https://github.com/alphagov/govuk-frontend/blob/5e23b3cbfc53740acc645c8e107b87e509ab2643/.github/workflows/actions/install-node/action.yml#L16) on CI.

## In more details

As those PRs are Dependabot updates, `package.json` and `package-lock.json` have been updated,
so dependencies are not cached and npm runs.

There's a mix of things happening:
- our `nvmrc` file only lists `24`, which resolves to `24.13.1`. That version installs `npm` at `11.8.0` (nodejs/node#61466 via https://nodejs.org/en/blog/release/v24.13.1)
- our `package.json`s expects `node` at `^24.11.0` which `24.13.1` satisfies
- however our `package.json`s file have a strict requirement for `npm` at `11.8.0`, which `11.8.0` does not satisfy. 

Because `.nvmrc` only controlls the version of Node being installed, not npm, having one with a loose requirement and one with a tight requirement led to the current situation.

Because there are issues running `11.8.0` with a lockfile from `11.6.2`, best to tighten the requirements on Node rather than loosen them.

We should keep an eye [on Node's releases](https://nodejs.org/en/blog/release/) to pick up new LTS releases.