### PR TITLE
Remove bottom padding from campaign full page example

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/campaign-page.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/campaign-page.scss
@@ -1,7 +1,6 @@
 @use "pkg:govuk-frontend/base" as *;
 
 .app-header--campaign {
-  padding-bottom: govuk-spacing(2);
   border-bottom: $govuk-border-width-wide solid #fff500;
 }
 


### PR DESCRIPTION
A little tidy-up of some custom header spacing on the campaign full page example.

It looks like this was originally done to manage spacing between the old header and the bottom border that used to be part of that header. Not necessary now!

## Before

<img width="615" height="235" alt="Campaign header with extra bottom padding" src="https://github.com/user-attachments/assets/e81ec1e0-f108-4685-8870-790e1ca52832" />

## After

<img width="592" height="244" alt="Campaign header without extra bottom padding" src="https://github.com/user-attachments/assets/10ef6a98-ae21-4aa9-9cef-56d9318be2b8" />
