### PR TITLE
Error if no browsers installed to test with

### DIFF
--- a/shared/helpers/jest/browser/download.mjs
+++ b/shared/helpers/jest/browser/download.mjs
@@ -16,13 +16,18 @@ export async function download() {
 
   // Downloaded versions
   const buildId = PUPPETEER_REVISIONS.chrome
-  const versions = cache.getInstalledBrowsers()
+  const previousVersions = cache.getInstalledBrowsers()
 
   // Download latest browser (unless cached)
-  if (!versions.some((version) => version.buildId === buildId)) {
+  if (!previousVersions.some((version) => version.buildId === buildId)) {
     await cache.clear()
 
     // Install into cache directory
     await install({ browser, buildId, cacheDir })
+  }
+
+  const currentVerisons = cache.getInstalledBrowsers()
+  if (!currentVerisons || !currentVerisons.length) {
+    throw new Error('No browser versions are installed.')
   }
 }

--- a/shared/helpers/jest/browser/download.unit.test.mjs
+++ b/shared/helpers/jest/browser/download.unit.test.mjs
@@ -24,16 +24,10 @@ describe('Browser tasks: Puppeteer browser downloader', () => {
     jest.mocked(Cache.prototype.clear).mockReturnValue()
   })
 
-  it('downloads by default', async () => {
-    await download()
-
-    expect(install).toHaveBeenCalledWith(
-      expect.objectContaining({ buildId: 'new-version' })
+  it('errors if no versions are available to download', async () => {
+    await expect(download()).rejects.toThrow(
+      'No browser versions are installed.'
     )
-    expect(install).toHaveBeenCalledTimes(1)
-
-    // Outdated versions always removed
-    expect(Cache.prototype.clear).toHaveBeenCalledTimes(1)
   })
 
   it('downloads with single version outdated', async () => {


### PR DESCRIPTION
We think that Puppeteer v24 is failing silently (https://github.com/puppeteer/puppeteer/issues/14957) so we want to double check that a version is downloaded