### PR TITLE
Show correct file size for files in PR stats

### DIFF
--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -140,26 +140,30 @@ function getFileSizeComparison(headFiles, baseFiles) {
   // Get initial percentage differences and check for deletions
   const comparedFileSizes = baseFiles.map((file) => {
     const headFile = findFileSizeRow(headFiles, file)
-    let percentage
 
+    // If the file doesn't exist in our branch (head), then the file was deleted
     if (!headFile) {
-      percentage = 'Deleted'
-    } else {
-      const sizeDiff = ((headFile.size - file.size) / file.size) * 100
-
-      // Remove '.0' here rather than check for it in the proceeding if to strip
-      // out instances of '4.0%'
-      percentage = sizeDiff.toFixed(1).replace('.0', '')
-
-      // Return null if there's no percentage difference
-      // Test as string because toFixed returns a string
-      if (percentage === '0') {
-        return null
+      return {
+        path: file.path,
+        size: 0,
+        percentage: 'Deleted'
       }
     }
 
+    const sizeDiff = ((headFile.size - file.size) / file.size) * 100
+
+    // Remove '.0' here rather than check for it in the proceeding if to strip
+    // out instances of '4.0%'
+    const percentage = sizeDiff.toFixed(1).replace('.0', '')
+
+    // Return null if there's no percentage difference
+    // Test as string because toFixed returns a string
+    if (percentage === '0') {
+      return null
+    }
+
     return {
-      ...file,
+      ...headFile,
       percentage: `${percentage}%`
     }
   })


### PR DESCRIPTION
The `getFileSizeComparison` function accepts a set of `headFiles`, representing the files in the PR’s branch and a set of `baseFiles`, representing the files in the target/base branch.

We’re iterating over the `baseFiles` first, checking to see if that file exists in `headFiles` (if not, it’s been deleted) and if the size has changed (if not, we skip over it).

We then push the entry *from `baseFiles`* into the results with the percentage change.

This means that PRs currently show the size of the file as it is *in the target branch* instead of the size of the file in the PR’s branch.

Update the function to push the corresponding entry from `headFiles` into the results, so that we correctly show the size of the file in the PR branch.

This also means we need to change how we handle deleted files, because `headFile` will be `undefined` and so the returned object wouldn’t have a path or size. Refactor the function passed to map to return early with a valid `FileSizeWithPercentage` for deleted files to avoid this.