### PR TITLE
Fixes for Sassdoc warnings

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_device-pixels.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_device-pixels.scss
@@ -1,3 +1,5 @@
+@use "sass:list";
+
 ////
 /// @group helpers
 ////
@@ -26,8 +28,6 @@
 ///   }
 ///
 /// @access public
-
-@use "sass:list";
 
 @mixin govuk-device-pixel-ratio($ratio: 2) {
   @media only screen and (-webkit-min-device-pixel-ratio: $ratio),

--- a/packages/govuk-frontend/src/govuk/helpers/_spacing.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_spacing.scss
@@ -62,8 +62,6 @@
 /// spacing scale, which defines different spacing values at different
 /// breakpoints. Wrapper for the `govuk-responsive-spacing.govuk-responsive-spacing` mixin.
 ///
-/// @see {mixin} govuk-responsive.govuk-responsive-spacing
-///
 /// @param {Number} $responsive-spacing-point - Point on the responsive spacing
 /// scale, corresponds to a map of breakpoints and spacing values
 /// @param {String} $direction [all] - Direction to add spacing to
@@ -93,8 +91,6 @@
 /// Adds responsive padding by fetching a 'spacing map' from the responsive
 /// spacing scale, which defines different spacing values at different
 /// breakpoints. Wrapper for the `_govuk-responsive-spacing` mixin.
-///
-/// @see {mixin} _govuk-responsive-spacing
 ///
 /// @param {Number} $responsive-spacing-point - Point on the responsive spacing
 ///   scale, corresponds to a map of breakpoints and spacing values

--- a/packages/govuk-frontend/src/govuk/settings/_measurements.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_measurements.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 ////
 /// @group settings/layout
 ////
@@ -10,8 +12,6 @@
 ///
 /// @type Number
 /// @access public
-
-@use "sass:math";
 
 $govuk-page-width: 960px !default;
 


### PR DESCRIPTION
Putting the `@use` between a Sassdoc comment and the thing the Sassdoc is documenting breaks the link between the two, resulting in warnings like:

```
» [WARNING] Annotation `parameter` is not allowed on comment from type `unknown` in `_device-pixels.scss:5:28`.
» [WARNING] Annotation `content` is not allowed on comment from type `unknown` in `_device-pixels.scss:5:28`.
» [WARNING] Annotation `type` is not allowed on comment from type `unknown` in `_measurements.scss:9:12`.
```

This also means that these things would not be documented correctly in our Sass API reference.

Move the `@use` to the top of each file to avoid this issue.

I've also remove references to private mixins from API docs, which are causing warnings:

```
» [WARNING] Item `govuk-responsive-margin` refers to `govuk-responsive.govuk-responsive-spacing` from type `mixin` but this item doesn't exist.
» [WARNING] Item `govuk-responsive-padding` refers to `_govuk-responsive-spacing` from type `mixin` but this item doesn't exist.
```

It’s also likely confusing for users if these annotations end up in our API docs, because they’re referring to a private mixin which will not appear in the documentation.