### PR TITLE
Add new line after injected CHANGELOG heading

### DIFF
--- a/shared/github-scripts/changelog-release-helper.mjs
+++ b/shared/github-scripts/changelog-release-helper.mjs
@@ -45,7 +45,7 @@ export function updateChangelog(newVersion, previousVersion) {
   }
   const newVersionTitle = `## v${validatedNewVersion} (${capitalise(convertIncTypeWord(versionDiff, validatedNewVersion))})`
 
-  const newLines = [newVersionTitle]
+  const newLines = [newVersionTitle, ``]
   if (newVersionIsAPrerelease) {
     newLines.push(
       `> [!WARNING]`,

--- a/shared/github-scripts/changelog-release-helper.unit.test.mjs
+++ b/shared/github-scripts/changelog-release-helper.unit.test.mjs
@@ -85,9 +85,12 @@ describe('Changelog release helper', () => {
         CHANGELOG_FILE_PATH,
         expect.stringContaining(outdent`
           ## v3.1.0-beta.1 (Beta release)
+
           > [!WARNING]
           > Do not use in production.
           > Use this release to prepare for the changes coming in version \`3.1.0\`.
+
+          To install this version with npm
         `)
       )
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -130,6 +133,7 @@ describe('Changelog release helper', () => {
         CHANGELOG_FILE_PATH,
         expect.stringContaining(outdent`
             ## v3.1.1 (Fix release)
+
             To install this version with npm, run \`npm install govuk-frontend@3.1.1\`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.
         `)
       )


### PR DESCRIPTION
Heading for the new release was missing a line break after it to conform to the rest of the headings in the CHANGELOG. Updates the test and `updateChangelog` helper to ensure the heading is followed by a double line break.