### PR TITLE
Add Dry Run functionality to release Actions

### DIFF
--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -53,7 +53,17 @@ jobs:
           fi
 
       - name: Create GitHub archive
-        run: git archive -o ./release-${{ steps.create-github-tag.outputs.GH_TAG }}.zip HEAD:dist
+        id: archive
+        run: |
+          ARCHIVE_FILE_PATH="./release-${{ steps.create-github-tag.outputs.GH_TAG }}.zip"
+          git archive -o "${ARCHIVE_FILE_PATH}" HEAD:dist
+          echo "ARCHIVE_FILE_PATH=${ARCHIVE_FILE_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Upload GitHub archive artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{steps.archive.outputs.ARCHIVE_FILE_PATH}}
+          archive: false # file is already compressed
 
       - name: Generate release notes
         uses: actions/github-script@v9.0.0
@@ -69,10 +79,11 @@ jobs:
           GH_TAG=${{ steps.create-github-tag.outputs.GH_TAG }}
           RELEASE_NAME="GOV.UK Frontend $GH_TAG"
           RELEASE_BODY=$(cat release-notes-body)
+          ARCHIVE_FILE_PATH="${{steps.archive.outputs.ARCHIVE_FILE_PATH}}"
 
           if gh release view "$GH_TAG" > /dev/null 2>&1; then
             echo "⚠️ Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
             exit 1
           else
-            gh release create "$GH_TAG" ./release-"${GH_TAG}".zip --title "${RELEASE_NAME}" --notes "$RELEASE_BODY"
+            gh release create "$GH_TAG" "$ARCHIVE_FILE_PATH" --title "${RELEASE_NAME}" --notes "$RELEASE_BODY"
           fi

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -1,7 +1,13 @@
 name: 'RELEASE: GitHub release'
+run-name: "RELEASE: GitHub release${{ inputs.dry_run && ' (Dry run)' || '' }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description: Dry run
+        default: true
 
 jobs:
   publish-release-to-github:
@@ -58,6 +64,7 @@ jobs:
             await generateReleaseNotes('${{ steps.create-github-tag.outputs.GH_TAG }}')
 
       - name: Create GitHub release
+        if: inputs.dry_run == false
         run: |
           GH_TAG=${{ steps.create-github-tag.outputs.GH_TAG }}
           RELEASE_NAME="GOV.UK Frontend $GH_TAG"

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -73,6 +73,17 @@ jobs:
 
             await generateReleaseNotes('${{ steps.create-github-tag.outputs.GH_TAG }}')
 
+      - name: Print information on release notes
+        run: |
+          {
+            echo "## Generated release notes"
+            cat release-notes-body
+            echo '## Files in archive'
+            echo '```bash'
+            tree dist
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
       - name: Create GitHub release
         if: inputs.dry_run == false
         run: |

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,7 +1,13 @@
 name: 'RELEASE: npm publish'
+run-name: "RELEASE: npm publish${{ inputs.dry_run && ' (Dry run)' || '' }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description: Dry run
+        default: true
 
 jobs:
   publish:
@@ -33,4 +39,5 @@ jobs:
         run: npm run build:package
 
       - name: Publish to npm
+        if: inputs.dry_run == false
         run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -38,6 +38,22 @@ jobs:
       - name: Build npm package
         run: npm run build:package
 
+      - name: Print information on package
+        id: pack
+        run: |
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          # Redirect the stderr which contains the useful meta data to the Action summary
+          ARCHIVE_FILE_PATH=$(npm pack --workspace govuk-frontend 2>> $GITHUB_STEP_SUMMARY)
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          echo "ARCHIVE_FILE_PATH=${ARCHIVE_FILE_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Upload npm package archive artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{steps.pack.outputs.ARCHIVE_FILE_PATH}}
+          archive: false # file is already compressed
+
       - name: Publish to npm
         if: inputs.dry_run == false
         run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}


### PR DESCRIPTION
We want to be able to improve the release process so by adding some simple dry run functionality we can begin to do more complicated improvements where we can run the workflows without them actually publishing anything.

Defaults to a dry run, so the checkbox must be unchecked for a production release.

Uses the `run-name` functionality to dynamically update the Workflow run so it's clear what runs are Dry runs.

Uploads archives as artifacts for future analysis, by default they'll stay around for 90 days.

Prints out various useful information about both npm package and the GitHub release e.g. release notes. 

Closes https://github.com/alphagov/govuk-frontend/issues/7024

