### PR TITLE
Update `helpers/spacing—internal` to use `if`

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_spacing--internal.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_spacing--internal.scss
@@ -7,7 +7,7 @@
 @use "../settings/spacing" as *;
 @use "media-queries" as *;
 
-@import "../tools/if";
+@use "../tools/if" as *;
 
 /// Responsive spacing
 ///


### PR DESCRIPTION
Looks like this was missed when we updated the helpers layer in #6848.

Once we merge #6960 and #6975 this should mean the only instances of `@import` are in the import-only files 🎉