### PR TITLE
[SPIKE] Custom styled select elements

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
@@ -2,10 +2,13 @@
 
 /// @access private
 @mixin styles {
+  $govuk-select-arrow-size: 12px;
+
   .govuk-select {
     @include base.govuk-font($size: 19, $line-height: 1.25);
 
     box-sizing: border-box;
+    position: relative;
 
     // This min-width was chosen because:
     // - it makes the Select wider than it is tall (which is what users expect)
@@ -15,6 +18,7 @@
     max-width: 100%;
     height: base.govuk-px-to-rem(40px);
     padding: base.govuk-spacing(1);
+    padding-right: $govuk-select-arrow-size + base.govuk-spacing(1) * 2;
     border: base.$govuk-border-width-form-element solid;
     border-color: base.govuk-functional-colour(input-border);
 
@@ -22,6 +26,84 @@
     // and may look disabled (#2435)
     color: base.govuk-functional-colour(text);
     background-color: base.govuk-colour("white");
+
+    // Enable custom select and dropdown styling in browsers that support them.
+    @supports (appearance: base-select) {
+      // ISSUE: Overriding the `appearance` stops the browser from doing the
+      // text truncation it would normally do, and trying other methods to
+      // prevent text overflowing the element don't seem to work, so just allow
+      // it to grow in height for now.
+      height: auto;
+      min-height: base.govuk-px-to-rem(40px);
+
+      border-radius: 0;
+      appearance: base-select;
+
+      &::picker-icon {
+        // Hide default arrow
+        content: "";
+
+        // ISSUE: The icon output from this mixin does not scale with changes
+        // to text size.
+        @include base.govuk-shape-arrow($direction: down, $base: $govuk-select-arrow-size);
+
+        position: absolute;
+        top: calc(50% - #{$govuk-select-arrow-size * 0.5});
+        right: base.govuk-spacing(1);
+      }
+
+      &::picker(select) {
+        // Position menu below the select and grow to the right if needed.
+        position-area: bottom span-right;
+
+        // Subtract top border to avoid doubling up with the input.
+        //
+        // ISSUE: The dropdown can appear above the input if there is more space
+        // available there, in which case this spacing is undesirable.
+        top: base.$govuk-border-width-form-element * -1;
+
+        // Be at least as wide as the select, and as tall as the available
+        // viewport allows.
+        min-width: anchor-size(self-inline);
+        max-height: stretch;
+        overflow: auto;
+
+        border: base.$govuk-border-width-form-element solid;
+        border-color: base.govuk-functional-colour(input-border);
+
+        // Default user agent colours for selects can have low contrast,
+        // and may look disabled (#2435)
+        color: base.govuk-functional-colour(text);
+        background-color: base.govuk-colour("white");
+
+        appearance: base-select;
+      }
+
+      option {
+        display: flex;
+        align-items: start;
+        gap: base.govuk-spacing(1);
+        padding: base.govuk-spacing(1);
+      }
+
+      // ISSUE: The checkmark does not scale with changes to text size, but this
+      // is also the case with our checkboxes generally.
+      option::checkmark {
+        content: "";
+        box-sizing: border-box;
+        width: 20px;
+        height: 11px;
+        margin-top: 3px;
+        transform: rotate(-45deg);
+        border: solid;
+        border-width: 0 0 3px 3px;
+      }
+
+      option:enabled:hover {
+        color: base.govuk-functional-colour(text);
+        background-color: base.govuk-colour("black", $variant: "tint-80");
+      }
+    }
 
     &:focus {
       @include base.govuk-focused-form-input;
@@ -35,10 +117,18 @@
   }
 
   .govuk-select option:active,
-  .govuk-select option:checked,
-  .govuk-select:focus::-ms-value {
+  .govuk-select option:checked {
     color: base.govuk-colour("white");
     background-color: base.govuk-colour("blue");
+  }
+
+  // Apply focus state for keyboard navigation. This uses :focus-visible
+  // instead of :focus, as otherwise it overrides the :checked colours
+  // (the checked option is always focused when opening the dropdown).
+  .govuk-select option:focus-visible {
+    outline: none;
+    color: base.govuk-functional-colour(focus-text);
+    background-color: base.govuk-functional-colour(focus);
   }
 
   .govuk-select--error {

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -123,6 +123,19 @@ examples:
         - value: 3
           text: GOV.UK frontend option 3
           disabled: true
+  - name: with HTML options
+    options:
+      name: select-1
+      label:
+        text: Label text goes here
+      items:
+        - value: 1
+          html: '<strong>GOV.UK</strong> frontend option 1'
+        - value: 2
+          html: 'GOV.UK frontend<br>option 2'
+          selected: true
+        - value: 3
+          html: '<img src="/assets/images/govuk-icon-mask.svg" width="20"> GOV.UK frontend option 3'
   - name: with hint text and error message
     options:
       id: select-2
@@ -139,7 +152,7 @@ examples:
         - value: 2
           text: GOV.UK frontend option 2
         - value: 3
-          text: GOV.UK frontend option 3
+          text: GOV.UK frontend option 3 is a bit longer
   - name: with label as page heading
     options:
       id: select-3

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -49,6 +49,9 @@
     {%- if params.disabled %} disabled{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
     {{- govukAttributes(params.attributes) }}>
+    <button>
+      <selectedcontent></selectedcontent>
+    </button>
   {% for item in params.items %}
     {% if item %}
     {#- Allow selecting by text content (the value for an option when no value attribute is specified) #}
@@ -57,7 +60,8 @@
       {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
       {{-" disabled" if item.disabled }}
       {{- govukAttributes(item.attributes) }}>
-      {{- item.text -}}
+      {# span element ensures that flex spacing does not get applied to HTML labels #}
+      <span>{{- item.html | safe if item.html else item.text -}}</span>
     </option>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Random thing I did for my own L&D: Applying the new CSS values (`appearance: base-select`) and pseudo selectors (`::picker-icon`, `::picker(select)` and `::checkmark`) to our Select component, allowing us to style them pretty much however we want to.

<img width="321" height="239" alt="Screenshot of a GOV.UK styled select menu with the menu open, showing three options. The first has some bolded text, the second has a line break in the middle of the label, and the third includes an inline image. The first option is selected, rendered in white text on a blue background and showing a checkmark next to it. The second is hovered, having a light grey background." src="https://github.com/user-attachments/assets/8dbccd2e-e618-4b81-a40e-1f0a36424a14" />

**I recommend opening the review app examples in new tabs, rather than checking them from the review app's landing page, for reasons described below.** 

## Changes
- Select options can now contain HTML.
- Closed select component now has a custom dropdown arrow.
- Select component menu has totally custom styles!
  - Menu itself is styled like an input, with a black border and white background.
  - Currently selected option has a brand blue background with white text, mirroring styles we previously applied for IE.
  - Currently selected option has a custom checkmark. 

## Neat stuff
- Both the initially displayed select and menu options are able to host phrasing HTML content. 
- This resolves a longstanding accessibility issue with many native select input menus not respecting user text scaling and zoom preferences.
- The custom styled select spec is entirely backwards compatible. Browsers that don't support it fallback to a native menu with plain text options, even if HTML has been inserted into options. 
  - You can test this yourself by going into the web inspector and disabling the `appearance: base-select` rule on the `<select>`. 
- We can use our focus styles too.
- It's on brand! 


## Awkward stuff
- **The initial input text doesn't appear to render visibly on Safari 27 beta on iOS.** Needs further investigation.
- Changing the select's `appearance` currently stops it from truncating text, so long options can wrap onto multiple lines and flow out of the input. 
  - My attempts to avoid this (using `white-space: nowrap` and `overflow: hidden`) didn't work, as those properties don't appear to have an effect on any of `<select>`, the nested `<button>`, or `<selectedcontent>`. 
  - Instead I conceded on allowing the input to grow in height, which might need to be considered anyway as the options can now also be multiple lines long. 
- Because the menu is now part of the webpage and not a native control, it is now bound to the dimensions of the browser viewport. The menu cannot display over the browser UI or break outside of an iframe (like on the review app).
  - If an iframe isn't very tall (again, like on the review app) then the menu is unable to grow very tall and can be difficult to navigate.
  - Iframes also change how the menu dismissal works. Multiple menus can appear open at once, as they will only be dismissed from clicking outside of the menu but within the iframe. 
  - The menu isn't always positioned correctly also when inside of an iframe. (Probably needs more testing in situations where there isn't adequate space below the input.) 