### PR TITLE
Remove file upload release notes from 6.2.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,43 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
+### New features
+
+#### Add custom classes and attributes to the File upload component's wrapper
+
+We've introduced two new parameters to the File upload component's Nunjucks macro: `wrapperClasses` and `wrapperAttributes`.
+
+These allow you to define custom classes and HTML attributes for the wrapper of the improved version of the File upload.
+
+```njk
+{{ govukFileUpload({
+  javascript: true,
+  wrapperClasses: "my-custom-class",
+  wrapperAttributes: {
+    "data-attribute": "value"
+  }
+}) }}
+```
+
+We made this change in [pull request #6933: Code improvements to File upload component](https://github.com/alphagov/govuk-frontend/pull/6933).
+
+### Recommended changes
+
+#### Rename the `govuk-drop-zone` class on the improved File upload component
+
+The class name of the element that wraps the improved File upload component has been changed from `govuk-drop-zone` to `govuk-file-upload-wrapper`. This was to better describe what function the element plays in the component.
+
+The old class name has been deprecated and will be removed in the next major version of GOV.UK Frontend.
+
+If you're using our Nunjucks macros, you don't need to update anything.
+
+We made this change in [pull request #6933: Code improvements to File upload component](https://github.com/alphagov/govuk-frontend/pull/6933).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
+- [#6925: Fix enhanced file upload lacking an error state](https://github.com/alphagov/govuk-frontend/pull/6925)
 - [#7021: Fix small inputs activating hover style when hovering on non-clickable areas](https://github.com/alphagov/govuk-frontend/pull/7021)
 - [#6959: Fix alignment of jewels and base in govuk-icon PNGs](https://github.com/alphagov/govuk-frontend/pull/6959), thanks to @matteason for reporting and fixing this issue
 
@@ -65,36 +98,6 @@ You can now omit the `dist/govuk` part of the path when including GOV.UK Fronten
 
 We made this change in [pull request #6861: Resolve `pkg:` URLs from `dist/govuk` and update the review app](https://github.com/alphagov/govuk-frontend/pull/6861).
 
-#### Add custom classes and attributes to the File upload component's wrapper
-
-We've introduced two new parameters to the File upload component's Nunjucks macro: `wrapperClasses` and `wrapperAttributes`.
-
-These allow you to define custom classes and HTML attributes for the wrapper of the improved version of the File upload.
-
-```njk
-{{ govukFileUpload({
-  javascript: true,
-  wrapperClasses: "my-custom-class",
-  wrapperAttributes: {
-    "data-attribute": "value"
-  }
-}) }}
-```
-
-We made this change in [pull request #6933: Code improvements to File upload component](https://github.com/alphagov/govuk-frontend/pull/6933).
-
-### Recommended changes
-
-#### Rename the `govuk-drop-zone` class on the improved File upload component
-
-The class name of the element that wraps the improved File upload component has been changed from `govuk-drop-zone` to `govuk-file-upload-wrapper`. This was to better describe what function the element plays in the component.
-
-The old class name has been deprecated and will be removed in the next major version of GOV.UK Frontend.
-
-If you're using our Nunjucks macros, you don't need to update anything.
-
-We made this change in [pull request #6933: Code improvements to File upload component](https://github.com/alphagov/govuk-frontend/pull/6933).
-
 ### Fixes
 
 #### Error summary no longer outputs the styles for lists
@@ -110,7 +113,6 @@ We made this change in [pull request #6975: Update index to use all layers and r
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#6831: Fix header link hover state in Safari](https://github.com/alphagov/govuk-frontend/pull/6831)
-- [#6925: Fix enhanced file upload lacking an error state](https://github.com/alphagov/govuk-frontend/pull/6925)
 
 ## v6.1.0 (Feature release)
 


### PR DESCRIPTION
These changes were not included in 6.2.0-beta.0, and should be listed as unreleased.