### PR TITLE
`@use` the `utilities` layer

### DIFF
--- a/packages/govuk-frontend/src/govuk/utilities/_clearfix.import.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_clearfix.import.scss
@@ -1,0 +1,7 @@
+@use "clearfix.mixin" as mixin;
+
+@import "../tools/exports";
+
+@include govuk-exports("govuk/utilities/clearfix") {
+  @include mixin.styles;
+}

--- a/packages/govuk-frontend/src/govuk/utilities/_clearfix.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_clearfix.mixin.scss
@@ -1,0 +1,8 @@
+@use "../base";
+@use "../helpers/clearfix" as *;
+
+@mixin styles {
+  .govuk-clearfix {
+    @include govuk-clearfix;
+  }
+}

--- a/packages/govuk-frontend/src/govuk/utilities/_clearfix.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_clearfix.scss
@@ -1,8 +1,3 @@
-@use "../tools/exports" as *;
-@use "../helpers/clearfix" as *;
+@use "clearfix.mixin" as clearfix;
 
-@include govuk-exports("govuk/utilities/clearfix") {
-  .govuk-clearfix {
-    @include govuk-clearfix;
-  }
-}
+@include clearfix.styles;

--- a/packages/govuk-frontend/src/govuk/utilities/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_index.import.scss
@@ -1,0 +1,2 @@
+@import "clearfix";
+@import "visually-hidden";

--- a/packages/govuk-frontend/src/govuk/utilities/_index.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_index.scss
@@ -1,2 +1,2 @@
-@import "clearfix";
-@import "visually-hidden";
+@use "clearfix";
+@use "visually-hidden";

--- a/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.import.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.import.scss
@@ -1,0 +1,7 @@
+@use "visually-hidden.mixin" as mixin;
+
+@import "../tools/exports";
+
+@include govuk-exports("govuk/utilities/visually-hidden") {
+  @include mixin.styles;
+}

--- a/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.mixin.scss
@@ -1,0 +1,12 @@
+@use "../base";
+@use "../helpers/visually-hidden" as *;
+
+@mixin styles {
+  .govuk-visually-hidden {
+    @include govuk-visually-hidden;
+  }
+
+  .govuk-visually-hidden-focusable {
+    @include govuk-visually-hidden-focusable;
+  }
+}

--- a/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.scss
@@ -1,12 +1,3 @@
-@use "../tools/exports" as *;
-@use "../helpers/visually-hidden" as *;
+@use "visually-hidden.mixin" as visually-hidden;
 
-@include govuk-exports("govuk/utilities/visually-hidden") {
-  .govuk-visually-hidden {
-    @include govuk-visually-hidden;
-  }
-
-  .govuk-visually-hidden-focusable {
-    @include govuk-visually-hidden-focusable;
-  }
-}
+@include visually-hidden.styles;

--- a/packages/govuk-frontend/src/govuk/utilities/utilities.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/utilities/utilities.unit.test.js
@@ -1,5 +1,15 @@
-const { compileSassString } = require('@govuk-frontend/helpers/tests')
+const { readFile } = require('node:fs/promises')
+const { join } = require('node:path')
+
+const { paths } = require('@govuk-frontend/config')
+const {
+  compileSassString,
+  getSassPathsFromLayer,
+  compileSassFile
+} = require('@govuk-frontend/helpers/tests')
 const stylelint = require('stylelint')
+
+const partials = getSassPathsFromLayer('utilities')
 
 describe('The utilities layer', () => {
   describe.each([
@@ -32,6 +42,46 @@ describe('The utilities layer', () => {
       }
 
       return expect(linter.results[0].warnings).toHaveLength(0)
+    })
+  })
+
+  describe.each(partials)('$name', ({ partialPath, name }) => {
+    let css
+    beforeAll(async () => {
+      const file = join(paths.package, partialPath)
+
+      css = (await compileSassFile(file)).css
+    })
+
+    // Sass will error when trying to access an undefined variable or mixin
+    // but will not on a function, so we need to check the output for calls
+    // to GOV.UK Frontend's API that are not namespaced with `base.`
+    it('does not contain any unexpected govuk- function calls', async () => {
+      const matches = css.matchAll(/_?govuk-[\w-]+\(.*?\)/g)
+
+      // `matchAll` does not return an actual `Array` so we need
+      // a little conversion before we can check its length
+      expect(Array.from(matches)).toHaveLength(0)
+    })
+
+    it('does not output the custom properties', () => {
+      const occurrences = css.matchAll(/--govuk-breakpoint-mobile/g)
+
+      expect(Array.from(occurrences)).toHaveLength(0)
+    })
+
+    it('has a corresponding import-only file', async () => {
+      const importOnlyPath = join(
+        paths.package,
+        partialPath.replace('.scss', '.import.scss')
+      )
+      const { moduleName } = /_(?<moduleName>.*)\.scss/.exec(name).groups
+
+      const fileContent = await readFile(importOnlyPath, { encoding: 'utf-8' })
+
+      expect(fileContent).toContain(
+        `@include govuk-exports("govuk/utilities/${moduleName}")`
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/utilities/utilities.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/utilities/utilities.unit.test.js
@@ -2,28 +2,36 @@ const { compileSassString } = require('@govuk-frontend/helpers/tests')
 const stylelint = require('stylelint')
 
 describe('The utilities layer', () => {
-  it('does not reference any undefined custom properties', async () => {
-    // Requires base as this is where the custom properties come from
-    const sass = `
-      @import "base";
+  describe.each([
+    [
+      'import',
+      `
       @import "utilities";
     `
+    ],
+    ['use', `@use "utilities";`]
+  ])('with `@%s`', (type, sass) => {
+    let css
 
-    const { css } = await compileSassString(sass)
-
-    const linter = await stylelint.lint({
-      config: { rules: { 'no-unknown-custom-properties': true } },
-      code: css
+    beforeAll(async () => {
+      css = (await compileSassString(sass)).css
     })
 
-    // Output stylelint warnings to make debugging easier
-    if (linter.results[0].warnings.length) {
-      console.log(
-        'Warnings were present when testing the utilities for unknown custom properties:'
-      )
-      console.log(linter.results[0].warnings)
-    }
+    it('does not reference any undefined custom properties', async () => {
+      const linter = await stylelint.lint({
+        config: { rules: { 'no-unknown-custom-properties': true } },
+        code: css
+      })
 
-    return expect(linter.results[0].warnings).toHaveLength(0)
+      // Output stylelint warnings to make debugging easier
+      if (linter.results[0].warnings.length) {
+        console.log(
+          'Warnings were present when testing the utilities layer for unknown custom properties:'
+        )
+        console.log(linter.results[0].warnings)
+      }
+
+      return expect(linter.results[0].warnings).toHaveLength(0)
+    })
   })
 })

--- a/shared/helpers/tests.js
+++ b/shared/helpers/tests.js
@@ -50,7 +50,12 @@ async function compileSassString(source, options = {}) {
 function getSassPathsFromLayer(layer) {
   return globSync(`**/src/govuk/${layer}/**/*.scss`, {
     cwd: paths.package,
-    exclude: ['**/_index.scss', '**/*.import.scss', '**/*--internal.scss']
+    exclude: [
+      '**/_index.scss',
+      '**/*.import.scss',
+      '**/*.mixin.scss',
+      '**/*--internal.scss'
+    ]
   }).map((partialPath) => ({
     partialPath,
     name: basename(partialPath)


### PR DESCRIPTION
Migrate `overrides` layer partial by partial, with added tests for:
 - compilation of `index` with both `@use` and `@import`
 - compilation of individual partials

Best reviewed commit by commit

Fixes #6852 