### PR TITLE
fix: include visually-hidden utility in modular component entrypoints

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/accordion/_index.scss
@@ -1,4 +1,9 @@
 @use "../../custom-properties";
 @use "mixin";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
@@ -4,5 +4,10 @@
 @use "../hint";
 @use "../label";
 @use "../textarea";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/error-message/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-message/_index.scss
@@ -1,4 +1,9 @@
 @use "../../custom-properties";
 @use "mixin";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_index.scss
@@ -1,6 +1,10 @@
 @use "../../custom-properties";
-
 @use "mixin";
 @use "../button";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -3,5 +3,10 @@
 @use "../error-message";
 @use "../hint";
 @use "../label";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -1,4 +1,9 @@
 @use "../../custom-properties";
 @use "mixin";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
@@ -1,4 +1,9 @@
 @use "../../custom-properties";
 @use "mixin";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_index.scss
@@ -1,7 +1,11 @@
 @use "../../custom-properties";
 @use "mixin";
-
+@use "../../helpers/visually-hidden";
 @use "../button";
 @use "../input";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -1,4 +1,9 @@
 @use "../../custom-properties";
 @use "mixin";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}

--- a/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
@@ -1,4 +1,9 @@
 @use "../../custom-properties";
 @use "mixin";
+@use "../../helpers/visually-hidden";
 
 @include mixin.styles;
+
+.govuk-visually-hidden {
+  @include visually-hidden.govuk-visually-hidden;
+}


### PR DESCRIPTION
Summary
This PR fixes an issue where modular component entry points were missing the .govuk-visually-hidden utility class. This resulted in accessible-only text being displayed visually when components were imported individually rather than as a full bundle.

Fixes #6928

Changes
Added @use "../../helpers/visually-hidden" to the _index.scss files of the affected components.

Explicitly included the govuk-visually-hidden mixin within these entry points to ensure CSS generation.

Verified that modular compilation for these components now correctly generates the required utility CSS.

Testing and Quality Assurance
[x] Verified via manual Sass compilation of individual components (including Accordion, Character Count, and Footer).

[x] npm run lint:scss passed locally after running the --fix command.