### PR TITLE
Create release on branch that Action is ran on

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -122,4 +122,4 @@ jobs:
           git commit -m "Release ${{ inputs.version }}"
           git checkout -b release-${{ inputs.version }}
           git push -u origin release-${{ inputs.version }}
-          gh pr create --base main --head release-${{ inputs.version }} --title "Release ${{ inputs.version }}" --body-file "release-notes-body"
+          gh pr create --base "${{ github.ref_name }}" --head release-${{ inputs.version }} --title "Release ${{ inputs.version }}" --body-file "release-notes-body"


### PR DESCRIPTION
Since we want to be able to run this on `main` and also `support/*`, change the base to be the one that action ran on.

> **github.ref_name** 
> The short ref name of the branch or tag that triggered the workflow run. 

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts

As part of https://github.com/alphagov/govuk-frontend/issues/5672