### PR TITLE
File upload required note

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -108,7 +108,7 @@ params:
   - name: attributes
     type: object
     required: false
-    description: HTML attributes (for example data attributes) to add to the file upload component.
+    description: HTML attributes (for example data attributes) to add to the file upload component. Note that the `required` attribute does not work for the improved file upload component.
 
 examples:
   - name: default


### PR DESCRIPTION
Exploring what to do about the fact that `required` doesn't work on the improved version.
See https://github.com/alphagov/govuk-design-system/issues/5231

This adds a note to the Nunjucks macro options that mentions that.
This is still a draft because we haven't decided yet which solution we are going with.