### PR TITLE
Allow configuration of button colour variables

### DIFF
--- a/packages/govuk-frontend/src/govuk/_base.import.scss
+++ b/packages/govuk-frontend/src/govuk/_base.import.scss
@@ -2,3 +2,4 @@
 @import "tools";
 @import "helpers";
 @import "custom-properties";
+@import "components/button/settings";

--- a/packages/govuk-frontend/src/govuk/_base.scss
+++ b/packages/govuk-frontend/src/govuk/_base.scss
@@ -1,3 +1,4 @@
 @forward "settings";
 @forward "tools";
 @forward "helpers";
+@forward "components/button/settings";

--- a/packages/govuk-frontend/src/govuk/components/button/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.import.scss
@@ -3,5 +3,10 @@
 @import "../../base";
 
 @include govuk-exports("govuk/component/button") {
-  @include mixin.styles;
+  @include mixin.styles(
+    $background-colour: $govuk-button-background-colour,
+    $text-colour: $govuk-button-text-colour,
+    $inverse-background-colour: $govuk-inverse-button-background-colour,
+    $inverse-text-colour: $govuk-inverse-button-text-colour
+  );
 }

--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -1,4 +1,10 @@
+@use "../../base";
 @use "../../custom-properties";
 @use "mixin";
 
-@include mixin.styles;
+@include mixin.styles(
+  $background-colour: base.$govuk-button-background-colour,
+  $text-colour: base.$govuk-button-text-colour,
+  $inverse-background-colour: base.$govuk-inverse-button-background-colour,
+  $inverse-text-colour: base.$govuk-inverse-button-text-colour
+);

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -4,37 +4,9 @@
 
 @use "../../base";
 
-/// Button component background colour
-///
-/// @type Colour
-/// @access public
-
-$govuk-button-background-colour: base.govuk-colour("green") !default;
-
-/// Button component text colour
-///
-/// @type Colour
-/// @access public
-
-$govuk-button-text-colour: base.govuk-colour("white") !default;
-
-/// Inverted button component background colour
-///
-/// @type Colour
-/// @access public
-
-$govuk-inverse-button-background-colour: base.govuk-colour("white") !default;
-
-/// Inverted button component text colour
-///
-/// @type Colour
-/// @access public
-
-$govuk-inverse-button-text-colour: base.govuk-functional-colour(brand) !default;
-
-@mixin styles {
-  $govuk-button-colour: $govuk-button-background-colour;
-  $govuk-button-text-colour: $govuk-button-text-colour;
+@mixin styles($background-colour, $text-colour, $inverse-background-colour, $inverse-text-colour) {
+  $govuk-button-colour: $background-colour;
+  $text-colour: $text-colour;
   $govuk-button-hover-colour: base.govuk-colour("green", $variant: "shade-25");
   $govuk-button-shadow-colour: base.govuk-colour("green", $variant: "shade-50");
 
@@ -51,8 +23,8 @@ $govuk-inverse-button-text-colour: base.govuk-functional-colour(brand) !default;
   $govuk-warning-button-shadow-colour: base.govuk-colour("red", $variant: "shade-50");
 
   // Inverse button variables
-  $govuk-inverse-button-colour: $govuk-inverse-button-background-colour;
-  $govuk-inverse-button-text-colour: $govuk-inverse-button-text-colour;
+  $govuk-inverse-button-colour: $inverse-background-colour;
+  $inverse-text-colour: $inverse-text-colour;
   $govuk-inverse-button-hover-colour: base.govuk-colour("blue", $variant: "tint-95");
   $govuk-inverse-button-shadow-colour: base.govuk-colour("blue", $variant: "shade-50");
 
@@ -76,7 +48,7 @@ $govuk-inverse-button-text-colour: base.govuk-functional-colour(brand) !default;
       (base.govuk-spacing(2) - base.$govuk-border-width-form-element - ($button-shadow-size * 0.5)); // s1
     border: base.$govuk-border-width-form-element solid transparent;
     border-radius: 0;
-    color: $govuk-button-text-colour;
+    color: $text-colour;
     background-color: $govuk-button-colour;
     box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0
     text-align: center;
@@ -93,7 +65,7 @@ $govuk-inverse-button-text-colour: base.govuk-functional-colour(brand) !default;
     &:visited,
     &:active,
     &:hover {
-      color: $govuk-button-text-colour;
+      color: $text-colour;
       text-decoration: none;
     }
 
@@ -221,7 +193,7 @@ $govuk-inverse-button-text-colour: base.govuk-functional-colour(brand) !default;
     &:visited,
     &:active,
     &:hover {
-      color: $govuk-inverse-button-text-colour;
+      color: $inverse-text-colour;
     }
 
     &:hover {

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.import.scss
@@ -1,0 +1,31 @@
+////
+/// @group components/button
+////
+
+/// Button component background colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-button-background-colour: govuk-colour("green") !default;
+
+/// Button component text colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-button-text-colour: govuk-colour("white") !default;
+
+/// Inverted button component background colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-background-colour: govuk-colour("white") !default;
+
+/// Inverted button component text colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-text-colour: govuk-functional-colour(brand) !default;

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.scss
@@ -1,0 +1,33 @@
+////
+/// @group components/button
+////
+
+@use "../../helpers";
+
+/// Button component background colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-button-background-colour: helpers.govuk-colour("green") !default;
+
+/// Button component text colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-button-text-colour: helpers.govuk-colour("white") !default;
+
+/// Inverted button component background colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-background-colour: helpers.govuk-colour("white") !default;
+
+/// Inverted button component text colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-text-colour: helpers.govuk-functional-colour(brand) !default;

--- a/packages/govuk-frontend/src/govuk/components/components.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.unit.test.js
@@ -215,5 +215,82 @@ describe('Components', () => {
         })
       })
     })
+
+    describe('component variables', () => {
+      // Map the user-configurable button colours to some test values
+      const buttonColours = [
+        {
+          variable: '$govuk-button-background-colour',
+          value: '#112233'
+        },
+        {
+          variable: '$govuk-button-text-colour',
+          value: '#445566'
+        },
+        {
+          variable: '$govuk-inverse-button-background-colour',
+          value: '#778899'
+        },
+        {
+          variable: '$govuk-inverse-button-text-colour',
+          value: '#aabbcc'
+        }
+      ]
+
+      const useConfiguration = buttonColours
+        .map(({ variable, value }) => `${variable}: ${value}`)
+        .join(',\n')
+
+      const importDeclarations = buttonColours
+        .map(({ variable, value }) => `${variable}: ${value};`)
+        .join('\n')
+
+      const sassSources = {
+        'with `@use` including the whole of GOV.UK Frontend': `
+            @use "index" with (
+              ${useConfiguration}
+            );
+          `,
+        'with `@import` including the whole of GOV.UK Frontend': `
+            ${importDeclarations}
+            @import "index";
+          `,
+        'with `@use` including the components layer': `
+            @use "base" with (
+              ${useConfiguration}
+            );
+            @use "components";
+          `,
+        'with `@import` including the components layer': `
+            ${importDeclarations}
+            @import "components";
+          `,
+        'with `@use` including the individual button file': `
+            @use "base" with (
+              ${useConfiguration}
+            );
+            @use "components/button";
+          `,
+        'with `@import` including the individual button file': `
+            ${importDeclarations}
+            @import "components/button";
+          `
+      }
+
+      describe.each(Object.entries(sassSources))('%s', (_, sass) => {
+        let css
+
+        beforeAll(async () => {
+          css = (await compileSassString(sass)).css
+        })
+
+        it.each(buttonColours)(
+          'uses the configured value for $variable',
+          ({ value }) => {
+            expect(css).toContain(value)
+          }
+        )
+      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -17,7 +17,6 @@
 @use "font-faces--internal";
 @use "typography--internal";
 @use "media-queries" as *;
-@use "spacing" as *;
 
 /// 'Common typography' helper
 ///

--- a/tests/sass-tests/__snapshots__/sass-file-compilation.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/sass-file-compilation.integration.test.mjs.snap
@@ -5185,6 +5185,8 @@ exports[`src/govuk/components/button/_index.scss matches snapshot 1`] = `
 
 exports[`src/govuk/components/button/_mixin.scss matches snapshot 1`] = `""`;
 
+exports[`src/govuk/components/button/_settings.scss matches snapshot 1`] = `""`;
+
 exports[`src/govuk/components/character-count/_index.scss matches snapshot 1`] = `
 "@charset "UTF-8";
 :root {


### PR DESCRIPTION
Adds a `_settings.scss` file to the button component to contain the variables for button.

This then gets emitted from the base layer, allowing users to do:

```
@use "base" with (
  ...<BUTTON_CONFIG>
)

@use "components/button"
```