### PR TITLE
Fix enhanced file upload lacking an error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We made this change in [pull request #6861: Resolve `pkg:` URLs from `dist/govuk
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6831: Fix header link hover state in Safari](https://github.com/alphagov/govuk-frontend/pull/6831)
+- [#6925: Fix enhanced file upload lacking an error state](https://github.com/alphagov/govuk-frontend/pull/6925)
 
 ## v6.1.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -106,7 +106,7 @@
     width: 100%;
     // align the padding to be same as notification banner and error summary accounting for the thicker borders
     padding: (govuk-spacing(3) + $govuk-border-width - $file-upload-border-width);
-    border: $file-upload-border-width govuk-colour("black", $variant: "tint-80") solid;
+    border: $file-upload-border-width solid govuk-colour("black", $variant: "tint-80");
     background-color: govuk-colour("white");
     cursor: pointer;
 
@@ -114,11 +114,17 @@
       padding: (govuk-spacing(4) + $govuk-border-width - $file-upload-border-width);
     }
 
+    @at-root .govuk-form-group--error & {
+      border-style: solid;
+      border-color: govuk-functional-colour("error");
+    }
+
     .govuk-file-upload-button__pseudo-button {
       background-color: govuk-colour("black", $variant: "tint-95");
     }
 
     &:hover {
+      border-style: dashed;
       border-color: govuk-colour("black", $variant: "tint-50");
 
       .govuk-file-upload-button__pseudo-button {


### PR DESCRIPTION
Closes #5780.

## Changes
- Added an error style to the enhanced File upload component's drop zone, when an error is present.
- Added dashed border style rule to the drop zone's hover state, so that the error's solid border doesn't persist into other states. 
- Altered an existing border rule to follow the standard `[width] [style] [color]` order that's used elsewhere.

### Screenshots

|State|Before|After|
|:-|:-:|:-:|
|File upload with error|<img width="1017" height="324" alt="File upload component with light grey dashed border." src="https://github.com/user-attachments/assets/7ae311da-a091-4b3e-875c-cd0f70e5aede" />|<img width="1017" height="324" alt="File upload component with red solid border." src="https://github.com/user-attachments/assets/f268659f-542e-4462-baf7-f63d709773b6" />|
|Hovered (unchanged)|<img width="1017" height="324" alt="File upload component with mid grey dashed border and light grey background." src="https://github.com/user-attachments/assets/92508a0e-46bf-4d65-957c-bc15491e9cdb" />|<img width="1017" height="324" alt="File upload component with mid grey dashed border and light grey background." src="https://github.com/user-attachments/assets/6c153b4c-1354-4efc-bd2f-8e2b5339f5a8" />|
|When dropping a file|<img width="1017" height="324" alt="File upload component with solid black border and light grey background." src="https://github.com/user-attachments/assets/d61cab4d-ac9a-4360-b56f-9485f8b8377c" />|<img width="1017" height="324" alt="File upload component with solid red border and light grey background." src="https://github.com/user-attachments/assets/a4acb544-0c7b-4067-9e4b-e3a3c447f865" />|
|With file selected|<img width="1017" height="324" alt="File upload component with solid light grey border." src="https://github.com/user-attachments/assets/89827166-371a-4f63-badc-b2b88d345d2d" />|<img width="1017" height="324" alt="File upload component with solid red border." src="https://github.com/user-attachments/assets/a557c49d-7b19-42c8-9de4-ec4cfd4307ca" />|

## Thoughts
The error style persists even after a new file has been chosen, as the majority of our other form controls do until the form has been resubmitted. (Character count is an exception as it validates the user's input in real time and not on form submission.) 

I've implemented this style based on the presence of the component being inside of an element with the `govuk-form-group--error` class. This was to avoid needing to add new Nunjucks logic to add the variant directly to `govuk-drop-zone`, which would in turn require port maintainers and users who don't use Nunjucks to update their code. If preferable, I can change this to use a new variant class on the dropzone and change this from a bugfix to a recommended change. 