### PR TITLE
Update the `govuk-text-colour` warning message 

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -51,7 +51,7 @@
 @mixin govuk-text-colour {
   @include _warning(
     "govuk-text-colour",
-    "The `govuk-text-colour` mixin is deprecated. Use `color: govuk-colour(text)` instead."
+    "The `govuk-text-colour` mixin is deprecated. Use `color: govuk-functional-colour(text)` instead."
   );
 
   color: govuk-functional-colour(text);

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -150,7 +150,7 @@ describe('@mixin govuk-text-colour', () => {
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the deprecation notice
     expect(mockWarnFunction).toHaveBeenCalledWith(
-      'The `govuk-text-colour` mixin is deprecated. Use `color: govuk-colour(text)` instead. To silence this warning, update $govuk-suppressed-warnings with key: "govuk-text-colour"',
+      'The `govuk-text-colour` mixin is deprecated. Use `color: govuk-functional-colour(text)` instead. To silence this warning, update $govuk-suppressed-warnings with key: "govuk-text-colour"',
       expect.anything()
     )
   })


### PR DESCRIPTION
Update the `govuk-text-colour` warning message to reference the correct `govuk-functional-colour(text)` replacement instead of incorrect `govuk-colour(text)` function