### PR TITLE
Make `generate-npm-tag` support `-<WHATEVER>` releases

### DIFF
--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -20,7 +20,7 @@ elif [ $(version "$PACKAGE_VERSION") -ge $(version "$LATEST_PUBLISHED_VERSION") 
   NPM_TAG="latest"
 else
   major_version_num=$(echo "$PACKAGE_VERSION" | cut -d. -f1)
-  NPM_TAG="latest-$major_version_num"
+  NPM_TAG="latest-v$major_version_num"
 fi
 
 echo "$NPM_TAG"

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -2,27 +2,27 @@
 set -e
 
 # Use first argument as version or extract tag version from ./packages/govuk-frontend/package.json
-CURRENT_VERSION=${1:-$(npm run get-version --silent --workspace govuk-frontend)}
+PACKAGE_VERSION=${1:-$(npm run get-version --silent --workspace govuk-frontend)}
 
-# Use second argument as highest published version or get highest tag published on Github
-HIGHEST_PUBLISHED_VERSION=${2:-$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')}
+# Use second argument as latest published version or get latest tag published on Github
+LATEST_PUBLISHED_VERSION=${2:-$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')}
 
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
-if [ "$CURRENT_VERSION" = "$HIGHEST_PUBLISHED_VERSION" ]; then
+if [ "$PACKAGE_VERSION" = "$LATEST_PUBLISHED_VERSION" ]; then
   echo "⚠️ Git tag $TAG already exists. Check you have run \`npm version\` correctly."
   exit 1
-elif echo "$CURRENT_VERSION" | grep -q "internal"; then
+elif echo "$PACKAGE_VERSION" | grep -q "internal"; then
   NPM_TAG="internal"
-elif echo "$CURRENT_VERSION" | grep -q "beta"; then
+elif echo "$PACKAGE_VERSION" | grep -q "beta"; then
   NPM_TAG="next"
-elif echo "$CURRENT_VERSION" | grep -q -E '^\d+\.\d+\.\d+-\D+(\.\d+)?$'; then
+elif echo "$PACKAGE_VERSION" | grep -q -E '^\d+\.\d+\.\d+-\D+(\.\d+)?$'; then
   echo "⚠️ Pre-releases with an identifier other than 'beta' or 'internal' are not allowed, therefore we will not generate an npm tag. Please check your current version."
   exit 1
-elif [ $(version "$CURRENT_VERSION") -ge $(version "$HIGHEST_PUBLISHED_VERSION") ]; then
+elif [ $(version "$PACKAGE_VERSION") -ge $(version "$LATEST_PUBLISHED_VERSION") ]; then
   NPM_TAG="latest"
 else
-  major_version_num=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+  major_version_num=$(echo "$PACKAGE_VERSION" | cut -d. -f1)
   NPM_TAG="latest-$major_version_num"
 fi
 

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -11,11 +11,8 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
 if echo "$PACKAGE_VERSION" | grep -q "internal"; then
   NPM_TAG="internal"
-elif echo "$PACKAGE_VERSION" | grep -q "beta"; then
+elif echo "$PACKAGE_VERSION" | grep -q "-"; then
   NPM_TAG="next"
-elif echo "$PACKAGE_VERSION" | grep -q -E '^\d+\.\d+\.\d+-\D+(\.\d+)?$'; then
-  echo "⚠️ Pre-releases with an identifier other than 'beta' or 'internal' are not allowed, therefore we will not generate an npm tag. Please check your current version."
-  exit 1
 elif [ $(version "$PACKAGE_VERSION") -ge $(version "$LATEST_PUBLISHED_VERSION") ]; then
   NPM_TAG="latest"
 else

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-# Get highest tag published on Github
-HIGHEST_PUBLISHED_VERSION=$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')
+# Use first argument as version or extract tag version from ./packages/govuk-frontend/package.json
+CURRENT_VERSION=${1:-$(npm run get-version --silent --workspace govuk-frontend)}
 
-# Extract tag version from ./packages/govuk-frontend/package.json
-CURRENT_VERSION=$(npm run get-version --silent --workspace govuk-frontend)
+# Use second argument as highest published version or get highest tag published on Github
+HIGHEST_PUBLISHED_VERSION=${2:-$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')}
 
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -5,7 +5,7 @@ set -e
 PACKAGE_VERSION=${1:-$(npm run get-version --silent --workspace govuk-frontend)}
 
 # Use second argument as latest published version or get latest tag published on Github
-LATEST_PUBLISHED_VERSION=${2:-$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')}
+LATEST_PUBLISHED_VERSION=${2:-$(npm view govuk-frontend version)}
 
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -9,10 +9,7 @@ LATEST_PUBLISHED_VERSION=${2:-$(npm view govuk-frontend version)}
 
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
-if [ "$PACKAGE_VERSION" = "$LATEST_PUBLISHED_VERSION" ]; then
-  echo "⚠️ Git tag $TAG already exists. Check you have run \`npm version\` correctly."
-  exit 1
-elif echo "$PACKAGE_VERSION" | grep -q "internal"; then
+if echo "$PACKAGE_VERSION" | grep -q "internal"; then
   NPM_TAG="internal"
 elif echo "$PACKAGE_VERSION" | grep -q "beta"; then
   NPM_TAG="next"

--- a/bin/generate-npm-tag.unit.test.mjs
+++ b/bin/generate-npm-tag.unit.test.mjs
@@ -15,6 +15,7 @@ describeIf(process.platform !== 'win32')('generate-npm-tag.sh', () => {
     ['major', '7.0.0', 'latest'],
     ['internal', '6.0.0-internal', 'internal'],
     ['beta', '6.0.0-beta', 'next'],
+    ['rc', '6.0.0-rc', 'next'],
     ['latest-...', '4.0.0', 'latest-v4']
   ])('%s bump', async (label, version, expectedTag) => {
     const { stdout } = await exec(
@@ -22,22 +23,6 @@ describeIf(process.platform !== 'win32')('generate-npm-tag.sh', () => {
     )
 
     expect(stdout.trim()).toBe(expectedTag)
-  })
-
-  it('errors for any pre-release which is not `beta` or `internal`', async () => {
-    expect.assertions(2)
-    // Unfortunately Jest's `.rejects.toThrow` only allows to test the type of error or its message
-    // so we need to explicitly `try/catch` to check the exit code and message
-    try {
-      await exec(`bin/generate-npm-tag.sh 6.0.0-rc ${highestReleasedVersion}`)
-    } catch (e) {
-      expect(e.code).toBe(1)
-      expect(e.stdout).toMatch(
-        "⚠️ Pre-releases with an identifier other than 'beta' or 'internal' " +
-          'are not allowed, therefore we will not generate an npm tag. ' +
-          'Please check your current version.'
-      )
-    }
   })
 })
 

--- a/bin/generate-npm-tag.unit.test.mjs
+++ b/bin/generate-npm-tag.unit.test.mjs
@@ -1,0 +1,55 @@
+import childProcess from 'node:child_process'
+import { promisify } from 'node:util'
+
+const exec = promisify(childProcess.exec)
+
+// Our build scripts are Shell scripts so won't run on Windows
+// Unfortunately, Jest wants test files to have test suites,
+// so we need to only run `describe` if the platform is not Windows
+describeIf(process.platform !== 'win32')('generate-npm-tag.sh', () => {
+  const highestReleasedVersion = '6.0.0'
+
+  it.each([
+    ['patch', '6.0.1', 'latest'],
+    ['minor', '6.1.0', 'latest'],
+    ['major', '7.0.0', 'latest'],
+    ['internal', '6.0.0-internal', 'internal'],
+    ['beta', '6.0.0-beta', 'next'],
+    ['latest-...', '4.0.0', 'latest-v4']
+  ])('%s bump', async (label, version, expectedTag) => {
+    const { stdout } = await exec(
+      `bin/generate-npm-tag.sh ${version} ${highestReleasedVersion}`
+    )
+
+    expect(stdout.trim()).toBe(expectedTag)
+  })
+
+  it('errors for any pre-release which is not `beta` or `internal`', async () => {
+    expect.assertions(2)
+    // Unfortunately Jest's `.rejects.toThrow` only allows to test the type of error or its message
+    // so we need to explicitly `try/catch` to check the exit code and message
+    try {
+      await exec(`bin/generate-npm-tag.sh 6.0.0-rc ${highestReleasedVersion}`)
+    } catch (e) {
+      expect(e.code).toBe(1)
+      expect(e.stdout).toMatch(
+        "⚠️ Pre-releases with an identifier other than 'beta' or 'internal' " +
+          'are not allowed, therefore we will not generate an npm tag. ' +
+          'Please check your current version.'
+      )
+    }
+  })
+})
+
+/**
+ * Allows to skip a `describe` block if the condition is not met
+ *
+ * Jest does not allow empty test suites, so this allows to skip all tests
+ * when a condition is not met (for ex. if tests are running in a specific platform)
+ *
+ * @param {boolean} condition - The condition that needs to be met for tests to run
+ * @returns {Function} Jest's `describe` function if the `condition` is met, `describe.skip` otherwise
+ */
+function describeIf(condition) {
+  return condition ? describe : describe.skip
+}


### PR DESCRIPTION
Update the `generate-npm-tag.sh` script so it no longer errors if running against a pre-release that's not `-internal` or `-beta` (for example: `-rc`).

The PR adds tests checking the output for various version numbers and fixes a couple of niggles:
- use npm rather than Git to grab the latest published version
- fixes how we detect pre-releases (only need to check for a `-` rather than a complex regex)
- fixes the `latest-v<SUPPORT_VERSION>` tag which was missing its `v`

It also removes the initial test that the version being published is not equal to the latest published version. The test would be inaccurate on support branches, and as `npm publish` would error in that situation we can do without it.

Commit history gives more detailed explanation of the changes.

Other scripts are happy with any pre-release id so this closes #6671.