### PR TITLE
Use a release type instead of a version number when building the release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,5 @@
 name: 'RELEASE: Build release'
+run-name: "RELEASE: Build release${{ inputs.dry_run && ' (Dry run)' || '' }}"
 
 on:
   workflow_dispatch:
@@ -7,6 +8,10 @@ on:
         description: 'New version number eg: 5.3.1'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run'
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -52,7 +57,26 @@ jobs:
       - name: Build release
         run: npm run build:release
 
+      - name: Output PR content in action summary
+        run: |
+          {
+            echo '## PR body'
+            cat release-notes-body
+            echo ''
+            echo '## Files in archive'
+            echo '```diff'
+            git diff
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload CHANGELOG as artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: CHANGELOG.md
+          archive: false # Saves having to decompress the CHANGELOG
+
       - name: Create pull request
+        if: inputs.dry_run == false
         env:
           GH_TOKEN: ${{ secrets.CI_PAT }}
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,7 +4,7 @@ run-name: "RELEASE: Build release${{ inputs.dry_run && ' (Dry run)' || '' }}"
 on:
   workflow_dispatch:
     inputs:
-      version:
+      release_type:
         description: 'Release type'
         required: true
         type: choice
@@ -33,7 +33,22 @@ jobs:
     name: Build release
     runs-on: Ubuntu-22.04
 
+    env:
+      RELEASE_TYPE: ${{inputs.release_type}}
+      PREID: ${{inputs.preid}}
+
     steps:
+      - name: Log inputs in the action summary
+        run: |
+          # Output the inputs in the summary before anything
+          {
+            echo "## Inputs"
+            echo '|Input|Value|'
+            echo '|-----|-----|'
+            echo "|release_type|\`$RELEASE_TYPE\`|"
+            echo "|preid|\`$PREID\`|"
+          } >> $GITHUB_STEP_SUMMARY
+
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
@@ -49,11 +64,8 @@ jobs:
         run: echo "PREVIOUS_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
 
       - name: Update package version
-        env:
-          VERSION: ${{inputs.version}}
-          PREID: ${{inputs.preid}}
         run: |
-          npm version --no-git-tag-version --workspace govuk-frontend "$VERSION" --preid "$PREID"
+          npm version --no-git-tag-version --workspace govuk-frontend "$RELEASE_TYPE" --preid "$PREID"
 
           # Save the new version number for access in future steps
           echo "PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,6 +12,13 @@ on:
           - major
           - minor
           - patch
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
+      preid:
+        description: 'Prerelease label (for ex. `internal`, `beta`, `rc`)'
+        type: string
       dry_run:
         description: 'Dry run'
         type: boolean
@@ -42,7 +49,14 @@ jobs:
         run: echo "PREVIOUS_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
 
       - name: Update package version
-        run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
+        env:
+          VERSION: ${{inputs.version}}
+          PREID: ${{inputs.preid}}
+        run: |
+          npm version --no-git-tag-version --workspace govuk-frontend "$VERSION" --preid "$PREID"
+
+          # Save the new version number for access in future steps
+          echo "PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
 
       - name: Update CHANGELOG
         uses: actions/github-script@v9.0.0
@@ -50,7 +64,7 @@ jobs:
           script: |
             const { updateChangelog } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
 
-            updateChangelog('${{ inputs.version }}', process.env.PREVIOUS_PACKAGE_VERSION)
+            updateChangelog(process.env.PACKAGE_VERSION, process.env.PREVIOUS_PACKAGE_VERSION)
 
       - name: Generate release notes
         uses: actions/github-script@v9.0.0
@@ -58,7 +72,7 @@ jobs:
           script: |
             const { generateReleaseNotes } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
 
-            generateReleaseNotes('${{ inputs.version }}', { actor: '${{ github.actor }}', runId: '${{ github.run_id }}' })
+            generateReleaseNotes(process.env.PACKAGE_VERSION, { actor: '${{ github.actor }}', runId: '${{ github.run_id }}' })
 
       - name: Build release
         run: npm run build:release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,17 +34,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Save current version
+        run: echo "PREVIOUS_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
+
+      - name: Update package version
+        run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
+
       - name: Update CHANGELOG
         uses: actions/github-script@v9.0.0
         with:
           script: |
             const { updateChangelog } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
-            const frontendPackage = await import('${{ github.workspace }}/packages/govuk-frontend/package.json', { with: { type: 'json' }})
 
-            updateChangelog('${{ inputs.version }}', frontendPackage.default.version)
-
-      - name: Update package version
-        run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
+            updateChangelog('${{ inputs.version }}', process.env.PREVIOUS_PACKAGE_VERSION)
 
       - name: Generate release notes
         uses: actions/github-script@v9.0.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,15 +29,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate version
-        uses: actions/github-script@v9.0.0
-        with:
-          script: |
-            const { validateVersion } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
-            const frontendPackage = await import('${{ github.workspace }}/packages/govuk-frontend/package.json', { with: { type: 'json' }})
-
-            validateVersion('${{ inputs.version }}', frontendPackage.default.version)
-
       - name: Update CHANGELOG
         uses: actions/github-script@v9.0.0
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,9 +5,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'New version number eg: 5.3.1'
+        description: 'Release type'
         required: true
-        type: string
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
       dry_run:
         description: 'Dry run'
         type: boolean

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -6,80 +6,12 @@ const processingErrorMessage =
   'There was a problem processing information from the changelog. This likely means that there is an issue with the changelog content itself. Please check it and try running this task again.'
 
 /**
- * Validate a new version of GOV.UK Frontend
- *
- * Throws an error if any of the following are true:
- *
- * - The version can't be processed by semver and we therefore presume it isn't
- * a valid semver
- * - The version is less than the current version
- * - The version increments the current version by more than one possible
- * increment, eg: going from 3.1.0 to 5.0.0, 3.3.0 or 3.1.2
- *
- * @param {string} newVersion - New version to validate
- * @param {string} previousVersion - Previous version to compare to
- */
-export function validateVersion(newVersion, previousVersion) {
-  if (!semver.valid(newVersion)) {
-    throw new Error(
-      `New version number ${newVersion} could not be processed by Semver. Please ensure you are providing a valid semantic version`
-    )
-  }
-
-  const previousReleaseNumber = validatePreviousVersionNumber(previousVersion)
-
-  // Check the new version against the old version. Firstly a quick check that
-  // the new one isn't less than the old one
-  if (semver.lte(newVersion, previousReleaseNumber)) {
-    throw new Error(
-      `New version number ${newVersion} is less than or equal to the most recent version (${previousReleaseNumber}). Please provide a newer version number`
-    )
-  }
-
-  // Get the version diff keyword (major, minor, patch plus prerelease versions
-  // of those 3 and prerelease for differences between prereleases) which we can
-  // use to help with validating the new version
-  const versionDiff = semver.diff(newVersion, previousReleaseNumber)
-  const identifier = versionIsAPrerelease(newVersion)
-    ? getPrereleaseIdentifier(newVersion)
-    : undefined
-
-  if (!versionDiff) {
-    throw new Error(
-      'Could not determine difference between new and previous versions. Please check the version number you provided and the changelog content'
-    )
-  }
-
-  // Check if the new version increments from the old version by one for
-  // its change type (major, minor, patch) and throws an error if it doesn't.
-  // Eg: if the current version is 4.3.12:
-  // - 4.3.13, 4.4.0 and 5.0.0 are valid
-  // - 4.3.14, 4.5.0, 6.0.0 and above for all aren't valid
-  const correctIncrement = semver.inc(
-    previousReleaseNumber,
-    versionDiff,
-    false,
-    identifier
-  )
-
-  if (!semver.satisfies(newVersion, `<=${correctIncrement}`)) {
-    throw new Error(
-      `New version number ${newVersion} is incrementing more than one for its increment type (${versionDiff}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${correctIncrement}`
-    )
-  }
-
-  console.log('No errors noted in the new version. We can proceed!')
-}
-
-/**
  * Update the changelog with a new version heading
  *
  * Inserts a new heading between the 'Unreleased' heading and the most recent
  * content
  *
- * @param {string} newVersion - New version to add to the changelog. We presume
- *   that this is a valid version as this function is always run after validateVersion
- *   has passed.
+ * @param {string} newVersion - New version to add to the changelog
  * @param {string} previousVersion - Previous version. Used for calculating difference
  *   in versions to build the changelog title
  */

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -1,7 +1,6 @@
 import fs from 'fs'
 
 import {
-  validateVersion,
   updateChangelog,
   generateReleaseNotes
 } from './changelog-release-helper.mjs'
@@ -19,68 +18,6 @@ describe('Changelog release helper', () => {
 
       ## v3.0.0 (Breaking release)
     `)
-  })
-
-  describe('Validate version', () => {
-    it('runs normally if a valid new version is parsed to it', () => {
-      expect(() => validateVersion('3.1.0', '3.0.0')).not.toThrow()
-    })
-
-    it('throws an error if an invalid semver is parsed', () => {
-      expect(() => validateVersion('pizza', '3.0.0')).toThrow(
-        'New version number pizza could not be processed by Semver. Please ensure you are providing a valid semantic version'
-      )
-    })
-
-    it('throws an error if new version is less than old version', () => {
-      expect(() => validateVersion('2.11.0', '3.0.0')).toThrow(
-        'New version number 2.11.0 is less than or equal to the most recent version (3.0.0). Please provide a newer version number'
-      )
-    })
-
-    it('throws an error if the previous version is falsy or invalid', () => {
-      expect(() => validateVersion('3.1.0', 'pizza')).toThrow(
-        'Previous version number pizza could not be processed by Semver. Please ensure a valid version is being passed to the script via the govuk-frontend package.json package.'
-      )
-    })
-
-    it.each([
-      {
-        badVersion: '5.0.0',
-        type: 'major',
-        goodVersion: '4.0.0'
-      },
-      {
-        badVersion: '3.2.0',
-        type: 'minor',
-        goodVersion: '3.1.0'
-      },
-      {
-        badVersion: '3.0.2',
-        type: 'patch',
-        goodVersion: '3.0.1'
-      },
-      {
-        badVersion: '3.0.2-beta.0',
-        type: 'prepatch',
-        goodVersion: '3.0.1-beta.0'
-      },
-      {
-        badVersion: '3.0.2',
-        type: 'patch',
-        goodVersion: '3.0.1',
-        customVersion: '3.0.1-beta.15'
-      }
-    ])(
-      'throws an error if new version is more than one possible `$type` increment',
-      ({ badVersion, type, goodVersion, customVersion }) => {
-        expect(() =>
-          validateVersion(badVersion, customVersion ?? '3.0.0')
-        ).toThrow(
-          `New version number ${badVersion} is incrementing more than one for its increment type (${type}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${goodVersion}`
-        )
-      }
-    )
   })
 
   describe('Update changelog', () => {


### PR DESCRIPTION
Let `npm` do the heavy lifting of computing the next version number when running the workflow to build the release. Instead of asking for an explicit version number, the workflow now asks for a type of release (`major`,`minor`, `patch`, `premajor`, `preminor`, `prepatch`,`prerelease`) and an optional pre-release label (for ex. `internal`, `beta` or `rc).

To help test and build the feature, the `build-release` workflow now also has a dry run mode where it does not raise a PR.

## Input validation

The workflow performs some validation on the inputs. While `npm version` will happily ignore its `--preid` flag if you ask for a `major`, `minor` or `patch` bump, it will not error if you forget to pass a pre-release label when running a `premajor`, `preminor` or `prepatch` version bump. To avoid doing any unnecessary runs, these validations happen first thing in the workflow, before even checking out the codebase.

## Action summary

To better understand what happened during the action, both when running a dry-run and actually creating the PR the action:
- outputs the PR body and the `git diff` as the action's summary
- uploads the updated CHANGELOG as an artifact

Closes #7031 