### PR TITLE
Mark all new ‘internal’ mixins as private

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/accordion/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $govuk-accordion-base-colour: base.govuk-colour("black");
   $govuk-accordion-hover-colour: base.govuk-colour("black", $variant: "tint-95");

--- a/packages/govuk-frontend/src/govuk/components/back-link/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/back-link/_mixin.scss
@@ -2,6 +2,7 @@
 
 @use "../../base";
 
+/// @access private
 @mixin styles {
   // Component font-size on the Frontend (used for calculations)
   $font-size: 16;

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
@@ -2,6 +2,7 @@
 
 @use "../../base";
 
+/// @access private
 @mixin styles {
   // Component font-size on the Frontend (used for calculations)
   $font-size: 16;

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -4,6 +4,7 @@
 
 @use "../../base";
 
+/// @access private
 @mixin styles($background-colour, $text-colour, $inverse-background-colour, $inverse-text-colour) {
   $govuk-button-colour: $background-colour;
   $text-colour: $text-colour;

--- a/packages/govuk-frontend/src/govuk/components/character-count/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/character-count/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-character-count {
     @include base.govuk-responsive-margin(6, "bottom");

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $govuk-touch-target-gutter: 4px;
   $govuk-checkboxes-size: 40px;

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   // This needs to be kept in sync with the header component's styles
   $border-bottom-width: base.govuk-spacing(2);

--- a/packages/govuk-frontend/src/govuk/components/date-input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/date-input/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-date-input {
     @include base.govuk-clearfix;

--- a/packages/govuk-frontend/src/govuk/components/details/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/details/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-details {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/error-message/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-message/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-error-message {
     @include base.govuk-font($size: 19, $weight: bold);

--- a/packages/govuk-frontend/src/govuk/components/error-summary/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-error-summary {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $indicator-size: 0.75em;
 

--- a/packages/govuk-frontend/src/govuk/components/fieldset/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-fieldset {
     min-width: 0;

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $file-upload-border-width: 2px;
   $component-padding: base.govuk-spacing(1);

--- a/packages/govuk-frontend/src/govuk/components/footer/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $govuk-footer-background: base.govuk-functional-colour(surface-background);
   $govuk-footer-text: base.govuk-functional-colour(surface-text);

--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $logo-bottom-margin: 2px;
 

--- a/packages/govuk-frontend/src/govuk/components/hint/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/hint/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-hint {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-input {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/inset-text/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-inset-text {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/label/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/label/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-label {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -2,6 +2,7 @@
 
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-notification-banner {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   // Flexbox enhancement for small screen visual design
   // Falls back to a float: left layout on non-flex browsers

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-panel {
     @include base.govuk-font($size: 36);

--- a/packages/govuk-frontend/src/govuk/components/password-input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-password-input__wrapper {
     // This element inherits styles from .govuk-input__wrapper, including:

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-phase-banner {
     padding-top: base.govuk-spacing(2);

--- a/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $govuk-touch-target-gutter: 4px;
   $govuk-radios-size: 40px;

--- a/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-select {
     @include base.govuk-font($size: 19, $line-height: 1.25);

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -2,6 +2,7 @@
 
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $govuk-service-navigation-active-link-border-width: base.govuk-spacing(1);
   $govuk-service-navigation-text-colour: base.govuk-functional-colour(surface-text);

--- a/packages/govuk-frontend/src/govuk/components/skip-link/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_mixin.scss
@@ -2,6 +2,7 @@
 
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-skip-link {
     @include base.govuk-visually-hidden-focusable;

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-summary-list {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/table/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/table/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-table {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-tabs {
     @include base.govuk-responsive-margin(1, "top");

--- a/packages/govuk-frontend/src/govuk/components/tag/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/tag/_mixin.scss
@@ -35,6 +35,7 @@
   background-color: _govuk-tag-background-colour($colour);
 }
 
+/// @access private
 @mixin styles {
   $govuk-tag-max-width: 0.5 * (map.get(base.$govuk-breakpoints, "mobile") or 320px);
 

--- a/packages/govuk-frontend/src/govuk/components/task-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/task-list/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   $govuk-task-list-hover-colour: base.govuk-colour("black", $variant: "tint-95");
 

--- a/packages/govuk-frontend/src/govuk/components/textarea/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/textarea/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-textarea {
     @include base.govuk-font($size: 19, $line-height: 1.25);

--- a/packages/govuk-frontend/src/govuk/components/warning-text/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/_mixin.scss
@@ -1,5 +1,6 @@
 @use "../../base";
 
+/// @access private
 @mixin styles {
   .govuk-warning-text {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/core/_global-styles.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_global-styles.mixin.scss
@@ -10,6 +10,7 @@
   }
 }
 
+/// @access private
 @mixin styles {
   @if base.$govuk-global-styles == true {
     @include govuk-global-styles;

--- a/packages/govuk-frontend/src/govuk/core/_links.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_links.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   %govuk-link {
     @include base.govuk-link-common;

--- a/packages/govuk-frontend/src/govuk/core/_lists.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_lists.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   %govuk-list {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/core/_section-break.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_section-break.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   %govuk-section-break {
     margin: 0;

--- a/packages/govuk-frontend/src/govuk/core/_typography.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_typography.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   // Headings
   %govuk-heading-xl {

--- a/packages/govuk-frontend/src/govuk/custom-properties/_breakpoints.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/custom-properties/_breakpoints.mixin.scss
@@ -2,6 +2,7 @@
 @use "../settings/media-queries" as *;
 @use "../tools/px-to-rem" as *;
 
+/// @access private
 @mixin styles {
   :root {
     @if $govuk-output-custom-properties {

--- a/packages/govuk-frontend/src/govuk/custom-properties/_frontend-version.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/custom-properties/_frontend-version.mixin.scss
@@ -1,3 +1,4 @@
+/// @access private
 @mixin styles {
   // This custom property is automatically overwritten during builds and
   // releases. It doesn't need to be updated manually.

--- a/packages/govuk-frontend/src/govuk/custom-properties/_functional-colours.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/custom-properties/_functional-colours.mixin.scss
@@ -2,6 +2,7 @@
 @use "../settings/colours-functional" as *;
 @use "../helpers/colour" as *;
 
+/// @access private
 @mixin styles {
   // CSS custom properties for each functional colour
   :root {

--- a/packages/govuk-frontend/src/govuk/index.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/index.unit.test.mjs
@@ -103,23 +103,25 @@ describe('GOV.UK Frontend', () => {
   })
 
   describe('Sass documentation', () => {
-    it('associates everything with a group', async () => {
+    it('associates public Sass members with a group', async () => {
       return sassdoc
         .parse([
           `${slash(paths.package)}/src/govuk/**/*.scss`,
           `!${slash(paths.package)}/src/govuk/vendor/*.scss`
         ])
         .then((docs) =>
-          docs.forEach((doc) => {
-            return expect(doc).toMatchObject({
-              // Include doc.context.name in the expected result when this fails,
-              // giving you the context to be able to fix it
-              context: {
-                name: doc.context.name
-              },
-              group: [expect.not.stringMatching('undefined')]
+          docs
+            .filter((doc) => doc.access !== 'private')
+            .forEach((doc) => {
+              return expect(doc).toMatchObject({
+                // Include doc.context.name in the expected result when this fails,
+                // giving you the context to be able to fix it
+                context: {
+                  name: doc.context.name
+                },
+                group: [expect.not.stringMatching('undefined')]
+              })
             })
-          })
         )
     })
   })

--- a/packages/govuk-frontend/src/govuk/objects/_button-group.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_button-group.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   // Button groups can be used to group buttons and links together as a group.
   //

--- a/packages/govuk-frontend/src/govuk/objects/_form-group.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_form-group.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   .govuk-form-group {
     @include base.govuk-clearfix;

--- a/packages/govuk-frontend/src/govuk/objects/_grid.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_grid.mixin.scss
@@ -2,6 +2,7 @@
 
 @use "../base";
 
+/// @access private
 @mixin styles {
   .govuk-grid-row {
     @include base.govuk-clearfix;

--- a/packages/govuk-frontend/src/govuk/objects/_main-wrapper.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_main-wrapper.mixin.scss
@@ -21,6 +21,7 @@
 //   </div>
 // </div>
 
+/// @access private
 @mixin styles {
   .govuk-main-wrapper {
     // In IE11 the `main` element can be used, but is not recognized  –

--- a/packages/govuk-frontend/src/govuk/objects/_template.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   // Applied to the <html> element
   .govuk-template {

--- a/packages/govuk-frontend/src/govuk/objects/_width-container.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_width-container.mixin.scss
@@ -1,5 +1,6 @@
 @use "../base";
 
+/// @access private
 @mixin styles {
   .govuk-width-container {
     @include base.govuk-width-container;

--- a/packages/govuk-frontend/src/govuk/objects/objects.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/objects/objects.unit.test.js
@@ -6,7 +6,6 @@ const {
   getSassPathsFromLayer
 } = require('@govuk-frontend/helpers/tests')
 const { compileSassString } = require('@govuk-frontend/helpers/tests')
-const sassdoc = require('sassdoc')
 const stylelint = require('stylelint')
 
 const partials = getSassPathsFromLayer('objects')
@@ -60,25 +59,6 @@ describe('The objects layer', () => {
         css: expect.any(String),
         loadedUrls: expect.arrayContaining([expect.any(URL)])
       })
-    })
-  })
-
-  describe('Sass documentation', () => {
-    it('associates everything with a "objects" group', async () => {
-      const docs = await sassdoc.parse(
-        join(paths.package, 'src/govuk/objects/**/*.scss')
-      )
-
-      for (const doc of docs) {
-        expect(doc).toMatchObject({
-          // Include doc.context.name in the expected result when this fails,
-          // giving you the context to be able to fix it
-          context: {
-            name: doc.context.name
-          },
-          group: [expect.stringMatching(/^objects/)]
-        })
-      }
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/overrides/_display.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_display.mixin.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important
+/// @access private
 @mixin styles {
   .govuk-\!-display-inline {
     display: inline !important;

--- a/packages/govuk-frontend/src/govuk/overrides/_spacing.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_spacing.mixin.scss
@@ -78,6 +78,7 @@ $_spacing-directions: ("top", "right", "bottom", "left") !default;
   }
 }
 
+/// @access private
 @mixin styles {
   @include _govuk-generate-responsive-spacing-overrides("margin");
   @include _govuk-generate-responsive-spacing-overrides("padding");

--- a/packages/govuk-frontend/src/govuk/overrides/_text-align.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_text-align.mixin.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important
+/// @access private
 @mixin styles {
   .govuk-\!-text-align-left {
     text-align: left !important;

--- a/packages/govuk-frontend/src/govuk/overrides/_typography.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_typography.mixin.scss
@@ -1,6 +1,7 @@
 @use "sass:map";
 @use "../base";
 
+/// @access private
 @mixin styles {
   // Font size and line height
 

--- a/packages/govuk-frontend/src/govuk/overrides/_width.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_width.mixin.scss
@@ -1,6 +1,7 @@
 @use "../base";
 
 // stylelint-disable declaration-no-important
+/// @access private
 @mixin styles {
   .govuk-\!-width-full {
     width: 100% !important;

--- a/packages/govuk-frontend/src/govuk/utilities/_clearfix.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_clearfix.mixin.scss
@@ -1,6 +1,7 @@
 @use "../base";
 @use "../helpers/clearfix" as *;
 
+/// @access private
 @mixin styles {
   .govuk-clearfix {
     @include govuk-clearfix;

--- a/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.mixin.scss
@@ -1,6 +1,7 @@
 @use "../base";
 @use "../helpers/visually-hidden" as *;
 
+/// @access private
 @mixin styles {
   .govuk-visually-hidden {
     @include govuk-visually-hidden;


### PR DESCRIPTION
We don’t intend to make these a part of our public API.

Without Sassdoc, they shouldn’t show up in our API reference anyway, but it’s good to be explicit for anyone trawling through our code.

Closes #6964.