### PR TITLE
Add messaging for installing releases and warnings for non-stable releases

### DIFF
--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -16,10 +16,13 @@ const processingErrorMessage =
  *   in versions to build the changelog title
  */
 export function updateChangelog(newVersion, previousVersion) {
+  const validatedNewVersion = validateVersionNumber(newVersion)
+  const validatedPreviousVersion = validateVersionNumber(previousVersion)
+
   // Skip the entire function if the release version is internal eg: 5.1.0-internal.0
-  const newVersionIsAPrerelease = versionIsAPrerelease(newVersion)
+  const newVersionIsAPrerelease = versionIsAPrerelease(validatedNewVersion)
   if (newVersionIsAPrerelease) {
-    const identifier = getPrereleaseIdentifier(newVersion)
+    const identifier = getPrereleaseIdentifier(validatedNewVersion)
 
     if (identifier === 'internal') {
       console.log(
@@ -33,29 +36,25 @@ export function updateChangelog(newVersion, previousVersion) {
   const [startIndex, previousReleaseLineIndex] =
     getChangelogLineIndexes(changelogLines)
 
-  const versionDiff = semver.diff(
-    newVersion,
-    validatePreviousVersionNumber(previousVersion)
-  )
-
+  const versionDiff = semver.diff(validatedNewVersion, validatedPreviousVersion)
   if (!versionDiff) {
     throw new Error(processingErrorMessage)
   }
-  const newVersionTitle = `## v${newVersion} (${convertIncTypeWord(versionDiff, newVersion, true, changelogLines[previousReleaseLineIndex])} release)`
+  const newVersionTitle = `## v${validatedNewVersion} (${convertIncTypeWord(versionDiff, validatedNewVersion, true, changelogLines[previousReleaseLineIndex])} release)`
 
   const newLines = [newVersionTitle]
   if (newVersionIsAPrerelease) {
     newLines.push(
       `> [!WARNING]`,
       `> Do not use in production.`,
-      `> Use this release to prepare for the changes coming in version \`${removePrereleaseFlag(newVersion)}\`.`,
+      `> Use this release to prepare for the changes coming in version \`${removePrereleaseFlag(validatedNewVersion)}\`.`,
       ``
     )
   }
 
   // Add content on how to install the release
   newLines.push(
-    `To install this version with npm, run \`npm install govuk-frontend@${newVersion}\`. ` +
+    `To install this version with npm, run \`npm install govuk-frontend@${validatedNewVersion}\`. ` +
       `You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.`,
     ``
   )
@@ -110,22 +109,21 @@ export function generateReleaseNotes(newVersion, options) {
 }
 
 /**
- * Validates the previous govuk-frontend version number, presumed passed from
- * the govuk-frontend package.json
+ * Validates the version number that it is a semantic versioned string.
  *
- * @param {string} previousVersion - pervious version number
- * @returns {string} - Validated semver of previous version
+ * @param {string} version - version number
+ * @returns {string} - Validated semver of version
  */
-function validatePreviousVersionNumber(previousVersion) {
-  const previousReleaseNumber = semver.valid(previousVersion)
+function validateVersionNumber(version) {
+  const validatedVersion = semver.valid(version)
 
-  if (!previousReleaseNumber) {
+  if (!validatedVersion) {
     throw new Error(
-      `Previous version number ${previousVersion} could not be processed by Semver. Please ensure a valid version is being passed to the script via the govuk-frontend package.json package.`
+      `Version number "${version}" could not be parsed as a semantic versioned string.`
     )
   }
 
-  return previousReleaseNumber
+  return validatedVersion
 }
 
 /**

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -53,6 +53,13 @@ export function updateChangelog(newVersion, previousVersion) {
     )
   }
 
+  // Add content on how to install the release
+  newLines.push(
+    `To install this version with npm, run \`npm install govuk-frontend@${newVersion}\`. ` +
+      `You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.`,
+    ``
+  )
+
   // Inject the new lines into the CHANGELOG
   changelogLines.splice(startIndex + 1, 0, '', ...newLines)
 

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -17,7 +17,8 @@ const processingErrorMessage =
  */
 export function updateChangelog(newVersion, previousVersion) {
   // Skip the entire function if the release version is internal eg: 5.1.0-internal.0
-  if (versionIsAPrerelease(newVersion)) {
+  const newVersionIsAPrerelease = versionIsAPrerelease(newVersion)
+  if (newVersionIsAPrerelease) {
     const identifier = getPrereleaseIdentifier(newVersion)
 
     if (identifier === 'internal') {
@@ -42,7 +43,19 @@ export function updateChangelog(newVersion, previousVersion) {
   }
   const newVersionTitle = `## v${newVersion} (${convertIncTypeWord(versionDiff, newVersion, true, changelogLines[previousReleaseLineIndex])} release)`
 
-  changelogLines.splice(startIndex + 1, 0, '', newVersionTitle)
+  const newLines = [newVersionTitle]
+  if (newVersionIsAPrerelease) {
+    newLines.push(
+      `> [!WARNING]`,
+      `> Do not use in production.`,
+      `> Use this release to prepare for the changes coming in version \`${removePrereleaseFlag(newVersion)}\`.`,
+      ``
+    )
+  }
+
+  // Inject the new lines into the CHANGELOG
+  changelogLines.splice(startIndex + 1, 0, '', ...newLines)
+
   writeFileSync('./CHANGELOG.md', changelogLines.join('\n'))
 }
 
@@ -261,4 +274,16 @@ function convertIncTypeWord(
   return capitalise
     ? `${rewordedIncType.charAt(0).toUpperCase()}${rewordedIncType.slice(1)}`
     : rewordedIncType
+}
+
+/**
+ * Remove any pre-release flag from a version e.g. 1.0.0-alpha -> 1.0.0
+ *
+ * @param {string} version - version number
+ * @returns {string} - version number without any pre-release flag
+ */
+function removePrereleaseFlag(version) {
+  const parsedVersion = semver.parse(version)
+  parsedVersion.prerelease = []
+  return parsedVersion.format()
 }

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -1,5 +1,7 @@
 import fs from 'fs'
 
+import { outdent } from 'outdent'
+
 import {
   updateChangelog,
   generateReleaseNotes
@@ -52,6 +54,47 @@ describe('Changelog release helper', () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         './CHANGELOG.md',
         expect.stringContaining('## v3.1.0-beta.1 (Beta feature release)')
+      )
+    })
+
+    it('displays a warning to not use non-stable releases in production', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.1.0-beta.0 (Beta feature release)
+      `)
+
+      updateChangelog('3.1.0-beta.1', '3.1.0-beta.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining(outdent`
+          ## v3.1.0-beta.1 (Beta feature release)
+          > [!WARNING]
+          > Do not use in production.
+          > Use this release to prepare for the changes coming in version \`3.1.0\`.
+        `)
+      )
+    })
+
+    it('does not display a warning when the change is a stable release', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.1.0 (Feature release)
+      `)
+
+      updateChangelog('3.1.1', '3.1.0')
+      expect(fs.writeFileSync).not.toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining('> [!WARNING]')
       )
     })
 

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -132,6 +132,26 @@ describe('Changelog release helper', () => {
       )
       expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
+
+    it('throws an error if the newVersion is not a semantic version string', () => {
+      expect(() => {
+        updateChangelog('a.b.c', '3.0.0')
+      }).toThrow(
+        new Error(
+          'Version number "a.b.c" could not be parsed as a semantic versioned string.'
+        )
+      )
+    })
+
+    it('throws an error if the previousVersion is not a semantic version string', () => {
+      expect(() => {
+        updateChangelog('3.0.0', 'x.y.z')
+      }).toThrow(
+        new Error(
+          'Version number "x.y.z" could not be parsed as a semantic versioned string.'
+        )
+      )
+    })
   })
 
   describe('Generate release notes', () => {

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -78,6 +78,10 @@ describe('Changelog release helper', () => {
           > Use this release to prepare for the changes coming in version \`3.1.0\`.
         `)
       )
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining('To install this version with npm')
+      )
     })
 
     it('does not display a warning when the change is a stable release', () => {
@@ -95,6 +99,27 @@ describe('Changelog release helper', () => {
       expect(fs.writeFileSync).not.toHaveBeenCalledWith(
         './CHANGELOG.md',
         expect.stringContaining('> [!WARNING]')
+      )
+    })
+
+    it('has instructions for how to install the release', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.1.0 (Feature release)
+      `)
+
+      updateChangelog('3.1.1', '3.1.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining(outdent`
+            ## v3.1.1 (Fix release)
+            To install this version with npm, run \`npm install govuk-frontend@3.1.1\`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.
+        `)
       )
     })
 


### PR DESCRIPTION
Automatically add a messaging to our CHANGELOG and Release notes:
- to warn people not to put non-stable releases e.g. 6.2.0-beta.0 into production.
- explain how to install the release.


These are things that we manually put in normally but sometimes forget so having them injected automatically will hopefully help with consistency.

## Example test runs that show the output

Major release: https://github.com/alphagov/govuk-frontend/actions/runs/25795024792
Prerelease: https://github.com/alphagov/govuk-frontend/actions/runs/25795038466

Closes https://github.com/alphagov/govuk-frontend/issues/6672

Closes https://github.com/alphagov/govuk-frontend/issues/6355