### PR TITLE
`objects` layer tidy-ups

### DIFF
--- a/packages/govuk-frontend/src/govuk/objects/_button-group.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_button-group.import.scss
@@ -2,7 +2,6 @@
 @use "../tools/exports" as *;
 
 @import "../base";
-@import "../custom-properties";
 
 @include govuk-exports("govuk/objects/button-group") {
   @include button-group.styles;

--- a/packages/govuk-frontend/src/govuk/objects/_button-group.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_button-group.import.scss
@@ -1,5 +1,4 @@
 @use "button-group.mixin" as button-group;
-@use "../tools/exports" as *;
 
 @import "../base";
 

--- a/packages/govuk-frontend/src/govuk/objects/_form-group.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_form-group.import.scss
@@ -2,7 +2,6 @@
 @use "../tools/exports" as *;
 
 @import "../base";
-@import "../custom-properties";
 
 @include govuk-exports("govuk/objects/form-group") {
   @include form-group.styles;

--- a/packages/govuk-frontend/src/govuk/objects/_form-group.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_form-group.import.scss
@@ -1,5 +1,4 @@
 @use "form-group.mixin" as form-group;
-@use "../tools/exports" as *;
 
 @import "../base";
 

--- a/packages/govuk-frontend/src/govuk/objects/_grid.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_grid.import.scss
@@ -2,7 +2,6 @@
 @use "../tools/exports" as *;
 
 @import "../base";
-@import "../custom-properties";
 
 @include govuk-exports("govuk/objects/grid") {
   @include grid.styles;

--- a/packages/govuk-frontend/src/govuk/objects/_grid.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_grid.import.scss
@@ -1,5 +1,4 @@
 @use "grid.mixin" as grid;
-@use "../tools/exports" as *;
 
 @import "../base";
 

--- a/packages/govuk-frontend/src/govuk/objects/_main-wrapper.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_main-wrapper.import.scss
@@ -2,7 +2,6 @@
 @use "../tools/exports" as *;
 
 @import "../base";
-@import "../custom-properties";
 
 @include govuk-exports("govuk/objects/main-wrapper") {
   @include main-wrapper.styles;

--- a/packages/govuk-frontend/src/govuk/objects/_main-wrapper.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_main-wrapper.import.scss
@@ -1,5 +1,4 @@
 @use "main-wrapper.mixin" as main-wrapper;
-@use "../tools/exports" as *;
 
 @import "../base";
 

--- a/packages/govuk-frontend/src/govuk/objects/_template.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.import.scss
@@ -1,5 +1,4 @@
 @use "template.mixin" as template;
-@use "../tools/exports" as *;
 
 @import "../base";
 

--- a/packages/govuk-frontend/src/govuk/objects/_template.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.import.scss
@@ -2,7 +2,6 @@
 @use "../tools/exports" as *;
 
 @import "../base";
-@import "../custom-properties";
 
 @include govuk-exports("govuk/objects/template") {
   @include template.styles;

--- a/packages/govuk-frontend/src/govuk/objects/_width-container.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_width-container.import.scss
@@ -2,7 +2,6 @@
 @use "../tools/exports" as *;
 
 @import "../base";
-@import "../custom-properties";
 
 @include govuk-exports("govuk/objects/width-container") {
   @include width-container.styles;

--- a/packages/govuk-frontend/src/govuk/objects/_width-container.import.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_width-container.import.scss
@@ -1,5 +1,4 @@
 @use "width-container.mixin" as width-container;
-@use "../tools/exports" as *;
 
 @import "../base";
 

--- a/packages/govuk-frontend/src/govuk/objects/_width-container.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_width-container.mixin.scss
@@ -1,7 +1,7 @@
-@use "../helpers/width-container" as width-container;
+@use "../base";
 
 @mixin styles {
   .govuk-width-container {
-    @include width-container.govuk-width-container;
+    @include base.govuk-width-container;
   }
 }

--- a/packages/govuk-frontend/src/govuk/objects/objects.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/objects/objects.unit.test.js
@@ -1,15 +1,17 @@
 const { join } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
-const { compileSassFile } = require('@govuk-frontend/helpers/tests')
+const {
+  compileSassFile,
+  getSassPathsFromLayer
+} = require('@govuk-frontend/helpers/tests')
 const { compileSassString } = require('@govuk-frontend/helpers/tests')
-const { getListing } = require('@govuk-frontend/lib/files')
 const sassdoc = require('sassdoc')
 const stylelint = require('stylelint')
 
-describe('The objects layer', () => {
-  let sassFiles
+const partials = getSassPathsFromLayer('objects')
 
+describe('The objects layer', () => {
   describe.each([
     [
       'import',
@@ -33,14 +35,6 @@ describe('The objects layer', () => {
     })
 
     it('does not reference any undefined custom properties', async () => {
-      // Requires base as this is where the custom properties come from
-      const sass = `
-        @import "base";
-        @import "objects";
-      `
-
-      const { css } = await compileSassString(sass)
-
       const linter = await stylelint.lint({
         config: { rules: { 'no-unknown-custom-properties': true } },
         code: css
@@ -58,24 +52,15 @@ describe('The objects layer', () => {
     })
   })
 
-  beforeAll(async () => {
-    sassFiles = await getListing('**/src/govuk/objects/**/*.scss', {
-      cwd: paths.package,
-      ignore: ['**/_all.scss', '**/_index.scss']
-    })
-  })
-
-  it('renders CSS for all objects', () => {
-    const sassTasks = sassFiles.map((sassFilePath) => {
-      const file = join(paths.package, sassFilePath)
+  describe.each(partials)('$name', ({ partialPath, name }) => {
+    it('renders without errors', () => {
+      const file = join(paths.package, partialPath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
         loadedUrls: expect.arrayContaining([expect.any(URL)])
       })
     })
-
-    return Promise.all(sassTasks)
   })
 
   describe('Sass documentation', () => {


### PR DESCRIPTION
Tidy ups a couple of details I missed during the review of #6956:
- tests did not follow the same structure as the other layers
- import of `custom-properties` is redundant as `base` already imports it
- `width-container` was importing from `helpers` rather than using `base`