### PR TITLE
Re-enable cssnano discardDuplicates plugin

### DIFF
--- a/packages/govuk-frontend/postcss.config.mjs
+++ b/packages/govuk-frontend/postcss.config.mjs
@@ -37,11 +37,7 @@ export default ({ to = '' } = {}) => ({
 
           // Sorted CSS is smaller when gzipped, but we sort using Stylelint
           // https://cssnano.co/docs/optimisations/cssdeclarationsorter/
-          cssDeclarationSorter: false,
-
-          // disable postcss-discard-duplicates temporarily so we can see
-          // custom properties duplications in the minified output
-          discardDuplicates: false
+          cssDeclarationSorter: false
         })
       })
   ],

--- a/packages/govuk-frontend/postcss.config.unit.test.mjs
+++ b/packages/govuk-frontend/postcss.config.unit.test.mjs
@@ -136,7 +136,7 @@ describe('PostCSS config', () => {
           'postcss-normalize-positions',
           'postcss-normalize-whitespace',
           'postcss-merge-longhand',
-          // 'postcss-discard-duplicates',
+          'postcss-discard-duplicates',
           'postcss-merge-rules',
           'postcss-discard-empty',
           'postcss-unique-selectors',


### PR DESCRIPTION
This reverts commit 47c5d25648a9fb324638dab7a4fa49dc850b6977.

We disabled this whilst we were working on the migration as it was masking the duplication in the built files used for the diffs on PRs.

Now that the migration is complete we can re-enable it – it is currently removing a small amount of duplication of focus styles caused by the way we structure our link-related mixins.