### PR TITLE
Code improvements to File upload component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,24 +20,35 @@ You can now omit the `dist/govuk` part of the path when including GOV.UK Fronten
 
 We made this change in [pull request #6861: Resolve `pkg:` URLs from `dist/govuk` and update the review app](https://github.com/alphagov/govuk-frontend/pull/6861).
 
-#### Pass custom classes and attributes to the enhanced File upload component's drop zone
+#### Add custom classes and attributes to the File upload component's wrapper
 
-We've introduced two new parameters to the File upload component's Nunjucks macro: `dropZoneClasses` and `dropZoneAttributes`.
+We've introduced two new parameters to the File upload component's Nunjucks macro: `wrapperClasses` and `wrapperAttributes`.
 
-These allow you to define custom classes and HTML attributes for the drop zone element used by the enhanced version of the File upload.
+These allow you to define custom classes and HTML attributes for the wrapper of the improved version of the File upload.
 
 ```njk
 {{ govukFileUpload({
   javascript: true,
-  dropZoneClasses: "my-custom-class",
-  dropZoneAttributes: {
+  wrapperClasses: "my-custom-class",
+  wrapperAttributes: {
     "data-attribute": "value"
   }
 }) }}
 ```
 
-We made this change in [pull request #6933: Code improvements to File upload component
-](https://github.com/alphagov/govuk-frontend/pull/6933).
+We made this change in [pull request #6933: Code improvements to File upload component](https://github.com/alphagov/govuk-frontend/pull/6933).
+
+### Recommended changes
+
+#### Rename the `govuk-drop-zone` class on the improved File upload component
+
+The class name of the element that wraps the improved File upload component has been changed from `govuk-drop-zone` to `govuk-file-upload-wrapper`. This was to better describe what function the element plays in the component.
+
+The old class name has been deprecated and will be removed in the next major version of GOV.UK Frontend.
+
+If you're using our Nunjucks macros, you don't need to update anything.
+
+We made this change in [pull request #6933: Code improvements to File upload component](https://github.com/alphagov/govuk-frontend/pull/6933).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ You can now omit the `dist/govuk` part of the path when including GOV.UK Fronten
 
 We made this change in [pull request #6861: Resolve `pkg:` URLs from `dist/govuk` and update the review app](https://github.com/alphagov/govuk-frontend/pull/6861).
 
+#### Pass custom classes and attributes to the enhanced File upload component's drop zone
+
+We've introduced two new parameters to the File upload component's Nunjucks macro: `dropZoneClasses` and `dropZoneAttributes`.
+
+These allow you to define custom classes and HTML attributes for the drop zone element used by the enhanced version of the File upload.
+
+```njk
+{{ govukFileUpload({
+  javascript: true,
+  dropZoneClasses: "my-custom-class",
+  dropZoneAttributes: {
+    "data-attribute": "value"
+  }
+}) }}
+```
+
+We made this change in [pull request #6933: Code improvements to File upload component
+](https://github.com/alphagov/govuk-frontend/pull/6933).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -56,6 +56,8 @@
     }
   }
 
+  .govuk-file-upload-wrapper,
+  // @deprecated .govuk-drop-zone class is deprecated in favour of .govuk-file-upload-wrapper
   .govuk-drop-zone {
     display: block;
     position: relative;
@@ -66,7 +68,7 @@
   // required because disabling pointer events
   // on the button means that the cursor style
   // be applied on the button itself
-  .govuk-drop-zone--disabled {
+  .govuk-file-upload-wrapper--disabled {
     cursor: not-allowed;
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -482,7 +482,7 @@ export class FileUpload extends ConfigurableComponent {
     this.$button.disabled = this.$input.disabled
 
     this.$root.classList.toggle(
-      'govuk-drop-zone--disabled',
+      'govuk-file-upload-wrapper--disabled',
       this.$button.disabled
     )
   }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -19,13 +19,21 @@ export class FileUpload extends ConfigurableComponent {
 
   /**
    * @private
+   * @type {HTMLButtonElement}
    */
   $button
 
   /**
    * @private
+   * @type {HTMLSpanElement}
    */
   $status
+
+  /**
+   * @private
+   * @type {HTMLLabelElement}
+   */
+  $label
 
   /** @private */
   i18n
@@ -89,6 +97,7 @@ export class FileUpload extends ConfigurableComponent {
     if (!$label.id) {
       $label.id = `${this.id}-label`
     }
+    this.$label = $label
 
     // we need to copy the 'id' of the root element
     // to the new button replacement element
@@ -98,6 +107,55 @@ export class FileUpload extends ConfigurableComponent {
     // Hide the native input
     this.$input.setAttribute('hidden', 'hidden')
 
+    // Inject status and button HTML
+    // $status has to come first as it's used within `createButton()`
+    this.$status = this.createStatus()
+    this.$button = this.createButton()
+
+    // Inject button into component
+    this.$root.insertAdjacentElement('afterbegin', this.$button)
+
+    // Bind change event to the underlying input
+    this.$input.addEventListener('change', this.onChange.bind(this))
+
+    // Synchronise the `disabled` state between the button and underlying input
+    this.updateDisabledState()
+    this.observeDisabledState()
+
+    // Handle drop zone visibility
+    // A live region to announce when users enter or leave the drop zone
+    this.$announcements = document.createElement('span')
+    this.$announcements.classList.add('govuk-file-upload-announcements')
+    this.$announcements.classList.add('govuk-visually-hidden')
+    this.$announcements.setAttribute('aria-live', 'assertive')
+    this.$root.insertAdjacentElement('afterend', this.$announcements)
+
+    // Bind all of the events relating to drag and drop functionality
+    this.bindDraggingEvents()
+  }
+
+  /**
+   * Create status element that shows what/how many files are selected
+   *
+   * @private
+   * @returns {HTMLSpanElement} - the status element
+   */
+  createStatus() {
+    const $status = document.createElement('span')
+    $status.className = 'govuk-body govuk-file-upload-button__status'
+    $status.setAttribute('aria-live', 'polite')
+    $status.innerText = this.i18n.t('noFileChosen')
+
+    return $status
+  }
+
+  /**
+   * Assembles the button HTML element.
+   *
+   * @private
+   * @returns {HTMLButtonElement} - the button element
+   */
+  createButton() {
     // Create the file selection button
     const $button = document.createElement('button')
     $button.classList.add('govuk-file-upload-button')
@@ -112,13 +170,8 @@ export class FileUpload extends ConfigurableComponent {
       $button.setAttribute('aria-describedby', ariaDescribedBy)
     }
 
-    // Create status element that shows what/how many files are selected
-    const $status = document.createElement('span')
-    $status.className = 'govuk-body govuk-file-upload-button__status'
-    $status.setAttribute('aria-live', 'polite')
-    $status.innerText = this.i18n.t('noFileChosen')
-
-    $button.appendChild($status)
+    // Inject status element
+    $button.appendChild(this.$status)
 
     const commaSpan = document.createElement('span')
     commaSpan.className = 'govuk-visually-hidden'
@@ -152,7 +205,7 @@ export class FileUpload extends ConfigurableComponent {
     $button.appendChild(containerSpan)
     $button.setAttribute(
       'aria-labelledby',
-      `${$label.id} ${commaSpan.id} ${$button.id}`
+      `${this.$label.id} ${commaSpan.id} ${$button.id}`
     )
     $button.addEventListener('click', this.onClick.bind(this))
     $button.addEventListener('dragover', (event) => {
@@ -160,28 +213,15 @@ export class FileUpload extends ConfigurableComponent {
       event.preventDefault()
     })
 
-    // Assemble these all together
-    this.$root.insertAdjacentElement('afterbegin', $button)
+    return $button
+  }
 
-    // Make all these new variables available to the module
-    this.$button = $button
-    this.$status = $status
-
-    // Bind change event to the underlying input
-    this.$input.addEventListener('change', this.onChange.bind(this))
-
-    // Synchronise the `disabled` state between the button and underlying input
-    this.updateDisabledState()
-    this.observeDisabledState()
-
-    // Handle drop zone visibility
-    // A live region to announce when users enter or leave the drop zone
-    this.$announcements = document.createElement('span')
-    this.$announcements.classList.add('govuk-file-upload-announcements')
-    this.$announcements.classList.add('govuk-visually-hidden')
-    this.$announcements.setAttribute('aria-live', 'assertive')
-    this.$root.insertAdjacentElement('afterend', this.$announcements)
-
+  /**
+   * Bind dragging events.
+   *
+   * @private
+   */
+  bindDraggingEvents() {
     // if there is no CSS and input is hidden
     // button will need to handle drop event
     this.$button.addEventListener('drop', this.onDrop.bind(this))
@@ -193,7 +233,7 @@ export class FileUpload extends ConfigurableComponent {
     //   (`relatedTarget` being a descendant of the wrapper)
     // - check if the user is still over the viewport
     //   (`relatedTarget` being null if outside)
-
+    //
     // Thanks to `dragenter` bubbling, we can listen on the `document` with a
     // single function and update the visibility based on whether we entered a
     // node inside or outside the wrapper.
@@ -385,7 +425,7 @@ export class FileUpload extends ConfigurableComponent {
    * Looks up the `<label>` element associated to the field
    *
    * @private
-   * @returns {HTMLElement} The `<label>` element associated to the field
+   * @returns {HTMLLabelElement} The `<label>` element associated to the field
    * @throws {ElementError} If the `<label>` cannot be found
    */
   findLabel() {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -96,7 +96,7 @@ export class FileUpload extends ConfigurableComponent {
     this.$input.id = `${this.id}-input`
 
     // Hide the native input
-    this.$input.setAttribute('hidden', 'true')
+    this.$input.setAttribute('hidden', 'hidden')
 
     // Create the file selection button
     const $button = document.createElement('button')

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -163,9 +163,6 @@ export class FileUpload extends ConfigurableComponent {
     // Assemble these all together
     this.$root.insertAdjacentElement('afterbegin', $button)
 
-    this.$input.setAttribute('tabindex', '-1')
-    this.$input.setAttribute('aria-hidden', 'true')
-
     // Make all these new variables available to the module
     this.$button = $button
     this.$status = $status

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -2,7 +2,8 @@
 
 const {
   render,
-  getAccessibleName
+  getAccessibleName,
+  isVisible
 } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -76,12 +77,10 @@ describe('/components/file-upload', () => {
         })
 
         describe('file input', () => {
-          it('sets tabindex to -1', async () => {
-            const inputElementTabindex = await page.$eval(inputSelector, (el) =>
-              el.getAttribute('tabindex')
-            )
+          it('gets hidden', async () => {
+            const $input = await page.$(inputSelector)
 
-            expect(inputElementTabindex).toBe('-1')
+            expect(await isVisible($input)).toBe(false)
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -8,7 +8,7 @@ const {
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 const inputSelector = '.govuk-file-upload'
-const wrapperSelector = '.govuk-drop-zone'
+const wrapperSelector = '.govuk-file-upload-wrapper'
 const buttonSelector = '.govuk-file-upload-button'
 const statusSelector = '.govuk-file-upload-button__status'
 const pseudoButtonSelector = '.govuk-file-upload-button__pseudo-button'
@@ -267,7 +267,7 @@ describe('/components/file-upload', () => {
         beforeEach(async () => {
           await render(page, 'file-upload', examples.enhanced)
 
-          $wrapper = await page.$('.govuk-drop-zone')
+          $wrapper = await page.$('.govuk-file-upload-wrapper')
           wrapperBoundingBox = await $wrapper.boundingBox()
 
           $announcements = await page.$('.govuk-file-upload-announcements')
@@ -352,7 +352,7 @@ describe('/components/file-upload', () => {
 
           // It doesn't seem doable to make Puppeteer drag outside the viewport
           // so instead, we can only mock two 'dragleave' events
-          await page.$eval('.govuk-drop-zone', ($el) => {
+          await page.$eval('.govuk-file-upload-wrapper', ($el) => {
             $el.dispatchEvent(new Event('dragleave', { bubbles: true }))
             $el.dispatchEvent(new Event('dragleave', { bubbles: true }))
           })
@@ -501,7 +501,7 @@ describe('/components/file-upload', () => {
             el.hasAttribute('disabled')
           )
           const dropZoneDisabled = await page.$eval(wrapperSelector, (el) =>
-            el.classList.contains('govuk-drop-zone--disabled')
+            el.classList.contains('govuk-file-upload-wrapper--disabled')
           )
 
           expect(buttonDisabled).toBeTruthy()
@@ -519,7 +519,7 @@ describe('/components/file-upload', () => {
             el.hasAttribute('disabled')
           )
           const dropZoneDisabled = await page.$eval(wrapperSelector, (el) =>
-            el.classList.contains('govuk-drop-zone--disabled')
+            el.classList.contains('govuk-file-upload-wrapper--disabled')
           )
 
           expect(buttonDisabledAfter).toBeTruthy()
@@ -543,7 +543,7 @@ describe('/components/file-upload', () => {
             el.hasAttribute('disabled')
           )
           const dropZoneDisabled = await page.$eval(wrapperSelector, (el) =>
-            el.classList.contains('govuk-drop-zone--disabled')
+            el.classList.contains('govuk-file-upload-wrapper--disabled')
           )
 
           expect(buttonDisabled).toBeFalsy()

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -76,12 +76,12 @@ describe('/components/file-upload', () => {
         })
 
         describe('file input', () => {
-          it('sets tabindex to -1', async () => {
-            const inputElementTabindex = await page.$eval(inputSelector, (el) =>
-              el.getAttribute('tabindex')
+          it('gets hidden', async () => {
+            const inputElementHidden = await page.$eval(inputSelector, (el) =>
+              el.getAttribute('hidden')
             )
 
-            expect(inputElementTabindex).toBe('-1')
+            expect(inputElementHidden).toBe('hidden')
           })
         })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -104,11 +104,19 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the file upload component.
+    description: Classes to add to the file upload `<input>` element.
   - name: attributes
     type: object
     required: false
-    description: HTML attributes (for example data attributes) to add to the file upload component.
+    description: HTML attributes (for example data attributes) to add to the file upload  `<input>` element.
+  - name: dropZoneClasses
+    type: string
+    required: false
+    description: Classes to add to the enhanced file upload component. If `javascript` is not provided, this option will be ignored.
+  - name: dropZoneAttributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the enhanced file upload component. If `javascript` is not provided, this option will be ignored.
 
 examples:
   - name: default
@@ -178,6 +186,18 @@ examples:
       label:
         text: Upload files
       multiple: true
+
+  - name: enhanced, custom classes and attributes
+    options:
+      javascript: true
+      id: file-upload-3
+      name: file-upload-3
+      label:
+        text: Upload files
+      dropZoneClasses: app-drop-zone--custom-class
+      dropZoneAttributes:
+        data-custom-attribute: custom-value
+        data-custom-attribute-2: custom-value-2
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: with value

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -109,14 +109,14 @@ params:
     type: object
     required: false
     description: HTML attributes (for example data attributes) to add to the file upload  `<input>` element.
-  - name: dropZoneClasses
+  - name: wrapperClasses
     type: string
     required: false
-    description: Classes to add to the enhanced file upload component. If `javascript` is not provided, this option will be ignored.
-  - name: dropZoneAttributes
+    description: Classes to add to the improved file upload component's wrapper. If `javascript` is not provided, this option will be ignored.
+  - name: wrapperAttributes
     type: object
     required: false
-    description: HTML attributes (for example data attributes) to add to the enhanced file upload component. If `javascript` is not provided, this option will be ignored.
+    description: HTML attributes (for example data attributes) to add to the improved file upload component's wrapper. If `javascript` is not provided, this option will be ignored.
 
 examples:
   - name: default
@@ -194,8 +194,8 @@ examples:
       name: file-upload-3
       label:
         text: Upload files
-      dropZoneClasses: app-drop-zone--custom-class
-      dropZoneAttributes:
+      wrapperClasses: app-drop-zone--custom-class
+      wrapperAttributes:
         data-custom-attribute: custom-value
         data-custom-attribute-2: custom-value-2
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -187,14 +187,14 @@ examples:
         text: Upload files
       multiple: true
 
-  - name: enhanced, custom classes and attributes
+  - name: enhanced, custom wrapper classes and attributes
     options:
       javascript: true
       id: file-upload-3
       name: file-upload-3
       label:
         text: Upload files
-      wrapperClasses: app-drop-zone--custom-class
+      wrapperClasses: app-file-upload--custom-class
       wrapperAttributes:
         data-custom-attribute: custom-value
         data-custom-attribute-2: custom-value-2

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -104,11 +104,11 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the file upload `<input>` element.
+    description: Classes to add to the file upload `<input>` element. If `javascript` is provided, these are not copied to the visible button. To use classes for the visible button, use the `wrapperClasses` option.
   - name: attributes
     type: object
     required: false
-    description: HTML attributes (for example data attributes) to add to the file upload  `<input>` element.
+    description: HTML attributes (for example data attributes) to add to the file upload  `<input>` element. If `javascript` is provided, these are not copied to the visible button. To add attributes to the container, use the `wrapperAttributes` option instead.
   - name: wrapperClasses
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -47,7 +47,7 @@
 {% endif %}
 {% if params.javascript %}
   <div
-    class="govuk-drop-zone {%- if params.wrapperClasses %} {{ params.wrapperClasses }}{% endif %}"
+    class="govuk-file-upload-wrapper {%- if params.wrapperClasses %} {{ params.wrapperClasses }}{% endif %}"
     data-module="govuk-file-upload"
     {{- govukI18nAttributes({
       key: 'choose-files-button',

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -47,7 +47,7 @@
 {% endif %}
 {% if params.javascript %}
   <div
-    class="govuk-drop-zone {%- if params.dropZoneClasses %} {{ params.dropZoneClasses }}{% endif %}"
+    class="govuk-drop-zone {%- if params.wrapperClasses %} {{ params.wrapperClasses }}{% endif %}"
     data-module="govuk-file-upload"
     {{- govukI18nAttributes({
       key: 'choose-files-button',
@@ -73,7 +73,7 @@
       key: 'left-drop-zone',
       message: params.leftDropZoneText
     }) -}}
-    {{- govukAttributes(params.dropZoneAttributes) }}
+    {{- govukAttributes(params.wrapperAttributes) }}
   >
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -47,7 +47,7 @@
 {% endif %}
 {% if params.javascript %}
   <div
-    class="govuk-drop-zone"
+    class="govuk-drop-zone {%- if params.dropZoneClasses %} {{ params.dropZoneClasses }}{% endif %}"
     data-module="govuk-file-upload"
     {{- govukI18nAttributes({
       key: 'choose-files-button',
@@ -73,6 +73,7 @@
       key: 'left-drop-zone',
       message: params.leftDropZoneText
     }) -}}
+    {{- govukAttributes(params.dropZoneAttributes) }}
   >
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="file"

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -225,21 +225,21 @@ describe('File upload', () => {
       expect($wrapper.attr('data-module')).toBe('govuk-file-upload')
     })
 
-    it('renders custom drop zone classes', () => {
+    it('renders custom wraper classes', () => {
       const $ = render(
         'file-upload',
-        examples['enhanced, custom classes and attributes']
+        examples['enhanced, custom wrapper classes and attributes']
       )
 
       const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
-      expect($wrapper.hasClass('app-drop-zone--custom-class')).toBeTruthy()
+      expect($wrapper.hasClass('app-file-upload--custom-class')).toBeTruthy()
     })
 
-    it('renders custom drop zone attributes', () => {
+    it('renders custom wrapper attributes', () => {
       const $ = render(
         'file-upload',
-        examples['enhanced, custom classes and attributes']
+        examples['enhanced, custom wrapper classes and attributes']
       )
 
       const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -225,6 +225,29 @@ describe('File upload', () => {
       expect($wrapper.attr('data-module')).toBe('govuk-file-upload')
     })
 
+    it('renders custom drop zone classes', () => {
+      const $ = render(
+        'file-upload',
+        examples['enhanced, custom classes and attributes']
+      )
+
+      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+
+      expect($wrapper.hasClass('app-drop-zone--custom-class')).toBeTruthy()
+    })
+
+    it('renders custom drop zone attributes', () => {
+      const $ = render(
+        'file-upload',
+        examples['enhanced, custom classes and attributes']
+      )
+
+      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+
+      expect($wrapper.attr('data-custom-attribute')).toBe('custom-value')
+      expect($wrapper.attr('data-custom-attribute-2')).toBe('custom-value-2')
+    })
+
     it('adds the data-module attribute when receiving an object', () => {
       const $ = render('file-upload', examples.translated)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -220,7 +220,7 @@ describe('File upload', () => {
     it('adds the data-module attribute to the wrapper when `true`', () => {
       const $ = render('file-upload', examples.enhanced)
 
-      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
       expect($wrapper.attr('data-module')).toBe('govuk-file-upload')
     })
@@ -231,7 +231,7 @@ describe('File upload', () => {
         examples['enhanced, custom classes and attributes']
       )
 
-      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
       expect($wrapper.hasClass('app-drop-zone--custom-class')).toBeTruthy()
     })
@@ -242,7 +242,7 @@ describe('File upload', () => {
         examples['enhanced, custom classes and attributes']
       )
 
-      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
       expect($wrapper.attr('data-custom-attribute')).toBe('custom-value')
       expect($wrapper.attr('data-custom-attribute-2')).toBe('custom-value-2')
@@ -251,7 +251,7 @@ describe('File upload', () => {
     it('adds the data-module attribute when receiving an object', () => {
       const $ = render('file-upload', examples.translated)
 
-      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
       expect($wrapper.attr('data-module')).toBe('govuk-file-upload')
     })
@@ -259,7 +259,7 @@ describe('File upload', () => {
     it('enables the rendering of translation messages when true', () => {
       const $ = render('file-upload', examples.translated)
 
-      const $wrapper = $('.govuk-form-group > .govuk-drop-zone')
+      const $wrapper = $('.govuk-form-group > .govuk-file-upload-wrapper')
 
       expect($wrapper.attr('data-i18n.choose-files-button')).toBe(
         'Dewiswch ffeil'

--- a/tests/sass-tests/__snapshots__/all-components-with-config.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/all-components-with-config.integration.test.mjs.snap
@@ -2843,6 +2843,7 @@ exports[`All components, with configuration works when user @imports everything 
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -2850,7 +2851,7 @@ exports[`All components, with configuration works when user @imports everything 
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 

--- a/tests/sass-tests/__snapshots__/all-components.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/all-components.integration.test.mjs.snap
@@ -2843,6 +2843,7 @@ exports[`All components works when user @imports everything 1`] = `
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -2850,7 +2851,7 @@ exports[`All components works when user @imports everything 1`] = `
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 

--- a/tests/sass-tests/__snapshots__/individual-components.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/individual-components.integration.test.mjs.snap
@@ -3777,6 +3777,7 @@ exports[`Individual components src/govuk/components/file-upload works when user 
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -3784,7 +3785,7 @@ exports[`Individual components src/govuk/components/file-upload works when user 
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 

--- a/tests/sass-tests/__snapshots__/itcss-layers.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/itcss-layers.integration.test.mjs.snap
@@ -2018,6 +2018,7 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -2025,7 +2026,7 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 

--- a/tests/sass-tests/__snapshots__/sass-file-compilation.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/sass-file-compilation.integration.test.mjs.snap
@@ -2058,6 +2058,7 @@ exports[`src/govuk/components/_index.scss matches snapshot 1`] = `
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -2065,7 +2066,7 @@ exports[`src/govuk/components/_index.scss matches snapshot 1`] = `
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 
@@ -11925,6 +11926,7 @@ exports[`src/govuk/components/file-upload/_file-upload.scss matches snapshot 1`]
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -11932,7 +11934,7 @@ exports[`src/govuk/components/file-upload/_file-upload.scss matches snapshot 1`]
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 
@@ -12299,6 +12301,7 @@ exports[`src/govuk/components/file-upload/_index.scss matches snapshot 1`] = `
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -12306,7 +12309,7 @@ exports[`src/govuk/components/file-upload/_index.scss matches snapshot 1`] = `
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 
@@ -27825,6 +27828,7 @@ exports[`src/govuk/index.scss matches snapshot 1`] = `
   cursor: not-allowed;
 }
 
+.govuk-file-upload-wrapper,
 .govuk-drop-zone {
   display: block;
   position: relative;
@@ -27832,7 +27836,7 @@ exports[`src/govuk/index.scss matches snapshot 1`] = `
   background-color: var(--govuk-body-background-colour, #ffffff);
 }
 
-.govuk-drop-zone--disabled {
+.govuk-file-upload-wrapper--disabled {
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
Small code improvements and refactoring. Closes #5689.

 ## Changes

- Split the component's constructor into some smaller, discrete functions responsible for generating HTML and binding dragging events. 
- Renamed the `.govuk-drop-zone` element to `.govuk-file-upload-wrapper`.
  - We feel this better describes what the element does, as all of the drop zone styles and functionality are contained on the nested button element and not this one. 
  - To avoid a breaking change, CSS styles are still present for the `.govuk-drop-zone` class so that it still renders correctly without any changes to HTML. JS functionality has not needed to be updated for this change as it did not reference the element by its class name. 
- Added `wrapperClasses` parameter, to add custom classes to the enhanced file upload's wrapper. This could resolve #6951. 
- Added `wrapperAttributes` parameter to add custom HTML attributes to the enhanced file upload's wrapper. This could resolve alphagov/govuk-design-system#5231. 
- Fixed setting of `hidden` HTML attribute to `true` on `<input>` element. 
  - Strictly speaking, the only valid attributes for the HTML `hidden` attribute are "hidden" and "until-found". A value of "true" still works for backwards compatibility with when the attribute was a boolean toggle, but it could be flagged as not being to spec. 
  - Updated the associated test to use the `isVisible` helper. 
- Removed setting `tabindex` and `aria-hidden` on the `<input>` element.
  - Hiding the input with the `hidden` HTML attribute already removes the element from the tab order and accessibility tree, making these redundant.
- Added/updated the types of some of the elements in JS to be more specific. 

## Thoughts

The `wrapperClasses` and `wrapperAttributes` parameters are applied via Nunjucks, which means they're always present even if the enhanced features don't initialise (JS errors, is blocked, etc.) This feels like it might be unexpected, but I'm not sure of a tidier way we could pass a list of attributes through `data-*` and have them applied by JS instead. This might be something better explained in the Nunjucks macro guidance. 

There are no tests for supporting the old `.govuk-drop-zone` class, as I'm unsure of how we would write these.

An issue about devising a way to pass attributes through to JS has been spun off into #6966. 