### PR TITLE
Update caching to use dependencies as a hash

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           # Use faster GNU tar for all runners
           enableCrossOsArchive: true
-          key: puppeteer-${{ runner.os }}
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
           path: .cache/puppeteer
 
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           # Use faster GNU tar for all runners
           enableCrossOsArchive: true
-          key: ${{ matrix.task.name }}-${{ runner.os }}
+          key: ${{ matrix.task.name }}-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
           path: ${{ matrix.task.cache }}
 
       - name: Run lint task
@@ -209,7 +209,7 @@ jobs:
         with:
           # Use faster GNU tar for all runners
           enableCrossOsArchive: true
-          key: ${{ matrix.task.name }}-${{ runner.os }}
+          key: ${{ matrix.task.name }}-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
           path: ${{ matrix.task.cache }}
 
       - name: Run test task


### PR DESCRIPTION
Since these tests depend on dependencies in the package.json we want to make sure when we update any dependencies that the caches bust.