### PR TITLE
Fix build with `npm@11.8.0`

### DIFF
--- a/docs/examples/webpack/package.json
+++ b/docs/examples/webpack/package.json
@@ -4,7 +4,7 @@
   "description": "Boilerplate example for govuk-frontend using webpack",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "scripts": {
     "dev": "webpack serve --progress --mode development",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "docs/examples/rollup": {
@@ -126,7 +126,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -236,7 +236,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2049,7 +2048,6 @@
       "integrity": "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2159,7 +2157,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2202,7 +2199,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5421,7 +5417,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -6086,7 +6081,6 @@
       "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -6191,7 +6185,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6882,7 +6875,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7289,7 +7281,7 @@
       "version": "25.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -7491,7 +7483,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -7543,7 +7534,6 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -8277,7 +8267,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8321,7 +8310,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9213,14 +9201,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
       "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/bare-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
       "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -9243,7 +9229,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
       "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
-      "dev": true,
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -9253,7 +9238,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -9263,7 +9247,6 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
       "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -9886,7 +9869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12227,8 +12209,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
       "devOptional": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -13029,7 +13010,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13284,7 +13264,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13651,7 +13630,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -13667,7 +13645,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
       "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -15458,7 +15435,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -16515,7 +16491,6 @@
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -22173,7 +22148,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -25206,7 +25180,6 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
       "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -26163,7 +26136,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -26220,7 +26192,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -27211,7 +27182,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
       "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -29181,7 +29151,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -29982,7 +29951,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -30207,7 +30175,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.0",
         "chromium-bidi": "12.0.1",
@@ -30229,7 +30196,6 @@
       "integrity": "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.0",
         "chromium-bidi": "12.0.1",
@@ -31077,7 +31043,6 @@
       "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -31488,7 +31453,6 @@
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.89.2.tgz",
       "integrity": "sha512-Ack2K8rc57kCFcYlf3HXpZEJFNUX8xd8DILldksREmYXQkRHI879yy8q4mRDJgrojkySMZqmmmW1NxrFxMsYaA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "buffer-builder": "^0.2.0",
@@ -32828,7 +32792,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -33493,7 +33457,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -33857,7 +33820,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -34340,7 +34302,6 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -34591,7 +34552,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -34795,8 +34755,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -35038,7 +34997,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -35174,7 +35132,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -36389,7 +36347,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -36482,7 +36439,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -36531,7 +36487,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -36684,7 +36639,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -37618,7 +37572,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "packages/govuk-frontend-review/node_modules/slash": {
@@ -37644,7 +37598,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "shared/config": {
@@ -37655,7 +37609,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "shared/github-scripts": {
@@ -37669,7 +37623,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "shared/helpers": {
@@ -37695,7 +37649,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       },
       "peerDependencies": {
         "@puppeteer/browsers": "^2.1.0",
@@ -37725,7 +37679,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "shared/lib/node_modules/minimatch": {
@@ -37768,7 +37722,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     },
     "shared/tasks": {
@@ -37794,7 +37748,7 @@
       },
       "engines": {
         "node": "^24.11.0",
-        "npm": "11.6.2"
+        "npm": "^11.6.1 <11.6.3 || ^11.6.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Used only for the development of GOV.UK Frontend, see `packages/govuk-frontend/package.json` for the published `package.json`",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "workspaces": [

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -5,7 +5,7 @@
   "main": "src/start.mjs",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "scripts": {

--- a/shared/bundler-integrations/package.json
+++ b/shared/bundler-integrations/package.json
@@ -3,7 +3,7 @@
   "description": "Boilerplate to verify that GOV.UK Frontend works OK with main bundlers",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "private": true,
   "scripts": {

--- a/shared/config/package.json
+++ b/shared/config/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "dependencies": {

--- a/shared/github-scripts/package.json
+++ b/shared/github-scripts/package.json
@@ -4,7 +4,7 @@
   "description": "GOV.UK Frontend GitHub Actions workflow scripts",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "devDependencies": {

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "devDependencies": {

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "dependencies": {

--- a/shared/stats/package.json
+++ b/shared/stats/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.mjs",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "scripts": {

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -5,7 +5,7 @@
   "main": "index.mjs",
   "engines": {
     "node": "^24.11.0",
-    "npm": "11.6.2"
+    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Move `optionalDependencies` into `devDependencies` as it leads to sub-dependencies of the `optionalDependencies` not to be listed inside `package.json`, which makes `npm@11.8.0` unable to run `npm ci`.

This should also help with Dependabot hoisting some optional dependencies in the `package-lock.json` file.

Also tidies up the required versions in our `engines` field of `package.json` to keep a wide range of version available to facilitate contribution.

## Why

We had a couple of CI fails from Dependabot updates:

- https://github.com/alphagov/govuk-frontend/actions/runs/22199182869/job/64207330184?pr=6756
- https://github.com/alphagov/govuk-frontend/actions/runs/22193376028/job/64187136429?pr=6755

These updates try to install our project using `npm@11.8.0` where our `engines` field
in `package.json` specifies `npm@11.6.2` (as an exact version).

PRs not updating `package.json` and `package-lock.json` seem unaffected (for now), so benefit from [the cached dependencies](https://github.com/alphagov/govuk-frontend/blob/5e23b3cbfc53740acc645c8e107b87e509ab2643/.github/workflows/actions/install-node/action.yml#L16) on CI.

Thanks @colinrotherham for [pointing out that freezing the version numbers wasn't a good idea](https://github.com/alphagov/govuk-frontend/pull/6759#issuecomment-3934987703) and pointing me in the right direction for the fix.