### PR TITLE
Update Sassdoc examples for `@use`

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_assets.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_assets.scss
@@ -46,16 +46,21 @@ $govuk-fonts-path: "#{$govuk-assets-path}fonts/" !default;
 ///   @use "url-handlers";
 ///
 ///   // Then pass the handler function using `meta.get-function`
-///   $govuk-image-url-function: meta.get-function("image-url", $module: "url-handlers");
+///   @use "node_modules/govuk-frontend/dist/govuk" as * with (
+///     $govuk-image-url-function: meta.get-function("image-url", $module: "url-handlers")
+///   )
 ///
 /// @example scss - Passing the name of a function (deprecated)
 ///
+///   // This is only available if you still use `@import`
 ///   @function my-url-handler($filename) {
 ///     // Some custom URL handling
 ///     @return url('example.jpg');
 ///   }
 ///
 ///   $govuk-image-url-function: 'my-url-handler';
+///
+///   @import "node_modules/govuk-frontend/dist/govuk";
 ///
 /// @see $govuk-images-path
 /// @see {function} govuk-image-url
@@ -83,16 +88,21 @@ $govuk-image-url-function: null !default;
 ///   @use "url-handlers";
 ///
 ///   // Then pass the handler function using `meta.get-function`
-///   $govuk-font-url-function: meta.get-function("font-url", $module: "url-handlers");
+///   @use "node_modules/govuk-frontend/dist/govuk" as * with (
+///     $govuk-font-url-function: meta.get-function("font-url", $module: "url-handlers")
+///   )
 ///
 /// @example scss - Passing the name of a function (deprecated)
 ///
+///   // This is only available if you still use `@import`
 ///   @function my-url-handler($filename) {
 ///     // Some custom URL handling
 ///     @return url('example.woff');
 ///   }
 ///
 ///   $govuk-font-url-function: 'my-url-handler';
+///
+///   @import "node_modules/govuk-frontend/dist/govuk";
 ///
 /// @see $govuk-fonts-path
 /// @see {function} govuk-font-url

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -140,14 +140,16 @@ $govuk-default-functional-colours: (
 ///
 /// @example scss – Redefining functional colours by setting them before import
 ///
-///   // These will be merged with the default functional colours
-///   $govuk-functional-colours: (
-///     // set the 'brand' colour to the 'primary' variant of 'purple'
-///     brand: (name: 'purple'),
-///     // set the 'template-background' colour to the 'tint-95' variant of 'purple'
-///     template-background: (name: 'purple', variant: 'tint-95'),
-///     // set the 'text' colour to an arbitrary colour `#221133`
-///     text: #221133
+///   @use "node_modules/govuk-frontend/dist/govuk" as * with (
+///     // These will be merged with the default functional colours
+///     $govuk-functional-colours: (
+///       // set the 'brand' colour to the 'primary' variant of 'purple'
+///       brand: (name: 'purple'),
+///       // set the 'template-background' colour to the 'tint-95' variant of 'purple'
+///       template-background: (name: 'purple', variant: 'tint-95'),
+///       // set the 'text' colour to an arbitrary colour `#221133`
+///       text: #221133
+///     )
 ///   );
 ///
 /// @see {function} govuk-functional-colour

--- a/packages/govuk-frontend/src/govuk/settings/_warnings.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_warnings.scss
@@ -13,12 +13,15 @@
 /// You can add to this map and define which warnings to suppress by appending to
 /// it using the warning key, found in the warning message. For example:
 ///
-/// @example scss:
-///   // warning message:
-///   //  $foobar is no longer supported. To silence this warning, update
-///   //  $govuk-suppressed-warnings with key: "foobar"
-///   $govuk-suppressed-warnings: (
-///     foobar
+/// @example scss Suppressing a warning message
+///
+///   // Prevent the following warning message to appear:
+///   // '$deprecated-feature is no longer supported. To silence this warning, update
+///   // $govuk-suppressed-warnings with key: "warning-key"'
+///   @use "node_modules/govuk-frontend/dist/govuk" as * with (
+///     $govuk-suppressed-warnings: (
+///       warning-key
+///     )
 ///   );
 ///
 /// @type List

--- a/packages/govuk-frontend/src/govuk/tools/_exports.scss
+++ b/packages/govuk-frontend/src/govuk/tools/_exports.scss
@@ -14,7 +14,13 @@ $govuk-imported-modules: () !default;
 ///
 /// Ensure that the modules of CSS that we define throughout Frontend are only
 /// included in the generated CSS once, no matter how many times they are
-/// imported across the individual components.
+/// imported across the individual components with `@import`.
+///
+/// If you include your stylesheets as Sass modules with `@use` or `@forward`
+/// Sass already ensures the CSS for the module is only output once without having
+/// to use `govuk-exports`.
+///
+/// `govuk-exports` can also prevent a mixin from outputting CSS multiple times.
 ///
 /// @param {String} $name - Name of module - must be unique within the codebase
 /// @content The passed content will only be outputted if a module of the same


### PR DESCRIPTION
Update the examples in the settings layer to show how to configure the settings with a `with` clause when using `@use`.

Also nuance the description of `govuk-exports` to highlight Sass already takes care of outputting CSS once, but that the mixin can be useful inside other mixins.

Fixes alphagov/govuk-frontend-docs#604