### PR TITLE
Rename version script to get-version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -65,14 +65,14 @@ jobs:
         run: npm ci
 
       - name: Save current version
-        run: echo "PREVIOUS_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
+        run: echo "PREVIOUS_PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
 
       - name: Update package version
         run: |
           npm version --no-git-tag-version --workspace govuk-frontend "$RELEASE_TYPE" --preid "$PREID"
 
           # Save the new version number for access in future steps
-          echo "PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
 
       - name: Update CHANGELOG
         uses: actions/github-script@v9.0.0

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Create GitHub tag
         id: create-github-tag
         run: |
-          ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)
+          ALL_PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)
           TAG="v${ALL_PACKAGE_VERSION}"
 
           if [ $(git tag -l "$TAG") ]; then

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -30,7 +30,7 @@ npm run test
 npm run build:package
 npm run build:release
 
-ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)
+ALL_PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)
 TAG="v$ALL_PACKAGE_VERSION"
 CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -5,7 +5,7 @@ set -e
 HIGHEST_PUBLISHED_VERSION=$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')
 
 # Extract tag version from ./packages/govuk-frontend/package.json
-CURRENT_VERSION=$(npm run version --silent --workspace govuk-frontend)
+CURRENT_VERSION=$(npm run get-version --silent --workspace govuk-frontend)
 
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 

--- a/bin/publish-prerelease.sh
+++ b/bin/publish-prerelease.sh
@@ -50,7 +50,7 @@ npm publish "${NPM_ARGS[@]}"
 echo "🗒 Package published!"
 
 # Extract tag version from ./packages/govuk-frontend/package.json
-ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)
+ALL_PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)
 TAG="v$ALL_PACKAGE_VERSION"
 
 if [ $(git tag -l "$TAG") ]; then

--- a/bin/publish-preview.sh
+++ b/bin/publish-preview.sh
@@ -2,7 +2,7 @@
 set -e
 
 CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-CURRENT_VERSION=$(npm run version --silent --workspace govuk-frontend)
+CURRENT_VERSION=$(npm run get-version --silent --workspace govuk-frontend)
 
 BRANCH_NAME="preview-$CURRENT_BRANCH_NAME"
 # `/` are not valid in npm version numbers, so we turn them into `-`

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -58,7 +58,7 @@ Developers should pair on pre-releases. When working remotely, it can be useful 
 7. Create and check out a new branch (`release-[version]`)
 
    ```shell
-   git switch -c "release-$(npm run version --silent --workspace govuk-frontend)"
+   git switch -c "release-$(npm run get-version --silent --workspace govuk-frontend)"
    ```
 
 8. If you're publishing a beta pre-release, update the [`CHANGELOG.md`](/CHANGELOG.md) by:

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -63,7 +63,7 @@
     "clean:package": "del-cli *.tsbuildinfo dist govuk-prototype-kit.config.json",
     "clean:release": "del-cli ../../dist --force",
     "postbuild:package": "npm run build:stats && govuk-prototype-kit validate-plugin .",
-    "version": "echo $npm_package_version"
+    "get-version": "echo $npm_package_version"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
To avoid confusion with the in-built `npm version` script we want to rename this to something clearer what it's doing.

Closes https://github.com/alphagov/govuk-frontend/issues/7032