### PR TITLE
Remove 6.2.0-rc heading from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
-## v6.2.0-rc.0 (Release candidate)
-
-> [!WARNING]
-> Do not use in production.
-> Use this release to prepare for the changes coming in version `6.2.0`.
-
-To install this version with npm, run `npm install govuk-frontend@6.2.0-rc.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.
-
 ### New features
 
 #### Use `@use` to include GOV.UK Frontend styles in Sass


### PR DESCRIPTION
Got forgotten in the previous PR