### PR TITLE
Disallow npm installs from non-registry sources

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,19 @@
+; Disallow installing packages from sources other than the npm registry – these
+; types of install are often used as part of supply-chain attacks. As we don't
+; need them, turn them off.
+
+; https://docs.npmjs.com/cli/v11/using-npm/config#allow-git
+; requires npm v11.10.0+
+allow-git=none
+
+; https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote
+; requires npm v11.15.0+ (because of https://github.com/npm/cli/issues/9347)
+allow-remote=none
+
+; https://docs.npmjs.com/cli/v11/using-npm/config#allow-directory
+; requires npm v11.16.0+ (because of https://github.com/npm/cli/issues/9392)
+allow-directory=none
+
+; https://docs.npmjs.com/cli/v11/using-npm/config#allow-file
+; requires npm v11.15.0+
+allow-file=none

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Used only for the development of GOV.UK Frontend, see `packages/govuk-frontend/package.json` for the published `package.json`",
   "engines": {
     "node": "^24.11.0",
-    "npm": "^11.6.1 <11.6.3 || ^11.6.4"
+    "npm": "^11.16.0"
   },
   "license": "MIT",
   "workspaces": [


### PR DESCRIPTION
Disallow installing packages from sources other than the npm registry – these types of install are often used as part of supply-chain attacks. As we don't need them, turn them off.

~~[`allow-directory=none` currently breaks `npm exec`](https://github.com/npm/cli/issues/9392), which in turn breaks our husky pre-commit hook – so we need to keep that enabled for now.~~ – fixed in npm v11.16.0.