### PR TITLE
Add language switcher component

### DIFF
--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -125,6 +125,10 @@ describe('GOV.UK Prototype Kit config', () => {
           macroName: 'govukLabel'
         },
         {
+          importFrom: 'govuk/components/language-switcher/macro.njk',
+          macroName: 'govukLanguageSwitcher'
+        },
+        {
           importFrom: 'govuk/components/notification-banner/macro.njk',
           macroName: 'govukNotificationBanner'
         },

--- a/packages/govuk-frontend/src/govuk/components/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/_index.import.scss
@@ -18,6 +18,7 @@
 @import "input";
 @import "inset-text";
 @import "label";
+@import "language-switcher";
 @import "notification-banner";
 @import "pagination";
 @import "panel";

--- a/packages/govuk-frontend/src/govuk/components/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/_index.scss
@@ -18,6 +18,7 @@
 @use "input";
 @use "inset-text";
 @use "label";
+@use "language-switcher";
 @use "notification-banner";
 @use "pagination";
 @use "panel";

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/README.md
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/README.md
@@ -1,0 +1,15 @@
+# Language switcher
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the language switcher component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/language-switcher).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/language-switcher/#options-language-switcher-example) for details.

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/_index.import.scss
@@ -1,0 +1,7 @@
+@use "mixin";
+
+@import "../../base";
+
+@include govuk-exports("govuk/component/language-switcher") {
+  @include mixin.styles;
+}

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/_index.scss
@@ -1,0 +1,5 @@
+@use "../../custom-properties";
+
+@use "mixin";
+
+@include mixin.styles;

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/_language-switcher.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/_language-switcher.import.scss
@@ -1,0 +1,5 @@
+@use "../../settings/warnings--internal";
+
+@include warnings--internal.component-scss-file-warning("language-switcher");
+
+@import "index";

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/_mixin.scss
@@ -1,0 +1,43 @@
+@use "../../base";
+
+/// @access private
+@mixin styles {
+  .govuk-language-switcher {
+    @include base.govuk-font($size: 19);
+
+    margin-top: base.govuk-spacing(3);
+    margin-bottom: base.govuk-spacing(3);
+    color: base.govuk-functional-colour(text);
+  }
+
+  .govuk-language-switcher__list {
+    display: inline-flex;
+    flex-wrap: wrap;
+    row-gap: base.govuk-spacing(1);
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  .govuk-language-switcher__list-item {
+    display: flex;
+    align-items: center;
+
+    &:not(:last-child) {
+      &::after {
+        content: "";
+        display: block;
+        height: 1em;
+        margin-right: base.govuk-spacing(2);
+        margin-left: base.govuk-spacing(2);
+        border-right: 1px solid;
+        border-right-color: base.govuk-functional-colour(secondary-text);
+      }
+    }
+  }
+
+  .govuk-language-switcher__link {
+    @include base.govuk-link-common;
+    @include base.govuk-link-style-default;
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/accessibility.puppeteer.test.mjs
@@ -1,0 +1,28 @@
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
+import { getExamples } from '@govuk-frontend/lib/components'
+
+describe('/components/language-switcher', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects language switcher links
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
+
+  describe('component examples', () => {
+    it('passes accessibility tests', async () => {
+      const examples = await getExamples('language-switcher')
+
+      for (const exampleName in examples) {
+        await render(page, 'language-switcher', examples[exampleName])
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
+      }
+    }, 120000)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
@@ -94,6 +94,17 @@ examples:
         - text: Cymraeg
           lang: cy
           current: true
+  - name: with mixed text directions
+    options:
+      items:
+        - text: English
+          lang: en
+          dir: ltr
+          current: true
+        - text: العربية
+          lang: ar
+          dir: rtl
+          href: '#/ar'
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
@@ -1,0 +1,144 @@
+params:
+  - name: items
+    type: array
+    required: true
+    description: The languages to display within the language switcher.
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Name of the language, written in that language (for example, "Cymraeg" for Welsh). If `html` is provided, the `text` option will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML to use for the language item. If `html` is provided, the `text` option will be ignored.
+      - name: lang
+        type: string
+        required: true
+        description: The language tag for the language item text (for example, `cy` for Welsh). Added as a `lang` attribute so that assistive technologies pronounce the language name correctly.
+      - name: hrefLang
+        type: string
+        required: false
+        description: The language tag for the linked page (for example, `cy` for Welsh). Added as an `hreflang` attribute for search engines and other machine readers. Defaults to `lang` when omitted.
+      - name: dir
+        type: string
+        required: false
+        description: The text direction for the language item element. Use this on every item when the switcher includes languages that use scripts with different directions.
+      - name: href
+        type: string
+        required: false
+        description: Link to the current page in this language.
+      - name: current
+        type: boolean
+        required: false
+        description: Whether this is the language of the current page. Defaults to `true` when `href` is not provided.
+      - name: attributes
+        type: object
+        required: false
+        description: HTML attributes to add to the language item anchor.
+  - name: ariaLabel
+    type: string
+    required: false
+    description: Plain text label identifying the navigation landmark to screen readers. Write it in the language of the current page. Defaults to "Language switcher".
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the language switcher container.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes to add to the language switcher container.
+
+examples:
+  - name: default
+    screenshot: true
+    options:
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
+  - name: with multiple languages
+    options:
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Français
+          lang: fr
+          href: '#/fr'
+        - text: हिंदी
+          lang: hi
+          href: '#/hi'
+        - text: 日本語
+          lang: ja
+          href: '#/ja'
+        - text: اردو
+          lang: ur
+          href: '#/ur'
+        - text: 中文
+          lang: zh
+          href: '#/zh'
+  - name: with translated navigation label
+    description: When the current page is not in English, translate the `ariaLabel` into the language of the current page.
+    options:
+      ariaLabel: Dewis iaith
+      attributes:
+        lang: cy
+      items:
+        - text: English
+          lang: en
+          href: '#/en'
+        - text: Cymraeg
+          lang: cy
+          current: true
+
+  # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    options:
+      classes: app-language-switcher--custom-modifier
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
+  - name: attributes
+    hidden: true
+    options:
+      attributes:
+        id: my-language-switcher
+        'data-foo': 'bar'
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
+  - name: item attributes
+    hidden: true
+    options:
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
+          attributes:
+            data-attribute: my-attribute
+  - name: html
+    hidden: true
+    options:
+      items:
+        - text: English
+          lang: en
+          current: true
+        - html: <span>Cymraeg</span>
+          lang: cy
+          href: '#/cy'

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/macro.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukLanguageSwitcher(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.jsdom.test.js
@@ -159,5 +159,75 @@ describe('Language switcher', () => {
 
       expect($link.innerHTML).toContain('<span>Cymraeg</span>')
     })
+
+    it('sets dir attributes on language items', () => {
+      document.body.innerHTML = render(
+        'language-switcher',
+        examples['with mixed text directions']
+      )
+
+      const $currentLanguage = document.querySelector(
+        '.govuk-language-switcher__text'
+      )
+      const $otherLanguage = document.querySelector(
+        '.govuk-language-switcher__link'
+      )
+
+      expect($currentLanguage).toHaveAttribute('dir', 'ltr')
+      expect($otherLanguage).toHaveAttribute('dir', 'rtl')
+    })
+
+    it('treats an item as current when href is missing', () => {
+      document.body.innerHTML = render('language-switcher', {
+        context: {
+          items: [
+            {
+              text: 'English',
+              lang: 'en',
+              href: '#/en'
+            },
+            {
+              text: 'Cymraeg',
+              lang: 'cy'
+            }
+          ]
+        }
+      })
+
+      const $items = document.querySelectorAll(
+        'li.govuk-language-switcher__list-item'
+      )
+      const $currentItem = $items[1]
+
+      expect($currentItem.querySelector('a')).toBeNull()
+      expect(
+        $currentItem.querySelector('.govuk-language-switcher__text')
+      ).toHaveAttribute('aria-current', 'true')
+    })
+
+    it('allows hreflang to differ from lang', () => {
+      document.body.innerHTML = render('language-switcher', {
+        context: {
+          items: [
+            {
+              text: 'English',
+              lang: 'en',
+              current: true
+            },
+            {
+              text: 'Welsh',
+              lang: 'en',
+              hrefLang: 'cy',
+              href: '#/cy'
+            }
+          ]
+        }
+      })
+
+      const $link = document.querySelector('.govuk-language-switcher__link')
+
+      expect($link).toHaveAttribute('lang', 'en')
+      expect($link).toHaveAttribute('hreflang', 'cy')
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.jsdom.test.js
@@ -1,0 +1,163 @@
+const { getExamples, render } = require('@govuk-frontend/lib/components')
+
+describe('Language switcher', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('language-switcher')
+  })
+
+  describe('default example', () => {
+    let $component, $list, $listItems
+
+    beforeAll(() => {
+      document.body.innerHTML = render('language-switcher', examples.default)
+
+      $component = document.querySelector('.govuk-language-switcher')
+      $list = document.querySelector('ul.govuk-language-switcher__list')
+      $listItems = document.querySelectorAll(
+        'li.govuk-language-switcher__list-item'
+      )
+    })
+
+    it('renders as a nav element', () => {
+      expect($component.tagName.toLowerCase()).toBe('nav')
+    })
+
+    it('renders with default aria-label', () => {
+      expect($component).toHaveAttribute('aria-label', 'Language switcher')
+    })
+
+    it('includes an unordered list', () => {
+      expect($component).toContainElement($list)
+    })
+
+    it('includes 2 list items within the list', () => {
+      expect($listItems).toHaveLength(2)
+    })
+
+    describe('the current language', () => {
+      let $currentItem
+
+      beforeAll(() => {
+        $currentItem = $listItems[0]
+      })
+
+      it('renders as plain text', () => {
+        expect($currentItem.querySelector('a')).toBeNull()
+      })
+
+      it('includes the language name', () => {
+        expect($currentItem).toHaveTextContent('English')
+      })
+
+      it('sets the lang attribute', () => {
+        expect(
+          $currentItem.querySelector('.govuk-language-switcher__text')
+        ).toHaveAttribute('lang', 'en')
+      })
+
+      it('sets the aria-current attribute to "true"', () => {
+        expect(
+          $currentItem.querySelector('.govuk-language-switcher__text')
+        ).toHaveAttribute('aria-current', 'true')
+      })
+    })
+
+    describe('other languages', () => {
+      let $link
+
+      beforeAll(() => {
+        $link = $listItems[1].querySelector('a')
+      })
+
+      it('renders as a link with the class govuk-language-switcher__link', () => {
+        expect($link).toHaveClass('govuk-language-switcher__link')
+      })
+
+      it('includes the language name', () => {
+        expect($link).toHaveTextContent('Cymraeg')
+      })
+
+      it('includes the href', () => {
+        expect($link).toHaveAttribute('href', '#/cy')
+      })
+
+      it('sets the lang attribute', () => {
+        expect($link).toHaveAttribute('lang', 'cy')
+      })
+
+      it('sets the hreflang attribute', () => {
+        expect($link).toHaveAttribute('hreflang', 'cy')
+      })
+
+      it('identifies the link as an alternate version of the page', () => {
+        expect($link).toHaveAttribute('rel', 'alternate')
+      })
+    })
+  })
+
+  describe('with multiple languages', () => {
+    it('renders a list item for every language', () => {
+      document.body.innerHTML = render(
+        'language-switcher',
+        examples['with multiple languages']
+      )
+
+      const $listItems = document.querySelectorAll(
+        'li.govuk-language-switcher__list-item'
+      )
+
+      expect($listItems).toHaveLength(6)
+    })
+  })
+
+  describe('custom options', () => {
+    it('sets custom aria-label', () => {
+      document.body.innerHTML = render(
+        'language-switcher',
+        examples['with translated navigation label']
+      )
+
+      const $component = document.querySelector('.govuk-language-switcher')
+
+      expect($component).toHaveAttribute('aria-label', 'Dewis iaith')
+    })
+
+    it('sets custom classes', () => {
+      document.body.innerHTML = render('language-switcher', examples.classes)
+
+      const $component = document.querySelector('.govuk-language-switcher')
+
+      expect($component).toHaveClass('app-language-switcher--custom-modifier')
+    })
+
+    it('sets custom attributes', () => {
+      document.body.innerHTML = render('language-switcher', examples.attributes)
+
+      const $component = document.querySelector('.govuk-language-switcher')
+
+      expect($component).toHaveAttribute('id', 'my-language-switcher')
+      expect($component).toHaveAttribute('data-foo', 'bar')
+    })
+
+    it('sets item attributes on the link', () => {
+      document.body.innerHTML = render(
+        'language-switcher',
+        examples['item attributes']
+      )
+
+      const $link = document.querySelector('.govuk-language-switcher__link')
+
+      expect($link).toHaveAttribute('data-attribute', 'my-attribute')
+    })
+
+    it('renders item html', () => {
+      document.body.innerHTML = render('language-switcher', examples.html)
+
+      const $link = document.querySelector('.govuk-language-switcher__link')
+
+      expect($link.innerHTML).toContain('<span>Cymraeg</span>')
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
@@ -7,7 +7,8 @@
   {% if isCurrent %}
     <li class="govuk-language-switcher__list-item">
       <span class="govuk-language-switcher__text"
-        {%- if item.lang %} lang="{{ item.lang }}"{% endif %} aria-current="true">
+        {%- if item.lang %} lang="{{ item.lang }}"{% endif %}
+        {%- if item.dir %} dir="{{ item.dir }}"{% endif %} aria-current="true">
         {{- item.html | safe if item.html else item.text -}}
       </span>
     </li>

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
@@ -1,0 +1,27 @@
+{% from "../../macros/attributes.njk" import govukAttributes %}
+
+<nav class="govuk-language-switcher {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }} aria-label="{{ params.ariaLabel | default("Language switcher") }}">
+  <ul class="govuk-language-switcher__list">
+{% for item in params.items %}
+  {% set isCurrent = item.current or (not item.href) %}
+  {% if isCurrent %}
+    <li class="govuk-language-switcher__list-item">
+      <span class="govuk-language-switcher__text"
+        {%- if item.lang %} lang="{{ item.lang }}"{% endif %} aria-current="true">
+        {{- item.html | safe if item.html else item.text -}}
+      </span>
+    </li>
+  {% else %}
+    <li class="govuk-language-switcher__list-item">
+      <a class="govuk-language-switcher__link" href="{{ item.href }}"
+        {%- if item.lang %} lang="{{ item.lang }}"{% endif %}
+        {%- if item.hrefLang or item.lang %} hreflang="{{ item.hrefLang if item.hrefLang else item.lang }}"{% endif %}
+        {%- if item.dir %} dir="{{ item.dir }}"{% endif %} rel="alternate"
+        {{- govukAttributes(item.attributes) }}>
+        {{- item.html | safe if item.html else item.text -}}
+      </a>
+    </li>
+  {% endif %}
+{% endfor %}
+  </ul>
+</nav>

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -26,6 +26,7 @@
     @media #{base.govuk-from-breakpoint(tablet)} {
       flex-direction: row;
       flex-wrap: wrap;
+      align-items: center;
     }
   }
 
@@ -114,6 +115,25 @@
   // nav items and use slots.
   .govuk-service-navigation__wrapper {
     flex-grow: 1;
+
+    // If the end slot is right-aligned, add some extra spacing to the right of
+    // the navigation. This ensures that the two elements don't get too close as
+    // viewports shrink but before the end slot content wraps to the next line.
+    &:has(+ .govuk-service-navigation__end) {
+      @media #{base.govuk-from-breakpoint(tablet)} {
+        margin-right: base.govuk-spacing(4);
+      }
+    }
+  }
+
+  .govuk-service-navigation__end {
+    width: 100%;
+  }
+
+  @media #{base.govuk-from-breakpoint(tablet)} {
+    .govuk-service-navigation__end {
+      width: auto;
+    }
   }
 
   //

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -378,6 +378,30 @@ examples:
           text: Navigation item 3
         - href: '#/4'
           text: Navigation item 4
+  - name: with language switcher
+    description: HTML rendered by the language switcher component can be injected into the `end` slot of the service header.
+    options:
+      serviceName: Service name
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+          active: true
+        - href: '#/2'
+          text: Navigation item 2
+        - href: '#/3'
+          text: Navigation item 3
+      slots:
+        end: |-
+          <nav class="govuk-language-switcher" aria-label="Language switcher">
+            <ul class="govuk-language-switcher__list">
+              <li class="govuk-language-switcher__list-item">
+                <span class="govuk-language-switcher__text" lang="en" aria-current="true">English</span>
+              </li>
+              <li class="govuk-language-switcher__list-item">
+                <a class="govuk-language-switcher__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
+              </li>
+            </ul>
+          </nav>
   - name: with slotted content
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -85,6 +85,10 @@ params:
         type: string
         required: false
         description: HTML injected at the end of the service header container.
+      - name: endRightAligned
+        type: boolean
+        required: false
+        description: If `true`, renders the `end` slot inline in the service navigation row and right aligns it at tablet and above. Defaults to `false`.
       - name: navigationStart
         type: string
         required: false
@@ -402,6 +406,31 @@ examples:
               </li>
             </ul>
           </nav>
+  - name: with right-aligned language switcher
+    description: HTML rendered by the language switcher component can be injected into the `end` slot of the service header.
+    options:
+      serviceName: Service name
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+          active: true
+        - href: '#/2'
+          text: Navigation item 2
+        - href: '#/3'
+          text: Navigation item 3
+      slots:
+        end: |-
+          <nav class="govuk-language-switcher" aria-label="Language switcher">
+            <ul class="govuk-language-switcher__list">
+              <li class="govuk-language-switcher__list-item">
+                <span class="govuk-language-switcher__text" lang="en" aria-current="true">English</span>
+              </li>
+              <li class="govuk-language-switcher__list-item">
+                <a class="govuk-language-switcher__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
+              </li>
+            </ul>
+          </nav>
+        endRightAligned: true
   - name: with slotted content
     hidden: true
     options:
@@ -410,3 +439,12 @@ examples:
         end: '<div>[end]</div>'
         navigationStart: '<li>[navigation start]</li>'
         navigationEnd: '<li>[navigation end]</li>'
+  - name: with right-aligned end slot
+    options:
+      serviceName: Service name
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+      slots:
+        end: '<div>[end]</div>'
+        endRightAligned: true

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
@@ -2,6 +2,7 @@
 
 {%- set menuButtonText = params.menuButtonText | default("Menu", true) -%}
 {%- set navigationId = params.navigationId | default("navigation", true) %}
+{%- set endSlotRightAligned = params.slots.endRightAligned | default(false) %}
 
 {%- set commonAttributes %}
 class="govuk-service-navigation {%- if params.classes %} {{ params.classes }}{% endif %}"
@@ -84,10 +85,17 @@ data-module="govuk-service-navigation"
           </ul>
         </nav>
       {% endif %}
+
+      {# Slot: end (right aligned) #}
+      {% if params.slots.end and endSlotRightAligned %}
+        <div class="govuk-service-navigation__end">
+          {{ params.slots.end | safe }}
+        </div>
+      {% endif %}
     </div>
 
     {# Slot: end #}
-    {%- if params.slots.end %}{{ params.slots.end | safe }}{% endif -%}
+    {%- if params.slots.end and not endSlotRightAligned %}{{ params.slots.end | safe }}{% endif -%}
 
   </div>
 {% endset -%}

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
@@ -488,6 +488,23 @@ describe('Service Navigation', () => {
       expect($slottedElement.prop('outerHTML')).toBe('<div>[end]</div>')
     })
 
+    it('inserts HTML from the `end` slot inline when `endRightAligned` is enabled', () => {
+      const $ = render(
+        'service-navigation',
+        examples['with right-aligned end slot']
+      )
+
+      const $endSlotInContainer = $('.govuk-service-navigation__end')
+      const $endSlotContent = $endSlotInContainer.find('> :first-child')
+      const $slottedElementAtRoot = $('.govuk-width-container > :last-child')
+
+      expect($endSlotInContainer).toHaveLength(1)
+      expect($endSlotContent.prop('outerHTML')).toBe('<div>[end]</div>')
+      expect(
+        $slottedElementAtRoot.hasClass('govuk-service-navigation__container')
+      ).toBeTruthy()
+    })
+
     it('renders the component as a <section> if `start` or `end` slots are used', () => {
       const $ = render('service-navigation', examples['with slotted content'])
       const tagName = $('.govuk-service-navigation').get(0).tagName


### PR DESCRIPTION
Adds a language switcher to change language on the page.

## English/Welsh toggle
<img width="177" height="50" alt="English/Welsh language toggle" src="https://github.com/user-attachments/assets/fc00f1a7-daac-4d2b-b746-f183bb4ac65d" />

## Multiple languages
<img width="407" height="46" alt="Multiple languages" src="https://github.com/user-attachments/assets/ef4c3892-dadf-48f0-bc93-bcffad9cc1a9" />

## Service navigation - right-aligned `end` slot
<img width="1001" height="92" alt="Service nav right-aligned" src="https://github.com/user-attachments/assets/0e03edd6-83b9-42ef-b936-de381c60c551" />

## Service navigation - small viewport
<img width="225" height="184" alt="Service nav small viewport" src="https://github.com/user-attachments/assets/6ceb4e3d-d756-4c13-a1f8-d258f30c4d84" />

## Outstanding questions

- should we collapse the language switch in the service nav on small viewports?
- should we be using buttons rather than links to make it easier to avoid losing already entered information?
- where should we place in-page language switchers?