### PR TITLE
[SPIKE] Make the header extendsible v2: add `start` and `end` slots

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -13,18 +13,14 @@
     background: base.govuk-functional-colour(brand);
   }
 
-  .govuk-header--unbranded {
-    background: base.govuk-colour("black");
+  .govuk-header__container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
   }
 
   .govuk-header__container--full-width {
     padding: 0 base.govuk-spacing(3);
-  }
-
-  .govuk-header__container--slots {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
   }
 
   .govuk-header__logo {
@@ -33,6 +29,11 @@
     // Magic numbers, set padding to vertically centre align the logo
     padding-top: 16px;
     padding-bottom: 14px - $logo-bottom-margin;
+  }
+
+  .govuk-header__slot {
+    box-sizing: border-box;
+    padding: base.govuk-spacing(3) 0;
   }
 
   .govuk-header__homepage-link {

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -2,23 +2,19 @@ params:
   - name: homepageUrl
     type: string
     required: false
-    description: The URL of the homepage. Defaults to the GOV.UK homepage.
-  - name: logo
-    type: string
-    required: false
-    description: HTML to use for the logo within the header. Will default to the GOV.UK logo if not specified.
+    description: The URL of the homepage. Defaults to the GOV.UK homepage. This option will not work if the start option is specified.
   - name: productName
     type: string
     required: false
-    description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use the [Service navigation component](https://design-system.service.gov.uk/components/service-navigation/).
-  - name: branded
-    type: boolean
-    required: false
-    description: Specifies if the header should use the GOV.UK brand or not. When set to `false`, will turn the header black. Will default to `true` if not specified.
-  - name: slotContent
+    description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use the [Service navigation component](https://design-system.service.gov.uk/components/service-navigation/). This option will not work if the start option is specified.
+  - name: start
     type: string
     required: false
-    description: HTML for extra elements to go in the header alongside the logo
+    description: HTML 'slot' placed at the start of the header. Will default to the GOV.UK logo if not specified.
+  - name: end
+    type: string
+    required: false
+    description: HTML 'slot' placed at the end of the header.
   - name: containerClasses
     type: string
     required: false
@@ -65,24 +61,19 @@ examples:
 
   - name: with custom logo
     options:
-      logo: |
-        <img src="/images/hmlr-header-logo.png" height="28">
-
-  - name: with custom logo and unbranded header
-    screenshot: true
-    options:
-      branded: false
-      logo: |
-        <img src="/images/hmlr-header-logo.png" height="28">
+      start: |
+        <a href="/">
+          <img src="/images/hmlr-header-logo.png" height="28">
+        </a>
 
   - name: full width
     options:
       containerClasses: govuk-header__container--full-width
 
-  - name: with slot content
+  - name: with end slot content
     screenshot: true
     options:
-      slotContent: |
+      end: |
         <a href="https://pizza.com" class="govuk-link govuk-link--inverse">Click here for big pizza</a>
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -2,17 +2,18 @@
 {% from "../../macros/logo.njk" import govukLogo -%}
 
 <div class="govuk-header {%- if params.branded == false %} govuk-header--unbranded{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
-  <div class="govuk-header__container {%- if params.slotContent %} govuk-header__container--slots{% endif %} {{ params.containerClasses | default("govuk-width-container", true) }}">
+  <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
+    {% if params.start %}
+    <div class="govuk-header__slot">
+      {{ params.start | safe }}
+    </div>
+    {% else %}
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default("//gov.uk", true) }}" class="govuk-header__homepage-link">
-        {% if params.logo %}
-          {{ params.logo | safe }}
-        {% else %}
-          {{ govukLogo({
-            classes: "govuk-header__logotype",
-            ariaLabelText: "GOV.UK"
-          }) | trim | indent(8) }}
-        {% endif %}
+        {{ govukLogo({
+          classes: "govuk-header__logotype",
+          ariaLabelText: "GOV.UK"
+        }) | trim | indent(8) }}
         {% if (params.productName) %}
         <span class="govuk-header__product-name">
           {{- params.productName -}}
@@ -20,8 +21,11 @@
         {% endif %}
       </a>
     </div>
-    {% if params.slotContent %}
-      {{ params.slotContent | safe }}
+    {% endif %}
+    {% if params.end %}
+    <div class="govuk-header__slot">
+      {{ params.end | safe }}
+    </div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Builds upon the work done in https://github.com/alphagov/govuk-frontend/pull/7026 with some revisions:

1. Removes the `branded` option. This is something we can allow users to manage themselves
2. Renames `logo` and `slotContent` to `start` and `end`
3. `start`, formerly `logo`, now replaces the entire `govuk-header__logo` element, including the product name
4. `govuk-header__container` is now a flex container
5. Adds a `govuk-header__slot` class to enforce padding on slot content

This is to test the idea of the header being 'slots-driven' in it's extensibility rather than us picking bits to replace. This makes the header even more flexible but has some potential drawbacks to consider:

- Management of a user's logo and domain name, including spacing, is entirely on them rather than the previous iteration providing some opinionated spacing and link scaffolding
- If `start` is set then the `homepageUrl` and `productName` params are invalidated. To my knowledge this isn't something we do anywhere else so we'd need to consider if it's a technical choice we want to make and how we manage it if we do