### PR TITLE
Support release candidate being output into CHANGELOG headings

### DIFF
--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -37,14 +37,13 @@ export function updateChangelog(newVersion, previousVersion) {
   }
 
   const changelogLines = getChangelogLines()
-  const [startIndex, previousReleaseLineIndex] =
-    getChangelogLineIndexes(changelogLines)
+  const [startIndex] = getChangelogLineIndexes(changelogLines)
 
   const versionDiff = semver.diff(validatedNewVersion, validatedPreviousVersion)
   if (!versionDiff) {
     throw new Error(processingErrorMessage)
   }
-  const newVersionTitle = `## v${validatedNewVersion} (${capitalise(convertIncTypeWord(versionDiff, validatedNewVersion, changelogLines[previousReleaseLineIndex]))} release)`
+  const newVersionTitle = `## v${validatedNewVersion} (${capitalise(convertIncTypeWord(versionDiff, validatedNewVersion))} release)`
 
   const newLines = [newVersionTitle]
   if (newVersionIsAPrerelease) {
@@ -249,10 +248,9 @@ function getPrereleaseIdentifier(version) {
  *
  * @param {string} incType - SemVer increment type
  * @param {string|null} version - SemVer version
- * @param {string|null} lastReleaseTitle - Previous release title
  * @returns {string} - The reworded increment type
  */
-function convertIncTypeWord(incType, version = null, lastReleaseTitle = null) {
+function convertIncTypeWord(incType, version) {
   let rewordedIncType
 
   if (incType === 'major') {
@@ -261,14 +259,8 @@ function convertIncTypeWord(incType, version = null, lastReleaseTitle = null) {
     rewordedIncType = 'feature'
   } else if (incType === 'patch') {
     rewordedIncType = 'fix'
-  } else if (incType === 'prerelease' && lastReleaseTitle != null) {
-    rewordedIncType = lastReleaseTitle.substring(
-      lastReleaseTitle.indexOf('(') + 1,
-      lastReleaseTitle.indexOf(' release')
-    )
-  } else if (incType.includes('pre') && version != null) {
-    const identifier = getPrereleaseIdentifier(version)
-    rewordedIncType = `${identifier} ${convertIncTypeWord(incType.slice(3))}`
+  } else if (incType.includes('pre')) {
+    rewordedIncType = getPrereleaseIdentifier(version)
   } else {
     rewordedIncType = incType
   }

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -43,7 +43,7 @@ export function updateChangelog(newVersion, previousVersion) {
   if (!versionDiff) {
     throw new Error(processingErrorMessage)
   }
-  const newVersionTitle = `## v${validatedNewVersion} (${capitalise(convertIncTypeWord(versionDiff, validatedNewVersion))} release)`
+  const newVersionTitle = `## v${validatedNewVersion} (${capitalise(convertIncTypeWord(versionDiff, validatedNewVersion))})`
 
   const newLines = [newVersionTitle]
   if (newVersionIsAPrerelease) {
@@ -229,43 +229,47 @@ function versionIsAPrerelease(version) {
  * @returns {string} - the identifier of the pre-release
  */
 function getPrereleaseIdentifier(version) {
-  return version.substring(version.indexOf('-') + 1, version.lastIndexOf('.'))
+  if (!versionIsAPrerelease(version)) {
+    return ''
+  }
+  // Prerelease is made up of an optional string label and a number increment
+  // e.g. `1.0.0-beta.0` and `1.0.0-0`, so only return something if we find a label
+  const prereleaseIdentifier = semver
+    .prerelease(version)
+    .find((part) => typeof part === 'string')
+  if (!prereleaseIdentifier) {
+    return ''
+  }
+  return prereleaseIdentifier
 }
 
 /**
  * Convert a standard SemVer increment word eg: major, minor or patch into the
- * wording we use for release titles. The conversion:
- *
- * - major -> breaking
- * - minor -> feature
- * - patch -> fix
- *
- * If the increment is a pre-release eg: prepatch, we split the 'pre' substring
- * from the inc and call this function recursively to generate a string of the
- * format '{identifier} {increment type}' Eg: where the current version is 6.2.1
- * and the new version is 6.3.0-beta.0, the generated string would be
- * 'Beta feature'
+ * wording we use for release titles.
  *
  * @param {string} incType - SemVer increment type
  * @param {string|null} version - SemVer version
  * @returns {string} - The reworded increment type
  */
 function convertIncTypeWord(incType, version) {
-  let rewordedIncType
+  let rewordedIncType = incType
 
-  if (incType === 'major') {
+  // If there's a prerelease flag e.g. 1.0.0-beta.0 use that to decide
+  const prereleaseIdentifier = getPrereleaseIdentifier(version)
+  if (prereleaseIdentifier) {
+    if (prereleaseIdentifier === 'rc') {
+      return 'release candidate'
+    }
+    rewordedIncType = prereleaseIdentifier
+  } else if (incType === 'major') {
     rewordedIncType = 'breaking'
   } else if (incType === 'minor') {
     rewordedIncType = 'feature'
   } else if (incType === 'patch') {
     rewordedIncType = 'fix'
-  } else if (incType.includes('pre')) {
-    rewordedIncType = getPrereleaseIdentifier(version)
-  } else {
-    rewordedIncType = incType
   }
 
-  return rewordedIncType
+  return `${rewordedIncType} release`
 }
 
 /**

--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -44,7 +44,7 @@ export function updateChangelog(newVersion, previousVersion) {
   if (!versionDiff) {
     throw new Error(processingErrorMessage)
   }
-  const newVersionTitle = `## v${validatedNewVersion} (${convertIncTypeWord(versionDiff, validatedNewVersion, true, changelogLines[previousReleaseLineIndex])} release)`
+  const newVersionTitle = `## v${validatedNewVersion} (${capitalise(convertIncTypeWord(versionDiff, validatedNewVersion, changelogLines[previousReleaseLineIndex]))} release)`
 
   const newLines = [newVersionTitle]
   if (newVersionIsAPrerelease) {
@@ -249,17 +249,10 @@ function getPrereleaseIdentifier(version) {
  *
  * @param {string} incType - SemVer increment type
  * @param {string|null} version - SemVer version
- * @param {boolean} capitalise - If the returned string should start with a capital
- *   letter or not
  * @param {string|null} lastReleaseTitle - Previous release title
  * @returns {string} - The reworded increment type
  */
-function convertIncTypeWord(
-  incType,
-  version = null,
-  capitalise = false,
-  lastReleaseTitle = null
-) {
+function convertIncTypeWord(incType, version = null, lastReleaseTitle = null) {
   let rewordedIncType
 
   if (incType === 'major') {
@@ -280,9 +273,7 @@ function convertIncTypeWord(
     rewordedIncType = incType
   }
 
-  return capitalise
-    ? `${rewordedIncType.charAt(0).toUpperCase()}${rewordedIncType.slice(1)}`
-    : rewordedIncType
+  return rewordedIncType
 }
 
 /**
@@ -295,4 +286,14 @@ function removePrereleaseFlag(version) {
   const parsedVersion = semver.parse(version)
   parsedVersion.prerelease = []
   return parsedVersion.format()
+}
+
+/**
+ * Capitalise a word or sentance so the first letter is uppercase
+ *
+ * @param {string} word
+ * @returns {string} - capitalised string
+ */
+function capitalise(word) {
+  return word.charAt(0).toUpperCase() + word.slice(1)
 }

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -35,11 +35,19 @@ describe('Changelog release helper', () => {
       )
     })
 
-    it('prefixes a new heading with a pre-release identifier if the new version is a pre-release', () => {
+    it('prefixes a new heading with a beta pre-release identifier', () => {
       updateChangelog('3.1.0-beta.0', '3.0.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         CHANGELOG_FILE_PATH,
         expect.stringContaining('## v3.1.0-beta.0 (Beta release)')
+      )
+    })
+
+    it('prefixes a new heading with a release candidate pre-release identifier', () => {
+      updateChangelog('3.1.0-rc.0', '3.0.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        CHANGELOG_FILE_PATH,
+        expect.stringContaining('## v3.1.0-rc.0 (Release candidate)')
       )
     })
 

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -39,7 +39,7 @@ describe('Changelog release helper', () => {
       updateChangelog('3.1.0-beta.0', '3.0.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         CHANGELOG_FILE_PATH,
-        expect.stringContaining('## v3.1.0-beta.0 (Beta feature release)')
+        expect.stringContaining('## v3.1.0-beta.0 (Beta release)')
       )
     })
 
@@ -51,13 +51,13 @@ describe('Changelog release helper', () => {
 
         Bing bong
 
-        ## v3.1.0-beta.0 (Beta feature release)
+        ## v3.1.0-beta.0 (Beta release)
       `)
 
       updateChangelog('3.1.0-beta.1', '3.1.0-beta.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         CHANGELOG_FILE_PATH,
-        expect.stringContaining('## v3.1.0-beta.1 (Beta feature release)')
+        expect.stringContaining('## v3.1.0-beta.1 (Beta release)')
       )
     })
 
@@ -69,14 +69,14 @@ describe('Changelog release helper', () => {
 
         Bing bong
 
-        ## v3.1.0-beta.0 (Beta feature release)
+        ## v3.1.0-beta.0 (Beta release)
       `)
 
       updateChangelog('3.1.0-beta.1', '3.1.0-beta.0')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         CHANGELOG_FILE_PATH,
         expect.stringContaining(outdent`
-          ## v3.1.0-beta.1 (Beta feature release)
+          ## v3.1.0-beta.1 (Beta release)
           > [!WARNING]
           > Do not use in production.
           > Use this release to prepare for the changes coming in version \`3.1.0\`.


### PR DESCRIPTION
Simplify how we generate the headings for the CHANGELOG when we update the package.

Changes: If a pre-release refer to the flag and dont specify what sort of pre-release it is e.g.
Beta feature release -> Beta release

Newly supported: If a release candidate create a special case so it's called "Release candidate".

Closes #7090