### PR TITLE
Update CHANGELOG entry when `npm version` is ran instead of only through GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Update package version and CHANGELOG
         run: |
           npm version --no-git-tag-version --workspace govuk-frontend "$RELEASE_TYPE" --preid "$PREID"
+          # After `npm version` runs, the `postversion` lifecycle hook script from the govuk-frontend package
+          # will be run which then updates the CHANGELOG.
 
           # Save the new version number for access in future steps
           echo "PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)" >> $GITHUB_ENV

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,23 +64,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Save current version
-        run: echo "PREVIOUS_PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
-
-      - name: Update package version
+      - name: Update package version and CHANGELOG
         run: |
           npm version --no-git-tag-version --workspace govuk-frontend "$RELEASE_TYPE" --preid "$PREID"
 
           # Save the new version number for access in future steps
           echo "PACKAGE_VERSION=$(npm run get-version --silent --workspace govuk-frontend)" >> $GITHUB_ENV
-
-      - name: Update CHANGELOG
-        uses: actions/github-script@v9.0.0
-        with:
-          script: |
-            const { updateChangelog } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
-
-            updateChangelog(process.env.PACKAGE_VERSION, process.env.PREVIOUS_PACKAGE_VERSION)
 
       - name: Generate release notes
         uses: actions/github-script@v9.0.0

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.mjs"],
+  "exclude": ["**/*.test.*"],
+  "compilerOptions": {
+    "strictNullChecks": false,
+    "types": ["node"]
+  }
+}

--- a/bin/update-changelog.mjs
+++ b/bin/update-changelog.mjs
@@ -1,0 +1,16 @@
+import { updateChangelog } from '../shared/github-scripts/changelog-release-helper.mjs'
+
+// npm exposes these environment variable as part of the lifecycle hooks
+// (https://github.com/npm/cli/blob/c97b39b1e3436cd20a67ab5f4012a5f395c538b9/workspaces/libnpmversion/lib/version.js#L100-L103)
+const { npm_old_version: previousVersion, npm_new_version: newVersion } =
+  process.env
+
+if (!previousVersion || !newVersion) {
+  throw new Error('Both previous and new version must be set to continue.')
+}
+
+console.log(
+  `Updating changelog from version ${previousVersion} to ${newVersion}...`
+)
+
+updateChangelog(newVersion, previousVersion)

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -63,6 +63,7 @@
     "clean:package": "del-cli *.tsbuildinfo dist govuk-prototype-kit.config.json",
     "clean:release": "del-cli ../../dist --force",
     "postbuild:package": "npm run build:stats && govuk-prototype-kit validate-plugin .",
+    "postversion": "node ../../bin/update-changelog.mjs",
     "get-version": "echo $npm_package_version"
   },
   "devDependencies": {

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -1,6 +1,10 @@
 import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
 
+import { paths } from '@govuk-frontend/config'
 import semver from 'semver'
+
+const CHANGELOG_FILE_PATH = join(paths.root, 'CHANGELOG.md')
 
 const processingErrorMessage =
   'There was a problem processing information from the changelog. This likely means that there is an issue with the changelog content itself. Please check it and try running this task again.'
@@ -62,7 +66,7 @@ export function updateChangelog(newVersion, previousVersion) {
   // Inject the new lines into the CHANGELOG
   changelogLines.splice(startIndex + 1, 0, '', ...newLines)
 
-  writeFileSync('./CHANGELOG.md', changelogLines.join('\n'))
+  writeFileSync(CHANGELOG_FILE_PATH, changelogLines.join('\n'))
 }
 
 /**
@@ -132,7 +136,7 @@ function validateVersionNumber(version) {
  * @returns {Array<string>} - Changelog split into an array by lines
  */
 function getChangelogLines() {
-  return readFileSync('./CHANGELOG.md', 'utf8').split('\n')
+  return readFileSync(CHANGELOG_FILE_PATH, 'utf8').split('\n')
 }
 
 /**

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -1,5 +1,7 @@
 import fs from 'fs'
+import { join } from 'path'
 
+import { paths } from '@govuk-frontend/config'
 import { outdent } from 'outdent'
 
 import {
@@ -8,6 +10,8 @@ import {
 } from './changelog-release-helper.mjs'
 
 jest.mock('fs')
+
+const CHANGELOG_FILE_PATH = join(paths.root, 'CHANGELOG.md')
 
 describe('Changelog release helper', () => {
   beforeEach(() => {
@@ -26,7 +30,7 @@ describe('Changelog release helper', () => {
     it('adds a new heading to the changelog for the new version', () => {
       updateChangelog('3.1.0', '3.0.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining('## v3.1.0 (Feature release)')
       )
     })
@@ -34,7 +38,7 @@ describe('Changelog release helper', () => {
     it('prefixes a new heading with a pre-release identifier if the new version is a pre-release', () => {
       updateChangelog('3.1.0-beta.0', '3.0.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining('## v3.1.0-beta.0 (Beta feature release)')
       )
     })
@@ -52,7 +56,7 @@ describe('Changelog release helper', () => {
 
       updateChangelog('3.1.0-beta.1', '3.1.0-beta.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining('## v3.1.0-beta.1 (Beta feature release)')
       )
     })
@@ -70,7 +74,7 @@ describe('Changelog release helper', () => {
 
       updateChangelog('3.1.0-beta.1', '3.1.0-beta.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining(outdent`
           ## v3.1.0-beta.1 (Beta feature release)
           > [!WARNING]
@@ -79,7 +83,7 @@ describe('Changelog release helper', () => {
         `)
       )
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining('To install this version with npm')
       )
     })
@@ -97,7 +101,7 @@ describe('Changelog release helper', () => {
 
       updateChangelog('3.1.1', '3.1.0')
       expect(fs.writeFileSync).not.toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining('> [!WARNING]')
       )
     })
@@ -115,7 +119,7 @@ describe('Changelog release helper', () => {
 
       updateChangelog('3.1.1', '3.1.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        './CHANGELOG.md',
+        CHANGELOG_FILE_PATH,
         expect.stringContaining(outdent`
             ## v3.1.1 (Fix release)
             To install this version with npm, run \`npm install govuk-frontend@3.1.1\`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/shared/github-scripts/package.json
+++ b/shared/github-scripts/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@govuk-frontend/config": "*",
     "@govuk-frontend/lib": "*",
     "@govuk-frontend/stats": "*",
     "outdent": "^0.8.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "./tsconfig.dev.json"
     },
     {
+      "path": "./bin/tsconfig.json"
+    },
+    {
       "path": "./packages/govuk-frontend-review/tsconfig.json"
     },
     {


### PR DESCRIPTION
Update the CHANGELOG entry using the "postversion" lifecycle hook which will execute after the `npm version` is completed.

> If preversion, version, or postversion are in the scripts property of the package.json, they will be executed as part of running npm version.
> The exact order of execution is as follows:
> 1. Check to make sure the git working directory is clean before we get started. Your scripts may add files to the commit in future steps. This step is skipped if the --force flag is set.
> 2. Run the preversion script. These scripts have access to the old version in package.json. A typical use would be running your full test suite before deploying. Any files you want added to the commit should be explicitly added using git add.
> 3. Bump version in package.json as requested (patch, minor, major, etc).
> 4. Run the version script. These scripts have access to the new version in package.json (so they can incorporate it into file headers in generated files for example). Again, scripts should explicitly add generated files to the commit using git add.
> 5. Commit and tag.
> **6. Run the postversion script. Use it to clean up the file system or automatically push the commit and/or tag.**

https://docs.npmjs.com/cli/v11/commands/npm-version#description

Uses undocumented environment variables to get both the old and new
versions:
https://github.com/npm/cli/blob/c97b39b1e3436cd20a67ab5f4012a5f395c538b9/workspaces/libnpmversion/lib/version.js#L100-L103

Closes https://github.com/alphagov/govuk-frontend/issues/7033
