### PR TITLE
Fix Git author's email in CI workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -94,6 +94,11 @@ jobs:
           path: CHANGELOG.md
           archive: false # Saves having to decompress the CHANGELOG
 
+      - name: Configure Git
+        run: |
+          git config --global user.name '${{ github.actor }}'
+          git config --global user.email '${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com'
+
       - name: Create pull request
         env:
           GH_TOKEN: ${{ secrets.CI_PAT }}
@@ -101,8 +106,6 @@ jobs:
           RELEASE_BRANCH_NAME="release-$PACKAGE_VERSION"
           RELEASE_TITLE="Release $PACKAGE_VERSION"
 
-          git config --global user.name '${{ github.actor }}'
-          git config --global user.email '${{ github.actor }}@digital.cabinet-office.gov.uk'
           git add .
           git commit -m "$RELEASE_TITLE"
           git checkout -b "$RELEASE_BRANCH_NAME"

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -36,10 +36,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set up Git
+      - name: Configure Git
         run: |
-          git config user.name '${{ github.actor }}'
-          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git config --global user.name '${{ github.actor }}'
+          git config --global user.email '${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com'
 
       - name: Create GitHub tag
         id: create-github-tag


### PR DESCRIPTION
Use the proper noreply URL for the person that triggered the workflow, including both the `actor_id` and their username.

See [this PR](https://github.com/alphagov/govuk-frontend/pull/7102/commits) for an example of commit properly associated to the person that launched the action.

Fixes #7091 