### PR TITLE
Fix percy screenshots running in Ubuntu 24

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -98,4 +98,6 @@ jobs:
 
       - name: Send screenshots to Percy
         if: steps.changes.outputs.relevant_changes == 'true'
-        run: npx --workspace @govuk-frontend/review percy exec -- npm run test:screenshots
+        # Ubuntu requires a profile for developer builds of Chrome to run without errors.
+        # (https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md)
+        run: aa-exec --profile=chrome npx --workspace @govuk-frontend/review percy exec -- npm run test:screenshots


### PR DESCRIPTION
Ubuntu requires a profile for developer builds of Chrome to run without errors. (https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md)

This was not found in the previous work (https://github.com/alphagov/govuk-frontend/pull/7037) as it only runs conditionally.