### PR TITLE
Update GitHub Actions Workflows to Ubuntu 24.04

### DIFF
--- a/.github/workflows/accessibility-bot.yml
+++ b/.github/workflows/accessibility-bot.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   images:
     name: Check images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check images for alt text

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   build-release:
     name: Build release
-    runs-on: Ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: ${{ inputs.environment == 'production' && 'production' || null }}
 
     env:

--- a/.github/workflows/bundler-integrations.yml
+++ b/.github/workflows/bundler-integrations.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-tree-shaking:
     name: Test tree shaking
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   generate-diff:
     name: Generate diff
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Skip workflows other than PRs such as merges to `main` but
     # also when token write permissions are unavailable on forks

--- a/.github/workflows/diff-change-to-package.yaml
+++ b/.github/workflows/diff-change-to-package.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   generate-diff:
     name: Generate diff
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Skip workflows other than PRs such as merges to `main` but
     # also when token write permissions are unavailable on forks

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish-release-to-github:
     name: Publish release to GitHub
-    runs-on: Ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: ${{ inputs.environment == 'production' && 'production' || null }}
     permissions:
       contents: write

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     name: Publish to npm
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: ${{ inputs.environment == 'production' && 'production' || null }}
     permissions:
       id-token: write

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   dart-sass:
     name: Dart Sass v1.79.0
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -58,7 +58,7 @@ jobs:
 
   dart-sass-latest:
     name: Dart Sass v1 (latest)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   screenshots:
     name: Send screenshots
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       PERCY_POSTINSTALL_BROWSER: false

--- a/.github/workflows/stats-comment.yml
+++ b/.github/workflows/stats-comment.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   generate-stats:
     name: Generate stats
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Skip workflows other than PRs such as merges to `main` but
     # also when token write permissions are unavailable on forks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         runner:
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-latest
 
@@ -55,7 +55,7 @@ jobs:
       matrix:
         runner:
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-latest
 
@@ -86,7 +86,7 @@ jobs:
       matrix:
         runner:
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-latest
 
@@ -146,7 +146,7 @@ jobs:
       matrix:
         runner:
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-latest
 
@@ -236,7 +236,7 @@ jobs:
       matrix:
         runner:
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-latest
 
@@ -264,7 +264,7 @@ jobs:
 
   package:
     name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [install, build]
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,6 +176,7 @@ jobs:
             cache: |
               .cache/jest
               .cache/puppeteer
+            puppeteer: true
             projects:
               - JavaScript component tests
 
@@ -190,6 +191,7 @@ jobs:
             cache: |
               .cache/jest
               .cache/puppeteer
+            puppeteer: true
             projects:
               - Accessibility tests
 
@@ -213,10 +215,17 @@ jobs:
           path: ${{ matrix.task.cache }}
 
       - name: Run test task
+        run: |
+          # Use 2x CPU cores for hosted GitHub runners (--maxWorkers)
+          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 
-        # Use 2x CPU cores for hosted GitHub runners
-        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        run: npx jest --color ${{ format('--coverage={0} --maxWorkers=2 --selectProjects "{1}"', matrix.task.coverage || false, join(matrix.task.projects, '", "')) }}
+          # Puppeteer uses Chrome to execute tests.
+          # Ubuntu requires a profile for developer builds of Chrome to run without errors.
+          # (https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md)
+          ${{ (
+            matrix.task.puppeteer == true &&
+            matrix.runner.name == 'Ubuntu'
+          ) && 'aa-exec --profile=chrome' || '' }} npx jest --color ${{ format('--coverage={0} --maxWorkers=2 --selectProjects "{1}"', matrix.task.coverage || false, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
         uses: actions/upload-artifact@v7.0.1


### PR DESCRIPTION
I have chosen to use Ubuntu 24.04 rather than `latest` since only the even Ubuntu number releases are LTS (Long Term Release) and hopefully more stable.

Image details:
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

We can use `aa-exec` to run the tests in the `chrome` profile that's bundled with Ubuntu.

> Individual binaries can be allowlisted by filepath using root-owned AppArmor profiles stored in /etc/apparmor.d/. Ubuntu ships with an AppArmor profile that applies to Chrome stable binaries installed at /opt/google/chrome/chrome (the default installation path). Ubuntu's packaged version of Chromium is a snap package, and snap generates an AppArmor profile at runtime that allows usage of user namespaces.
[AppArmor User Namespace Restrictions vs. Chromium Developer Builds]
>
> (https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md)

Upstream bug report related to this:
https://issues.chromium.org/issues/373753919

Closes https://github.com/alphagov/govuk-frontend/issues/5484