### PR TITLE
Align publish config with recommendations

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # never use caching in release builds
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment == 'production' && 'production' || null }}
     permissions:
-      id-token: write
+      id-token: write # Used when [generating provenance statements](https://docs.npmjs.com/generating-provenance-statements)
 
     steps:
       - name: Checkout
@@ -59,6 +59,7 @@ jobs:
           path: ${{steps.pack.outputs.ARCHIVE_FILE_PATH}}
           archive: false # file is already compressed
 
+      # Publish the package using [trusted-publishing](https://docs.npmjs.com/trusted-publishers)
       - name: Publish to npm
         if: inputs.environment == 'production'
         run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -62,4 +62,4 @@ jobs:
       # Publish the package using [trusted-publishing](https://docs.npmjs.com/trusted-publishers)
       - name: Publish to npm
         if: inputs.environment == 'production'
-        run: npm publish --workspace govuk-frontend --provenance --tag ${{steps.generate_tag.outputs.NPM_TAG}}
+        run: npm publish --workspace govuk-frontend --tag ${{steps.generate_tag.outputs.NPM_TAG}}


### PR DESCRIPTION
When reviewing the [documentation for trusted publishing](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow) I noticed a few differences in our implementation.

These changes bring it more inline with their recommendations.

There is a suggestion that the automatic provenance generation is more secure as well.

> Note: If you use trusted publishing, provenance attestations are automatically generated for your packages without requiring the --provenance flag.
> This provides enhanced security and eliminates the need for access tokens in your CI/CD workflows.
From: https://docs.npmjs.com/generating-provenance-statements

Example GitHub action mode run in test environment:
https://github.com/alphagov/govuk-frontend/actions/runs/26032075841

As part of https://github.com/alphagov/govuk-frontend/issues/6676