### PR TITLE
Suppress sass warnings in file-url and image-url tests

### DIFF
--- a/packages/govuk-frontend/src/govuk/tools/font-url.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/font-url.unit.test.js
@@ -49,6 +49,7 @@ describe('@function font-url', () => {
       it('executes a native Sass function', async () => {
         const sass = `
           @use "settings" with (
+            $govuk-suppressed-warnings: ("font-url-string"),
             $govuk-font-url-function: 'to-upper-case'
           );
           @use "tools/font-url" as *;
@@ -60,7 +61,10 @@ describe('@function font-url', () => {
         `
 
         await expect(
-          compileSassString(sass, { fatalDeprecations })
+          compileSassString(sass, {
+            fatalDeprecations,
+            silenceDeprecations: ['global-builtin']
+          })
         ).resolves.toMatchObject({
           css: outdent`
             @font-face {
@@ -74,6 +78,7 @@ describe('@function font-url', () => {
       it('uses the default for a non-native function', async () => {
         const sass = `
           @use "settings" with (
+            $govuk-suppressed-warnings: ("font-url-string"),
             $govuk-fonts-path: '/path/to/fonts/',
             $govuk-font-url-function: non-native-function
           );
@@ -122,6 +127,7 @@ describe('@function font-url', () => {
       describe('with `@import`', () => {
         it('can be overridden to use a custom function', async () => {
           const sass = `
+            $govuk-suppressed-warnings: ("font-url-string");
             $govuk-font-url-function: 'fonts-url';
 
             @import "pkg:@govuk-frontend/helpers/assets-urls";
@@ -149,6 +155,7 @@ describe('@function font-url', () => {
           const sass = `
             @import "tools/font-url";
 
+            $govuk-suppressed-warnings: ("font-url-string");
             $govuk-fonts-path: '/path/to/fonts/';
             $govuk-font-url-function: unknown-function;
 

--- a/packages/govuk-frontend/src/govuk/tools/image-url.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/image-url.unit.test.js
@@ -46,6 +46,7 @@ describe('@function image-url', () => {
       it('executes a native Sass function', async () => {
         const sass = `
           @use "settings" with (
+            $govuk-suppressed-warnings: ("image-url-string"),
             $govuk-image-url-function: 'to-upper-case'
           );
           @use "tools/image-url" as *;
@@ -62,7 +63,10 @@ describe('@function image-url', () => {
         )
 
         await expect(
-          compileSassString(sass, { fatalDeprecations })
+          compileSassString(sass, {
+            fatalDeprecations,
+            silenceDeprecations: ['global-builtin']
+          })
         ).resolves.toMatchObject({
           css: outdent`
             .foo {
@@ -75,6 +79,7 @@ describe('@function image-url', () => {
       it('uses the default for a non-native function', async () => {
         const sass = `
           @use "settings" with (
+            $govuk-suppressed-warnings: ("image-url-string"),
             $govuk-images-path: '/path/to/images/',
             $govuk-image-url-function: non-native-function
           );
@@ -121,6 +126,7 @@ describe('@function image-url', () => {
     describe('with `@import`', () => {
       it('executes a custom function', async () => {
         const sass = `
+          $govuk-suppressed-warnings: ("image-url-string");
           $govuk-image-url-function: 'images-url';
 
           @import "pkg:@govuk-frontend/helpers/assets-urls";
@@ -146,6 +152,7 @@ describe('@function image-url', () => {
         const sass = `
         @import "tools/image-url";
 
+        $govuk-suppressed-warnings: ("image-url-string");
         $govuk-images-path: '/path/to/images/';
         $govuk-image-url-function: unknown-function;
 


### PR DESCRIPTION
We're getting some noise in the logs for these tests which we can suppress.