### PR TITLE
Add production environment to release workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,7 @@ jobs:
   build-release:
     name: Build release
     runs-on: Ubuntu-22.04
+    environment: production
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -7,6 +7,7 @@ jobs:
   publish-release-to-github:
     name: Publish release to GitHub
     runs-on: Ubuntu-22.04
+    environment: production
     permissions:
       contents: write
     env:

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -7,6 +7,7 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-22.04
+    environment: production
     permissions:
       id-token: write
 


### PR DESCRIPTION
In the main branch we now specify the environment we want to run the workflow on to improve security.

Since the 5.x support branch does not have any other improvements the only requirement here is to ensure they actions always run in production, this'll mean the existing documentation on this support branch will still make sense.

Originally added in main as 12f1320636c87efbeaecb3380854070b28cb3845

Closes https://github.com/alphagov/govuk-frontend/issues/7039