### PR TITLE
Remove Sass string interpolation from media queries

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/full-page-examples/search.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/full-page-examples/search.scss
@@ -27,7 +27,7 @@
 .app-search-result-list__children {
   margin-left: govuk-spacing(4);
 
-  @media #{govuk-from-breakpoint(tablet)} {
+  @media govuk-from-breakpoint(tablet) {
     display: grid;
     grid-template-columns: 1fr 1fr;
     column-gap: 15px;

--- a/packages/govuk-frontend/src/govuk/components/accordion/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/accordion/_mixin.scss
@@ -93,7 +93,7 @@
       cursor: pointer;
       -webkit-appearance: none;
 
-      @media #{base.govuk-from-breakpoint(tablet)} {
+      @media base.govuk-from-breakpoint(tablet) {
         margin-bottom: 14px;
       }
 
@@ -209,7 +209,7 @@
       cursor: pointer;
       -webkit-appearance: none;
 
-      @media #{base.govuk-from-breakpoint(tablet)} {
+      @media base.govuk-from-breakpoint(tablet) {
         padding-bottom: base.govuk-spacing(2);
       }
 
@@ -272,7 +272,7 @@
       padding-bottom: base.govuk-spacing(3);
       border-bottom: 0;
 
-      @media #{base.govuk-from-breakpoint(tablet)} {
+      @media base.govuk-from-breakpoint(tablet) {
         padding-bottom: base.govuk-spacing(4);
       }
     }
@@ -282,7 +282,7 @@
     .govuk-accordion__section-button:focus .govuk-accordion__section-toggle-focus {
       padding-bottom: 3px;
 
-      @media #{base.govuk-from-breakpoint(desktop)} {
+      @media base.govuk-from-breakpoint(desktop) {
         padding-bottom: 2px;
       }
     }

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
@@ -102,7 +102,7 @@
   }
 
   .govuk-breadcrumbs--collapse-on-mobile {
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       .govuk-breadcrumbs__list-item {
         display: none;
 

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -57,7 +57,7 @@
     cursor: pointer;
     -webkit-appearance: none;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: auto;
     }
 
@@ -225,7 +225,7 @@
     // (https://github.com/w3c/csswg-drafts/issues/6310)
     forced-color-adjust: auto;
 
-    @media #{base.govuk-from-breakpoint(desktop)} {
+    @media base.govuk-from-breakpoint(desktop) {
       margin-left: base.govuk-spacing(2);
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
@@ -12,7 +12,7 @@
     left: 0;
     width: 100%;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: inline-block;
       right: 0;
       left: auto;

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -109,7 +109,7 @@
     background-color: base.govuk-colour("white");
     cursor: pointer;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding: (base.govuk-spacing(4) + base.$govuk-border-width - $file-upload-border-width);
     }
 

--- a/packages/govuk-frontend/src/govuk/components/footer/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_mixin.scss
@@ -56,7 +56,7 @@
 
   .govuk-footer__meta-item--grow {
     flex: 1; // Support: Flexbox
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       flex-basis: 320px; // Support: Flexbox
     }
   }
@@ -64,7 +64,7 @@
   .govuk-footer__licence-logo {
     display: inline-block;
     margin-right: base.govuk-spacing(2);
-    @media #{base.govuk-until-breakpoint(desktop)} {
+    @media base.govuk-until-breakpoint(desktop) {
       margin-bottom: base.govuk-spacing(3);
     }
     vertical-align: top;
@@ -146,7 +146,7 @@
     margin-bottom: base.govuk-spacing(6);
     padding-bottom: base.govuk-spacing(4);
 
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       padding-bottom: base.govuk-spacing(2);
     }
 
@@ -174,7 +174,7 @@
     list-style: none;
   }
 
-  @media #{base.govuk-from-breakpoint(desktop)} {
+  @media base.govuk-from-breakpoint(desktop) {
     .govuk-footer__list--columns-2 {
       column-count: 2; // Support: Columns
     }

--- a/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
@@ -100,7 +100,7 @@
     }
 
     // Split prefix/suffix onto separate lines on narrow screens
-    @media #{base.govuk-until-breakpoint(mobile)} {
+    @media base.govuk-until-breakpoint(mobile) {
       display: block;
 
       .govuk-input {
@@ -130,7 +130,7 @@
     // Emphasise non-editable status of prefixes and suffixes
     cursor: default;
     // Split prefix/suffix onto separate lines on narrow screens
-    @media #{base.govuk-until-breakpoint(mobile)} {
+    @media base.govuk-until-breakpoint(mobile) {
       display: block;
       height: 100%;
       white-space: normal;
@@ -138,20 +138,20 @@
   }
 
   .govuk-input__prefix {
-    @media #{base.govuk-until-breakpoint(mobile)} {
+    @media base.govuk-until-breakpoint(mobile) {
       border-bottom: 0;
     }
-    @media #{base.govuk-from-breakpoint(mobile)} {
+    @media base.govuk-from-breakpoint(mobile) {
       border-right: 0;
     }
   }
 
   // Split prefix/suffix onto separate lines on narrow screens
   .govuk-input__suffix {
-    @media #{base.govuk-until-breakpoint(mobile)} {
+    @media base.govuk-until-breakpoint(mobile) {
       border-top: 0;
     }
-    @media #{base.govuk-from-breakpoint(mobile)} {
+    @media base.govuk-from-breakpoint(mobile) {
       border-left: 0;
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -26,7 +26,7 @@
     // text in high contrast mode
     border-bottom: 1px solid transparent;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding: 2px base.govuk-spacing(4) base.govuk-spacing(1);
     }
   }
@@ -48,7 +48,7 @@
     color: base.govuk-functional-colour(text);
     background-color: base.govuk-functional-colour(body-background);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding: $padding-tablet;
     }
 

--- a/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
@@ -11,7 +11,7 @@
     flex-wrap: wrap;
     align-items: center;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       flex-direction: row;
       align-items: flex-start;
     }
@@ -48,7 +48,7 @@
     // visually sit in the middle of their touch area
     text-align: center;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: block;
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -14,7 +14,7 @@
 
     text-align: center;
 
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       padding: base.govuk-spacing(4) - base.$govuk-border-width;
 
       // Support IE (autoprefixer doesn't add this as it's not a prefix)

--- a/packages/govuk-frontend/src/govuk/components/password-input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/password-input/_mixin.scss
@@ -8,7 +8,7 @@
     //   breakpoint
     // - being display: flex above the mobile breakpoint
 
-    @media #{base.govuk-from-breakpoint(mobile)} {
+    @media base.govuk-from-breakpoint(mobile) {
       flex-direction: row;
 
       // The default of `stretch` makes the toggle button appear taller than the
@@ -41,7 +41,7 @@
       display: none;
     }
 
-    @media #{base.govuk-from-breakpoint(mobile)} {
+    @media base.govuk-from-breakpoint(mobile) {
       flex-basis: 5em;
       flex-shrink: 0;
       // Buttons are normally 100% wide on mobile, but we don't want that here

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/_mixin.scss
@@ -29,7 +29,7 @@
     @include base.govuk-font-size($size: 16);
     margin-right: base.govuk-spacing(3);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       margin-right: base.govuk-spacing(2);
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
@@ -145,7 +145,7 @@
   // =========================================================
 
   .govuk-radios--inline {
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: flex;
       flex-wrap: wrap;
       align-items: flex-start;

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -23,7 +23,7 @@
     flex-direction: column;
     align-items: start;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       flex-direction: row;
       flex-wrap: wrap;
     }
@@ -42,7 +42,7 @@
     border-style: solid;
     border-color: base.govuk-functional-colour(link);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       // inline-block is used as a fallback for browsers that don't support flexbox
       display: inline-block;
 
@@ -75,7 +75,7 @@
   }
 
   .govuk-service-navigation__item--active {
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       // Negative offset the left margin so we can place a current page indicator
       // to the left without misaligning the list item text.
       margin-left: ((base.govuk-spacing(2) + $govuk-service-navigation-active-link-border-width) * -1);
@@ -83,7 +83,7 @@
       border-left-width: $govuk-service-navigation-active-link-border-width;
     }
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding-bottom: base.govuk-spacing(3) - $govuk-service-navigation-active-link-border-width;
       border-bottom-width: $govuk-service-navigation-active-link-border-width;
     }
@@ -170,7 +170,7 @@
     //   readers would pointlessly announce.
     // - Fixes an NVDA issue in Firefox and Chrome <= 124 where it would read
     //   all of the links as a run-on sentence.
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: flex;
       flex-wrap: wrap;
       margin-bottom: 0;

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
@@ -7,7 +7,7 @@
 
     color: base.govuk-functional-colour(text);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: table;
       width: 100%;
       table-layout: fixed; // Required to allow us to wrap words that overflow.
@@ -25,10 +25,10 @@
     border-bottom: 1px solid;
     border-bottom-color: base.govuk-functional-colour(border);
 
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       margin-bottom: base.govuk-spacing(3);
     }
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: table-row;
     }
   }
@@ -41,7 +41,7 @@
   // Provide an empty 'cell' for rows that don't have actions – otherwise the
   // bottom border is not drawn for that part of the row in some browsers.
   .govuk-summary-list__row--no-actions {
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       &::after {
         content: "";
         display: table-cell;
@@ -55,7 +55,7 @@
   .govuk-summary-list__actions {
     margin: 0; // Reset default user agent styles
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: table-cell;
       padding-top: base.govuk-spacing(2);
       padding-right: base.govuk-spacing(4);
@@ -70,7 +70,7 @@
 
   .govuk-summary-list__actions {
     margin-bottom: base.govuk-spacing(3);
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 20%;
       text-align: right;
     }
@@ -86,13 +86,13 @@
   .govuk-summary-list__key {
     margin-bottom: base.govuk-spacing(1);
     @include base.govuk-typography-weight-bold;
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 30%;
     }
   }
 
   .govuk-summary-list__value {
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       margin-bottom: base.govuk-spacing(3);
     }
   }
@@ -116,7 +116,7 @@
     display: inline-block;
   }
 
-  @media #{base.govuk-until-breakpoint(tablet)} {
+  @media base.govuk-until-breakpoint(tablet) {
     .govuk-summary-list__actions-list-item,
     .govuk-summary-card__action {
       margin-right: base.govuk-spacing(2);
@@ -133,7 +133,7 @@
     }
   }
 
-  @media #{base.govuk-from-breakpoint(tablet)} {
+  @media base.govuk-from-breakpoint(tablet) {
     .govuk-summary-list__actions-list-item,
     .govuk-summary-card__action {
       margin-left: base.govuk-spacing(2);
@@ -170,7 +170,7 @@
     }
 
     // Increase padding by 1px to compensate for 'missing' border
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       .govuk-summary-list__key,
       .govuk-summary-list__value,
       .govuk-summary-list__actions {
@@ -184,7 +184,7 @@
     border: 0;
 
     // Increase padding by 1px to compensate for 'missing' border
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       .govuk-summary-list__key,
       .govuk-summary-list__value,
       .govuk-summary-list__actions {
@@ -208,7 +208,7 @@
     border-bottom: 1px solid transparent;
     background-color: base.govuk-colour("black", $variant: "tint-95");
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       display: flex;
       flex-wrap: nowrap;
       justify-content: space-between;
@@ -221,7 +221,7 @@
     margin: base.govuk-spacing(1) base.govuk-spacing(4) base.govuk-spacing(2) 0;
     color: base.govuk-functional-colour(text);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       margin-bottom: base.govuk-spacing(1);
     }
   }
@@ -236,7 +236,7 @@
     padding: 0;
     list-style: none;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       justify-content: right;
       text-align: right;
     }
@@ -269,7 +269,7 @@
   .govuk-summary-card__content {
     padding: base.govuk-spacing(3) base.govuk-spacing(3) 0;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding: base.govuk-spacing(3) base.govuk-spacing(4);
     }
 

--- a/packages/govuk-frontend/src/govuk/components/table/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/table/_mixin.scss
@@ -16,7 +16,7 @@
   // Modifier for tables with a lot of data. Tables with lots of data benefit
   // from a smaller font size on small screens.
   .govuk-table--small-text-until-tablet {
-    @media #{base.govuk-until-breakpoint(tablet)} {
+    @media base.govuk-until-breakpoint(tablet) {
       @include base.govuk-font-size($size: 16);
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
@@ -50,7 +50,7 @@
 
   // GOV.UK Frontend JavaScript enabled
   .govuk-frontend-supported {
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       .govuk-tabs__list {
         @include base.govuk-clearfix;
         margin-bottom: 0;

--- a/packages/govuk-frontend/src/govuk/components/warning-text/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/_mixin.scss
@@ -22,7 +22,7 @@
     min-height: 35px;
     margin-top: -7px;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       margin-top: -5px;
     }
 

--- a/packages/govuk-frontend/src/govuk/core/_lists.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_lists.mixin.scss
@@ -46,7 +46,7 @@
   %govuk-list--number > li {
     margin-bottom: 0;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       margin-bottom: base.govuk-spacing(1);
     }
   }
@@ -54,7 +54,7 @@
   %govuk-list--spaced > li {
     margin-bottom: base.govuk-spacing(2);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       margin-bottom: base.govuk-spacing(3);
     }
   }

--- a/packages/govuk-frontend/src/govuk/core/_typography.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/core/_typography.mixin.scss
@@ -79,7 +79,7 @@
     margin-bottom: base.govuk-spacing(1);
     color: base.govuk-functional-colour(secondary-text);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       margin-bottom: 0;
     }
   }
@@ -146,7 +146,7 @@
   %govuk-body-l + %govuk-heading-l {
     padding-top: base.govuk-spacing(1);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding-top: base.govuk-spacing(2);
     }
   }
@@ -165,7 +165,7 @@
   %govuk-list + %govuk-heading-s {
     padding-top: base.govuk-spacing(1);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       padding-top: base.govuk-spacing(2);
     }
   }

--- a/packages/govuk-frontend/src/govuk/helpers/_media-queries.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_media-queries.scss
@@ -76,13 +76,13 @@
 ///
 /// @example scss
 ///  .example {
-///    @media #{govuk-from-breakpoint(tablet)} {
+///    @media govuk-from-breakpoint(tablet) {
 ///      color: red;
 ///    }
-///    @media #{govuk-from-breakpoint(30em)} {
+///    @media govuk-from-breakpoint(30em) {
 ///      color: green;
 ///    }
-///    @media #{govuk-from-breakpoint(tablet)} and (orientation: landscape) {
+///    @media govuk-from-breakpoint(tablet) and (orientation: landscape) {
 ///      color: blue;
 ///    }
 ///    $custom-breakpoint-map: (
@@ -91,7 +91,7 @@
 ///      large: 1100px,
 ///      extra-large: 1600px
 ///    );
-///    @media #{govuk-from-breakpoint(extra-large, $custom-breakpoint-map)} {
+///    @media govuk-from-breakpoint(extra-large, $custom-breakpoint-map) {
 ///      color: cyan;
 ///    }
 ///  }
@@ -121,13 +121,13 @@
 ///
 /// @example scss
 ///  .example {
-///    @media #{govuk-until-breakpoint(desktop)} {
+///    @media govuk-until-breakpoint(desktop) {
 ///      color: red;
 ///    }
-///    @media #{govuk-until-breakpoint(40em)} {
+///    @media govuk-until-breakpoint(40em) {
 ///      color: green;
 ///    }
-///    @media #{govuk-until-breakpoint(tablet)} and (orientation: landscape) {
+///    @media govuk-until-breakpoint(tablet) and (orientation: landscape) {
 ///      color: blue;
 ///    }
 ///    $custom-breakpoint-map: (
@@ -136,7 +136,7 @@
 ///      large: 1100px,
 ///      extra-large: 1600px
 ///    );
-///    @media #{govuk-until-breakpoint(extra-large, $custom-breakpoint-map)} {
+///    @media govuk-until-breakpoint(extra-large, $custom-breakpoint-map) {
 ///      color: cyan;
 ///    }
 ///  }

--- a/packages/govuk-frontend/src/govuk/helpers/_width-container.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_width-container.scss
@@ -40,7 +40,7 @@
   }
 
   // On tablet, add full width gutters
-  @media #{govuk-from-breakpoint(tablet)} {
+  @media govuk-from-breakpoint(tablet) {
     margin-right: $govuk-gutter;
     margin-left: $govuk-gutter;
 

--- a/packages/govuk-frontend/src/govuk/objects/_button-group.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_button-group.mixin.scss
@@ -58,7 +58,7 @@
 
     // On tablet and above, we also introduce a 'column gap' between the
     // buttons and links in each row and left align links
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       flex-direction: row;
       flex-wrap: wrap;
       align-items: baseline;

--- a/packages/govuk-frontend/src/govuk/objects/_main-wrapper.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_main-wrapper.mixin.scss
@@ -31,7 +31,7 @@
     padding-top: base.govuk-spacing(4);
     padding-bottom: base.govuk-spacing(4);
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       // This spacing is manually adjusted to replicate the margin of
       // govuk-heading-xl (50px) minus the spacing of back link and
       // breadcrumbs (10px)

--- a/packages/govuk-frontend/src/govuk/overrides/_width.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_width.mixin.scss
@@ -10,7 +10,7 @@
   .govuk-\!-width-three-quarters {
     width: 100% !important;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 75% !important;
     }
   }
@@ -18,7 +18,7 @@
   .govuk-\!-width-two-thirds {
     width: 100% !important;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 66.66% !important;
     }
   }
@@ -26,7 +26,7 @@
   .govuk-\!-width-one-half {
     width: 100% !important;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 50% !important;
     }
   }
@@ -34,7 +34,7 @@
   .govuk-\!-width-one-third {
     width: 100% !important;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 33.33% !important;
     }
   }
@@ -42,7 +42,7 @@
   .govuk-\!-width-one-quarter {
     width: 100% !important;
 
-    @media #{base.govuk-from-breakpoint(tablet)} {
+    @media base.govuk-from-breakpoint(tablet) {
       width: 25% !important;
     }
   }


### PR DESCRIPTION
We had these for backwards compatibility with LibSass and RubySass. Dart Sass doesn't require functions in media queries to be interpolated, so we're able to get rid of these now.

Closes #6835.