### PR TITLE
Add date input `day`, `month`, `year` and `values` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,110 @@ The Generic header component is a version of the GOV.UK header component that yo
 
 This was added in [pull request #7061: Add Generic Header component](https://github.com/alphagov/govuk-frontend/pull/7061).
 
+#### You can now pass `day`, `month`, `year`, `error` and `values` options to the Date input component
+
+We've updated the Date input component to add the following Nunjucks options:
+
+- `day`, `month` and `year` options to customise individual items
+- `error` boolean option to set the error state on individual items
+- `values` option to set individual item values using a single object
+
+For consistency with other components, the Date input component's error state is now set automatically when `errorMessage` is provided.
+
+For example, it is no longer necessary to set the `"govuk-input--error"` class on every item:
+
+```patch
+  {{ govukDateInput({
+    fieldset: {
+      legend: {
+        text: "What is your date of birth?"
+      }
+    },
+    errorMessage: {
+      text: "Enter your date of birth"
+-   },
+-   items: [
+-     {
+-       name: "day",
+-       label: "Day",
+-       classes: "govuk-input--width-2 govuk-input--error"
+-     },
+-     {
+-       name: "month",
+-       label: "Month",
+-       classes: "govuk-input--width-2 govuk-input--error"
+-     },
+-     {
+-       name: "year",
+-       label: "Year",
+-       classes: "govuk-input--width-4 govuk-input--error"
+-     }
+-   ]
++   }
+  }) }}
+```
+
+If only one field has an error, use the new `day`, `month` or `year` options to set `error: true` for that field only:
+
+```patch
+  {{ govukDateInput({
+    fieldset: {
+      legend: {
+        text: "What is your date of birth?"
+      }
+    },
+    errorMessage: {
+      text: "Date of birth must include a year"
+    },
+-   items: [
+-     {
+-       name: "day",
+-       label: "Day",
+-       classes: "govuk-input--width-2"
+-     },
+-     {
+-       name: "month",
+-       label: "Month",
+-       classes: "govuk-input--width-2"
+-     },
+-     {
+-       name: "year",
+-       label: "Year",
+-       classes: "govuk-input--width-4 govuk-input--error"
+-     }
+-   ]
++   year: {
++     error: true
++   }
+  }) }}
+```
+
+When using the GOV.UK Prototype Kit, given the following `data` object:
+
+```json
+{
+  "dob-day": "31",
+  "dob-month": "3",
+  "dob-year": "1980"
+}
+```
+
+You can now pass in `values: data` to automatically set item values:
+
+```njk
+  {{ govukDateInput({
+    fieldset: {
+      legend: {
+        text: "What is your date of birth?"
+      }
+    },
+    namePrefix: "dob",
+    values: data
+  }) }}
+```
+
+We made this change in [pull request #6971: Add date input `day`, `month`, `year` and `values` options](https://github.com/alphagov/govuk-frontend/pull/6971).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/date-input/__snapshots__/template.test.js.snap
+++ b/packages/govuk-frontend/src/govuk/components/date-input/__snapshots__/template.test.js.snap
@@ -43,6 +43,14 @@ exports[`Date input passes through html fieldset params without breaking 1`] = `
 </fieldset>
 `;
 
+exports[`Date input when it includes a field with an error by omission renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
 exports[`Date input when it includes a field with an error class renders the error message 1`] = `
 <p id="dob-errors-error"
    class="govuk-error-message"
@@ -76,6 +84,14 @@ exports[`Date input when it includes an error message (using items) renders the 
 `;
 
 exports[`Date input when it includes an error message renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
+exports[`Date input when it includes an item with an error by omission renders the error message 1`] = `
 <p id="dob-errors-error"
    class="govuk-error-message"
 >

--- a/packages/govuk-frontend/src/govuk/components/date-input/__snapshots__/template.test.js.snap
+++ b/packages/govuk-frontend/src/govuk/components/date-input/__snapshots__/template.test.js.snap
@@ -43,6 +43,22 @@ exports[`Date input passes through html fieldset params without breaking 1`] = `
 </fieldset>
 `;
 
+exports[`Date input when it includes a field with an error class renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
+exports[`Date input when it includes a field with an error renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
 exports[`Date input when it includes a hint renders the hint 1`] = `
 <div id="dob-hint"
      class="govuk-hint"
@@ -51,7 +67,31 @@ exports[`Date input when it includes a hint renders the hint 1`] = `
 </div>
 `;
 
+exports[`Date input when it includes an error message (using items) renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
 exports[`Date input when it includes an error message renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
+exports[`Date input when it includes an item with an error class renders the error message 1`] = `
+<p id="dob-errors-error"
+   class="govuk-error-message"
+>
+  Error message goes here
+</p>
+`;
+
+exports[`Date input when it includes an item with an error renders the error message 1`] = `
 <p id="dob-errors-error"
    class="govuk-error-message"
 >

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -117,7 +117,7 @@ params:
   - name: values
     type: object
     required: false
-    description: An optional object used to specify `value` attributes for the date parts without setting items.
+    description: Specify `value` attributes for the date parts without setting items. You can also use the `name` for the fields as keys, including any `namePrefix`.
     params:
       day:
         type: string

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -179,6 +179,20 @@ examples:
           text: What is your date of birth?
       errorMessage:
         text: Error message goes here
+      day:
+        classes: govuk-input--error
+      month:
+        classes: govuk-input--error
+      year:
+        classes: govuk-input--error
+  - name: with errors only (using items)
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      errorMessage:
+        text: Error message goes here
       items:
         - name: day
           classes: govuk-input--width-2 govuk-input--error
@@ -196,6 +210,22 @@ examples:
         text: For example, 31 3 1980
       errorMessage:
         text: Error message goes here
+      day:
+        classes: govuk-input--error
+      month:
+        classes: govuk-input--error
+      year:
+        classes: govuk-input--error
+  - name: with errors and hint (using items)
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
       items:
         - name: day
           classes: govuk-input--width-2 govuk-input--error
@@ -204,6 +234,19 @@ examples:
         - name: year
           classes: govuk-input--width-4 govuk-input--error
   - name: with error on day input
+    options:
+      id: dob-day-error
+      namePrefix: dob-day-error
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      day:
+        classes: govuk-input--error
+  - name: with error on day input (using items)
     options:
       id: dob-day-error
       namePrefix: dob-day-error
@@ -232,6 +275,19 @@ examples:
         text: For example, 31 3 1980
       errorMessage:
         text: Error message goes here
+      month:
+        classes: govuk-input--error
+  - name: with error on month input (using items)
+    options:
+      id: dob-month-error
+      namePrefix: dob-month-error
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
       items:
         - name: day
           classes: govuk-input--width-2
@@ -240,6 +296,19 @@ examples:
         - name: year
           classes: govuk-input--width-4
   - name: with error on year input
+    options:
+      id: dob-year-error
+      namePrefix: dob-year-error
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      year:
+        classes: govuk-input--error
+  - name: with error on year input (using items)
     options:
       id: dob-year-error
       namePrefix: dob-year-error

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -110,6 +110,23 @@ params:
     type: object
     required: false
     description: Options for the year input within the date input component. See items.
+  - name: values
+    type: object
+    required: false
+    description: An optional object used to specify `value` attributes for the date parts without setting items.
+    params:
+      day:
+        type: string
+        required: false
+        description: The `value` attribute for the day input.
+      month:
+        type: string
+        required: false
+        description: The `value` attribute for the month input.
+      year:
+        type: string
+        required: false
+        description: The `value` attribute for the year input.
   - name: classes
     type: string
     required: false
@@ -143,6 +160,53 @@ examples:
         label: Mis
       year:
         label: Blwyddyn
+  - name: with values
+    options:
+      id: with-values
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      values:
+        day: 31
+        month: 3
+        year: 1980
+  - name: with values and name prefix
+    options:
+      id: with-values-name-prefix
+      namePrefix: dob
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      values:
+        dob-day: 31
+        dob-month: 3
+        dob-year: 1980
+  - name: with values, name prefix and custom names
+    options:
+      id: with-values-name-prefix-custom
+      namePrefix: dob
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      day:
+        label: Day
+        name: user1-day
+      month:
+        label: Month
+        name: user1-month
+      year:
+        label: Year
+        name: user1-year
+      values:
+        dob-user1-day: 31
+        dob-user1-month: 3
+        dob-user1-year: 1980
   - name: day and month
     options:
       id: bday
@@ -468,6 +532,30 @@ examples:
           value: 2018
       year:
         value: 2023
+  - name: with field value, item value and values
+    hidden: true
+    options:
+      id: with-field-value-item-value-values
+      items:
+        - id: day
+          name: day
+        - id: month
+          name: month
+        - id: year
+          name: year
+          value: 2018
+      year:
+        value: 2023
+      values:
+        year: 2026
+  - name: with field value overriding values
+    hidden: true
+    options:
+      id: with-field-value-values
+      year:
+        value: 2023
+      values:
+        year: 2026
   - name: with hint and describedBy
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -423,10 +423,10 @@ examples:
         - name: day
         - name: month
         - name: year
-  - name: with values
+  - name: with item value
     hidden: true
     options:
-      id: with-values
+      id: with-item-value
       items:
         - id: day
           name: day
@@ -435,6 +435,39 @@ examples:
         - id: year
           name: year
           value: 2018
+  - name: with field value
+    hidden: true
+    options:
+      id: with-field-value
+      year:
+        value: 2023
+  - name: with field value and items
+    hidden: true
+    options:
+      id: with-field-value-items
+      items:
+        - id: day
+          name: day
+        - id: month
+          name: month
+        - id: year
+          name: year
+      year:
+        value: 2023
+  - name: with field value and item value
+    hidden: true
+    options:
+      id: with-field-value-item-value
+      items:
+        - id: day
+          name: day
+        - id: month
+          name: month
+        - id: year
+          name: year
+          value: 2018
+      year:
+        value: 2023
   - name: with hint and describedBy
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -322,12 +322,6 @@ examples:
         text: For example, 31 3 1980
       errorMessage:
         text: Error message goes here
-      day:
-        error: true
-      month:
-        error: true
-      year:
-        error: true
   - name: with error message and hint (using items)
     options:
       id: dob-errors
@@ -341,13 +335,10 @@ examples:
       items:
         - name: day
           classes: govuk-input--width-2
-          error: true
         - name: month
           classes: govuk-input--width-2
-          error: true
         - name: year
           classes: govuk-input--width-4
-          error: true
   - name: with error on day input
     options:
       id: dob-day-error
@@ -617,6 +608,21 @@ examples:
         text: Error message goes here
       day:
         error: true
+  - name: with error on single field by omission
+    hidden: true
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      month:
+        error: false
+      year:
+        error: false
   - name: with error on single field using classes
     hidden: true
     options:
@@ -649,6 +655,26 @@ examples:
           classes: govuk-input--width-2
         - name: year
           classes: govuk-input--width-4
+  - name: with error on single item by omission
+    hidden: true
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      items:
+        - name: day
+          classes: govuk-input--width-2
+        - name: month
+          classes: govuk-input--width-2
+          error: false
+        - name: year
+          classes: govuk-input--width-4
+          error: false
   - name: with error on single item using classes
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -98,6 +98,18 @@ params:
     required: false
     description: Can be used to add a fieldset to the date input component.
     isComponent: true
+  - name: day
+    type: object
+    required: false
+    description: Options for the day input within the date input component. See items.
+  - name: month
+    type: object
+    required: false
+    description: Options for the month input within the date input component. See items.
+  - name: year
+    type: object
+    required: false
+    description: Options for the year input within the date input component. See items.
   - name: classes
     type: string
     required: false
@@ -117,6 +129,26 @@ examples:
           text: What is your date of birth?
       hint:
         text: For example, 31 3 1980
+  - name: with translations
+    options:
+      id: with-translations
+      fieldset:
+        legend:
+          text: Pryd gafodd eich pasbort ei gyhoeddi?
+      hint:
+        text: Er enghraifft, 27 3 2007
+      day:
+        label: Dydd
+        name: day
+        classes: govuk-input--width-2
+      month:
+        label: Mis
+        name: month
+        classes: govuk-input--width-2
+      year:
+        label: Blwyddyn
+        name: year
+        classes: govuk-input--width-4
   - name: day and month
     options:
       id: bday

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -320,7 +320,6 @@ examples:
   - name: with error on day input
     options:
       id: dob-day-error
-      namePrefix: dob-day-error
       fieldset:
         legend:
           text: What is your date of birth?
@@ -333,7 +332,6 @@ examples:
   - name: with error on day input (using items)
     options:
       id: dob-day-error
-      namePrefix: dob-day-error
       fieldset:
         legend:
           text: What is your date of birth?
@@ -351,7 +349,6 @@ examples:
   - name: with error on month input
     options:
       id: dob-month-error
-      namePrefix: dob-month-error
       fieldset:
         legend:
           text: What is your date of birth?
@@ -364,7 +361,6 @@ examples:
   - name: with error on month input (using items)
     options:
       id: dob-month-error
-      namePrefix: dob-month-error
       fieldset:
         legend:
           text: What is your date of birth?
@@ -382,7 +378,6 @@ examples:
   - name: with error on year input
     options:
       id: dob-year-error
-      namePrefix: dob-year-error
       fieldset:
         legend:
           text: What is your date of birth?
@@ -395,7 +390,6 @@ examples:
   - name: with error on year input (using items)
     options:
       id: dob-year-error
-      namePrefix: dob-year-error
       fieldset:
         legend:
           text: What is your date of birth?

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -152,12 +152,32 @@ examples:
           text: What is your birthday?
       hint:
         text: For example, 5 12
+      year: false
+  - name: day and month (using items)
+    options:
+      id: bday
+      namePrefix: bday
+      fieldset:
+        legend:
+          text: What is your birthday?
+      hint:
+        text: For example, 5 12
       items:
         - name: day
           classes: govuk-input--width-2
         - name: month
           classes: govuk-input--width-2
   - name: month and year
+    options:
+      id: dob
+      namePrefix: dob
+      fieldset:
+        legend:
+          text: When did you move to this property?
+      hint:
+        text: For example, 3 1980
+      day: false
+  - name: month and year (using items)
     options:
       id: dob
       namePrefix: dob

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -28,6 +28,10 @@ params:
         type: string
         required: false
         description: If provided, it will be used as the initial value of the input.
+      - name: error
+        type: boolean
+        required: false
+        description: If set to `true`, it will show a red error border on the item input. If provided, you must set the top-level `errorMessage` option to add an error message to the date input component.
       - name: autocomplete
         type: string
         required: false
@@ -262,12 +266,40 @@ examples:
         legend:
           text: What is your date of birth?
       day:
+        error: true
+      month:
+        error: true
+      year:
+        error: true
+  - name: with errors only (using classes)
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      day:
         classes: govuk-input--error
       month:
         classes: govuk-input--error
       year:
         classes: govuk-input--error
   - name: with errors only (using items)
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      items:
+        - name: day
+          classes: govuk-input--width-2
+          error: true
+        - name: month
+          classes: govuk-input--width-2
+          error: true
+        - name: year
+          classes: govuk-input--width-4
+          error: true
+  - name: with errors only (using items and classes)
     options:
       id: dob-errors
       fieldset:
@@ -291,11 +323,11 @@ examples:
       errorMessage:
         text: Error message goes here
       day:
-        classes: govuk-input--error
+        error: true
       month:
-        classes: govuk-input--error
+        error: true
       year:
-        classes: govuk-input--error
+        error: true
   - name: with error message and hint (using items)
     options:
       id: dob-errors
@@ -308,11 +340,14 @@ examples:
         text: Error message goes here
       items:
         - name: day
-          classes: govuk-input--width-2 govuk-input--error
+          classes: govuk-input--width-2
+          error: true
         - name: month
-          classes: govuk-input--width-2 govuk-input--error
+          classes: govuk-input--width-2
+          error: true
         - name: year
-          classes: govuk-input--width-4 govuk-input--error
+          classes: govuk-input--width-4
+          error: true
   - name: with error on day input
     options:
       id: dob-day-error
@@ -324,7 +359,7 @@ examples:
       errorMessage:
         text: Error message goes here
       day:
-        classes: govuk-input--error
+        error: true
   - name: with error on day input (using items)
     options:
       id: dob-day-error
@@ -337,7 +372,8 @@ examples:
         text: Error message goes here
       items:
         - name: day
-          classes: govuk-input--width-2 govuk-input--error
+          classes: govuk-input--width-2
+          error: true
         - name: month
           classes: govuk-input--width-2
         - name: year
@@ -353,7 +389,7 @@ examples:
       errorMessage:
         text: Error message goes here
       month:
-        classes: govuk-input--error
+        error: true
   - name: with error on month input (using items)
     options:
       id: dob-month-error
@@ -368,7 +404,8 @@ examples:
         - name: day
           classes: govuk-input--width-2
         - name: month
-          classes: govuk-input--width-2 govuk-input--error
+          classes: govuk-input--width-2
+          error: true
         - name: year
           classes: govuk-input--width-4
   - name: with error on year input
@@ -382,7 +419,7 @@ examples:
       errorMessage:
         text: Error message goes here
       year:
-        classes: govuk-input--error
+        error: true
   - name: with error on year input (using items)
     options:
       id: dob-year-error
@@ -399,7 +436,8 @@ examples:
         - name: month
           classes: govuk-input--width-2
         - name: year
-          classes: govuk-input--width-4 govuk-input--error
+          classes: govuk-input--width-4
+          error: true
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes
@@ -566,6 +604,69 @@ examples:
           text: What is your date of birth?
       errorMessage:
         text: Error message goes here
+  - name: with error on single field
+    hidden: true
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      day:
+        error: true
+  - name: with error on single field using classes
+    hidden: true
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      day:
+        classes: govuk-input--error
+  - name: with error on single item
+    hidden: true
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      items:
+        - name: day
+          classes: govuk-input--width-2
+          error: true
+        - name: month
+          classes: govuk-input--width-2
+        - name: year
+          classes: govuk-input--width-4
+  - name: with error on single item using classes
+    hidden: true
+    options:
+      id: dob-errors
+      fieldset:
+        legend:
+          text: What is your date of birth?
+      hint:
+        text: For example, 31 3 1980
+      errorMessage:
+        text: Error message goes here
+      items:
+        - name: day
+          classes: govuk-input--width-2 govuk-input--error
+        - name: month
+          classes: govuk-input--width-2
+        - name: year
+          classes: govuk-input--width-4
   - name: fieldset html
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -139,16 +139,10 @@ examples:
         text: Er enghraifft, 27 3 2007
       day:
         label: Dydd
-        name: day
-        classes: govuk-input--width-2
       month:
         label: Mis
-        name: month
-        classes: govuk-input--width-2
       year:
         label: Blwyddyn
-        name: year
-        classes: govuk-input--width-4
   - name: day and month
     options:
       id: bday

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -284,7 +284,7 @@ examples:
           classes: govuk-input--width-2 govuk-input--error
         - name: year
           classes: govuk-input--width-4 govuk-input--error
-  - name: with errors and hint
+  - name: with error message and hint
     options:
       id: dob-errors
       fieldset:
@@ -300,7 +300,7 @@ examples:
         classes: govuk-input--error
       year:
         classes: govuk-input--error
-  - name: with errors and hint (using items)
+  - name: with error message and hint (using items)
     options:
       id: dob-errors
       fieldset:
@@ -556,7 +556,7 @@ examples:
         value: 2023
       values:
         year: 2026
-  - name: with hint and describedBy
+  - name: with hint and described by
     hidden: true
     options:
       id: dob-errors
@@ -566,7 +566,7 @@ examples:
           text: What is your date of birth?
       hint:
         text: For example, 31 3 1980
-  - name: with error and describedBy
+  - name: with error message and described by
     hidden: true
     options:
       id: dob-errors

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -261,8 +261,6 @@ examples:
       fieldset:
         legend:
           text: What is your date of birth?
-      errorMessage:
-        text: Error message goes here
       day:
         classes: govuk-input--error
       month:
@@ -275,8 +273,6 @@ examples:
       fieldset:
         legend:
           text: What is your date of birth?
-      errorMessage:
-        text: Error message goes here
       items:
         - name: day
           classes: govuk-input--width-2 govuk-input--error

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -11,22 +11,28 @@
 {#- fieldset is false by default -#}
 {% set hasFieldset = true if params.fieldset else false %}
 
+{%- set dateInputDay = params.day | default({
+  name: "day",
+  classes: "govuk-input--width-2"
+}) -%}
+
+{%- set dateInputMonth = params.month | default({
+  name: "month",
+  classes: "govuk-input--width-2"
+}) -%}
+
+{%- set dateInputYear = params.year | default({
+  name: "year",
+  classes: "govuk-input--width-4"
+}) -%}
+
 {%- if params.items | length %}
   {% set dateInputItems = params.items %}
 {% else %}
   {% set dateInputItems = [
-    {
-      name: "day",
-      classes: "govuk-input--width-2"
-    },
-    {
-      name: "month",
-      classes: "govuk-input--width-2"
-    },
-    {
-      name: "year",
-      classes: "govuk-input--width-4"
-    }
+    dateInputDay,
+    dateInputMonth,
+    dateInputYear
   ] %}
 {% endif %}
 

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -36,6 +36,26 @@
   ] %}
 {% endif %}
 
+{%- macro _dateInputItem(params, item) %}
+<div class="govuk-date-input__item">
+  {{ govukInput({
+    label: {
+      text: item.label if item.label else item.name | capitalize,
+      classes: "govuk-date-input__label"
+    },
+    id: item.id if item.id else (params.id + "-" + item.name),
+    classes: "govuk-date-input__input " + (item.classes if item.classes),
+    name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
+    value: item.value,
+    type: "text",
+    inputmode: item.inputmode if item.inputmode else "numeric",
+    autocomplete: item.autocomplete,
+    pattern: item.pattern,
+    attributes: item.attributes
+  }) | trim | indent(2) }}
+</div>
+{%- endmacro -%}
+
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
@@ -68,23 +88,7 @@
     {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
     {% endif %}
     {% for item in dateInputItems %}
-    <div class="govuk-date-input__item">
-      {{ govukInput({
-        label: {
-          text: item.label if item.label else item.name | capitalize,
-          classes: "govuk-date-input__label"
-        },
-        id: item.id if item.id else (params.id + "-" + item.name),
-        classes: "govuk-date-input__input " + (item.classes if item.classes),
-        name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
-        value: item.value,
-        type: "text",
-        inputmode: item.inputmode if item.inputmode else "numeric",
-        autocomplete: item.autocomplete,
-        pattern: item.pattern,
-        attributes: item.attributes
-      }) | trim | indent(6) }}
-    </div>
+      {{- _dateInputItem(params, item) | trim | indent(4, true) }}
     {% endfor %}
     {% if params.formGroup.afterInputs %}
     {{ params.formGroup.afterInputs.html | safe | trim | indent(4) if params.formGroup.afterInputs.html else params.formGroup.afterInputs.text }}

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -57,6 +57,10 @@
   {% set itemWidth = 4 %}
 {% endif %}
 
+{%- if item.error and (not item.classes or not "govuk-input--error" in item.classes) %}
+  {% set itemClasses = (itemClasses + " govuk-input--error") | trim %}
+{% endif -%}
+
 {%- if not item.classes or not "govuk-input--width-" in item.classes %}
   {% set itemClasses = (itemClasses + " govuk-input--width-" + itemWidth) | trim %}
 {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -115,7 +115,9 @@
     {{ params.formGroup.beforeInputs.html | safe | trim | indent(4) if params.formGroup.beforeInputs.html else params.formGroup.beforeInputs.text }}
     {% endif %}
     {% for item in dateInputItems %}
-      {{- _dateInputItem(params, item) | trim | indent(4, true) }}
+      {% if item %}
+        {{- _dateInputItem(params, item) | trim | indent(4, true) }}
+      {% endif %}
     {% endfor %}
     {% if params.formGroup.afterInputs %}
     {{ params.formGroup.afterInputs.html | safe | trim | indent(4) if params.formGroup.afterInputs.html else params.formGroup.afterInputs.text }}

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -13,16 +13,19 @@
 
 {%- set dateInputDay = params.day | default({
   name: "day",
+  value: params.values.day,
   classes: "govuk-input--width-2"
 }) -%}
 
 {%- set dateInputMonth = params.month | default({
   name: "month",
+  value: params.values.month,
   classes: "govuk-input--width-2"
 }) -%}
 
 {%- set dateInputYear = params.year | default({
   name: "year",
+  value: params.values.year,
   classes: "govuk-input--width-4"
 }) -%}
 
@@ -73,7 +76,7 @@
     id: item.id if item.id else (params.id + "-" + itemName),
     classes: "govuk-date-input__input " + (itemClasses if itemClasses),
     name: namePrefix + itemName,
-    value: itemValue,
+    value: itemValue | default(params.values[namePrefix + itemName]),
     type: "text",
     inputmode: item.inputmode if item.inputmode else "numeric",
     autocomplete: item.autocomplete,

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -74,7 +74,7 @@
       classes: "govuk-date-input__label"
     },
     id: item.id if item.id else (params.id + "-" + itemName),
-    classes: "govuk-date-input__input " + (itemClasses if itemClasses),
+    classes: "govuk-date-input__input" + (" " + itemClasses if itemClasses),
     name: namePrefix + itemName,
     value: itemValue | default(params.values[namePrefix + itemName]),
     type: "text",

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -37,16 +37,43 @@
 {% endif %}
 
 {%- macro _dateInputItem(params, item) %}
+{% set itemName = item.name %}
+{% set itemValue = item.value %}
+{% set itemWidth = 2 %}
+{% set itemClasses = "" %}
+
+{%- if item is sameas(dateInputDay) or (item.name and item.name in ["day", dateInputDay.name]) %}
+  {% set itemName = item.name | default("day") %}
+  {% set itemValue = item.value | default(dateInputDay.value) %}
+{% elif item is sameas(dateInputMonth) or (item.name and item.name in ["month", dateInputMonth.name]) %}
+  {% set itemName = item.name | default("month") %}
+  {% set itemValue = item.value | default(dateInputMonth.value) %}
+{% elif item is sameas(dateInputYear) or (item.name and item.name in ["year", dateInputYear.name]) %}
+  {% set itemName = item.name | default("year") %}
+  {% set itemValue = item.value | default(dateInputYear.value) %}
+  {% set itemWidth = 4 %}
+{% endif %}
+
+{%- if not item.classes or not "govuk-input--width-" in item.classes %}
+  {% set itemClasses = (itemClasses + " govuk-input--width-" + itemWidth) | trim %}
+{% endif %}
+
+{%- if item.classes %}
+  {% set itemClasses = (itemClasses + " " + item.classes) | trim %}
+{% endif %}
+
+{%- set namePrefix = (params.namePrefix + "-") if params.namePrefix else "" -%}
+
 <div class="govuk-date-input__item">
   {{ govukInput({
     label: {
-      text: item.label if item.label else item.name | capitalize,
+      text: item.label if item.label else itemName | capitalize,
       classes: "govuk-date-input__label"
     },
-    id: item.id if item.id else (params.id + "-" + item.name),
-    classes: "govuk-date-input__input " + (item.classes if item.classes),
-    name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
-    value: item.value,
+    id: item.id if item.id else (params.id + "-" + itemName),
+    classes: "govuk-date-input__input " + (itemClasses if itemClasses),
+    name: namePrefix + itemName,
+    value: itemValue,
     type: "text",
     inputmode: item.inputmode if item.inputmode else "numeric",
     autocomplete: item.autocomplete,

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.njk
@@ -39,11 +39,12 @@
   ] %}
 {% endif %}
 
-{%- macro _dateInputItem(params, item) %}
+{%- macro _dateInputItem(params, item, anyItemHasError) %}
 {% set itemName = item.name %}
 {% set itemValue = item.value %}
 {% set itemWidth = 2 %}
 {% set itemClasses = "" %}
+{% set itemHasError = true if item.error or (item.classes and "govuk-input--error" in item.classes) else false %}
 
 {%- if item is sameas(dateInputDay) or (item.name and item.name in ["day", dateInputDay.name]) %}
   {% set itemName = item.name | default("day") %}
@@ -57,7 +58,9 @@
   {% set itemWidth = 4 %}
 {% endif %}
 
-{%- if item.error and (not item.classes or not "govuk-input--error" in item.classes) %}
+{%- if (not item.classes or not "govuk-input--error" in item.classes) and (
+  itemHasError or (item.error != false and params.errorMessage and not anyItemHasError)
+) %}
   {% set itemClasses = (itemClasses + " govuk-input--error") | trim %}
 {% endif -%}
 
@@ -89,6 +92,12 @@
   }) | trim | indent(2) }}
 </div>
 {%- endmacro -%}
+
+{#- Determine if any date input item has an error #}
+{%- set anyItemHasError = false %}
+{% for item in dateInputItems %}
+  {% set anyItemHasError = true if item.error or (item.classes and "govuk-input--error" in item.classes) else anyItemHasError %}
+{% endfor -%}
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
@@ -123,7 +132,7 @@
     {% endif %}
     {% for item in dateInputItems %}
       {% if item %}
-        {{- _dateInputItem(params, item) | trim | indent(4, true) }}
+        {{- _dateInputItem(params, item, anyItemHasError) | trim | indent(4, true) }}
       {% endif %}
     {% endfor %}
     {% if params.formGroup.afterInputs %}

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -431,6 +431,41 @@ describe('Date input', () => {
     })
   })
 
+  describe('when it includes a field with an error by omission', () => {
+    it('renders the error message', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single field by omission']
+      )
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the input', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single field by omission']
+      )
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeFalsy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeFalsy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single field by omission']
+      )
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
   describe('when it includes a field with an error class', () => {
     it('renders the error message', () => {
       const $ = render(
@@ -486,6 +521,41 @@ describe('Date input', () => {
 
     it('includes the error modifier class on the form group wrapper', () => {
       const $ = render('date-input', examples['with error on single item'])
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes an item with an error by omission', () => {
+    it('renders the error message', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single item by omission']
+      )
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the input', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single item by omission']
+      )
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeFalsy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeFalsy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single item by omission']
+      )
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -250,7 +250,19 @@ describe('Date input', () => {
       )
     })
 
-    it('renders with a form group wrapper that has an error state', () => {
+    it('includes the error modifier class on the inputs', () => {
+      const $ = render('date-input', examples['with errors only'])
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeTruthy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
       const $ = render('date-input', examples['with errors only'])
 
       const $formGroup = $('.govuk-form-group')
@@ -327,6 +339,13 @@ describe('Date input', () => {
     const $dayInput = $('[name="day"]')
     const $monthInput = $('[name="month"]')
     const $yearInput = $('[name="year"]')
+
+    // All fields set default classes
+    expect($dayInput.hasClass('govuk-date-input__input')).toBeTruthy()
+    expect($monthInput.hasClass('govuk-date-input__input')).toBeTruthy()
+    expect($yearInput.hasClass('govuk-date-input__input')).toBeTruthy()
+
+    // All fields set custom classes
     expect($dayInput.hasClass('app-date-input__day')).toBeTruthy()
     expect($monthInput.hasClass('app-date-input__month')).toBeTruthy()
     expect($yearInput.hasClass('app-date-input__year')).toBeTruthy()
@@ -338,6 +357,13 @@ describe('Date input', () => {
     const $dayInput = $('[name="day"]')
     const $monthInput = $('[name="month"]')
     const $yearInput = $('[name="year"]')
+
+    // All fields set default classes
+    expect($dayInput.hasClass('govuk-date-input__input')).toBeTruthy()
+    expect($monthInput.hasClass('govuk-date-input__input')).toBeTruthy()
+    expect($yearInput.hasClass('govuk-date-input__input')).toBeTruthy()
+
+    // No fields set undefined classes
     expect($dayInput.hasClass('undefined')).toBeFalsy()
     expect($monthInput.hasClass('undefined')).toBeFalsy()
     expect($yearInput.hasClass('undefined')).toBeFalsy()

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -370,6 +370,163 @@ describe('Date input', () => {
     })
   })
 
+  describe('when it includes an error message (using items)', () => {
+    it('renders the error message', () => {
+      const $ = render(
+        'date-input',
+        examples['with error message and hint (using items)']
+      )
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the inputs', () => {
+      const $ = render(
+        'date-input',
+        examples['with error message and hint (using items)']
+      )
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeTruthy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render(
+        'date-input',
+        examples['with error message and hint (using items)']
+      )
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes a field with an error', () => {
+    it('renders the error message', () => {
+      const $ = render('date-input', examples['with error on single field'])
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the input', () => {
+      const $ = render('date-input', examples['with error on single field'])
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeFalsy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeFalsy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render('date-input', examples['with error on single field'])
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes a field with an error class', () => {
+    it('renders the error message', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single field using classes']
+      )
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the input', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single field using classes']
+      )
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeFalsy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeFalsy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single field using classes']
+      )
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes an item with an error', () => {
+    it('renders the error message', () => {
+      const $ = render('date-input', examples['with error on single item'])
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the input', () => {
+      const $ = render('date-input', examples['with error on single item'])
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeFalsy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeFalsy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render('date-input', examples['with error on single item'])
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes an item with an error class', () => {
+    it('renders the error message', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single item using classes']
+      )
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('includes the error modifier class on the input', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single item using classes']
+      )
+
+      const $dayInput = $('[name="day"]')
+      const $monthInput = $('[name="month"]')
+      const $yearInput = $('[name="year"]')
+
+      expect($dayInput.hasClass('govuk-input--error')).toBeTruthy()
+      expect($monthInput.hasClass('govuk-input--error')).toBeFalsy()
+      expect($yearInput.hasClass('govuk-input--error')).toBeFalsy()
+    })
+
+    it('includes the error modifier class on the form group wrapper', () => {
+      const $ = render(
+        'date-input',
+        examples['with error on single item using classes']
+      )
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
   describe('when they include both a hint and an error message', () => {
     it('sets the `group` role on the fieldset to force JAWS18 to announce the hint and error message', () => {
       const $ = render('date-input', examples['with error message and hint'])

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -312,12 +312,12 @@ describe('Date input', () => {
 
   describe('when it includes an error message', () => {
     it('renders the error message', () => {
-      const $ = render('date-input', examples['with errors only'])
+      const $ = render('date-input', examples['with error message and hint'])
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('uses the id as a prefix for the error message id', () => {
-      const $ = render('date-input', examples['with errors only'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $errorMessage = $('.govuk-error-message')
 
@@ -325,7 +325,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the error message', () => {
-      const $ = render('date-input', examples['with errors only'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -351,7 +351,7 @@ describe('Date input', () => {
     })
 
     it('includes the error modifier class on the inputs', () => {
-      const $ = render('date-input', examples['with errors only'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $dayInput = $('[name="day"]')
       const $monthInput = $('[name="month"]')
@@ -363,7 +363,7 @@ describe('Date input', () => {
     })
 
     it('includes the error modifier class on the form group wrapper', () => {
-      const $ = render('date-input', examples['with errors only'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -297,7 +297,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const $ = render('date-input', examples['with hint and describedBy'])
+      const $ = render('date-input', examples['with hint and described by'])
 
       const $fieldset = $('.govuk-fieldset')
       const hintId = $('.govuk-hint').attr('id')
@@ -338,7 +338,10 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = render('date-input', examples['with error and describedBy'])
+      const $ = render(
+        'date-input',
+        examples['with error message and described by']
+      )
 
       const $fieldset = $('.govuk-fieldset')
 
@@ -369,7 +372,7 @@ describe('Date input', () => {
 
   describe('when they include both a hint and an error message', () => {
     it('sets the `group` role on the fieldset to force JAWS18 to announce the hint and error message', () => {
-      const $ = render('date-input', examples['with errors and hint'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
 
@@ -377,7 +380,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = render('date-input', examples['with errors and hint'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -391,7 +394,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = render('date-input', examples['with errors and hint'])
+      const $ = render('date-input', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
 

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -118,6 +118,55 @@ describe('Date input', () => {
       expect($lastItems.val()).toBe('2018')
     })
 
+    it('renders items with values', () => {
+      const $ = render('date-input', examples['with values'])
+
+      const $input1 = $('.govuk-date-input__item:nth-of-type(1) input')
+      const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
+      const $input3 = $('.govuk-date-input__item:nth-of-type(3) input')
+
+      expect($input1.val()).toBe('31')
+      expect($input2.val()).toBe('3')
+      expect($input3.val()).toBe('1980')
+    })
+
+    it('renders items with values and name prefix', () => {
+      const $ = render('date-input', examples['with values and name prefix'])
+
+      const $input1 = $('.govuk-date-input__item:nth-of-type(1) input')
+      const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
+      const $input3 = $('.govuk-date-input__item:nth-of-type(3) input')
+
+      expect($input1.attr('name')).toBe('dob-day')
+      expect($input1.val()).toBe('31')
+
+      expect($input2.attr('name')).toBe('dob-month')
+      expect($input2.val()).toBe('3')
+
+      expect($input3.attr('name')).toBe('dob-year')
+      expect($input3.val()).toBe('1980')
+    })
+
+    it('renders items with values, name prefix and custom names', () => {
+      const $ = render(
+        'date-input',
+        examples['with values, name prefix and custom names']
+      )
+
+      const $input1 = $('.govuk-date-input__item:nth-of-type(1) input')
+      const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
+      const $input3 = $('.govuk-date-input__item:nth-of-type(3) input')
+
+      expect($input1.attr('name')).toBe('dob-user1-day')
+      expect($input1.val()).toBe('31')
+
+      expect($input2.attr('name')).toBe('dob-user1-month')
+      expect($input2.val()).toBe('3')
+
+      expect($input3.attr('name')).toBe('dob-user1-year')
+      expect($input3.val()).toBe('1980')
+    })
+
     it('renders items with field value', () => {
       const $ = render('date-input', examples['with field value'])
 
@@ -142,6 +191,28 @@ describe('Date input', () => {
       // Item value takes precedence over field value
       const $lastItems = $('.govuk-date-input__item:last-child input')
       expect($lastItems.val()).toBe('2018')
+    })
+
+    it('renders items with field value, item value and values', () => {
+      const $ = render(
+        'date-input',
+        examples['with field value, item value and values']
+      )
+
+      // Item value takes precedence over both field value and values option
+      const $lastItems = $('.govuk-date-input__item:last-child input')
+      expect($lastItems.val()).toBe('2018')
+    })
+
+    it('renders items with field value overriding values', () => {
+      const $ = render(
+        'date-input',
+        examples['with field value overriding values']
+      )
+
+      // Field value takes precedence over values option
+      const $lastItems = $('.govuk-date-input__item:last-child input')
+      expect($lastItems.val()).toBe('2023')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -112,8 +112,34 @@ describe('Date input', () => {
     })
 
     it('renders items with value', () => {
-      const $ = render('date-input', examples['with values'])
+      const $ = render('date-input', examples['with item value'])
 
+      const $lastItems = $('.govuk-date-input__item:last-child input')
+      expect($lastItems.val()).toBe('2018')
+    })
+
+    it('renders items with field value', () => {
+      const $ = render('date-input', examples['with field value'])
+
+      const $lastItems = $('.govuk-date-input__item:last-child input')
+      expect($lastItems.val()).toBe('2023')
+    })
+
+    it('renders items with field value and items', () => {
+      const $ = render('date-input', examples['with field value and items'])
+
+      // Item lacks value so field value is used
+      const $lastItems = $('.govuk-date-input__item:last-child input')
+      expect($lastItems.val()).toBe('2023')
+    })
+
+    it('renders items with field value and item value', () => {
+      const $ = render(
+        'date-input',
+        examples['with field value and item value']
+      )
+
+      // Item value takes precedence over field value
       const $lastItems = $('.govuk-date-input__item:last-child input')
       expect($lastItems.val()).toBe('2018')
     })


### PR DESCRIPTION
This PR contributes some date input changes from NHS.UK frontend to add new Nunjucks options:

- `day`, `month` and `year` to customise individual items
- `error` boolean option to set the error state on individual items
- `values` option to set individual item values using a single object

It closes https://github.com/alphagov/govuk-frontend/issues/1154 and is based on: https://github.com/nhsuk/nhsuk-frontend/pull/1869

Apologies to @joelanman as this PR re-implements https://github.com/alphagov/govuk-frontend/pull/4932 without any breaking changes

## Setting individual values and errors

The date input error state is now set automatically when `errorMessage` is provided.

For example, it is no longer necessary to set the `"govuk-input--error"` class on every item:

```patch
  {{ govukDateInput({
    fieldset: {
      legend: {
        text: "What is your date of birth?"
      }
    },
    errorMessage: {
      text: "Enter your date of birth"
-   },
-   items: [
-     {
-       name: "day",
-       label: "Day",
-       classes: "govuk-input--width-2 govuk-input--error"
-     },
-     {
-       name: "month",
-       label: "Month",
-       classes: "govuk-input--width-2 govuk-input--error"
-     },
-     {
-       name: "year",
-       label: "Year",
-       classes: "govuk-input--width-4 govuk-input--error"
-     }
-   ]
+   }
  }) }}
```

If only one field has an error, use the new `day`, `month` or `year` options to set `error: true` for that field only:

```patch
  {{ govukDateInput({
    fieldset: {
      legend: {
        text: "What is your date of birth?"
      }
    },
    errorMessage: {
      text: "Date of birth must include a year"
    },
-   items: [
-     {
-       name: "day",
-       label: "Day",
-       classes: "govuk-input--width-2"
-     },
-     {
-       name: "month",
-       label: "Month",
-       classes: "govuk-input--width-2"
-     },
-     {
-       name: "year",
-       label: "Year",
-       classes: "govuk-input--width-4 govuk-input--error"
-     }
-   ]
+   year: {
+     error: true
+   }
  }) }}
```

Similarly, you can also use `error: false` to _remove_ a single red border versus multiple `error: true`

For example, it can make it easier to turn off the error state for the fields you have values for:

```patch
  {{ govukDateInput({
    fieldset: {
      legend: {
        text: "What is your date of birth?"
      }
    },
    errorMessage: {
      text: "Date of birth must include a month and year"
    },
    day: {
-     value: "31"
+     value: "31",
+     error: false
-   },
-   month: {
-     error: true
-   },
-   year: {
-     error: true
    }
  }) }}
```

## Setting all values at once

Or when using the GOV.UK Prototype Kit, given the following `data` object:

```json
{
  "dob-day": "31",
  "dob-month": "3",
  "dob-year": "1980"
}
```

You can now automatically set item values by passing in `values: data` as shown:

```njk
  {{ govukDateInput({
    fieldset: {
      legend: {
        text: "What is your date of birth?"
      }
    },
    namePrefix: "dob",
    values: data
  }) }}
```