### PR TITLE
docs: fix commited -> committed typo in publish-preview.sh comment

### DIFF
--- a/bin/publish-preview.sh
+++ b/bin/publish-preview.sh
@@ -9,7 +9,7 @@ BRANCH_NAME="preview-$CURRENT_BRANCH_NAME"
 # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
 VERSION="$CURRENT_VERSION-${CURRENT_BRANCH_NAME/\//-}"
 
-# Check if there are files that need to be commited
+# Check if there are files that need to be committed
 if [[ -n $(git status --porcelain) ]]; then
   echo "⚠️ You have unstaged files, please commit these and then try again."
   exit 1


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a typo (`commited` → `committed`) in a comment in `bin/publish-preview.sh`. No runtime change — this is purely a shell-script comment.

## Why

Trivial copy-edit; consistent with prior typo-fix PRs in this repo (e.g. [#7041](https://github.com/alphagov/govuk-frontend/pull/7041), [#6555](https://github.com/alphagov/govuk-frontend/pull/6555)).

## How verified

Comment-only change inside a shell script that is not executed in this PR. Verified the script still parses with `bash -n bin/publish-preview.sh` locally.

## Maintainer note

Happy for this to be closed if you prefer not to take agent-authored changes — completely understand.
