### PR TITLE
Inject instructions for how to install the release to CHANGELOG

### DIFF
--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -48,9 +48,17 @@ export function updateChangelog(newVersion, previousVersion) {
     newLines.push(
       `> [!WARNING]`,
       `> Do not use in production.`,
-      `> Use this release to prepare for the changes coming in version \`${removePrereleaseFlag(newVersion)}\`.`
+      `> Use this release to prepare for the changes coming in version \`${removePrereleaseFlag(newVersion)}\`.`,
+      ` `
     )
   }
+
+  // Add content on how to install the release
+  newLines.push(
+    `To install this version with npm, run \`npm install govuk-frontend@${newVersion}\`. ` +
+      `You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.`,
+    ` `
+  )
 
   // Inject the new lines while replacing the unreleased heading.
   changelogLines.splice(startIndex + 1, 0, '', ...newLines)

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -78,6 +78,10 @@ describe('Changelog release helper', () => {
           > Use this release to prepare for the changes coming in version \`3.1.0\`.
         `)
       )
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining('To install this version with npm')
+      )
     })
 
     it('does not display a warning when the change is a stable release', () => {
@@ -95,6 +99,27 @@ describe('Changelog release helper', () => {
       expect(fs.writeFileSync).not.toHaveBeenCalledWith(
         './CHANGELOG.md',
         expect.stringContaining('> [!WARNING]')
+      )
+    })
+
+    it('has instructions for how to install the release', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.1.0 (Feature release)
+      `)
+
+      updateChangelog('3.1.1', '3.1.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining(outdent`
+            ## v3.1.1 (Fix release)
+            To install this version with npm, run \`npm install govuk-frontend@3.1.1\`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.
+        `)
       )
     })
 


### PR DESCRIPTION
Automatically adds content that we add to every release so we dont forget to add them.

See this in action here:
https://github.com/alphagov/govuk-frontend/actions/runs/25744280702

Closes https://github.com/alphagov/govuk-frontend/issues/6355