### PR TITLE
Fix small inputs activating hover style when hovering on non-clickable areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#7021: Fix small inputs activating hover style when hovering on non-clickable areas](https://github.com/alphagov/govuk-frontend/pull/7021)
+
 ## v6.2.0-beta.0 (Beta feature release)
 
 ### New features

--- a/packages/govuk-frontend-review/src/views/examples/form-controls-states/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-controls-states/index.njk
@@ -117,15 +117,15 @@
           </label>
         </div>
 
-        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-checkboxes__input" id="foo3" name="foo" type="checkbox" value="bar">
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input :hover" id="foo3" name="foo" type="checkbox" value="bar">
           <label class="govuk-label govuk-checkboxes__label" for="foo3">
             Hover
           </label>
         </div>
 
-        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-checkboxes__input" id="foo4" name="foo" type="checkbox" value="bar" checked>
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input :hover" id="foo4" name="foo" type="checkbox" value="bar" checked>
           <label class="govuk-label govuk-checkboxes__label" for="foo4">
             Hover, Checked
           </label>
@@ -145,15 +145,15 @@
           </label>
         </div>
 
-        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-checkboxes__input :focus" id="foo7" name="foo" type="checkbox" value="bar">
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input :hover :focus" id="foo7" name="foo" type="checkbox" value="bar">
           <label class="govuk-label govuk-checkboxes__label" for="foo7">
             Focus, Hover
           </label>
         </div>
 
-        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-checkboxes__input :focus" id="foo8" name="foo" type="checkbox" value="bar" checked>
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input :hover :focus" id="foo8" name="foo" type="checkbox" value="bar" checked>
           <label class="govuk-label govuk-checkboxes__label" for="foo8">
             Focus, Checked, Hover
           </label>
@@ -200,15 +200,15 @@
           </label>
         </div>
 
-        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-radios__input" id="fizz3" name="fizz3" type="radio" value="">
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input :hover" id="fizz3" name="fizz3" type="radio" value="">
           <label class="govuk-label govuk-radios__label" for="fizz3">
             Hover
           </label>
         </div>
 
-        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-radios__input" id="fizz4" name="fizz4" type="radio" value="" checked>
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input :hover" id="fizz4" name="fizz4" type="radio" value="" checked>
           <label class="govuk-label govuk-radios__label" for="fizz4">
             Hover, Checked
           </label>
@@ -228,15 +228,15 @@
           </label>
         </div>
 
-        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-radios__input :focus" id="fizz7" name="fizz7" type="radio" value="">
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input :hover :focus" id="fizz7" name="fizz7" type="radio" value="">
           <label class="govuk-label govuk-radios__label" for="fizz7">
             Focus, Hover
           </label>
         </div>
 
-        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
-          <input class="govuk-radios__input :focus" id="fizz8" name="fizz8" type="radio" value="" checked>
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input :hover :focus" id="fizz8" name="fizz8" type="radio" value="" checked>
           <label class="govuk-label govuk-radios__label" for="fizz8">
             Focus, Checked, Hover
           </label>

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
@@ -267,7 +267,7 @@
     // is so much larger than their visible size, and so we need to provide
     // feedback to the user as to which checkbox they will select when their
     // cursor is outside of the visible area.
-    .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+    .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
       // Forced colours modes tend to ignore box-shadow.
       // Apply an outline for those modes to use instead.
       outline: base.$govuk-focus-width dashed transparent;
@@ -280,7 +280,7 @@
     //
     // We use two box shadows, one that restores the original focus state [1]
     // and another that then applies the hover state [2].
-    .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+    .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
       // Set different HCM colour when we have both hover/focus applied at once
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
         outline-color: Highlight;
@@ -298,11 +298,11 @@
     // state in browsers that don't support `@media (hover)` (like Internet
     // Explorer) – so we have to 'undo' the hover state instead.
     @media (hover: none), (pointer: coarse) {
-      .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+      .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
         box-shadow: initial;
       }
 
-      .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+      .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
         box-shadow: 0 0 0 base.$govuk-focus-width base.govuk-functional-colour(focus);
       }
     }

--- a/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
@@ -286,7 +286,7 @@
     // is so much larger than their visible size, and so we need to provide
     // feedback to the user as to which radio they will select when their
     // cursor is outside of the visible area.
-    .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+    .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
       // Forced colours modes tend to ignore box-shadow.
       // Apply an outline for those modes to use instead.
       outline: $govuk-radios-focus-width dashed transparent;
@@ -299,7 +299,7 @@
     //
     // We use two box shadows, one that restores the original focus state [1]
     // and another that then applies the hover state [2].
-    .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+    .govuk-radios__input:focus:hover + .govuk-radios__label::before {
       // Set different HCM colour when we have both hover/focus applied at once
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
         outline-color: Highlight;
@@ -317,11 +317,11 @@
     // state in browsers that don't support `@media (hover)` (like Internet
     // Explorer) – so we have to 'undo' the hover state instead.
     @media (hover: none), (pointer: coarse) {
-      .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+      .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
         box-shadow: initial;
       }
 
-      .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+      .govuk-radios__input:focus:hover + .govuk-radios__label::before {
         box-shadow: 0 0 0 $govuk-radios-focus-width base.govuk-functional-colour(focus);
       }
     }

--- a/tests/sass-tests/__snapshots__/all-components-with-config.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/all-components-with-config.integration.test.mjs.snap
@@ -2083,24 +2083,24 @@ p + .govuk-heading-s,
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }
@@ -3946,24 +3946,24 @@ p + .govuk-heading-s,
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }

--- a/tests/sass-tests/__snapshots__/all-components.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/all-components.integration.test.mjs.snap
@@ -2081,24 +2081,24 @@ exports[`All components works when user @imports everything 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }
@@ -3944,24 +3944,24 @@ exports[`All components works when user @imports everything 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }

--- a/tests/sass-tests/__snapshots__/individual-components.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/individual-components.integration.test.mjs.snap
@@ -1642,24 +1642,24 @@ exports[`Individual components src/govuk/components/checkboxes works when user @
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }"
@@ -6517,24 +6517,24 @@ exports[`Individual components src/govuk/components/radios works when user @impo
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }"

--- a/tests/sass-tests/__snapshots__/itcss-layers.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/itcss-layers.integration.test.mjs.snap
@@ -1241,24 +1241,24 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }
@@ -3104,24 +3104,24 @@ exports[`ITCSS layers components works when user @imports the layer 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }

--- a/tests/sass-tests/__snapshots__/sass-file-compilation.integration.test.mjs.snap
+++ b/tests/sass-tests/__snapshots__/sass-file-compilation.integration.test.mjs.snap
@@ -1279,24 +1279,24 @@ exports[`src/govuk/components/_index.scss matches snapshot 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }
@@ -3142,24 +3142,24 @@ exports[`src/govuk/components/_index.scss matches snapshot 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }
@@ -5909,24 +5909,24 @@ exports[`src/govuk/components/checkboxes/_index.scss matches snapshot 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }"
@@ -10824,24 +10824,24 @@ exports[`src/govuk/components/radios/_index.scss matches snapshot 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }"
@@ -17343,24 +17343,24 @@ exports[`src/govuk/index.scss matches snapshot 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
   outline: 3px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+.govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
   box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
     box-shadow: initial;
   }
-  .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes--small .govuk-checkboxes__input:focus:hover + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px var(--govuk-focus-colour, #ffdd00);
   }
 }
@@ -19206,24 +19206,24 @@ exports[`src/govuk/index.scss matches snapshot 1`] = `
   width: 24px;
   margin-bottom: 5px;
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
   outline: 4px dashed transparent;
   outline-offset: 1px;
   box-shadow: 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
-.govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+.govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
   box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00), 0 0 0 10px var(--govuk-hover-colour, #cecece);
 }
 @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     outline-color: Highlight;
   }
 }
 @media (hover: none), (pointer: coarse) {
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
     box-shadow: initial;
   }
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios--small .govuk-radios__input:focus:hover + .govuk-radios__label::before {
     box-shadow: 0 0 0 4px var(--govuk-focus-colour, #ffdd00);
   }
 }


### PR DESCRIPTION
Currently, hovering anywhere over the container of a small checkbox or radio button will activate the hover style, including hovering over empty space next to the label, or hint text associated with the input. 

This is misleading, as the input can only be checked by clicking on the visible input or label and not anywhere else where the hover state is shown.

This commit rewrites the styles to instead be shown when hovering over the input element only (not the label or container). The hover styles still appear when hovering on the label because `<label>` elements relay their states to the inputs they're associated with, in effect, meaning that hovering over the label is equivalent to hovering over the input. https://html.spec.whatwg.org/multipage/semantics-other.html#selector-hover

Fixes #5370.

## Changes
- Updated hover style selectors for small checkboxes and radio buttons to refer to the input rather than the container.
- Updated review app's form states test page to update which element hover styles are applied to for small checkboxes and radio buttons.

### Screenshots

Radio buttons only shown here but the results are the same for checkboxes.

Not pictured but have also tested for disabled inputs, which work identically both before and after (no hover style).

||Before|After|
|:-|:-:|:-:|
|Hovering over empty space|<img width="345" height="230" alt="List of radio buttons. Mouse cursor is hovering over empty space next to the second button, causing it to render a hover state." src="https://github.com/user-attachments/assets/50852bec-d0d9-47dc-b243-8b62094ed817" />|<img width="345" height="230" alt="List of radio buttons. Mouse cursor is hovering over empty space next to the second button, but no hover state is shown." src="https://github.com/user-attachments/assets/5f95f306-c895-4a64-bd9c-750cc5a5a826" />|
|Hovering over hint text|<img width="345" height="230" alt="List of radio buttons, the first of which includes accompanying 'hint' text. The mouse cursor is positioned over the hint, causing a hover state to be rendered around the input." src="https://github.com/user-attachments/assets/4ddeb704-2203-4ae3-84a3-ff7437e90474" />|<img width="345" height="230" alt="List of radio buttons, the first of which includes accompanying 'hint' text. The mouse cursor is positioned over the hint, but no hover state is rendered on the input." src="https://github.com/user-attachments/assets/0cf1b8a5-58fe-4b24-aadc-33c43a370818" />|
|Hovering over focused input's empty space|<img width="345" height="230" alt="List of radio buttons, the first of which is disabled and second has keyboard focus. The mouse cursor is in the empty space next to the focused input, which renders both the focus and hover states simultaneously." src="https://github.com/user-attachments/assets/bbe21cb5-7977-407c-a1aa-4a158346e9dd" />|<img width="345" height="230" alt="List of radio buttons, the first of which is disabled and second has keyboard focus. The mouse cursor is in the empty space next to the focused input, which only renders the focus state." src="https://github.com/user-attachments/assets/f26c2301-48f7-4f86-906e-f31601fd90c7" />|

