### PR TITLE
[SPIKE] Explore implementing a concept of solid surface

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
@@ -51,31 +51,10 @@
   <h1 class="govuk-heading-l">Components with solid surfaces</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" data-module="app-examples">
-      <h2 class="govuk-heading-m">Examples</h2>
+      <h2 class="govuk-heading-m">Blue examples</h2>
 
       <h3 class="govuk-heading-s">Inverse section via custom props</h3>
-      <style style="display: block; white-space: pre; font-family: monospace">
-:root {
-  --app-brand-surface-text-colour: #ffffff;
-  --app-brand-surface-text-hover-colour: #f4f8fb;
-  --app-brand-surface-background-colour: var(--govuk-brand-colour);
-  --app-brand-surface-shadow-colour:  #0f385c;
-}
-
-.app-brand-surface {
-  background: var(--app-brand-surface-background-colour);
-  color: var(--app-brand-surface-text-colour);
-  --govuk-text-colour: var(--app-brand-surface-text-colour);
-  --govuk-link-colour: var(--app-brand-surface-text-colour);
-  --govuk-link-visited-colour: var(--app-brand-surface-text-colour);
-  --govuk-link-hover-colour: var(--app-brand-surface-text-colour);
-  --govuk-button-colour: var(--app-brand-surface-text-colour);
-  --govuk-button-text-colour: var(--app-brand-surface-background-colour);
-  --govuk-button-shadow-colour: var(--app-brand-surface-shadow-colour);
-  --govuk-button-hover-colour: var(--app-brand-surface-text-hover-colour);
-}
-      </style>
-      <div class="app-brand-surface govuk-!-padding-3">
+      <div class="govuk-surface--brand govuk-!-padding-3">
         <h4 class="govuk-heading-s">Oh! Hello!</h4>
         <p class="govuk-body">Inside this block, <a class="govuk-link" href="">`govuk-link`s</a> and <a class="govuk-link govuk-link--text">`govuk-link--text`</a> do not need custom properties to adapt to the background.
         <p class="govuk-body">Buttons do not either:</p>
@@ -113,39 +92,29 @@
       {{ govukHeader(componentFixtures['header']['with product name'][0].options) }}
 
       <h3 class="govuk-heading-s">Breadcrumbs (inverse)</h3>
-      <div class="app-template__body--inverse govuk-!-padding-2">
-      {{ govukBreadcrumbs(componentFixtures['breadcrumbs']['inverse'][0].options) }}
+      <div class="govuk-surface--brand govuk-!-padding-2">
+      {{ govukBreadcrumbs(componentFixtures['breadcrumbs']['default'][0].options) }}
+      </div>
+
+      <h3 class="govuk-heading-s">Back link</h3>
+      <div class="govuk-surface--brand govuk-!-padding-2">
+      {{ govukBackLink({ href: "/" }) }}
       </div>
 
       <h3 class="govuk-heading-s">Service navigation (inverse)</h3>
       {{ govukServiceNavigation(componentFixtures['service-navigation'].inverse[0].options) }}
 
-      <h3 class="govuk-heading-s">Panel</h3>
-      {{ govukPanel(componentFixtures['panel']['default'][0].options) }}
-
       <h3 class="govuk-heading-s">Notification banner</h3>
       {{ govukNotificationBanner(componentFixtures['notification-banner']['default'][0].options) }}
 
-      <h3 class="govuk-heading-s">Notification banner (success)</h3>
-      {{ govukNotificationBanner(componentFixtures['notification-banner']['with type as success'][0].options) }}
-
       <h3 class="govuk-heading-s">Link (inverse)</h3>
-      <div class="app-template__body--inverse govuk-!-padding-2">
-        <a class="govuk-link govuk-link--inverse" href="">Contact</a>
+      <div class="govuk-surface--brand govuk-!-padding-2">
+        <a class="govuk-link" href="">Contact</a>
       </div>
 
-      <h3 class="govuk-heading-s">Button</h3>
-      {{govukButton(componentFixtures['button']['default'][0].options)}}
-
-      <h3 class="govuk-heading-s">Button (start)</h3>
-      {{govukButton(componentFixtures['button']['start'][0].options)}}
-
-      <h3 class="govuk-heading-s">Button (warning)</h3>
-      {{govukButton(componentFixtures['button']['warning'][0].options)}}
-
       <h3 class="govuk-heading-s">Button (inverse)</h3>
-      <div class="app-template__body--inverse govuk-!-padding-2">
-        {{govukButton(componentFixtures['button']['inverse'][0].options)}}
+      <div class="govuk-surface--brand govuk-!-padding-2">
+        {{govukButton(componentFixtures['button']['default'][0].options)}}
       </div>
 
       <h3 class="govuk-heading-s">Select (selected value)</h3>
@@ -153,6 +122,25 @@
 
       <h3 class="govuk-heading-s">File upload (filled)</h3>
       {{govukFileUpload(componentFixtures['file-upload']['enhanced'][0].options)}}
+
+      <h2 class="govuk-heading-m">Green examples</h2>
+
+      <h3 class="govuk-heading-s">Panel</h3>
+      {{ govukPanel(componentFixtures['panel']['default'][0].options) }}
+
+      <h3 class="govuk-heading-s">Notification banner (success)</h3>
+      {{ govukNotificationBanner(componentFixtures['notification-banner']['with type as success'][0].options) }}
+
+      <h3 class="govuk-heading-s">Button</h3>
+      {{govukButton(componentFixtures['button']['default'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (start)</h3>
+      {{govukButton(componentFixtures['button']['start'][0].options)}}
+
+      <h2 class="govuk-heading-m">Red examples</h2>
+
+      <h3 class="govuk-heading-s">Button (warning)</h3>
+      {{govukButton(componentFixtures['button']['warning'][0].options)}}
 
     </div>
     <div class="govuk-grid-column-one-third">

--- a/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
@@ -10,6 +10,11 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% block head %}
   {{super()}}
@@ -84,6 +89,17 @@
 }
         </style>
         {{govukButton({text: 'A green button', classes: 'app-button--default'})}}
+
+      <p class="govuk-body">Let's look at what form fields would look like</p>
+      {{govukInput(componentFixtures['input']['with hint text'][0].options)}}
+      {{govukSelect(componentFixtures['select']['with hint text and error message'][0].options)}}
+      {{govukTextarea(componentFixtures['textarea']['with error message'][0].options)}}
+      {{govukCheckboxes(componentFixtures['checkboxes']['default'][0].options)}}
+      {{govukCheckboxes(componentFixtures['checkboxes']['small'][0].options)}}
+      {{govukRadios(componentFixtures['radios']['default'][0].options)}}
+      {{govukRadios(componentFixtures['radios']['small'][0].options)}}
+      {{govukRadios(componentFixtures['radios']['small'][0].options)}}
+
 
 
       </div>

--- a/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/solid-surface-components/index.njk
@@ -9,6 +9,7 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 {% block head %}
   {{super()}}
@@ -59,7 +60,6 @@
   --app-brand-surface-text-hover-colour: #f4f8fb;
   --app-brand-surface-background-colour: var(--govuk-brand-colour);
   --app-brand-surface-shadow-colour:  #0f385c;
-
 }
 
 .app-brand-surface {
@@ -85,6 +85,26 @@
         <p class="govuk-body">We can still have red warning buttons too</p>
         {{govukButton(componentFixtures['button']['warning'][0].options)}}
         <p class="govuk-body">But would need extra CSS to allow green buttons</p>
+        <style style="display: block; white-space: pre; font-family: monospace">
+:root {
+  /* Save the default button colours
+   * so we can re-use them when
+   * `--govuk-button(-...)-colour` have been overridden
+   */
+  --app-default-button-colour: var(--govuk-button-colour);
+  --app-default-button-text-colour: var(--govuk-button-text-colour);
+  --app-default-button-hover-colour: var(--govuk-button-hover-colour);
+  --app-default-button-shadow-colour: var(--govuk-button-shadow-colour);
+}
+
+.app-button--default {
+  --govuk-button-colour: var(--app-default-button-colour);
+  --govuk-button-text-colour: var(--app-default-button-text-colour);
+  --govuk-button-shadow-colour: var(--app-default-button-shadow-colour);
+  --govuk-button-hover-colour: var(--app-default-button-hover-colour);
+}
+        </style>
+        {{govukButton({text: 'A green button', classes: 'app-button--default'})}}
 
 
       </div>
@@ -130,6 +150,9 @@
 
       <h3 class="govuk-heading-s">Select (selected value)</h3>
       {{govukSelect(componentFixtures['select']['default'][0].options)}}
+
+      <h3 class="govuk-heading-s">File upload (filled)</h3>
+      {{govukFileUpload(componentFixtures['file-upload']['enhanced'][0].options)}}
 
     </div>
     <div class="govuk-grid-column-one-third">

--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -6,11 +6,11 @@
 
   .govuk-header {
     @include base.govuk-font($size: 16, $line-height: 1);
+    @include base.govuk-surface;
+    @include base.govuk-surface-style-brand;
 
     // Add a transparent bottom border for forced-colour modes
     border-bottom: 1px solid transparent;
-    color: base.govuk-functional-colour(header-text);
-    background: base.govuk-functional-colour(brand);
   }
 
   .govuk-header__container--full-width {
@@ -47,7 +47,7 @@
     > * {
       word-spacing: 0;
     }
-    @include base.govuk-link-style-inverse;
+    @include base.govuk-link-style-text;
 
     &:link,
     &:visited {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -9,9 +9,9 @@
     @include base.govuk-responsive-margin(8, "bottom");
 
     border: base.$govuk-border-width solid;
-    border-color: base.govuk-functional-colour(brand);
-
-    background-color: base.govuk-functional-colour(brand);
+    @include base.govuk-surface;
+    @include base.govuk-surface-style-brand;
+    border-color: var(--govuk-surface-background);
 
     &:focus {
       outline: base.$govuk-focus-width solid;
@@ -44,6 +44,9 @@
   .govuk-notification-banner__content {
     $padding-tablet: base.govuk-spacing(4);
     padding: base.govuk-spacing(3);
+
+    @include base.govuk-surface;
+    @include base.govuk-surface-style-body;
 
     color: base.govuk-functional-colour(text);
     background-color: base.govuk-functional-colour(body-background);

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -200,11 +200,8 @@
     // Remove bottom border to add width-container ones
     border-bottom: none;
 
-    // Set colour here so non-link text (service name, slot content) can
-    // use it too.
-    color: base.govuk-functional-colour(service-navigation-inverse-text);
-
-    background-color: base.govuk-functional-colour(brand);
+    @include base.govuk-surface;
+    @include base.govuk-surface-style-brand;
 
     .govuk-width-container {
       border-width: 1px 0;
@@ -220,12 +217,7 @@
     // Override the 'active' border colour
     .govuk-service-navigation__item,
     .govuk-service-navigation__service-name {
-      border-color: base.govuk-functional-colour(service-navigation-inverse-text);
-    }
-
-    // Override link styles
-    .govuk-service-navigation__link {
-      @include base.govuk-link-style-inverse;
+      border-color: base.govuk-functional-colour(text);
     }
 
     // Override mobile menu toggle colour when not focused

--- a/packages/govuk-frontend/src/govuk/helpers/_index.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_index.scss
@@ -7,6 +7,7 @@
 @forward "media-queries";
 @forward "shape-arrow";
 @forward "spacing";
+@forward "surface";
 @forward "typography";
 @forward "visually-hidden";
 @forward "width-container";

--- a/packages/govuk-frontend/src/govuk/helpers/_surface.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_surface.scss
@@ -2,6 +2,9 @@
 
 @mixin govuk-surface() {
   --govuk-text-colour: var(--govuk-surface-text);
+  // TODO: Feels like back-link and breadcrumbs could benefit
+  // from a functional colour for their chevrons rather than use `secondary-text`
+  --govuk-secondary-text-colour: var(--govuk-surface-text);
 
   // This would likely be applying the `link-style-text` mixin
   --govuk-link-colour: #{govuk-functional-colour(text)};
@@ -26,4 +29,5 @@
   --govuk-surface-text: #{govuk-colour("white")};
   --govuk-surface-text-hover: #{govuk-colour("blue", $variant: "tint-95")};
   --govuk-surface-shadow: #{govuk-colour("blue", $variant: "shade-50")};
+  --govuk-surface-graphic: #{govuk-colour("white")};
 }

--- a/packages/govuk-frontend/src/govuk/helpers/_surface.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_surface.scss
@@ -31,3 +31,8 @@
   --govuk-surface-shadow: #{govuk-colour("blue", $variant: "shade-50")};
   --govuk-surface-graphic: #{govuk-colour("white")};
 }
+
+@mixin govuk-surface-style-body() {
+  --govuk-surface-background: #{govuk-functional-colour(body-background)};
+  --govuk-surface-text: #{govuk-functional-colour(body-text)};
+}

--- a/packages/govuk-frontend/src/govuk/helpers/_surface.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_surface.scss
@@ -1,0 +1,29 @@
+@use "colour" as *;
+
+@mixin govuk-surface() {
+  --govuk-text-colour: var(--govuk-surface-text);
+
+  // This would likely be applying the `link-style-text` mixin
+  --govuk-link-colour: #{govuk-functional-colour(text)};
+  --govuk-link-visited-colour: #{govuk-functional-colour(text)};
+  --govuk-link-hover-colour: #{govuk-functional-colour(text)};
+
+  // This would likely be applying some form of mixin too
+  --govuk-button-colour: var(--govuk-surface-text);
+  --govuk-button-text-colour: var(--govuk-surface-background);
+  --govuk-button-shadow-colour: var(--govuk-surface-shadow);
+  --govuk-button-hover-colour: var(--govuk-surface-text-hover);
+  color: govuk-functional-colour(text);
+
+  background: var(--govuk-surface-background);
+}
+
+@mixin govuk-surface-style-brand() {
+  // TODO: Figure if these need to be functional. Watch out for the `--govuk-suface-background`,
+  // which, if set on `:root`, will not get updated if `--govuk-brand-colour` gets updated on a descendant
+  // on the page, as its value will already have been resolved on `:root`.
+  --govuk-surface-background: #{govuk-functional-colour(brand)};
+  --govuk-surface-text: #{govuk-colour("white")};
+  --govuk-surface-text-hover: #{govuk-colour("blue", $variant: "tint-95")};
+  --govuk-surface-shadow: #{govuk-colour("blue", $variant: "shade-50")};
+}

--- a/packages/govuk-frontend/src/govuk/objects/_index.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_index.scss
@@ -2,5 +2,6 @@
 @use "form-group";
 @use "grid";
 @use "main-wrapper";
+@use "surface";
 @use "template";
 @use "width-container";

--- a/packages/govuk-frontend/src/govuk/objects/_surface.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_surface.scss
@@ -1,0 +1,6 @@
+@use "../helpers/surface" as *;
+
+.govuk-surface--brand {
+  @include govuk-surface;
+  @include govuk-surface-style-brand;
+}

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -30,6 +30,9 @@ $govuk-default-functional-colours: (
     "body-background": (
       name: "white"
     ),
+    "body-text": (
+      name: "black"
+    ),
     // Use 'true black' to avoid printers using colour ink to print body text
     "print-text": #000000,
     // Used in for example 'muted' text and help text.

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -231,9 +231,6 @@ $govuk-default-functional-colours: (
       name: "black",
       variant: "tint-95"
     ),
-    "header-text": (
-      name: "white"
-    ),
     "header-dot": (
       name: "teal",
       variant: "accent"


### PR DESCRIPTION
> [!IMPORTANT]
> This is work in progress, still partially implemented

Moves the concept of 'brand surface' from the review app into GOV.UK Frontend, through a:
- `govuk-surface` mixin that maps the surface colours to buttons and links
- `govuk-surface-style-brand` mixin that sets the surface colours to blue background and white text
- `govuk-surface-style-body` mixin that sets the surface colours black on white
- `.govuk-surface--brand` class that creates a white on blue area

The mixin reconfigures existing functional colours so components inside the element it is applied to get their colours updated without having to explicitly add `--inverse` to each of them. 

The colours being applied are currently hardcoded in the `govuk-surface-style-brand` mixin, but could come from existing functional colours similar to those added by #7166. This may signify that our first step should be implementing the colours for #7166 before implementing a `surface` abstraction.

Having the concept of `surface` would allow to retire a couple of `--inverse` classes (buttons, links, breadcrumbs), enable the back button to turn white as well if necessary. It affects form field labels and some inputs too, though only radios and checkboxes will turn white. Input, select and textarea form controls will remain with a black border and white background. The error colour may need some update to work on blue background, signalling that a surface may need to adjust more colours than initially thought.


