### PR TITLE
Add Generic Header component

### DIFF
--- a/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs
@@ -28,8 +28,11 @@ describe('Full page examples', () => {
       const $title = await page.$('title')
       const titleText = await getProperty($title, 'textContent')
 
-      // Check for matching title
-      expect(titleText).toBe(`${example.title} - GOV.UK`)
+      if (exampleName === 'non-govuk-service') {
+        expect(titleText).toBe(`${example.title}`)
+      } else {
+        expect(titleText).toBe(`${example.title} - GOV.UK`)
+      }
     }
   })
 })

--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -6,5 +6,6 @@
 @use "partials/component-preview";
 @use "partials/feature-flag-banner";
 @use "partials/links";
+@use "partials/non-govuk-service";
 @use "partials/organisation-swatch";
 @use "partials/prose";

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_non-govuk-service.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_non-govuk-service.scss
@@ -1,0 +1,7 @@
+@use "pkg:govuk-frontend/base" as *;
+
+// Resets the brand colour to our palette red.
+// Used by the "non-GOV.UK service" full page example.
+.app-template--hmpf {
+  --govuk-brand-colour: #{govuk-colour("red")};
+}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/non-govuk-service/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/non-govuk-service/index.njk
@@ -1,0 +1,62 @@
+---
+title: HM Pizza Finder
+name: non-GOV.UK service
+scenario: You want to sign in to the HM Pizza Finder service
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/generic-header/macro.njk" import govukGenericHeader %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set htmlClasses = "app-template--hmpf" %}
+
+{% block pageTitle %}HM Pizza Finder{% endblock %}
+
+{% set logoContent %}
+<svg width="28" height="30" viewBox="0 0 28 30" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="13.5549" cy="4.21349" r="4.21349"/>
+  <circle cx="13.5549" cy="25.7865" r="4.21349"/>
+  <circle cx="22.8963" cy="9.6068" r="4.21349"/>
+  <circle cx="4.2135" cy="20.3932" r="4.21349"/>
+  <circle cx="22.8963" cy="20.3932" r="4.21349"/>
+  <circle cx="4.21351" cy="9.60674" r="4.21349"/>
+</svg> | HM Pizza Finder service
+{% endset %}
+
+{% block govukHeader %}
+{{ govukGenericHeader({
+  url: "#",
+  logoHtml: logoContent
+}) }}
+{% endblock %}
+
+{% block headerEnd %}
+{{ govukPhaseBanner({
+  tag: {
+    text: 'Beta'
+  },
+  html: 'This is a new service'
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<h1 class="govuk-heading-xl">Welcome to the HM Pizza Finder service (HMPF)</h1>
+
+<h2 class="govuk-heading-l">Sign in to HMPF online services</h2>
+
+<p class="govuk-body">When logged in you can:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>find a nearby pizza</li>
+  <li>register a pizza</li>
+  <li>manage a pizza</li>
+  <li>locate an existing pizza</li>
+</ul>
+
+{{ govukButton({
+  text: "Sign in",
+  href: "#"
+}) }}
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -105,6 +105,10 @@ describe('GOV.UK Prototype Kit config', () => {
           macroName: 'govukFooter'
         },
         {
+          importFrom: 'govuk/components/generic-header/macro.njk',
+          macroName: 'govukGenericHeader'
+        },
+        {
           importFrom: 'govuk/components/header/macro.njk',
           macroName: 'govukHeader'
         },

--- a/packages/govuk-frontend/src/govuk/components/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/_index.import.scss
@@ -13,6 +13,7 @@
 @import "fieldset";
 @import "file-upload";
 @import "footer";
+@import "generic-header";
 @import "header";
 @import "hint";
 @import "input";

--- a/packages/govuk-frontend/src/govuk/components/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/_index.scss
@@ -13,6 +13,7 @@
 @use "fieldset";
 @use "file-upload";
 @use "footer";
+@use "generic-header";
 @use "header";
 @use "hint";
 @use "input";

--- a/packages/govuk-frontend/src/govuk/components/generic-header/README.md
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/README.md
@@ -1,0 +1,15 @@
+# Generic header
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and examples
+
+See the Design System website for more information on [how to use the Generic header component](https://design-system.service.gov.uk/components/generic-header) in your service.
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro (for example, to change the text).
+
+See the [options table](https://design-system.service.gov.uk/components/generic-header/#options-generic-header-example) for details.

--- a/packages/govuk-frontend/src/govuk/components/generic-header/_generic-header.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/_generic-header.import.scss
@@ -1,0 +1,5 @@
+@use "../../settings/warnings--internal";
+
+@include warnings--internal.component-scss-file-warning("generic-header");
+
+@import "index";

--- a/packages/govuk-frontend/src/govuk/components/generic-header/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/_index.import.scss
@@ -1,0 +1,7 @@
+@use "mixin";
+
+@import "../../base";
+
+@include govuk-exports("govuk/component/generic-header") {
+  @include mixin.styles;
+}

--- a/packages/govuk-frontend/src/govuk/components/generic-header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/_index.scss
@@ -1,0 +1,4 @@
+@use "../../custom-properties";
+@use "mixin";
+
+@include mixin.styles;

--- a/packages/govuk-frontend/src/govuk/components/generic-header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/_mixin.scss
@@ -1,0 +1,135 @@
+////
+/// @group components/generic-header
+////
+
+@use "../../base";
+
+/// Width of transparent bottom border of header.
+/// Set to provide a visual border in forced colour modes
+///
+/// @type Number
+/// @access private
+$header-forced-colour-border-width: 1px;
+
+/// Shared block header styles, with automatic background setting
+///
+/// @param {String} $background - background colour of header
+/// @access private
+@mixin block-styles($background: base.govuk-colour("black")) {
+  @include base.govuk-font($size: 16, $line-height: 1);
+
+  // Add a transparent bottom border for forced-colour modes
+  border-bottom: $header-forced-colour-border-width solid transparent;
+  color: base.govuk-colour("white");
+  background: $background;
+
+  @media print {
+    border-bottom-width: 0;
+    color: base.govuk-functional-colour(text);
+    background: transparent;
+  }
+}
+
+/// Shared header full width container styles
+///
+/// @access private
+@mixin full-width-container-styles() {
+  padding: 0 base.$govuk-gutter-half;
+}
+
+/// Shared header logo container element styles, with automating padding setting
+///
+/// @param {String} $padding-top - top padding of logo container
+/// @param {String} $padding-bottom - bottom padding of logo container
+/// @access private
+@mixin logo-styles(
+  $padding-top: (
+    base.govuk-spacing(3)
+  ),
+  $padding-bottom: (
+    base.govuk-spacing(3)
+  )
+) {
+  padding-top: $padding-top;
+  padding-bottom: $padding-bottom;
+}
+
+/// Shared header logo link element styles
+///
+/// @access private
+@mixin link-styles {
+  // Avoid using the `base.govuk-link-common` mixin because the links in the
+  // header get a special treatment, because:
+  //
+  // - underlines are only visible on hover
+  // - all links get a 3px underline regardless of text size, as there are
+  //   multiple grouped elements close to one another and having slightly
+  //   different underline widths looks unbalanced
+  //
+  // Font size needs to be set on the link so that the box sizing is correct
+  // in Firefox
+  display: inline;
+  margin-right: base.govuk-spacing(2);
+  font-size: 30px; // We don't have a mixin that produces 30px font size
+  text-decoration: none;
+
+  @include base.govuk-link-style-inverse;
+
+  &:link,
+  &:visited {
+    text-decoration: none;
+  }
+
+  &:hover,
+  &:active {
+    // Negate the added border
+    $link-underline-thickness: 3px;
+    margin-bottom: $link-underline-thickness * -1;
+    border-bottom: $link-underline-thickness solid;
+  }
+
+  &:focus {
+    // Remove any borders that show when focused and hovered.
+    margin-bottom: 0;
+    border-bottom: 0;
+
+    @include base.govuk-focused-text;
+  }
+
+  @media print {
+    &:link,
+    &:visited {
+      color: base.govuk-functional-colour(text);
+    }
+
+    // Do not append link href to GOV.UK link when printing (e.g. '(/)')
+    &::after {
+      content: "";
+    }
+  }
+}
+
+/// @access private
+@mixin styles {
+  .govuk-generic-header {
+    @include block-styles;
+  }
+
+  .govuk-generic-header__container--full-width {
+    @include full-width-container-styles;
+  }
+
+  .govuk-generic-header__logo {
+    @include logo-styles;
+  }
+
+  .govuk-generic-header__homepage-link {
+    @include link-styles;
+
+    // Automatically centre align direct child elements to help users with
+    // positioning their logo assets eg: as `svg`s or `img`s
+    > * {
+      vertical-align: top;
+    }
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/generic-header/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/accessibility.puppeteer.test.mjs
@@ -1,0 +1,15 @@
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
+import { getExamples } from '@govuk-frontend/lib/components'
+
+describe('/components/generic-header', () => {
+  describe('component examples', () => {
+    it('passes accessibility tests', async () => {
+      const examples = await getExamples('generic-header')
+
+      for (const exampleName in examples) {
+        await render(page, 'generic-header', examples[exampleName])
+        await expect(axe(page)).resolves.toHaveNoViolations()
+      }
+    }, 120000)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/generic-header/generic-header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/generic-header.yaml
@@ -1,0 +1,108 @@
+params:
+  - name: url
+    type: string
+    required: false
+    description: The URL of the logo link. Defaults to the root of the current web domain ("/").
+  - name: logoText
+    type: string
+    required: true
+    description: If `logoHtml` is set, this is not required. Text content for the logo section of the Generic header.
+  - name: logoHtml
+    type: string
+    required: true
+    description: If `logoText` is set, this is not required. HTML content for the logo section of the Generic header.
+  - name: containerClasses
+    type: string
+    required: false
+    description: Classes for the container. Useful if you want to make the Generic header fixed width.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the Generic header container.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example, data attributes) to add to the Generic header container.
+
+previewLayout: full-width
+accessibilityCriteria: |
+  Text and links in the Generic header must:
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+  Links in the Generic header must:
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when they have focus
+  - change in appearance when touched (in the touch-down state)
+  - change in appearance when hovered
+  - have visible text
+
+  Images in the Generic header must:
+  - be presentational when linked to from accompanying text
+
+examples:
+  - name: default
+    screenshot: true
+    options:
+      logoText: My cool service
+
+  - name: with image logo
+    options:
+      logoHtml: |
+        <svg width="28" height="30" viewBox="0 0 28 30" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <title>HM Pizza Finder service</title>
+        <circle cx="13.5549" cy="4.21349" r="4.21349"/>
+        <circle cx="13.5549" cy="25.7865" r="4.21349"/>
+        <circle cx="22.8963" cy="9.6068" r="4.21349"/>
+        <circle cx="4.2135" cy="20.3932" r="4.21349"/>
+        <circle cx="22.8963" cy="20.3932" r="4.21349"/>
+        <circle cx="4.21351" cy="9.60674" r="4.21349"/>
+        </svg>
+
+  - name: with text and image logo
+    screenshot: true
+    options:
+      logoHtml: |
+        <svg width="28" height="30" viewBox="0 0 28 30" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <title>HM Pizza Finder service</title>
+        <circle cx="13.5549" cy="4.21349" r="4.21349"/>
+        <circle cx="13.5549" cy="25.7865" r="4.21349"/>
+        <circle cx="22.8963" cy="9.6068" r="4.21349"/>
+        <circle cx="4.2135" cy="20.3932" r="4.21349"/>
+        <circle cx="22.8963" cy="20.3932" r="4.21349"/>
+        <circle cx="4.21351" cy="9.60674" r="4.21349"/>
+        </svg> | HM Pizza Finder service
+
+  - name: full width
+    options:
+      containerClasses: govuk-generic-header__container--full-width
+      logoHtml: |
+        <svg width="28" height="30" viewBox="0 0 28 30" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <title>HM Pizza Finder service</title>
+        <circle cx="13.5549" cy="4.21349" r="4.21349"/>
+        <circle cx="13.5549" cy="25.7865" r="4.21349"/>
+        <circle cx="22.8963" cy="9.6068" r="4.21349"/>
+        <circle cx="4.2135" cy="20.3932" r="4.21349"/>
+        <circle cx="22.8963" cy="20.3932" r="4.21349"/>
+        <circle cx="4.21351" cy="9.60674" r="4.21349"/>
+        </svg> | HM Pizza Finder service
+
+  # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: attributes
+    hidden: true
+    options:
+      logoText: Some logo text
+      attributes:
+        data-test-attribute: value
+        data-test-attribute-2: value-2
+  - name: classes
+    hidden: true
+    options:
+      logoText: Some logo text
+      classes: app-header--custom-modifier
+  - name: custom url
+    hidden: true
+    options:
+      logoText: Some logo text
+      url: 'https://www.pizza.gov.uk'

--- a/packages/govuk-frontend/src/govuk/components/generic-header/macro.njk
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukGenericHeader(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/govuk-frontend/src/govuk/components/generic-header/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/template.jsdom.test.js
@@ -1,0 +1,72 @@
+const { getExamples, render } = require('@govuk-frontend/lib/components')
+
+describe('generic header', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('generic-header')
+  })
+
+  describe('custom options', () => {
+    it('renders attributes correctly', () => {
+      document.body.innerHTML = render('generic-header', examples.attributes)
+
+      const $component = document.querySelector('.govuk-generic-header')
+      expect($component).toHaveAttribute('data-test-attribute', 'value')
+      expect($component).toHaveAttribute('data-test-attribute-2', 'value-2')
+    })
+
+    it('renders classes', () => {
+      document.body.innerHTML = render('generic-header', examples.classes)
+
+      const $component = document.querySelector('.govuk-generic-header')
+      expect($component).toHaveClass('app-header--custom-modifier')
+    })
+
+    it('renders custom container classes', () => {
+      document.body.innerHTML = render('generic-header', examples['full width'])
+
+      const $container = document.querySelector(
+        '.govuk-generic-header__container'
+      )
+
+      expect($container).toHaveClass(
+        'govuk-generic-header__container--full-width'
+      )
+    })
+
+    it('renders URL', () => {
+      document.body.innerHTML = render('generic-header', examples['custom url'])
+
+      const $homepageLink = document.querySelector(
+        '.govuk-generic-header__homepage-link'
+      )
+      expect($homepageLink).toHaveAttribute('href', 'https://www.pizza.gov.uk')
+    })
+  })
+
+  describe('with logo', () => {
+    it('renders text logo content', () => {
+      document.body.innerHTML = render('generic-header', examples.default)
+
+      const $logoLink = document.querySelector(
+        '.govuk-generic-header__homepage-link'
+      )
+
+      expect($logoLink).toHaveTextContent('My cool service')
+    })
+
+    it('renders text logo content', () => {
+      document.body.innerHTML = render(
+        'generic-header',
+        examples['with image logo']
+      )
+
+      const $logoSvg = document.querySelector(
+        '.govuk-generic-header__homepage-link svg'
+      )
+
+      expect($logoSvg).toBeTruthy()
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/generic-header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/template.njk
@@ -1,0 +1,14 @@
+{% from "../../macros/attributes.njk" import govukAttributes -%}
+{# _namespace is a private macro option which allows the generic header macro
+to also be used by the 'main' header #}
+{% set namespace = params._namespace | default("govuk-generic") %}
+
+<div class="{{ namespace }}-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
+  <div class="{{ namespace }}-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
+    <div class="{{ namespace }}-header__logo">
+      <a href="{{ params.url | default("/", true) }}" class="{{ namespace }}-header__homepage-link">
+        {{ params.logoHtml | safe if params.logoHtml else params.logoText }}
+      </a>
+    </div>
+  </div>
+</div>

--- a/packages/govuk-frontend/src/govuk/components/header/README.md
+++ b/packages/govuk-frontend/src/govuk/components/header/README.md
@@ -1,4 +1,4 @@
-# Header
+# GOV.UK Header
 
 ## Installation
 

--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -1,73 +1,32 @@
 @use "../../base";
+@use "../generic-header/mixin" as genericHeader;
 
 /// @access private
 @mixin styles {
   $logo-bottom-margin: 2px;
 
   .govuk-header {
-    @include base.govuk-font($size: 16, $line-height: 1);
-
-    // Add a transparent bottom border for forced-colour modes
-    border-bottom: 1px solid transparent;
-    color: base.govuk-colour("white");
-    background: base.govuk-functional-colour(brand);
+    @include genericHeader.block-styles($background: base.govuk-functional-colour("brand"));
   }
 
   .govuk-header__container--full-width {
-    padding: 0 base.govuk-spacing(3);
+    @include genericHeader.full-width-container-styles;
   }
 
   .govuk-header__logo {
-    box-sizing: border-box;
-
     // Magic numbers, set padding to vertically centre align the logo
-    padding-top: 16px;
-    padding-bottom: 14px - $logo-bottom-margin;
+    @include genericHeader.logo-styles($padding-top: 16px, $padding-bottom: 14px - $logo-bottom-margin);
   }
 
   .govuk-header__homepage-link {
-    // Avoid using the `base.govuk-link-common` mixin because the links in the
-    // header get a special treatment, because:
-    //
-    // - underlines are only visible on hover
-    // - all links get a 3px underline regardless of text size, as there are
-    //   multiple grouped elements close to one another and having slightly
-    //   different underline widths looks unbalanced
-    //
-    // Font size needs to be set on the link so that the box sizing is correct
-    // in Firefox
-    display: inline;
-    margin-right: base.govuk-spacing(2);
-    font-size: 30px; // We don't have a mixin that produces 30px font size
-    text-decoration: none;
+    @include genericHeader.link-styles;
+
     // Remove word-spacing from within the logo so we can ignore
     // whitespace characters in the HTML
     word-spacing: base.govuk-px-to-rem(-6px);
     // Reset word-spacing for child elements
     > * {
       word-spacing: 0;
-    }
-    @include base.govuk-link-style-inverse;
-
-    &:link,
-    &:visited {
-      text-decoration: none;
-    }
-
-    &:hover,
-    &:active {
-      // Negate the added border
-      $link-underline-thickness: 3px;
-      margin-bottom: $link-underline-thickness * -1;
-      border-bottom: $link-underline-thickness solid;
-    }
-
-    &:focus {
-      // Remove any borders that show when focused and hovered.
-      margin-bottom: 0;
-      border-bottom: 0;
-
-      @include base.govuk-focused-text;
     }
   }
 
@@ -146,24 +105,6 @@
   }
 
   @media print {
-    .govuk-header {
-      border-bottom-width: 0;
-      color: base.govuk-colour("black");
-      background: transparent;
-    }
-
-    .govuk-header__homepage-link {
-      &:link,
-      &:visited {
-        color: base.govuk-colour("black");
-      }
-
-      // Do not append link href to GOV.UK link when printing (e.g. '(/)')
-      &::after {
-        display: none;
-      }
-    }
-
     .govuk-header__product-name {
       // Fix product name alignment in Firefox when printing
       @-moz-document url-prefix() {

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -1,20 +1,23 @@
-{% from "../../macros/attributes.njk" import govukAttributes -%}
+{% from "../generic-header/macro.njk" import govukGenericHeader -%}
 {% from "../../macros/logo.njk" import govukLogo -%}
 
-<div class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }}>
-  <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
-    <div class="govuk-header__logo">
-      <a href="{{ params.homepageUrl | default("//gov.uk", true) }}" class="govuk-header__homepage-link">
-        {{ govukLogo({
-          classes: "govuk-header__logotype",
-          ariaLabelText: "GOV.UK"
-        }) | trim | indent(8) }}
-        {% if (params.productName) %}
-        <span class="govuk-header__product-name">
-          {{- params.productName -}}
-        </span>
-        {% endif %}
-      </a>
-    </div>
-  </div>
-</div>
+{% set logoContent %}
+  {{ govukLogo({
+    classes: "govuk-header__logotype",
+    ariaLabelText: "GOV.UK"
+  }) | trim | indent(8) }}
+  {%- if (params.productName) %}
+    <span class="govuk-header__product-name">
+      {{- params.productName -}}
+    </span>
+  {% endif -%}
+{% endset %}
+
+{{ govukGenericHeader({
+  _namespace: 'govuk',
+  logoHtml: logoContent,
+  url: params.homepageUrl | default("//gov.uk", true),
+  containerClasses: params.containerClasses,
+  classes: params.classes,
+  attributes: params.attributes
+}) }}


### PR DESCRIPTION
> [!NOTE]
> This PR is ready for review but should not be merged until we've written guidance

## Change

Adds a new component: the Generic Header; a stripped back version of the GOV.UK Header for use by GOV.UK-adjacent services.

As well as adding the component, this PR changes the scaffolding of the GOV.UK Header to consume the styling and markup of the Generic Header so that both components share how they're constructed whilst continuing to be separate. Specifically:

- the Generic Header includes 3 mixins which the GOV.UK Header builds upon
  - `genericHeader.block-styles` for the root block
  - `genericHeader.full-width-container-styles` for the full width container modifier
  - `genericHeader.logo-styles` for logo area padding and `box-sizing: border-box`
  - `genericHeader.link-styles` for the logo link state styling ie: hover and focus
- the GOV.UK Header calls the Generic Header nunjucks macro with specific modifications like the default gov.uk homepage URL and the addition of the product name

Closes https://github.com/alphagov/govuk-frontend/issues/7057

## Notes

This PR doesn't have a changelog because we're going to handle it holistically as part of https://github.com/alphagov/govuk-frontend/issues/7162

The Generic header uses rounded 15px top and bottom padding, as opposed to the GOV.UK Header's magic numbers, to give users some padding to work with rather than no spacing at all. The plan is to recommend in guidance to adjust the spacing via [component extension](https://design-system.service.gov.uk/get-started/extending-and-modifying-components/) if they need to for their logos and domain/service names.

This PR also ties the spacing for the full width container modifier to `$govuk-gutter-half`. This applies to both the Generic header and the GOV.UK header. I don't think this is an especially controversial choice, since at full width you'd expect the header's spacing to follow the spacing of the template. 

I've removed the `word-spacing` rule from the Generic Header link element (and added it back in for the GOV.UK Header) which removes spacing from the root of the link element to help with spacing because I was finding for the Generic Header that it would mean users couldn't put text straight into the component's `logo` param. It's not clear to me if we should keep this for everything and ensure users are using child elements when adding logo html to the Generic Header.

Whilst the test suites of both headers now look very similar, I think it makes sense to keep them as they are to make sure that their different contexts aren't resulting in unexpected behaviours.