### PR TITLE
Update the Sassdoc for asset url functions

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_assets.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_assets.scss
@@ -29,28 +29,17 @@ $govuk-fonts-path: "#{$govuk-assets-path}fonts/" !default;
 
 /// Custom image URL function
 ///
-/// If the built-in image URL helper does not meet your needs, you can specify
-/// the name of a custom handler – either built in or by writing your own
-/// function.
+/// If you need more control than $govuk-images-path provides, you can use a
+/// function to resolve image filenames to URLs.
 ///
-/// If you are writing your own handler, ensure that it returns a string wrapped
-/// with `url()`
+/// The function should accept a filename and return the URL as a string,
+/// wrapped with `url()`.
 ///
-/// @type String
+/// Passing the name of a function as a string is deprecated.
 ///
-/// @example scss - Rails asset handling
-///   $govuk-image-url-function: 'image-url';
+/// @type Function | String | null
 ///
-/// @example scss - Custom asset handling
-///
-///   @function my-url-handler($filename) {
-///     // Some custom URL handling
-///     @return url('example.jpg');
-///   }
-///
-///   $govuk-image-url-function: 'my-url-handler';
-///
-/// @example scss - From an external module
+/// @example scss - Using your own function
 ///
 ///   @use "sass:meta";
 ///   // Include the module containing the handler function
@@ -59,34 +48,39 @@ $govuk-fonts-path: "#{$govuk-assets-path}fonts/" !default;
 ///   // Then pass the handler function using `meta.get-function`
 ///   $govuk-image-url-function: meta.get-function("image-url", $module: "url-handlers");
 ///
-/// @access public
-
-$govuk-image-url-function: false !default;
-
-/// Custom font URL function
+/// @example scss - Using sass-rails' `image-url` helper
 ///
-/// If the built-in font URL helper does not meet your needs, you can specify
-/// the name of a custom handler – either built in or by writing your own
-/// function.
+///   $govuk-image-url-function: meta.get-function('image-url');
 ///
-/// If you are writing your own handler, ensure that it returns a string wrapped
-/// with `url()`
-///
-/// @type String
-///
-/// @example scss - Rails asset handling
-///   $govuk-font-url-function: 'font-url';
-///
-/// @example scss - Custom asset handling
+/// @example scss - Passing the name of a function (deprecated)
 ///
 ///   @function my-url-handler($filename) {
 ///     // Some custom URL handling
-///     @return url('example.woff');
+///     @return url('example.jpg');
 ///   }
 ///
-///   $govuk-font-url-function: 'my-url-handler';
+///   $govuk-image-url-function: 'my-url-handler';
 ///
-/// @example scss - From an external module
+/// @see $govuk-images-path
+/// @see {function} govuk-image-url
+///
+/// @access public
+
+$govuk-image-url-function: null !default;
+
+/// Custom font URL function
+///
+/// If you need more control than $govuk-fonts-path provides, you can use a
+/// function to resolve font filenames to URLs.
+///
+/// The function should accept a filename and return the URL as a string,
+/// wrapped with `url()`.
+///
+/// Passing the name of a function as a string is deprecated.
+///
+/// @type Function | String | null
+///
+/// @example scss - Using your own function
 ///
 ///   @use "sass:meta";
 ///   // Include the module containing the handler function
@@ -95,6 +89,22 @@ $govuk-image-url-function: false !default;
 ///   // Then pass the handler function using `meta.get-function`
 ///   $govuk-font-url-function: meta.get-function("font-url", $module: "url-handlers");
 ///
+/// @example scss - Using sass-rails' `font-url` helper
+///
+///   $govuk-font-url-function: meta.get-function('font-url');
+///
+/// @example scss - Passing the name of a function (deprecated)
+///
+///   @function my-url-handler($filename) {
+///     // Some custom URL handling
+///     @return url('example.woff');
+///   }
+///
+///   $govuk-font-url-function: 'my-url-handler';
+///
+/// @see $govuk-fonts-path
+/// @see {function} govuk-font-url
+///
 /// @access public
 
-$govuk-font-url-function: false !default;
+$govuk-font-url-function: null !default;

--- a/packages/govuk-frontend/src/govuk/settings/_assets.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_assets.scss
@@ -39,7 +39,7 @@ $govuk-fonts-path: "#{$govuk-assets-path}fonts/" !default;
 ///
 /// @type Function | String | null
 ///
-/// @example scss - Using your own function
+/// @example scss - Passing a function
 ///
 ///   @use "sass:meta";
 ///   // Include the module containing the handler function
@@ -47,10 +47,6 @@ $govuk-fonts-path: "#{$govuk-assets-path}fonts/" !default;
 ///
 ///   // Then pass the handler function using `meta.get-function`
 ///   $govuk-image-url-function: meta.get-function("image-url", $module: "url-handlers");
-///
-/// @example scss - Using sass-rails' `image-url` helper
-///
-///   $govuk-image-url-function: meta.get-function('image-url');
 ///
 /// @example scss - Passing the name of a function (deprecated)
 ///
@@ -80,7 +76,7 @@ $govuk-image-url-function: null !default;
 ///
 /// @type Function | String | null
 ///
-/// @example scss - Using your own function
+/// @example scss - Passing a function
 ///
 ///   @use "sass:meta";
 ///   // Include the module containing the handler function
@@ -88,10 +84,6 @@ $govuk-image-url-function: null !default;
 ///
 ///   // Then pass the handler function using `meta.get-function`
 ///   $govuk-font-url-function: meta.get-function("font-url", $module: "url-handlers");
-///
-/// @example scss - Using sass-rails' `font-url` helper
-///
-///   $govuk-font-url-function: meta.get-function('font-url');
 ///
 /// @example scss - Passing the name of a function (deprecated)
 ///


### PR DESCRIPTION
In [#6767](https://github.com/alphagov/govuk-frontend/issues/6767) we made it possible for `$govuk-image-url-function` and `$govuk-font-url-function` to be set to functions as well as strings.

In [#6857](https://github.com/alphagov/govuk-frontend/issues/6857) we then deprecated setting `$govuk-image-url-function` and `$govuk-font-url-function` to strings. Using a string does not work when loading GOV.UK Frontend as a module with `@use` or `@forward`, because each module can only see what it explicitly `@uses`.

Update the Sassdoc to reflect these changes, by:

- changing the type to `Function | String | null` [^1]
- updating the existing examples to set the variables to functions [^2]
- adding a new example where the variable is set to a string, but marking it as deprecated

I’ve also taken the opportunity to rewrite the Sassdoc description to make it clearer what the function should look like, and to add see annotations for the related parts of the API.

Closes [#6945](https://github.com/alphagov/govuk-frontend/issues/6945).

[^1]: I’ve also changed the default value of both settings from `false` to `null` as `null` is more appropriate and it means we can then include `null` in the types.
[^2]: There’s no longer an example using a function in the same file. This is because with `@use` the `@use` statement must come before any `@function` definitions (as flagged in https://github.com/alphagov/govuk-frontend/pull/6982#discussion_r3136995526)