### PR TITLE
Correct typo in `$govuk-success-colour` deprecation message

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_colours-legacy-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-legacy-functional.scss
@@ -114,7 +114,7 @@ $govuk-error-colour: govuk-functional-colour(error);
 /// @access public
 /// @deprecated
 ///   Variables for applied colours are deprecated. Please use the `govuk-functional-colour`
-///   function instead: `govuk-functional-colour(error)`.
+///   function instead: `govuk-functional-colour(success)`.
 $govuk-success-colour: govuk-functional-colour(success);
 
 /// Border colour


### PR DESCRIPTION
Correct typo in `$govuk-success-colour` deprecation message.