### PR TITLE
Add note to file upload `id` option

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -6,7 +6,7 @@ params:
   - name: id
     type: string
     required: false
-    description: The ID of the input. Defaults to the value of `name`.
+    description: The ID of the input. Defaults to the value of `name`. If `javascript` is provided, this ID will be on the button of the improved version, and the hidden input's ID will get the suffix "-input".
   - name: disabled
     type: boolean
     required: false


### PR DESCRIPTION
Add a note to the file upload `id` option to tell people about the different behaviour of the `id` when used for the improved version. This fixes https://github.com/alphagov/govuk-frontend/issues/6952.