### PR TITLE
Add 'environment' choice input to publication workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,9 +1,16 @@
 name: 'RELEASE: Build release'
-run-name: "RELEASE: Build release${{ inputs.dry_run && ' (Dry run)' || '' }}"
+run-name: 'RELEASE: Build release to ${{inputs.environment}}'
 
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: Environment
+        required: true # For UI consistency with other required options
+        type: choice
+        options:
+          - test
+          - production
       release_type:
         description: 'Release type'
         required: true
@@ -17,12 +24,8 @@ on:
           - prepatch
           - prerelease
       preid:
-        description: 'Prerelease label (for ex. `internal`, `beta`, `rc`)'
+        description: "Prerelease label (for example: 'beta')"
         type: string
-      dry_run:
-        description: 'Dry run'
-        type: boolean
-        default: true
 
 permissions:
   contents: write
@@ -32,6 +35,7 @@ jobs:
   build-release:
     name: Build release
     runs-on: Ubuntu-22.04
+    environment: ${{ inputs.environment == 'production' && 'production' || null }}
 
     env:
       RELEASE_TYPE: ${{inputs.release_type}}
@@ -108,7 +112,7 @@ jobs:
           archive: false # Saves having to decompress the CHANGELOG
 
       - name: Create pull request
-        if: inputs.dry_run == false
+        if: inputs.environment == 'production'
         env:
           GH_TOKEN: ${{ secrets.CI_PAT }}
         run: |

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -1,18 +1,22 @@
 name: 'RELEASE: GitHub release'
-run-name: "RELEASE: GitHub release${{ inputs.dry_run && ' (Dry run)' || '' }}"
+run-name: 'RELEASE: GitHub release to ${{inputs.environment}}'
 
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        type: boolean
-        description: Dry run
-        default: true
+      environment:
+        description: Environment
+        required: true # For UI consistency with other required options
+        type: choice
+        options:
+          - test
+          - production
 
 jobs:
   publish-release-to-github:
     name: Publish release to GitHub
     runs-on: Ubuntu-22.04
+    environment: ${{ inputs.environment == 'production' && 'production' || null }}
     permissions:
       contents: write
     env:
@@ -85,7 +89,7 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub release
-        if: inputs.dry_run == false
+        if: inputs.environment == 'production'
         run: |
           GH_TAG=${{ steps.create-github-tag.outputs.GH_TAG }}
           RELEASE_NAME="GOV.UK Frontend $GH_TAG"

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,18 +1,22 @@
 name: 'RELEASE: npm publish'
-run-name: "RELEASE: npm publish${{ inputs.dry_run && ' (Dry run)' || '' }}"
+run-name: 'RELEASE: npm publish to ${{inputs.environment}}'
 
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        type: boolean
-        description: Dry run
-        default: true
+      environment:
+        description: Environment
+        required: true
+        type: choice
+        options:
+          - test
+          - production
 
 jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-22.04
+    environment: ${{ inputs.environment == 'production' && 'production' || null }}
     permissions:
       id-token: write
 
@@ -55,5 +59,5 @@ jobs:
           archive: false # file is already compressed
 
       - name: Publish to npm
-        if: inputs.dry_run == false
+        if: inputs.environment == 'production'
         run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}


### PR DESCRIPTION
In the workflows for the release, replace the 'Dry run' option with a choice for the environment to deploy to:
 * 'production' sets up the workflow to run against our [GitHub production environment](https://github.com/alphagov/govuk-frontend/settings/environments), enabling branch protections and asking for a review before running
 * 'test' creates a dry run of the action for when we need to make changes to the workflows.

See:
- https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idenvironment