### PR TITLE
Pin Node version to 24.15

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,4 +1,4 @@
-24
+24.15
 # When updating this version, remember to update:
 # - the 'engines' fields in the various `package.json` files of the project
 # - `package-lock.json` by running `npm install`


### PR DESCRIPTION
Puppeteer has issues with Node >24.15: https://github.com/puppeteer/puppeteer/issues/14957#issuecomment-4572656651. Until we update to Puppeteer 25, we should stick to Node 24.15.