### PR TITLE
Remove visible scrollbar from component preview iframes

### DIFF
--- a/packages/govuk-frontend-review/src/javascripts/component-preview.mjs
+++ b/packages/govuk-frontend-review/src/javascripts/component-preview.mjs
@@ -5,10 +5,30 @@ const $examples = document.querySelectorAll('iframe.js-component-preview')
 /**
  * Resize component preview iframe
  *
- * @this {HTMLElement}
+ * @this {HTMLIFrameElement}
  */
 function resize() {
-  iframeResize({ scrolling: 'omit' }, this)
+  iframeResize(
+    {
+      // Omit scrolling as this otherwise adds the iframe `scrolling` attribute
+      // which is deprecated
+      scrolling: 'omit',
+      onInit: () => {
+        // Set the y axis overflow of the HTML element within the resized iframe
+        // to 'hidden'.
+        // This is to remove a functionally useless visible scrollbar within
+        // component preview iframes that appears because we're omitting scrolling
+        // via iframe-resizer and we've set `overflow-y: scroll` on `govuk-template`
+        // which we need to override to remove the scroll bar.
+        // We need to do this at the js level rather than in sass in case
+        // iframe-resizer fails to run, leaving us with a bunch of iframes whose
+        // sizes might mean we need to scroll to see the whole component, which
+        // we wouldn't be able to do if this was applied by default.
+        this.contentWindow.document.documentElement.style.overflowY = 'hidden'
+      }
+    },
+    this
+  )
 }
 
 /**

--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -2,6 +2,7 @@
 @import "partials/app";
 @import "partials/banner";
 @import "partials/code";
+@import "partials/component-preview";
 @import "partials/feature-flag-banner";
 @import "partials/links";
 @import "partials/organisation-swatch";

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
@@ -2,23 +2,6 @@
   background-color: govuk-functional-colour(body-background);
 }
 
-// Injected into the preview page, that is then put in an iframe
-.app-template__body--component-preview {
-  margin: 15px 0;
-
-  // Highlight the whitespace around a component, so you can see without having to
-  // inspect it.
-  .app-whitespace-highlight {
-    @include govuk-clearfix;
-
-    content: " ";
-    display: table;
-    width: 100%;
-    clear: both;
-    box-shadow: 0 0 0 5px govuk-colour("blue", $variant: "tint-80");
-  }
-}
-
 // Darken page background for previewing inversely coloured components
 .app-template__body--inverse {
   background-color: govuk-colour("blue");
@@ -32,18 +15,4 @@
 
 .app-width-container--wide {
   @include govuk-width-container(1200px);
-}
-
-.app-component-preview {
-  position: relative;
-  width: 100%;
-  margin-bottom: 15px;
-}
-
-.app-component-preview__iframe {
-  display: block;
-  position: relative;
-  z-index: 20;
-  width: 100%;
-  border: 0;
 }

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_component-preview.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_component-preview.scss
@@ -1,0 +1,30 @@
+.app-component-preview {
+  position: relative;
+  width: 100%;
+  margin-bottom: 15px;
+}
+
+.app-component-preview__iframe {
+  display: block;
+  position: relative;
+  z-index: 20;
+  width: 100%;
+  border: 0;
+}
+
+// Injected into the preview page, that is then put in an iframe
+.app-template__body--component-preview {
+  margin: 15px 0;
+
+  // Highlight the whitespace around a component, so you can see without having to
+  // inspect it.
+  .app-whitespace-highlight {
+    @include govuk-clearfix;
+
+    content: " ";
+    display: table;
+    width: 100%;
+    clear: both;
+    box-shadow: 0 0 0 5px govuk-colour("blue", $variant: "tint-80");
+  }
+}


### PR DESCRIPTION
## Change

Adds `overflow-y: hidden` to the `html` tag of component previews when they're in an iframe. This removes a visible scrollbar floating on the right edge of the page, which appears to be caused by `govuk-template` having `overflow-y: scroll` which sets a scrollbar regardless of if there's a need to scroll.

This is done in js rather than CSS so that it happens in sync with iframe resizer and means that if js doesn't initiate that there's still a scrollbar for iframes that won't get resized to fit their component.

Whilst I'm here I also moved the component preview styling into it's own sass import.

## Visual changes

### Before

<img width="1452" height="568" alt="Screenshot of accordion preview with extra scrollbar on the right" src="https://github.com/user-attachments/assets/eac5861d-648f-43b5-99e1-b5207d82a952" />

Note the scrollbar on the right hand side of the page

### After

<img width="1445" height="515" alt="Screenshot of accordion preview without an extra scrollbar" src="https://github.com/user-attachments/assets/c0d43775-c60d-4960-b451-e8d4013c2f85" />

## Notes

Another option is to not `omit` scrolling via iframe resizer which would allow us to set the ifram `scrolling` attribute to `yes` or `no`. That attribute however is deprecated, which is likely why we `omit`ed it.

I'm not 100% confident about moving `app-template__body--component-preview` into the component preview sass file. Open to thoughts on this.