### PR TITLE
Output errors to workflow summary

### DIFF
--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          fetch-tags: true
 
       - name: Setup Node
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -46,7 +46,7 @@ jobs:
           TAG="v${ALL_PACKAGE_VERSION}"
 
           if [ $(git tag -l "$TAG") ]; then
-            echo "⚠️ Tag $TAG already exists. Please delete $TAG via the GitHub UI and re-run this workflow"
+            echo "::error::Tag $TAG already exists. Please delete $TAG via the GitHub UI and re-run this workflow"
             exit 1
           else
             echo "🗒 Tagging repo using tag version: $TAG ..."
@@ -97,7 +97,7 @@ jobs:
           ARCHIVE_FILE_PATH="${{steps.archive.outputs.ARCHIVE_FILE_PATH}}"
 
           if gh release view "$GH_TAG" > /dev/null 2>&1; then
-            echo "⚠️ Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+            echo "::error::Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
             exit 1
           else
             gh release create "$GH_TAG" "$ARCHIVE_FILE_PATH" --title "${RELEASE_NAME}" --notes "$RELEASE_BODY"


### PR DESCRIPTION
To increase visibility we want to surface any errors that stop the workflow at the top level GitHub Action summary

Example run: https://github.com/alphagov/govuk-frontend/actions/runs/26035482657


> \# Whether to fetch tags, even if fetch-depth > 0.
> \# Default: false
>    fetch-tags: ''
https://github.com/actions/checkout#usage

As part of: https://github.com/alphagov/govuk-frontend/issues/6676