### PR TITLE
Add integration tests simulating libaries including GOV.UK Frontend

### DIFF
--- a/tests/sass-tests/helpers/sass.js
+++ b/tests/sass-tests/helpers/sass.js
@@ -1,9 +1,11 @@
+const { resolve } = require('node:path')
+
 const { paths } = require('@govuk-frontend/config')
 const { NodePackageImporter, compileStringAsync } = require('sass-embedded')
 
 /** @type {import('sass-embedded').StringOptions<"async">} */
 const sassConfig = {
-  loadPaths: [paths.root, __dirname],
+  loadPaths: [paths.root, resolve(__dirname, '..')],
   quietDeps: true,
   silenceDeprecations: ['import', 'mixed-decls'],
   importers: [new NodePackageImporter()]

--- a/tests/sass-tests/libaries.integration.test.mjs
+++ b/tests/sass-tests/libaries.integration.test.mjs
@@ -80,4 +80,58 @@ describe('libraries', () => {
       })
     })
   })
+
+  describe('if the library `@use`s GOV.UK Frontend', () => {
+    describe('without configuration', () => {
+      let css
+
+      beforeAll(async () => {
+        const sass = `
+          @use 'pkg:govuk-frontend';
+          @use 'libraries/with-use';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('outputs the CSS of GOV.UK Frontend only once', async () => {
+        expect(css.match(/govuk-visually-hidden/)).toHaveLength(1)
+      })
+
+      it('applied the default GOV.UK Frontend configuration to the library', async () => {
+        expect(css).toContain(
+          '--with-use-colour: var(--govuk-brand-colour, #1d70b8)'
+        )
+        expect(css).toContain(
+          '--with-use-icon: url("/assets/images/home-icon.svg")'
+        )
+      })
+    })
+
+    describe('with configuration', () => {
+      let css
+
+      beforeAll(async () => {
+        const sass = `
+          @use "sass:meta";
+          @use 'pkg:@govuk-frontend/helpers/assets-urls';
+          @use 'pkg:govuk-frontend' with (
+            $govuk-functional-colours: (brand: hotpink),
+            $govuk-image-url-function: meta.get-function('images-url', $module: 'assets-urls')
+          );
+          @use 'libraries/with-use';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('applies configuration to both GOV.UK Frontend and the library', async () => {
+        expect(css).toContain('--govuk-brand-colour: hotpink')
+        expect(css).toContain(
+          '--with-use-colour: var(--govuk-brand-colour, hotpink)'
+        )
+        expect(css).toContain('--with-use-icon: url("example.svg")')
+      })
+    })
+  })
 })

--- a/tests/sass-tests/libaries.integration.test.mjs
+++ b/tests/sass-tests/libaries.integration.test.mjs
@@ -134,4 +134,68 @@ describe('libraries', () => {
       })
     })
   })
+
+  describe('if a library `@forward`s GOV.UK Frontend and another `@use`s it', () => {
+    describe('without configuration', () => {
+      let css
+
+      beforeAll(async () => {
+        const sass = `
+          @use 'libraries/with-forward';
+          @use 'libraries/with-use';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('outputs the CSS of GOV.UK Frontend only once', async () => {
+        expect(css.match(/govuk-visually-hidden/)).toHaveLength(1)
+      })
+
+      it('applied the default GOV.UK Frontend configuration to both libaries', async () => {
+        expect(css).toContain(
+          '--with-use-colour: var(--govuk-brand-colour, #1d70b8)'
+        )
+        expect(css).toContain(
+          '--with-use-icon: url("/assets/images/home-icon.svg")'
+        )
+        expect(css).toContain(
+          '--with-forward-colour: var(--govuk-brand-colour, #1d70b8)'
+        )
+        expect(css).toContain(
+          '--with-forward-icon: url("/assets/images/home-icon.svg")'
+        )
+      })
+    })
+
+    describe('with configuration', () => {
+      let css
+
+      beforeAll(async () => {
+        const sass = `
+          @use "sass:meta";
+          @use 'pkg:@govuk-frontend/helpers/assets-urls';
+          @use 'libraries/with-forward' with (
+            $govuk-functional-colours: (brand: hotpink),
+            $govuk-image-url-function: meta.get-function('images-url', $module: 'assets-urls')
+          );
+          @use 'libraries/with-use';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('applies configuration to both GOV.UK Frontend and the libraries', async () => {
+        expect(css).toContain('--govuk-brand-colour: hotpink')
+        expect(css).toContain(
+          '--with-use-colour: var(--govuk-brand-colour, hotpink)'
+        )
+        expect(css).toContain('--with-use-icon: url("example.svg")')
+        expect(css).toContain(
+          '--with-forward-colour: var(--govuk-brand-colour, hotpink)'
+        )
+        expect(css).toContain('--with-forward-icon: url("example.svg")')
+      })
+    })
+  })
 })

--- a/tests/sass-tests/libaries.integration.test.mjs
+++ b/tests/sass-tests/libaries.integration.test.mjs
@@ -1,0 +1,83 @@
+import { compileSassStringLikeUsers } from './helpers/sass.js'
+
+describe('libraries', () => {
+  describe('if the library `@import`s GOV.UK Frontend', () => {
+    describe('without configuration', () => {
+      let css
+
+      beforeAll(async () => {
+        // Sass does not resolve import-only files when using `pkg:` URLs
+        // with `@import` so we need to explicitely load `index.import`
+        // See: https://github.com/sass/sass/issues/4224
+        const sass = `
+          @import 'pkg:govuk-frontend/index.import';
+          @import 'libraries/with-import/index';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('outputs the CSS of GOV.UK Frontend only once', async () => {
+        expect(css.match(/govuk-visually-hidden/)).toHaveLength(1)
+      })
+
+      it('applied the default GOV.UK Frontend configuration to the library', async () => {
+        expect(css).toContain(
+          '--with-import-colour: var(--govuk-brand-colour, #1d70b8)'
+        )
+        expect(css).toContain(
+          '--with-import-icon: url("/assets/images/home-icon.svg")'
+        )
+      })
+    })
+
+    describe('with configuration', () => {
+      let css
+
+      beforeAll(async () => {
+        const sass = `
+          $govuk-functional-colours: (brand: hotpink);
+          $govuk-image-url-function: 'images-url';
+
+          @import 'pkg:@govuk-frontend/helpers/assets-urls';
+          @import 'pkg:govuk-frontend/index.import';
+          @import 'libraries/with-import/index';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('applies configuration to both GOV.UK Frontend and the library', async () => {
+        expect(css).toContain('--govuk-brand-colour: hotpink')
+        expect(css).toContain(
+          '--with-import-colour: var(--govuk-brand-colour, hotpink)'
+        )
+        expect(css).toContain('--with-import-icon: url("example.svg")')
+      })
+    })
+
+    describe('without explicitly `@import`ing GOV.UK Frontend', () => {
+      let css
+
+      beforeAll(async () => {
+        const sass = `
+          $govuk-functional-colours: (brand: hotpink);
+          $govuk-image-url-function: 'images-url';
+
+          @import 'pkg:@govuk-frontend/helpers/assets-urls';
+          @import 'libraries/with-import/index';
+        `
+
+        css = await compileSassStringLikeUsers(sass)
+      })
+
+      it('applies configuration to both GOV.UK Frontend and the library', async () => {
+        expect(css).toContain('--govuk-brand-colour: hotpink')
+        expect(css).toContain(
+          '--with-import-colour: var(--govuk-brand-colour, hotpink)'
+        )
+        expect(css).toContain('--with-import-icon: url("example.svg")')
+      })
+    })
+  })
+})

--- a/tests/sass-tests/libraries/with-forward/index.scss
+++ b/tests/sass-tests/libraries/with-forward/index.scss
@@ -1,0 +1,7 @@
+@forward "pkg:govuk-frontend";
+@use "pkg:govuk-frontend" as *;
+
+:root {
+  --with-forward-colour: #{govuk-functional-colour("brand")};
+  --with-forward-icon: #{govuk-image-url("home-icon.svg")};
+}

--- a/tests/sass-tests/libraries/with-import/index.scss
+++ b/tests/sass-tests/libraries/with-import/index.scss
@@ -1,0 +1,6 @@
+@import "pkg:govuk-frontend/index.import";
+
+:root {
+  --with-import-colour: #{govuk-functional-colour("brand")};
+  --with-import-icon: #{govuk-image-url("home-icon.svg")};
+}

--- a/tests/sass-tests/libraries/with-use/index.scss
+++ b/tests/sass-tests/libraries/with-use/index.scss
@@ -1,0 +1,6 @@
+@use "pkg:govuk-frontend" as *;
+
+:root {
+  --with-use-colour: #{govuk-functional-colour("brand")};
+  --with-use-icon: #{govuk-image-url("home-icon.svg")};
+}


### PR DESCRIPTION
Add tests checking that configuration gets applied properly when libraries include GOV.UK Frontend:
- that with `@import` both GOV.UK Frontend and the library get appropriately configured by global variables
- that with `@use` the library gets appropriately affected by configuration of `pkg:govuk-frontend`
- that with `@forward` configuring the library appropriately configures both GOV.UK Frontend and a subsequent library that `@use`s GOV.UK Frontend

As we're recommending to either only `@use` or `@import` all your stylesheets, this PR does not add any tests about mixing `@use` and `@import` (we already know this may lead to duplicate output or GOV.UK Frontend getting loaded again with a blank configuration due to how Sass loads files).