### PR TITLE
[SPIKE] Functional colours for white against solid colour

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -79,6 +79,12 @@ export default async () => {
     ({ path }) => path
   )
 
+  app.locals.componentFixtures = Object.fromEntries(
+    componentsFixtures.map(({ component, fixtures }) => {
+      return [component, Object.groupBy(fixtures, ({ name }) => name)]
+    })
+  )
+
   // Configure nunjucks
   const env = nunjucks.renderer(app)
 

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
@@ -6,7 +6,7 @@
 
 // Darken page background for previewing inversely coloured components
 .app-template__body--inverse {
-  background-color: govuk-colour("blue");
+  background-color: govuk-functional-colour(brand);
 }
 
 .app-template__body--component-preview.app-template__body--inverse {

--- a/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
@@ -51,6 +51,44 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" data-module="app-examples">
       <h2 class="govuk-heading-m">Examples</h2>
+
+      <h3 class="govuk-heading-s">Inverse section via custom props</h3>
+      <style style="display: block; white-space: pre; font-family: monospace">
+:root {
+  --app-brand-surface-text-colour: #ffffff;
+  --app-brand-surface-text-hover-colour: #f4f8fb;
+  --app-brand-surface-background-colour: var(--govuk-brand-colour);
+  --app-brand-surface-shadow-colour:  #0f385c;
+
+}
+
+.app-brand-surface {
+  background: var(--app-brand-surface-background-colour);
+  color: var(--app-brand-surface-text-colour);
+  --govuk-text-colour: var(--app-brand-surface-text-colour);
+  --govuk-link-colour: var(--app-brand-surface-text-colour);
+  --govuk-link-visited-colour: var(--app-brand-surface-text-colour);
+  --govuk-link-hover-colour: var(--app-brand-surface-text-colour);
+  --govuk-button-colour: var(--app-brand-surface-text-colour);
+  --govuk-button-text-colour: var(--app-brand-surface-background-colour);
+  --govuk-button-shadow-colour: var(--app-brand-surface-shadow-colour);
+  --govuk-button-hover-colour: var(--app-brand-surface-text-hover-colour);
+}
+      </style>
+      <div class="app-brand-surface govuk-!-padding-3">
+        <h4 class="govuk-heading-s">Oh! Hello!</h4>
+        <p class="govuk-body">Inside this block, <a class="govuk-link" href="">`govuk-link`s</a> and <a class="govuk-link govuk-link--text">`govuk-link--text`</a> do not need custom properties to adapt to the background.
+        <p class="govuk-body">Buttons do not either:</p>
+        {{govukButton({text: 'A regular `govuk-button`'})}}
+        <p class="govuk-body">Start buttons do not either:</p>
+        {{govukButton(componentFixtures['button']['start'][0].options)}}
+        <p class="govuk-body">We can still have red warning buttons too</p>
+        {{govukButton(componentFixtures['button']['warning'][0].options)}}
+        <p class="govuk-body">But would need extra CSS to allow green buttons</p>
+
+
+      </div>
+
       <h3 class="govuk-heading-s">Header</h3>
       {{ govukHeader(componentFixtures['header']['with product name'][0].options) }}
 
@@ -112,11 +150,10 @@
   {{super()}}
   <script type="module">
     const template = document.querySelector('[data-module="app-colour-form"]');
-    const examples = document.querySelector('[data-module="app-examples"]');
 
-    const colourProperties = getCustomProperties(document.documentElement).filter(({propertyName}) => {
-      return propertyName.startsWith('--govuk') && propertyName.endsWith('-colour')
-    })
+    const colourProperties = Array.from(getCustomProperties(document.documentElement)
+      .filter(({propertyName}) => propertyName.endsWith('-colour')))
+      .sort(({propertyName: a}, {propertyName: b}) => a > b ? -1 : (a < b ? 1 : 0))
 
     for (const property of colourProperties) {
       template.insertAdjacentElement('afterEnd', createField(property))
@@ -125,7 +162,7 @@
     document.addEventListener('input', (event) => {
       const propertyName = event.target.name;
       const value = event.target.value;
-      examples.style.setProperty(propertyName, value);
+      document.documentElement.style.setProperty(propertyName, value);
     })
 
     //////

--- a/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
@@ -1,0 +1,173 @@
+{% extends "layouts/examples.njk" %}
+
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% block head %}
+  {{super()}}
+  <style>
+    /*
+     * As the list of colours is pretty long
+     * make it scrollable so they're easier to tweak
+     */
+    .govuk-grid-row {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+
+      > * {
+        width: 100%;
+      }
+    }
+
+    .govuk-grid-column-one-third {
+      position: relative;
+
+      > * {
+        position: absolute;
+        inset: 0;
+        overflow-y: scroll;
+        overflow-behaviour-y: contain;
+        padding-left: 15px;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    href: "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">Components with solid surfaces</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" data-module="app-examples">
+      <h2 class="govuk-heading-m">Examples</h2>
+      <h3 class="govuk-heading-s">Header</h3>
+      {{ govukHeader(componentFixtures['header']['with product name'][0].options) }}
+
+      <h3 class="govuk-heading-s">Breadcrumbs (inverse)</h3>
+      <div class="app-template__body--inverse govuk-!-padding-2">
+      {{ govukBreadcrumbs(componentFixtures['breadcrumbs']['inverse'][0].options) }}
+      </div>
+
+      <h3 class="govuk-heading-s">Service navigation (inverse)</h3>
+      {{ govukServiceNavigation(componentFixtures['service-navigation'].inverse[0].options) }}
+
+      <h3 class="govuk-heading-s">Panel</h3>
+      {{ govukPanel(componentFixtures['panel']['default'][0].options) }}
+
+      <h3 class="govuk-heading-s">Notification banner</h3>
+      {{ govukNotificationBanner(componentFixtures['notification-banner']['default'][0].options) }}
+
+      <h3 class="govuk-heading-s">Notification banner (success)</h3>
+      {{ govukNotificationBanner(componentFixtures['notification-banner']['with type as success'][0].options) }}
+
+      <h3 class="govuk-heading-s">Link (inverse)</h3>
+      <div class="app-template__body--inverse govuk-!-padding-2">
+        <a class="govuk-link govuk-link--inverse" href="">Contact</a>
+      </div>
+
+      <h3 class="govuk-heading-s">Button</h3>
+      {{govukButton(componentFixtures['button']['default'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (start)</h3>
+      {{govukButton(componentFixtures['button']['start'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (warning)</h3>
+      {{govukButton(componentFixtures['button']['warning'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (inverse)</h3>
+      <div class="app-template__body--inverse govuk-!-padding-2">
+        {{govukButton(componentFixtures['button']['inverse'][0].options)}}
+      </div>
+
+      <h3 class="govuk-heading-s">Select (selected value)</h3>
+      {{govukSelect(componentFixtures['select']['default'][0].options)}}
+
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div>
+        <h2 class="govuk-heading-m">Colours</h2>
+        <template data-module="app-colour-form">
+          <div class="govuk-form-group">
+            <input type="color">
+            <label class="govuk-label govuk-label--s"></label>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block bodyEnd %}
+  {{super()}}
+  <script type="module">
+    const template = document.querySelector('[data-module="app-colour-form"]');
+    const examples = document.querySelector('[data-module="app-examples"]');
+
+    const colourProperties = getCustomProperties(document.documentElement).filter(({propertyName}) => {
+      return propertyName.startsWith('--govuk') && propertyName.endsWith('-colour')
+    })
+
+    for (const property of colourProperties) {
+      template.insertAdjacentElement('afterEnd', createField(property))
+    }
+
+    document.addEventListener('input', (event) => {
+      const propertyName = event.target.name;
+      const value = event.target.value;
+      examples.style.setProperty(propertyName, value);
+    })
+
+    //////
+    ///. Supporting functions .
+    //////
+
+    function createField({propertyName, propertyValue}) {
+      const id = propertyName.replace('--','')
+
+      const field = template.content.cloneNode(true)
+      const label = field.querySelector('label')
+      const input = field.querySelector('input')
+
+      label.for = id
+      label.textContent = propertyName
+      input.id = id
+      input.name = propertyName
+      input.value = propertyValue
+
+      return field.children[0];
+    }
+
+    /**
+     * Creates a generator to iterate on all the custom properties styling an element
+     *
+     * @param {Element} element - The element whose custom properties to iterate on
+     * @return {Generator<{propertyName: string, propertyValue: string}>}
+     */
+    function* getCustomProperties(element) {
+      const computedStyles = getComputedStyle(element);
+      for (const property in computedStyles) {
+        // For some reason custom properties are not listed as direct JavaScript properties
+        // of the computed styles. Instead, they're listed as values for number indices of the computed styles
+        if (!Number.isNaN(parseInt(property))) {
+          const propertyName = computedStyles[property];
+          if (propertyName.startsWith('--')) {
+            const propertyValue = computedStyles.getPropertyValue(propertyName);
+            yield {propertyName, propertyValue}
+          }
+        }
+      }
+    }
+
+  </script>
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/accordion/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/accordion/_mixin.scss
@@ -2,8 +2,8 @@
 
 /// @access private
 @mixin styles {
-  $govuk-accordion-base-colour: base.govuk-colour("black");
-  $govuk-accordion-hover-colour: base.govuk-colour("black", $variant: "tint-95");
+  $govuk-accordion-base-colour: base.govuk-functional-colour(accordion-base);
+  $govuk-accordion-hover-colour: base.govuk-functional-colour(accordion-hover);
   $govuk-accordion-icon-focus-colour: base.govuk-functional-colour(focus);
   $govuk-accordion-bottom-border-width: 1px;
 

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
@@ -124,7 +124,7 @@
   }
 
   .govuk-breadcrumbs--inverse {
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(breadcrumbs-inverse);
 
     .govuk-breadcrumbs__link {
       @include base.govuk-link-style-inverse;

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -8,26 +8,26 @@
 @mixin styles($background-colour, $text-colour, $inverse-background-colour, $inverse-text-colour) {
   $govuk-button-colour: $background-colour;
   $text-colour: $text-colour;
-  $govuk-button-hover-colour: base.govuk-colour("green", $variant: "shade-25");
-  $govuk-button-shadow-colour: base.govuk-colour("green", $variant: "shade-50");
+  $govuk-button-hover-colour: base.govuk-functional-colour(button-hover);
+  $govuk-button-shadow-colour: base.govuk-functional-colour(button-shadow);
 
   // Secondary button variables
-  $govuk-secondary-button-colour: base.govuk-colour("black", $variant: "tint-95");
-  $govuk-secondary-button-text-colour: base.govuk-colour("black");
-  $govuk-secondary-button-hover-colour: base.govuk-colour("black", $variant: "tint-80");
-  $govuk-secondary-button-shadow-colour: base.govuk-colour("black", $variant: "tint-50");
+  $govuk-secondary-button-colour: base.govuk-functional-colour(secondary-button);
+  $govuk-secondary-button-text-colour: base.govuk-functional-colour(secondary-button-text);
+  $govuk-secondary-button-hover-colour: base.govuk-functional-colour(secondary-button-hover);
+  $govuk-secondary-button-shadow-colour: base.govuk-functional-colour(secondary-button-shadow);
 
   // Warning button variables
-  $govuk-warning-button-colour: base.govuk-colour("red");
-  $govuk-warning-button-text-colour: base.govuk-colour("white");
-  $govuk-warning-button-hover-colour: base.govuk-colour("red", $variant: "shade-25");
-  $govuk-warning-button-shadow-colour: base.govuk-colour("red", $variant: "shade-50");
+  $govuk-warning-button-colour: base.govuk-functional-colour(warning-button);
+  $govuk-warning-button-text-colour: base.govuk-functional-colour(warning-button-text);
+  $govuk-warning-button-hover-colour: base.govuk-functional-colour(warning-button-hover);
+  $govuk-warning-button-shadow-colour: base.govuk-functional-colour(warning-button-shadow);
 
   // Inverse button variables
   $govuk-inverse-button-colour: $inverse-background-colour;
   $inverse-text-colour: $inverse-text-colour;
-  $govuk-inverse-button-hover-colour: base.govuk-colour("blue", $variant: "tint-95");
-  $govuk-inverse-button-shadow-colour: base.govuk-colour("blue", $variant: "shade-50");
+  $govuk-inverse-button-hover-colour: base.govuk-functional-colour(inverse-button-hover);
+  $govuk-inverse-button-shadow-colour: base.govuk-functional-colour(inverse-button-shadow);
 
   // Because the shadow (s0) is visually 'part of' the button, we need to reduce
   // the height of the button to compensate by adjusting its padding (s1) and

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.import.scss
@@ -7,21 +7,21 @@
 /// @type Colour
 /// @access public
 
-$govuk-button-background-colour: govuk-colour("green") !default;
+$govuk-button-background-colour: govuk-functional-colour("button") !default;
 
 /// Button component text colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-button-text-colour: govuk-colour("white") !default;
+$govuk-button-text-colour: govuk-functional-colour("button-text") !default;
 
 /// Inverted button component background colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-inverse-button-background-colour: govuk-colour("white") !default;
+$govuk-inverse-button-background-colour: govuk-functional-colour("inverse-button-background") !default;
 
 /// Inverted button component text colour
 ///

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.scss
@@ -9,21 +9,21 @@
 /// @type Colour
 /// @access public
 
-$govuk-button-background-colour: helpers.govuk-colour("green") !default;
+$govuk-button-background-colour: helpers.govuk-functional-colour("button") !default;
 
 /// Button component text colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-button-text-colour: helpers.govuk-colour("white") !default;
+$govuk-button-text-colour: helpers.govuk-functional-colour("button-text") !default;
 
 /// Inverted button component background colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-inverse-button-background-colour: helpers.govuk-colour("white") !default;
+$govuk-inverse-button-background-colour: helpers.govuk-functional-colour("inverse-button-background") !default;
 
 /// Inverted button component text colour
 ///

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
@@ -68,7 +68,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    background-color: base.govuk-colour("white");
+    background-color: base.govuk-functional-colour(exit-this-page-overlay-background);
   }
 
   // This class is added to the body when the Exit This Page button is activated

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -4,9 +4,9 @@
 @mixin styles {
   $file-upload-border-width: 2px;
   $component-padding: base.govuk-spacing(1);
-  $empty-button-background-colour: base.govuk-colour("white");
-  $empty-pseudo-button-background-colour: base.govuk-colour("black", $variant: "tint-95");
-  $empty-status-background-colour: base.govuk-colour("blue", $variant: "tint-80");
+  $empty-button-background-colour: base.govuk-functional-colour(file-upload-empty-button-background);
+  $empty-pseudo-button-background-colour: base.govuk-functional-colour(file-upload-empty-pseudo-button-background);
+  $empty-status-background-colour: base.govuk-functional-colour(file-upload-empty-status-background);
 
   .govuk-file-upload {
     @include base.govuk-font($size: 19);
@@ -86,8 +86,8 @@
     display: block;
     margin-bottom: base.govuk-spacing(2);
     padding: base.govuk-spacing(3) base.govuk-spacing(2);
-    color: base.govuk-colour("white");
-    background-color: base.govuk-colour("blue");
+    color: base.govuk-functional-colour("file-upload-status-text");
+    background-color: base.govuk-functional-colour("file-upload-status-background");
     text-align: left;
     @include base.govuk-text-break-word;
   }
@@ -105,8 +105,8 @@
     width: 100%;
     // align the padding to be same as notification banner and error summary accounting for the thicker borders
     padding: (base.govuk-spacing(3) + base.$govuk-border-width - $file-upload-border-width);
-    border: $file-upload-border-width solid base.govuk-colour("black", $variant: "tint-80");
-    background-color: base.govuk-colour("white");
+    border: $file-upload-border-width solid base.govuk-functional-colour("file-upload-button-border");
+    background-color: base.govuk-functional-colour("file-upload-button-background");
     cursor: pointer;
 
     @media #{base.govuk-from-breakpoint(tablet)} {
@@ -119,30 +119,32 @@
     }
 
     .govuk-file-upload-button__pseudo-button {
-      background-color: base.govuk-colour("black", $variant: "tint-95");
+      background-color: base.govuk-functional-colour(file-upload-pseudo-button-background);
     }
 
     &:hover {
       border-style: dashed;
-      border-color: base.govuk-colour("black", $variant: "tint-50");
+      border-color: base.govuk-functional-colour(file-upload-hover-button-border);
 
       .govuk-file-upload-button__pseudo-button {
-        background-color: base.govuk-colour("black", $variant: "tint-80");
+        background-color: base.govuk-functional-colour(file-upload-hover-pseudo-button-background);
       }
 
       .govuk-file-upload-button__status {
-        background-color: base.govuk-colour("blue");
+        // Not creating a new variable here as the intent is to keep the colour the same when hovered
+        // Maybe we don't need the selector?
+        background-color: base.govuk-functional-colour(file-upload-status-background);
       }
     }
 
     &:active,
     &:focus {
-      border: $file-upload-border-width solid base.govuk-colour("black");
+      border: $file-upload-border-width solid base.govuk-functional-colour(file-upload-focus-button-border);
       outline: base.$govuk-focus-width solid;
       outline-color: base.govuk-functional-colour(focus);
       // Ensure outline appears outside of the element
       outline-offset: 0;
-      background-color: base.govuk-colour("black", $variant: "tint-95");
+      background-color: base.govuk-functional-colour("file-upload-focus-button-background");
       // Double the border by adding its width again. Use `box-shadow` for this
       // instead of changing `border-width` - this is for consistency with
       // components such as textarea where we avoid changing `border-width` as
@@ -152,13 +154,13 @@
 
       .govuk-file-upload-button__pseudo-button {
         background-color: base.govuk-functional-colour(focus);
-        box-shadow: 0 2px 0 base.govuk-colour("black");
+        box-shadow: 0 2px 0 base.govuk-functional-colour(file-upload-focus-button-border);
       }
 
       &:hover .govuk-file-upload-button__pseudo-button {
         border-color: base.govuk-functional-colour(focus);
         outline: 3px solid transparent;
-        background-color: base.govuk-colour("black", $variant: "tint-80");
+        background-color: base.govuk-functional-colour(file-upload-focus-pseudo-button-shadow);
         box-shadow: inset 0 0 0 1px base.govuk-functional-colour(focus);
       }
     }
@@ -173,29 +175,29 @@
     }
 
     .govuk-file-upload-button__status {
-      color: base.govuk-colour("black");
+      color: base.govuk-functional-colour(file-upload-empty-status-text);
       background-color: $empty-status-background-colour;
     }
 
     &:hover,
     &:focus,
     &:active {
-      background-color: base.govuk-colour("black", $variant: "tint-95");
+      background-color: base.govuk-functional-colour(file-upload-empty-hover-button-background);
 
       .govuk-file-upload-button__status {
-        background-color: base.govuk-colour("blue", $variant: "tint-80");
+        background-color: $empty-status-background-colour;
       }
     }
   }
 
   .govuk-file-upload-button--dragging {
     border-style: solid;
-    border-color: base.govuk-colour("black");
+    border-color: base.govuk-functional-colour(file-upload-dragging-button-border);
 
     // extra specificity to apply when
     // empty
     &.govuk-file-upload-button--empty {
-      background-color: base.govuk-colour("black", $variant: "tint-95");
+      background-color: base.govuk-functional-colour(file-upload-dragging-empty-button-background);
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -9,7 +9,7 @@
 
     // Add a transparent bottom border for forced-colour modes
     border-bottom: 1px solid transparent;
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(header-text);
     background: base.govuk-functional-colour(brand);
   }
 
@@ -100,7 +100,7 @@
 
   // Colour in the Dot
   .govuk-logo-dot {
-    fill: base.govuk-colour("teal", "accent");
+    fill: base.govuk-functional-colour(header-dot);
 
     // Override Dot colour when printing
     @media print {
@@ -148,14 +148,14 @@
   @media print {
     .govuk-header {
       border-bottom-width: 0;
-      color: base.govuk-colour("black");
+      color: base.govuk-functional-colour(text);
       background: transparent;
     }
 
     .govuk-header__homepage-link {
       &:link,
       &:visited {
-        color: base.govuk-colour("black");
+        color: base.govuk-functional-colour(text); // inherit?
       }
 
       // Do not append link href to GOV.UK link when printing (e.g. '(/)')

--- a/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
@@ -124,7 +124,7 @@
     padding: base.govuk-spacing(1);
     border: base.$govuk-border-width-form-element solid;
     border-color: base.govuk-functional-colour(input-border);
-    background-color: base.govuk-colour("black", $variant: "tint-95");
+    background-color: base.govuk-functional-colour(input-suffix-background);
     text-align: center;
     white-space: nowrap;
     // Emphasise non-editable status of prefixes and suffixes

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -38,7 +38,7 @@
     @include base.govuk-typography-weight-bold;
     margin: 0;
     padding: 0;
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(notification-banner-title-text);
   }
 
   .govuk-notification-banner__content {

--- a/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
@@ -35,7 +35,7 @@
     float: left; // Float is ignored if flex is active for prev/next links
 
     &:hover {
-      background-color: base.govuk-colour("black", $variant: "tint-95");
+      background-color: base.govuk-functional-colour(pagination-hover);
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -36,8 +36,8 @@
   }
 
   .govuk-panel--confirmation {
-    color: base.govuk-colour("white");
-    background: base.govuk-colour("green");
+    color: base.govuk-functional-colour(panel-text);
+    background: base.govuk-functional-colour(panel-background);
 
     @media print {
       border-color: currentcolor;

--- a/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
@@ -21,7 +21,7 @@
     // Default user agent colours for selects can have low contrast,
     // and may look disabled (#2435)
     color: base.govuk-functional-colour(text);
-    background-color: base.govuk-colour("white");
+    background-color: base.govuk-functional-colour(select-background);
 
     &:focus {
       @include base.govuk-focused-form-input;
@@ -37,8 +37,8 @@
   .govuk-select option:active,
   .govuk-select option:checked,
   .govuk-select:focus::-ms-value {
-    color: base.govuk-colour("white");
-    background-color: base.govuk-colour("blue");
+    color: base.govuk-functional-colour(select-active-text);
+    background-color: base.govuk-functional-colour(select-active-background);
   }
 
   .govuk-select--error {

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -202,7 +202,7 @@
 
     // Set colour here so non-link text (service name, slot content) can
     // use it too.
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(service-navigation-inverse-text);
 
     background-color: base.govuk-functional-colour(brand);
 
@@ -220,7 +220,7 @@
     // Override the 'active' border colour
     .govuk-service-navigation__item,
     .govuk-service-navigation__service-name {
-      border-color: base.govuk-colour("white");
+      border-color: base.govuk-functional-colour(service-navigation-inverse-text);
     }
 
     // Override link styles

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
@@ -206,7 +206,7 @@
     // Ensures the card header appears separate to the summary list in forced
     // colours mode
     border-bottom: 1px solid transparent;
-    background-color: base.govuk-colour("black", $variant: "tint-95");
+    background-color: base.govuk-functional-colour(summary-card-title-background);
 
     @media #{base.govuk-from-breakpoint(tablet)} {
       display: flex;

--- a/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
@@ -71,7 +71,7 @@
         padding: base.govuk-spacing(2) base.govuk-spacing(4);
 
         float: left;
-        background-color: base.govuk-colour("black", $variant: "tint-95");
+        background-color: base.govuk-functional-colour(tabs-list-item-background);
         text-align: center;
 
         &::before {

--- a/packages/govuk-frontend/src/govuk/components/task-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/task-list/_mixin.scss
@@ -2,7 +2,7 @@
 
 /// @access private
 @mixin styles {
-  $govuk-task-list-hover-colour: base.govuk-colour("black", $variant: "tint-95");
+  $govuk-task-list-hover-colour: base.govuk-functional-colour(task-list-hover);
 
   .govuk-task-list {
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -125,7 +125,7 @@
   }
 
   &:hover {
-    color: govuk-colour("red", $variant: "shade-50");
+    color: govuk-functional-colour(link-error-hover);
   }
 
   &:active {
@@ -162,7 +162,7 @@
   }
 
   &:hover {
-    color: govuk-colour("green", $variant: "shade-50");
+    color: govuk-functional-colour(link-success-hover);
   }
 
   &:active {
@@ -257,7 +257,7 @@
 @mixin govuk-link-style-inverse {
   &:link,
   &:visited {
-    color: govuk-colour("white");
+    color: govuk-functional-colour(link-inverse);
   }
 
   &:focus {

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -100,11 +100,13 @@ $govuk-default-functional-colours: (
     "accordion-base": (
       name: "black"
     ),
-    // Should this be `text`?
     "accordion-hover": (
-        name: "black",
-        variant: "tint-95"
-      )
+      name: "black",
+      variant: "tint-95"
+    ),
+    "breadcrumbs-inverse": (
+      name: "white"
+    )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -246,7 +246,11 @@ $govuk-default-functional-colours: (
     // Should this be "surface-background"?
     "notification-banner-title-text": (
         name: "white"
-      )
+      ),
+    "pagination-hover": (
+      name: "black",
+      variant: "tint-95"
+    )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -238,8 +238,11 @@ $govuk-default-functional-colours: (
       name: "teal",
       variant: "accent"
     ),
-
     // Should this be a functional colour?,
+    "input-suffix-background": (
+        name: "black",
+        variant: "tint-95"
+      ) // Should this be "surface-background"?
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -277,6 +277,11 @@ $govuk-default-functional-colours: (
       variant: "tint-95"
     ),
     // Should it be `surface` ?
+    "tabs-list-item-background": (
+        name: "black",
+        variant: "tint-95"
+      ),
+    // Should it be `surface` ?
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -167,6 +167,70 @@ $govuk-default-functional-colours: (
       name: "white"
     ),
     // Should it be `template-background`?
+    "file-upload-status-background": (
+        name: "blue"
+      ),
+    // Should it be `brand`?
+    "file-upload-status-text": (
+        name: "white"
+      ),
+    "file-upload-button-border": (
+      name: "black",
+      variant: "tint-80"
+    ),
+    "file-upload-button-background": (
+      name: "white"
+    ),
+    "file-upload-hover-button-border": (
+      name: "black",
+      variant: "tint-50"
+    ),
+    "file-upload-hover-pseudo-button-background": (
+      name: "black",
+      variant: "tint-80"
+    ),
+    "file-upload-focus-button-background": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    "file-upload-focus-button-border": (
+      name: "black"
+    ),
+    // Should it reference `focus-text`?
+    "file-upload-focus-pseudo-button-shadow": (
+        name: "black",
+        variant: "tint-80"
+      ),
+    "file-upload-pseudo-button-background": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    "file-upload-empty-button-background": (
+      name: "white"
+    ),
+    "file-upload-empty-pseudo-button-background": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    "file-upload-empty-status-text": (
+      name: "black"
+    ),
+    // Should it be 'text'
+    "file-upload-empty-status-background": (
+        name: "blue",
+        variant: "tint-80"
+      ),
+    "file-upload-empty-hover-button-background": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    "file-upload-dragging-button-border": (
+      name: "black"
+    ),
+    "file-upload-dragging-empty-button-background": (
+      name: "black",
+      variant: "tint-95"
+    )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -250,7 +250,14 @@ $govuk-default-functional-colours: (
     "pagination-hover": (
       name: "black",
       variant: "tint-95"
-    )
+    ),
+    "panel-text": (
+      name: "white"
+    ),
+    "panel-background": (
+      name: "green"
+    ),
+    // Should it be `success`?
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -258,6 +258,17 @@ $govuk-default-functional-colours: (
       name: "green"
     ),
     // Should it be `success`?
+    "select-background": (
+        name: "white"
+      ),
+    // Should it be "template-background"?
+    "select-active-text": (
+        name: "white"
+      ),
+    // Another white on blue
+    "select-active-background": (
+        name: "blue"
+      )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -271,7 +271,12 @@ $govuk-default-functional-colours: (
       ),
     "service-navigation-inverse-text": (
       name: "white"
-    )
+    ),
+    "summary-card-title-background": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    // Should it be `surface` ?
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -162,7 +162,11 @@ $govuk-default-functional-colours: (
     "inverse-button-shadow": (
       name: "blue",
       variant: "shade-50"
-    )
+    ),
+    "exit-this-page-overlay-background": (
+      name: "white"
+    ),
+    // Should it be `template-background`?
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -230,7 +230,16 @@ $govuk-default-functional-colours: (
     "file-upload-dragging-empty-button-background": (
       name: "black",
       variant: "tint-95"
-    )
+    ),
+    "header-text": (
+      name: "white"
+    ),
+    "header-dot": (
+      name: "teal",
+      variant: "accent"
+    ),
+
+    // Should this be a functional colour?,
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -268,7 +268,10 @@ $govuk-default-functional-colours: (
     // Another white on blue
     "select-active-background": (
         name: "blue"
-      )
+      ),
+    "service-navigation-inverse-text": (
+      name: "white"
+    )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -242,7 +242,11 @@ $govuk-default-functional-colours: (
     "input-suffix-background": (
         name: "black",
         variant: "tint-95"
-      ) // Should this be "surface-background"?
+      ),
+    // Should this be "surface-background"?
+    "notification-banner-title-text": (
+        name: "white"
+      )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -281,7 +281,22 @@ $govuk-default-functional-colours: (
         name: "black",
         variant: "tint-95"
       ),
+    "task-list-hover": (
+      name: "black",
+      variant: "tint-95"
+    ),
     // Should it be `surface` ?
+    "link-error-hover": (
+        name: "red",
+        variant: "shade-50"
+      ),
+    "link-success-hover": (
+      name: "green",
+      variant: "shade-50"
+    ),
+    "link-inverse": (
+      name: "white"
+    )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -96,7 +96,15 @@ $govuk-default-functional-colours: (
     "surface-border": (
       name: "blue",
       variant: "tint-50"
-    )
+    ),
+    "accordion-base": (
+      name: "black"
+    ),
+    // Should this be `text`?
+    "accordion-hover": (
+        name: "black",
+        variant: "tint-95"
+      )
   )
 );
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -106,6 +106,62 @@ $govuk-default-functional-colours: (
     ),
     "breadcrumbs-inverse": (
       name: "white"
+    ),
+    "button": (
+      name: "green"
+    ),
+    "button-text": (
+      name: "white"
+    ),
+    "button-hover": (
+      name: "green",
+      variant: "shade-25"
+    ),
+    "button-shadow": (
+      name: "green",
+      variant: "shade-50"
+    ),
+    "secondary-button": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    "secondary-button-text": (
+      name: "black"
+    ),
+    "secondary-button-hover": (
+      name: "black",
+      variant: "tint-80"
+    ),
+    "secondary-button-shadow": (
+      name: "black",
+      variant: "tint-50"
+    ),
+    "warning-button": (
+      name: "red"
+    ),
+    "warning-button-text": (
+      name: "white"
+    ),
+    "warning-button-hover": (
+      name: "red",
+      variant: "shade-25"
+    ),
+    "warning-button-shadow": (
+      name: "red",
+      variant: "shade-50"
+    ),
+    // No inverse-button-text as it's `brand`
+    "inverse-button-background": (
+        name: "white"
+      ),
+    // Why was the variable not `inverse-button`
+    "inverse-button-hover": (
+        name: "blue",
+        variant: "tint-95"
+      ),
+    "inverse-button-shadow": (
+      name: "blue",
+      variant: "shade-50"
     )
   )
 );


### PR DESCRIPTION
Naive implementation turning each use of `govuk-colour` in a component into a specific component custom property. If anything it highlights the number of places we have hardcoded colours from the palette rather than functional ones.