### PR TITLE
Avoid using `if` from within settings

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_typography-font.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_typography-font.scss
@@ -3,8 +3,6 @@
 ////
 @use "sass:list";
 
-@import "../tools/if";
-
 // =========================================================
 // Font families
 // =========================================================
@@ -34,7 +32,7 @@ $govuk-font-family-print: sans-serif !default;
 /// @type Boolean
 /// @access public
 
-$govuk-include-default-font-face: govuk-if(list.index($govuk-font-family, "GDS Transport"), true, false) !default;
+$govuk-include-default-font-face: (list.index($govuk-font-family, "GDS Transport") != null) !default;
 
 // =========================================================
 // Font weights

--- a/tests/sass-tests/__snapshots__/all-components-with-config.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/all-components-with-config.integration.test.mjs.snap
@@ -83,8 +83,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -136,7 +134,6 @@ exports[`All components, with configuration works when user @imports everything 
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
 
 
 
@@ -343,7 +340,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
 .govuk-list {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -410,7 +406,6 @@ exports[`All components, with configuration works when user @imports everything 
     margin-bottom: 15px;
   }
 }
-
 
 
 
@@ -1046,10 +1041,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
 .govuk-button-group {
   margin-bottom: 5px;
   display: flex;
@@ -1203,8 +1194,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-form-group {
   margin-bottom: 20px;
 }
@@ -1231,8 +1220,6 @@ exports[`All components, with configuration works when user @imports everything 
   padding: 0;
   border: 0;
 }
-
-
 
 
 
@@ -1580,8 +1567,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-main-wrapper {
   display: block;
   padding-top: 20px;
@@ -1604,8 +1589,6 @@ exports[`All components, with configuration works when user @imports everything 
     padding-top: 50px;
   }
 }
-
-
 
 
 
@@ -1830,8 +1813,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-width-container {
   max-width: 960px;
   margin-right: 15px;
@@ -1867,10 +1848,6 @@ exports[`All components, with configuration works when user @imports everything 
     }
   }
 }
-
-
-
-
 
 
 
@@ -2498,8 +2475,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-back-link {
   font-size: 1rem;
   line-height: 1.25;
@@ -2597,8 +2572,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-back-link--inverse::before {
   border-color: currentcolor;
 }
-
-
 
 
 
@@ -2839,8 +2812,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-breadcrumbs--inverse .govuk-breadcrumbs__list-item::before {
   border-color: currentcolor;
 }
-
-
 
 
 
@@ -3312,10 +3283,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
 .govuk-error-message {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3340,8 +3307,6 @@ exports[`All components, with configuration works when user @imports everything 
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -3575,8 +3540,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-label {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3665,14 +3628,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-label-wrapper {
   margin: 0;
 }
-
-
-
-
-
-
-
-
 
 
 
@@ -4452,12 +4407,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
-
 .govuk-fieldset {
   min-width: 0;
   margin: 0;
@@ -4570,10 +4519,6 @@ exports[`All components, with configuration works when user @imports everything 
   font-size: inherit;
   font-weight: inherit;
 }
-
-
-
-
 
 
 
@@ -5166,10 +5111,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
 .govuk-cookie-banner {
   padding-top: 20px;
   border-bottom: 10px solid transparent;
@@ -5190,18 +5131,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-cookie-banner__message:focus {
   outline: none;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -6271,12 +6200,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
-
 .govuk-date-input {
   font-size: 0;
 }
@@ -6300,8 +6223,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-date-input__input {
   margin-bottom: 0;
 }
-
-
 
 
 
@@ -6786,11 +6707,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
 .govuk-error-summary {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -6924,10 +6840,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-error-summary__list a:focus {
   color: var(--govuk-focus-text-colour, #0b0c0c);
 }
-
-
-
-
 
 
 
@@ -7702,16 +7614,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
-
-
-
-
-
 .govuk-file-upload {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -7876,8 +7778,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-file-upload-button:disabled .govuk-file-upload-button__status {
   background-color: #d2e2f1;
 }
-
-
 
 
 
@@ -8240,8 +8140,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-footer__list-item:last-child {
   margin-bottom: 0;
 }
-
-
 
 
 
@@ -9085,18 +8983,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
 .govuk-inset-text {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9140,10 +9026,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-inset-text > :last-child {
   margin-bottom: 0;
 }
-
-
-
-
 
 
 
@@ -9604,8 +9486,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-pagination {
   margin-bottom: 20px;
   display: flex;
@@ -9927,8 +9807,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-panel {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -10002,18 +9880,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-panel__title:last-child {
   margin-bottom: 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -10834,10 +10700,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
 .govuk-tag {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -10983,16 +10845,6 @@ exports[`All components, with configuration works when user @imports everything 
   display: table-cell;
   vertical-align: middle;
 }
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -12086,14 +11938,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
-
-
-
 .govuk-select {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -12147,8 +11991,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-select--error:focus {
   border-color: var(--govuk-input-border-colour, #0b0c0c);
 }
-
-
 
 
 
@@ -12622,8 +12464,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-skip-link {
   text-decoration: underline;
   text-decoration-thickness: max(1px, .0625rem);
@@ -12691,8 +12531,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-skip-link-focused-element:focus {
   outline: none;
 }
-
-
 
 
 
@@ -13189,8 +13027,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
 .govuk-table {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13323,8 +13159,6 @@ exports[`All components, with configuration works when user @imports everything 
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -13920,12 +13754,6 @@ exports[`All components, with configuration works when user @imports everything 
 
 
 
-
-
-
-
-
-
 .govuk-task-list {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -14007,16 +13835,6 @@ exports[`All components, with configuration works when user @imports everything 
   margin-top: 5px;
   color: var(--govuk-secondary-text-colour, #484949);
 }
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -15792,7 +15610,6 @@ exports[`All components, with configuration works when user @imports everything 
 .govuk-\\!-text-align-right {
   text-align: right !important;
 }
-
 
 
 

--- a/tests/sass-tests/__snapshots__/all-components.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/all-components.integration.test.mjs.snap
@@ -83,8 +83,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -136,7 +134,6 @@ exports[`All components works when user @imports everything 1`] = `
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
 
 
 
@@ -343,7 +340,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
 .govuk-list {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -410,7 +406,6 @@ exports[`All components works when user @imports everything 1`] = `
     margin-bottom: 15px;
   }
 }
-
 
 
 
@@ -1046,10 +1041,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
 .govuk-button-group {
   margin-bottom: 5px;
   display: flex;
@@ -1203,8 +1194,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-form-group {
   margin-bottom: 20px;
 }
@@ -1231,8 +1220,6 @@ exports[`All components works when user @imports everything 1`] = `
   padding: 0;
   border: 0;
 }
-
-
 
 
 
@@ -1580,8 +1567,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-main-wrapper {
   display: block;
   padding-top: 20px;
@@ -1604,8 +1589,6 @@ exports[`All components works when user @imports everything 1`] = `
     padding-top: 50px;
   }
 }
-
-
 
 
 
@@ -1830,8 +1813,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-width-container {
   max-width: 960px;
   margin-right: 15px;
@@ -1867,10 +1848,6 @@ exports[`All components works when user @imports everything 1`] = `
     }
   }
 }
-
-
-
-
 
 
 
@@ -2498,8 +2475,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-back-link {
   font-size: 1rem;
   line-height: 1.25;
@@ -2597,8 +2572,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-back-link--inverse::before {
   border-color: currentcolor;
 }
-
-
 
 
 
@@ -2839,8 +2812,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-breadcrumbs--inverse .govuk-breadcrumbs__list-item::before {
   border-color: currentcolor;
 }
-
-
 
 
 
@@ -3312,10 +3283,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
 .govuk-error-message {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3340,8 +3307,6 @@ exports[`All components works when user @imports everything 1`] = `
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -3575,8 +3540,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-label {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3665,14 +3628,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-label-wrapper {
   margin: 0;
 }
-
-
-
-
-
-
-
-
 
 
 
@@ -4452,12 +4407,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
-
 .govuk-fieldset {
   min-width: 0;
   margin: 0;
@@ -4570,10 +4519,6 @@ exports[`All components works when user @imports everything 1`] = `
   font-size: inherit;
   font-weight: inherit;
 }
-
-
-
-
 
 
 
@@ -5166,10 +5111,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
 .govuk-cookie-banner {
   padding-top: 20px;
   border-bottom: 10px solid transparent;
@@ -5190,18 +5131,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-cookie-banner__message:focus {
   outline: none;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -6271,12 +6200,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
-
 .govuk-date-input {
   font-size: 0;
 }
@@ -6300,8 +6223,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-date-input__input {
   margin-bottom: 0;
 }
-
-
 
 
 
@@ -6786,11 +6707,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
 .govuk-error-summary {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -6924,10 +6840,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-error-summary__list a:focus {
   color: var(--govuk-focus-text-colour, #0b0c0c);
 }
-
-
-
-
 
 
 
@@ -7702,16 +7614,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
-
-
-
-
-
 .govuk-file-upload {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -7876,8 +7778,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-file-upload-button:disabled .govuk-file-upload-button__status {
   background-color: #d2e2f1;
 }
-
-
 
 
 
@@ -8240,8 +8140,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-footer__list-item:last-child {
   margin-bottom: 0;
 }
-
-
 
 
 
@@ -9085,18 +8983,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
 .govuk-inset-text {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9140,10 +9026,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-inset-text > :last-child {
   margin-bottom: 0;
 }
-
-
-
-
 
 
 
@@ -9604,8 +9486,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-pagination {
   margin-bottom: 20px;
   display: flex;
@@ -9927,8 +9807,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-panel {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -10002,18 +9880,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-panel__title:last-child {
   margin-bottom: 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -10834,10 +10700,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
 .govuk-tag {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -10983,16 +10845,6 @@ exports[`All components works when user @imports everything 1`] = `
   display: table-cell;
   vertical-align: middle;
 }
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -12086,14 +11938,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
-
-
-
 .govuk-select {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -12147,8 +11991,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-select--error:focus {
   border-color: var(--govuk-input-border-colour, #0b0c0c);
 }
-
-
 
 
 
@@ -12622,8 +12464,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-skip-link {
   text-decoration: underline;
   text-decoration-thickness: max(1px, .0625rem);
@@ -12691,8 +12531,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-skip-link-focused-element:focus {
   outline: none;
 }
-
-
 
 
 
@@ -13189,8 +13027,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
 .govuk-table {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13323,8 +13159,6 @@ exports[`All components works when user @imports everything 1`] = `
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -13920,12 +13754,6 @@ exports[`All components works when user @imports everything 1`] = `
 
 
 
-
-
-
-
-
-
 .govuk-task-list {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -14007,16 +13835,6 @@ exports[`All components works when user @imports everything 1`] = `
   margin-top: 5px;
   color: var(--govuk-secondary-text-colour, #484949);
 }
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -15792,7 +15610,6 @@ exports[`All components works when user @imports everything 1`] = `
 .govuk-\\!-text-align-right {
   text-align: right !important;
 }
-
 
 
 

--- a/tests/sass-tests/__snapshots__/individual-components.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/individual-components.integration.test.mjs.snap
@@ -82,8 +82,6 @@ exports[`Individual components dist/govuk/components/accordion works when user @
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -568,8 +566,6 @@ exports[`Individual components dist/govuk/components/back-link works when user @
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -743,8 +739,6 @@ exports[`Individual components dist/govuk/components/back-link works when user @
 
 exports[`Individual components dist/govuk/components/breadcrumbs works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -1041,8 +1035,6 @@ exports[`Individual components dist/govuk/components/breadcrumbs works when user
 
 exports[`Individual components dist/govuk/components/button works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -1453,8 +1445,6 @@ exports[`Individual components dist/govuk/components/character-count works when 
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -1506,8 +1496,6 @@ exports[`Individual components dist/govuk/components/character-count works when 
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -1749,8 +1737,6 @@ exports[`Individual components dist/govuk/components/character-count works when 
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1784,8 +1770,6 @@ exports[`Individual components dist/govuk/components/character-count works when 
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -1974,14 +1958,6 @@ exports[`Individual components dist/govuk/components/character-count works when 
 .govuk-label-wrapper {
   margin: 0;
 }
-
-
-
-
-
-
-
-
 
 
 
@@ -2550,8 +2526,6 @@ exports[`Individual components dist/govuk/components/checkboxes works when user 
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -2705,8 +2679,6 @@ exports[`Individual components dist/govuk/components/checkboxes works when user 
 
 
 
-
-
 .govuk-error-message {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -2746,8 +2718,6 @@ exports[`Individual components dist/govuk/components/checkboxes works when user 
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -3060,8 +3030,6 @@ exports[`Individual components dist/govuk/components/checkboxes works when user 
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3095,8 +3063,6 @@ exports[`Individual components dist/govuk/components/checkboxes works when user 
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -3566,8 +3532,6 @@ exports[`Individual components dist/govuk/components/cookie-banner works when us
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -3619,8 +3583,6 @@ exports[`Individual components dist/govuk/components/cookie-banner works when us
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -4019,8 +3981,6 @@ exports[`Individual components dist/govuk/components/date-input works when user 
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -4072,8 +4032,6 @@ exports[`Individual components dist/govuk/components/date-input works when user 
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -4512,12 +4470,6 @@ exports[`Individual components dist/govuk/components/date-input works when user 
 
 
 
-
-
-
-
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -4551,8 +4503,6 @@ exports[`Individual components dist/govuk/components/date-input works when user 
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -4919,12 +4869,6 @@ exports[`Individual components dist/govuk/components/date-input works when user 
     border-left: 0;
   }
 }
-
-
-
-
-
-
 
 
 
@@ -5446,8 +5390,6 @@ exports[`Individual components dist/govuk/components/details works when user @im
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -5757,8 +5699,6 @@ exports[`Individual components dist/govuk/components/error-message works when us
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -5939,8 +5879,6 @@ exports[`Individual components dist/govuk/components/error-summary works when us
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -5992,7 +5930,6 @@ exports[`Individual components dist/govuk/components/error-summary works when us
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
 
 
 
@@ -6330,8 +6267,6 @@ exports[`Individual components dist/govuk/components/exit-this-page works when u
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -6383,8 +6318,6 @@ exports[`Individual components dist/govuk/components/exit-this-page works when u
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -6842,8 +6775,6 @@ exports[`Individual components dist/govuk/components/fieldset works when user @i
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -7112,8 +7043,6 @@ exports[`Individual components dist/govuk/components/file-upload works when user
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -7165,8 +7094,6 @@ exports[`Individual components dist/govuk/components/file-upload works when user
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -7408,8 +7335,6 @@ exports[`Individual components dist/govuk/components/file-upload works when user
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -7443,8 +7368,6 @@ exports[`Individual components dist/govuk/components/file-upload works when user
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -7805,8 +7728,6 @@ exports[`Individual components dist/govuk/components/file-upload works when user
 
 exports[`Individual components dist/govuk/components/footer works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -8305,8 +8226,6 @@ exports[`Individual components dist/govuk/components/header works when user @imp
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -8611,8 +8530,6 @@ exports[`Individual components dist/govuk/components/hint works when user @impor
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -8802,8 +8719,6 @@ exports[`Individual components dist/govuk/components/input works when user @impo
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -8855,8 +8770,6 @@ exports[`Individual components dist/govuk/components/input works when user @impo
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -9098,8 +9011,6 @@ exports[`Individual components dist/govuk/components/input works when user @impo
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9133,8 +9044,6 @@ exports[`Individual components dist/govuk/components/input works when user @impo
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -9587,8 +9496,6 @@ exports[`Individual components dist/govuk/components/inset-text works when user 
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -9708,8 +9615,6 @@ exports[`Individual components dist/govuk/components/inset-text works when user 
 
 exports[`Individual components dist/govuk/components/label works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -10034,8 +9939,6 @@ exports[`Individual components dist/govuk/components/notification-banner works w
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -10273,8 +10176,6 @@ exports[`Individual components dist/govuk/components/notification-banner works w
 
 exports[`Individual components dist/govuk/components/pagination works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -10732,8 +10633,6 @@ exports[`Individual components dist/govuk/components/panel works when user @impo
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -10963,8 +10862,6 @@ exports[`Individual components dist/govuk/components/password-input works when u
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -11016,8 +10913,6 @@ exports[`Individual components dist/govuk/components/password-input works when u
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -11506,10 +11401,6 @@ exports[`Individual components dist/govuk/components/password-input works when u
 
 
 
-
-
-
-
 .govuk-error-message {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -11534,8 +11425,6 @@ exports[`Individual components dist/govuk/components/password-input works when u
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -11669,8 +11558,6 @@ exports[`Individual components dist/govuk/components/password-input works when u
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -12152,8 +12039,6 @@ exports[`Individual components dist/govuk/components/phase-banner works when use
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -12205,8 +12090,6 @@ exports[`Individual components dist/govuk/components/phase-banner works when use
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -12555,8 +12438,6 @@ exports[`Individual components dist/govuk/components/radios works when user @imp
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -12710,8 +12591,6 @@ exports[`Individual components dist/govuk/components/radios works when user @imp
 
 
 
-
-
 .govuk-error-message {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -12751,8 +12630,6 @@ exports[`Individual components dist/govuk/components/radios works when user @imp
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -13065,8 +12942,6 @@ exports[`Individual components dist/govuk/components/radios works when user @imp
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13100,8 +12975,6 @@ exports[`Individual components dist/govuk/components/radios works when user @imp
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -13578,8 +13451,6 @@ exports[`Individual components dist/govuk/components/select works when user @imp
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -13631,8 +13502,6 @@ exports[`Individual components dist/govuk/components/select works when user @imp
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -13874,8 +13743,6 @@ exports[`Individual components dist/govuk/components/select works when user @imp
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13909,8 +13776,6 @@ exports[`Individual components dist/govuk/components/select works when user @imp
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -14160,8 +14025,6 @@ exports[`Individual components dist/govuk/components/select works when user @imp
 
 exports[`Individual components dist/govuk/components/service-navigation works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -14671,8 +14534,6 @@ exports[`Individual components dist/govuk/components/skip-link works when user @
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -14816,8 +14677,6 @@ exports[`Individual components dist/govuk/components/skip-link works when user @
 
 exports[`Individual components dist/govuk/components/summary-list works when user @imports the component 1`] = `
 "
-
-
 
 
 
@@ -15350,8 +15209,6 @@ exports[`Individual components dist/govuk/components/table works when user @impo
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -15560,8 +15417,6 @@ exports[`Individual components dist/govuk/components/table works when user @impo
 
 exports[`Individual components dist/govuk/components/tabs works when user @imports the component 1`] = `
 "@charset "UTF-8";
-
-
 
 
 
@@ -15996,8 +15851,6 @@ exports[`Individual components dist/govuk/components/tag works when user @import
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -16241,8 +16094,6 @@ exports[`Individual components dist/govuk/components/task-list works when user @
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -16294,8 +16145,6 @@ exports[`Individual components dist/govuk/components/task-list works when user @
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -16669,8 +16518,6 @@ exports[`Individual components dist/govuk/components/textarea works when user @i
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -16722,8 +16569,6 @@ exports[`Individual components dist/govuk/components/textarea works when user @i
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -16965,8 +16810,6 @@ exports[`Individual components dist/govuk/components/textarea works when user @i
 
 
 
-
-
 .govuk-hint {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -17000,8 +16843,6 @@ exports[`Individual components dist/govuk/components/textarea works when user @i
 .govuk-fieldset__legend + .govuk-hint {
   margin-top: -5px;
 }
-
-
 
 
 
@@ -17252,8 +17093,6 @@ exports[`Individual components dist/govuk/components/textarea works when user @i
 
 exports[`Individual components dist/govuk/components/warning-text works when user @imports the component 1`] = `
 "
-
-
 
 
 

--- a/tests/sass-tests/__snapshots__/itcss-layers.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/itcss-layers.integration.test.mjs.snap
@@ -83,8 +83,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -136,10 +134,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
-
-
 
 
 
@@ -783,8 +777,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-back-link {
   font-size: 1rem;
   line-height: 1.25;
@@ -882,8 +874,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-back-link--inverse::before {
   border-color: currentcolor;
 }
-
-
 
 
 
@@ -1124,8 +1114,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-breadcrumbs--inverse .govuk-breadcrumbs__list-item::before {
   border-color: currentcolor;
 }
-
-
 
 
 
@@ -1597,10 +1585,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
 .govuk-error-message {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1625,8 +1609,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -1860,8 +1842,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-label {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1950,14 +1930,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-label-wrapper {
   margin: 0;
 }
-
-
-
-
-
-
-
-
 
 
 
@@ -2737,12 +2709,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
-
 .govuk-fieldset {
   min-width: 0;
   margin: 0;
@@ -2855,10 +2821,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
   font-size: inherit;
   font-weight: inherit;
 }
-
-
-
-
 
 
 
@@ -3451,10 +3413,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
 .govuk-cookie-banner {
   padding-top: 20px;
   border-bottom: 10px solid transparent;
@@ -3475,18 +3433,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-cookie-banner__message:focus {
   outline: none;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -4556,12 +4502,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
-
 .govuk-date-input {
   font-size: 0;
 }
@@ -4585,8 +4525,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-date-input__input {
   margin-bottom: 0;
 }
-
-
 
 
 
@@ -5070,11 +5008,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
 .govuk-list {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -5276,10 +5209,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-error-summary__list a:focus {
   color: var(--govuk-focus-text-colour, #0b0c0c);
 }
-
-
-
-
 
 
 
@@ -6054,16 +5983,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
-
-
-
-
-
 .govuk-file-upload {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -6228,8 +6147,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-file-upload-button:disabled .govuk-file-upload-button__status {
   background-color: #d2e2f1;
 }
-
-
 
 
 
@@ -6592,8 +6509,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-footer__list-item:last-child {
   margin-bottom: 0;
 }
-
-
 
 
 
@@ -7437,18 +7352,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
 .govuk-inset-text {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -7492,10 +7395,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-inset-text > :last-child {
   margin-bottom: 0;
 }
-
-
-
-
 
 
 
@@ -7956,8 +7855,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-pagination {
   margin-bottom: 20px;
   display: flex;
@@ -8279,8 +8176,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-panel {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -8354,18 +8249,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-panel__title:last-child {
   margin-bottom: 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -9186,10 +9069,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
 .govuk-tag {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9335,16 +9214,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
   display: table-cell;
   vertical-align: middle;
 }
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -10438,14 +10307,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
-
-
-
 .govuk-select {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -10499,8 +10360,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-select--error:focus {
   border-color: var(--govuk-input-border-colour, #0b0c0c);
 }
-
-
 
 
 
@@ -10974,8 +10833,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-skip-link {
   text-decoration: underline;
   text-decoration-thickness: max(1px, .0625rem);
@@ -11043,8 +10900,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 .govuk-skip-link-focused-element:focus {
   outline: none;
 }
-
-
 
 
 
@@ -11541,8 +11396,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-table {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -11675,8 +11528,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
     line-height: 1.15;
   }
 }
-
-
 
 
 
@@ -11974,12 +11825,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
     display: none;
   }
 }
-
-
-
-
-
-
 
 
 
@@ -12855,16 +12700,6 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
 
 
 
-
-
-
-
-
-
-
-
-
-
 .govuk-warning-text {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13021,8 +12856,6 @@ exports[`ITCSS layers core works when user @imports the layer 1`] = `
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -13074,7 +12907,6 @@ exports[`ITCSS layers core works when user @imports the layer 1`] = `
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
 
 
 
@@ -13281,7 +13113,6 @@ exports[`ITCSS layers core works when user @imports the layer 1`] = `
 
 
 
-
 .govuk-list {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13348,7 +13179,6 @@ exports[`ITCSS layers core works when user @imports the layer 1`] = `
     margin-bottom: 15px;
   }
 }
-
 
 
 
@@ -13885,15 +13715,11 @@ exports[`ITCSS layers core works when user @imports the layer 1`] = `
 
 
 
-
-
 "
 `;
 
 exports[`ITCSS layers helpers works when user @imports the layer 1`] = `
 "
-
-
 
 
 
@@ -14025,7 +13851,6 @@ exports[`ITCSS layers helpers works when user @imports the layer 1`] = `
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
 
 
 
@@ -14165,8 +13990,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -14218,8 +14041,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
     --govuk-text-colour: var(--govuk-print-text-colour, #000000);
   }
 }
-
-
 
 
 
@@ -14490,8 +14311,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-form-group {
   margin-bottom: 20px;
 }
@@ -14518,8 +14337,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
   padding: 0;
   border: 0;
 }
-
-
 
 
 
@@ -14867,8 +14684,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-main-wrapper {
   display: block;
   padding-top: 20px;
@@ -14891,8 +14706,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
     padding-top: 50px;
   }
 }
-
-
 
 
 
@@ -15117,8 +14930,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
 
 
 
-
-
 .govuk-width-container {
   max-width: 960px;
   margin-right: 15px;
@@ -15161,8 +14972,6 @@ exports[`ITCSS layers objects works when user @imports the layer 1`] = `
 
 exports[`ITCSS layers overrides works when user @imports the layer 1`] = `
 "
-
-
 
 
 
@@ -16477,7 +16286,6 @@ exports[`ITCSS layers overrides works when user @imports the layer 1`] = `
 
 
 
-
 .govuk-\\!-font-size-80 {
   font-size: 3.3125rem !important;
   line-height: 1.0377358491 !important;
@@ -16743,8 +16551,6 @@ exports[`ITCSS layers settings works when user @imports the layer 1`] = `
 
 
 
-
-
 :root {
   --govuk-breakpoint-mobile: 20rem;
   --govuk-breakpoint-tablet: 40.0625rem;
@@ -16815,14 +16621,11 @@ exports[`ITCSS layers settings works when user @imports the layer 1`] = `
 
 
 
-
 "
 `;
 
 exports[`ITCSS layers tools works when user @imports the layer 1`] = `
 "
-
-
 
 
 
@@ -16971,8 +16774,6 @@ exports[`ITCSS layers tools works when user @imports the layer 1`] = `
 
 exports[`ITCSS layers utilities works when user @imports the layer 1`] = `
 "@charset "UTF-8";
-
-
 
 
 


### PR DESCRIPTION
We generally try and avoid depending on things that exist in layers ‘above’ in the ITCSS pyramid. Using `if` from helpers breaks that rule.

As we’re resolving to a boolean anyway, we can just check if `list.index` returns null and negate the result to get the same result.