### PR TITLE
Remove choice of environment for building the release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,13 +4,6 @@ run-name: 'RELEASE: Build release to ${{inputs.environment}}'
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: Environment
-        required: true # For UI consistency with other required options
-        type: choice
-        options:
-          - test
-          - production
       release_type:
         description: 'Release type'
         required: true
@@ -35,7 +28,6 @@ jobs:
   build-release:
     name: Build release
     runs-on: ubuntu-24.04
-    environment: ${{ inputs.environment == 'production' && 'production' || null }}
 
     env:
       RELEASE_TYPE: ${{inputs.release_type}}
@@ -103,7 +95,6 @@ jobs:
           archive: false # Saves having to decompress the CHANGELOG
 
       - name: Create pull request
-        if: inputs.environment == 'production'
         env:
           GH_TOKEN: ${{ secrets.CI_PAT }}
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,5 @@
 name: 'RELEASE: Build release'
-run-name: 'RELEASE: Build release to ${{inputs.environment}}'
+run-name: "RELEASE: Build release (${{ join(inputs.*, ', ') }})"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
All the workflow does is raise a PR, which we can easily close. Not relying on running against the `production` environment also allows us to run the actual `git` and `gh` commands creating the PR to verify everything is working OK.

As we're removing the `to ${{ inputs.environment }}` from the title, took the opportunity to display the chosen inputs in the title. See the following runs for examples with:
- [both inputs configured](https://github.com/alphagov/govuk-frontend/actions/runs/26453916596)
- [only the release type configured](https://github.com/alphagov/govuk-frontend/actions/runs/26453890868)

Fixes #7092 