### PR TITLE
Update review app to `@use` govuk-frontend

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -1,10 +1,10 @@
 @use "pkg:govuk-frontend";
 
-@import "partials/app";
-@import "partials/banner";
-@import "partials/code";
-@import "partials/component-preview";
-@import "partials/feature-flag-banner";
-@import "partials/links";
-@import "partials/organisation-swatch";
-@import "partials/prose";
+@use "partials/app";
+@use "partials/banner";
+@use "partials/code";
+@use "partials/component-preview";
+@use "partials/feature-flag-banner";
+@use "partials/links";
+@use "partials/organisation-swatch";
+@use "partials/prose";

--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -1,4 +1,5 @@
-@import "pkg:govuk-frontend";
+@use "pkg:govuk-frontend";
+
 @import "partials/app";
 @import "partials/banner";
 @import "partials/code";

--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/campaign-page.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/campaign-page.scss
@@ -1,5 +1,4 @@
-@import "pkg:govuk-frontend/base";
-@import "pkg:govuk-frontend/core";
+@use "pkg:govuk-frontend/base" as *;
 
 .app-header--campaign {
   padding-bottom: govuk-spacing(2);

--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/product-page.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/product-page.scss
@@ -1,4 +1,4 @@
-@import "pkg:govuk-frontend/base";
+@use "pkg:govuk-frontend/base" as *;
 
 .app-masthead {
   display: flow-root;

--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/search.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/search.scss
@@ -1,5 +1,4 @@
-@import "pkg:govuk-frontend/base";
-@import "pkg:govuk-frontend/core";
+@use "pkg:govuk-frontend/base" as *;
 
 .app-document-list > li {
   padding-top: govuk-spacing(4);

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 .app-template {
   background-color: govuk-functional-colour(body-background);
 }

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_banner.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_banner.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 .app-banner {
   padding-top: govuk-spacing(6);
   padding-bottom: govuk-spacing(6);

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_code.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_code.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 @import "highlight";
 
 .app-code {

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_code.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_code.scss
@@ -1,6 +1,6 @@
 @use "pkg:govuk-frontend/base" as *;
 
-@import "highlight";
+@use "highlight";
 
 .app-code {
   @include govuk-responsive-margin(6, "bottom");

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_component-preview.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_component-preview.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 .app-component-preview {
   position: relative;
   width: 100%;

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_feature-flag-banner.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_feature-flag-banner.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 .app-feature-flag-banner {
   padding: govuk-spacing(4) 0;
   border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_links.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_links.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 // Custom links specifically for the links page to test our error and success
 // link styles, since we don't provide these as link classes
 

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_organisation-swatch.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_organisation-swatch.scss
@@ -1,3 +1,5 @@
+@use "pkg:govuk-frontend/base" as *;
+
 .app-organisation-swatch {
   padding-left: govuk-spacing(3);
   border-left: 6px solid #777777;

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_prose.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_prose.scss
@@ -1,3 +1,6 @@
+@use "pkg:govuk-frontend/base" as *;
+@use "pkg:govuk-frontend/core";
+
 .app-prose-scope {
   h1 {
     @extend %govuk-heading-xl;


### PR DESCRIPTION
Update the main import of the govuk-frontend package from `@import` to `@use`.

Because of the way the Sass module system works, update every partial from the review app’s sass that makes use of a mixin, function or variable from govuk-frontend to `@use base` as well.