### PR TITLE
[SPIKE] Explore minimal changes to adapt content to the interruption panel

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -8,3 +8,24 @@
 @use "partials/links";
 @use "partials/organisation-swatch";
 @use "partials/prose";
+
+:root {
+  --govuk-brand-colour: #b81db3;
+  --govuk-inverse-text-colour: #0b0b0c;
+  --govuk-text-colour: #f3f3f3;
+  --govuk-template-background-colour: #0f385c;
+  --govuk-body-background-colour: #061625;
+  --govuk-hover-colour: #cecece;
+  --govuk-link-colour: #8eb8dc;
+  --govuk-link-visited-colour: #aa98cf;
+  --govuk-link-hover-colour: #d2e2f1;
+  --govuk-link-active-colour: #0b0c0c;
+  --govuk-surface-background-colour: #0f385c;
+  --govuk-surface-text-colour: #ffffff;
+  --govuk-surface-border-colour: #0f385c;
+  --govuk-secondary-text-colour: #8eb8dc;
+  --govuk-input-border-colour: #ffffff;
+  --govuk-error-colour: #d76868;
+  --govuk-emphasis-background-colour: #0a253e;
+  color-scheme: dark;
+}

--- a/packages/govuk-frontend-review/src/views/examples/panels/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/panels/index.njk
@@ -17,11 +17,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2>Examples</h2>
+      <h3>Text and buttons/links only</h3>
 {% call govukPanel({
   titleText: "Is your age correct?",
   classes: 'govuk-panel--interruption'})
 %}
-  <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>.</p>
+  <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>. This wouldn't match our <a class="govuk-link govuk-!-color-inverse" href="">policy for wellbeing of the livings</a>.</p>
   <div class="govuk-button-group">
     <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
       Yes, this is correct
@@ -30,8 +31,7 @@
   </div>
 {% endcall %}
 
-
-
+<h3>With input fields</h3>
 {% call govukPanel({ classes: 'govuk-panel--interruption'}) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -54,11 +54,13 @@
             text: "Yes, start claim to get back your student loan repayments",
             hint: {
               text: "You will lose progress on your first claim"
-            }
+            },
+            classes: 'govuk-!-inverse-colour'
           },
           {
             value: "no",
-            text: "No, finish the claim I have in progress"
+            text: "No, finish the claim I have in progress",
+            classes: 'govuk-!-inverse-colour'
           }
         ]
       }) }}

--- a/packages/govuk-frontend-review/src/views/examples/panels/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/panels/index.njk
@@ -14,6 +14,9 @@
 {% block content %}
 <h1 class="govuk-heading-xl">Panels</h1>
 
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2>Examples</h2>
 {% call govukPanel({
   titleText: "Is your age correct?",
   classes: 'govuk-panel--interruption'})
@@ -67,5 +70,80 @@
       </div>
   </div>
 {% endcall %}
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div>
+        <h2 class="govuk-heading-m">Colours</h2>
+        <template data-module="app-colour-form">
+          <div class="govuk-form-group">
+            <input type="color">
+            <label class="govuk-label govuk-label--s"></label>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+{% endblock %}
 
+{% block bodyEnd %}
+  {{super()}}
+  <script type="module">
+    const template = document.querySelector('[data-module="app-colour-form"]');
+
+    const colourProperties = Array.from(getCustomProperties(document.documentElement)
+      .filter(({propertyName}) => propertyName.endsWith('-colour') && propertyName.includes('brand')))
+      .sort(({propertyName: a}, {propertyName: b}) => a > b ? -1 : (a < b ? 1 : 0))
+
+    for (const property of colourProperties) {
+      template.insertAdjacentElement('afterEnd', createField(property))
+    }
+
+    document.addEventListener('input', (event) => {
+      const propertyName = event.target.name;
+      const value = event.target.value;
+      document.documentElement.style.setProperty(propertyName, value);
+    })
+
+    //////
+    ///. Supporting functions .
+    //////
+
+    function createField({propertyName, propertyValue}) {
+      const id = propertyName.replace('--','')
+
+      const field = template.content.cloneNode(true)
+      const label = field.querySelector('label')
+      const input = field.querySelector('input')
+
+      label.for = id
+      label.textContent = propertyName
+      input.id = id
+      input.name = propertyName
+      input.value = propertyValue
+
+      return field.children[0];
+    }
+
+    /**
+     * Creates a generator to iterate on all the custom properties styling an element
+     *
+     * @param {Element} element - The element whose custom properties to iterate on
+     * @return {Generator<{propertyName: string, propertyValue: string}>}
+     */
+    function* getCustomProperties(element) {
+      const computedStyles = getComputedStyle(element);
+      for (const property in computedStyles) {
+        // For some reason custom properties are not listed as direct JavaScript properties
+        // of the computed styles. Instead, they're listed as values for number indices of the computed styles
+        if (!Number.isNaN(parseInt(property))) {
+          const propertyName = computedStyles[property];
+          if (propertyName.startsWith('--')) {
+            const propertyValue = computedStyles.getPropertyValue(propertyName);
+            yield {propertyName, propertyValue}
+          }
+        }
+      }
+    }
+
+  </script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/panels/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/panels/index.njk
@@ -16,11 +16,63 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2>Examples</h2>
-      <h3>Text and buttons/links only</h3>
+      <h2 class="govuk-heading-l">Examples</h2>
+      <h3 class="govuk-heading-m">Text and buttons/links only</h3>
 {% call govukPanel({
   titleText: "Is your age correct?",
   classes: 'govuk-panel--interruption'})
+%}
+  <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>. This wouldn't match our <a class="govuk-link govuk-!-color-inverse" href="">policy for wellbeing of the livings</a>.</p>
+  <div class="govuk-button-group">
+    <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+      Yes, this is correct
+    </button>
+    <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+  </div>
+{% endcall %}
+
+<h3 class="govuk-heading-m">Branded panels</h3>
+{% call govukPanel({
+  titleText: "Department for Business and Trade",
+  classes: 'govuk-panel--interruption',
+  attributes: {
+    style: "--govuk-brand-colour: #e02c13"
+  }
+  })
+%}
+  <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>. This wouldn't match our <a class="govuk-link govuk-!-color-inverse" href="">policy for wellbeing of the livings</a>.</p>
+  <div class="govuk-button-group">
+    <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+      Yes, this is correct
+    </button>
+    <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+  </div>
+{% endcall %}
+
+{% call govukPanel({
+  titleText: "Department for Food and Rural Affairs",
+  classes: 'govuk-panel--interruption',
+  attributes: {
+    style: "--govuk-brand-colour: #008531"
+  }
+  })
+%}
+  <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>. This wouldn't match our <a class="govuk-link govuk-!-color-inverse" href="">policy for wellbeing of the livings</a>.</p>
+  <div class="govuk-button-group">
+    <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+      Yes, this is correct
+    </button>
+    <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+  </div>
+{% endcall %}
+
+{% call govukPanel({
+  titleText: "Department for Transport",
+  classes: 'govuk-panel--interruption',
+  attributes: {
+    style: "--govuk-brand-colour: #006853"
+  }
+  })
 %}
   <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>. This wouldn't match our <a class="govuk-link govuk-!-color-inverse" href="">policy for wellbeing of the livings</a>.</p>
   <div class="govuk-button-group">

--- a/packages/govuk-frontend-review/src/views/examples/panels/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/panels/index.njk
@@ -1,0 +1,71 @@
+{% extends "layouts/examples.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    href: "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Panels</h1>
+
+{% call govukPanel({
+  titleText: "Is your age correct?",
+  classes: 'govuk-panel--interruption'})
+%}
+  <p class="govuk-body govuk-!-color-inverse">You entered your age as <strong>109</strong>.</p>
+  <div class="govuk-button-group">
+    <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+      Yes, this is correct
+    </button>
+    <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+  </div>
+{% endcall %}
+
+
+
+{% call govukPanel({ classes: 'govuk-panel--interruption'}) %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {{ govukRadios({
+        name: "signIn",
+        fieldset: {
+          legend: {
+            text: "Are you sure you want to start a claim to get back your student loan repayments?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          text: "You have a claim in progress to get back your student loan repayments. You will lose your progress on this claim if you start a different claim before you send it."
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes, start claim to get back your student loan repayments",
+            hint: {
+              text: "You will lose progress on your first claim"
+            }
+          },
+          {
+            value: "no",
+            text: "No, finish the claim I have in progress"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue",
+        classes: "govuk-button--inverse"
+      }) }}
+      </div>
+  </div>
+{% endcall %}
+
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/are-you-sure/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/are-you-sure/index.njk
@@ -1,0 +1,63 @@
+---
+title: Are you sure you want to start a claim?
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = example.title + " - Claim back your student loan repayments - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " if errorSummary | length }}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+{% call govukPanel({ classes: 'govuk-panel--interruption'}) %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {{ govukRadios({
+      name: "signIn",
+      fieldset: {
+        legend: {
+          text: "Are you sure you want to start a claim to get back your student loan repayments?",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+      },
+      hint: {
+        text: "You have a claim in progress to get back your student loan repayments. You will lose your progress on this claim if you start a different claim before you send it."
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes, start claim to get back your student loan repayments",
+          hint: {
+            text: "You will lose progress on your first claim"
+          }
+        },
+        {
+          value: "no",
+          text: "No, finish the claim I have in progress"
+        }
+      ]
+    }) }}
+
+    {{ govukButton({
+      text: "Continue",
+      classes: "govuk-button--inverse"
+    }) }}
+    </div>
+</div>
+{% endcall %}
+
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
@@ -124,7 +124,9 @@
   }
 
   .govuk-breadcrumbs--inverse {
-    color: base.govuk-colour("white");
+    // Because the section would be right under the brand-text content of the Header
+    // the text needs to be `brand-text` rather than `inverse-text`?
+    color: base.govuk-functional-colour(inverse-text);
 
     .govuk-breadcrumbs__link {
       @include base.govuk-link-style-inverse;

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -19,7 +19,7 @@
 
   // Warning button variables
   $govuk-warning-button-colour: base.govuk-colour("red");
-  $govuk-warning-button-text-colour: base.govuk-colour("white");
+  $govuk-warning-button-text-colour: base.govuk-functional-colour(inverse-text);
   $govuk-warning-button-hover-colour: base.govuk-colour("red", $variant: "shade-25");
   $govuk-warning-button-shadow-colour: base.govuk-colour("red", $variant: "shade-50");
 

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -26,8 +26,8 @@
   // Inverse button variables
   $govuk-inverse-button-colour: $inverse-background-colour;
   $inverse-text-colour: $inverse-text-colour;
-  $govuk-inverse-button-hover-colour: base.govuk-colour("blue", $variant: "tint-95");
-  $govuk-inverse-button-shadow-colour: base.govuk-colour("blue", $variant: "shade-50");
+  $govuk-inverse-button-hover-colour: base.govuk-functional-colour(brand-inverse-hover);
+  $govuk-inverse-button-shadow-colour: base.govuk-functional-colour(brand-shadow);
 
   // Because the shadow (s0) is visually 'part of' the button, we need to reduce
   // the height of the button to compensate by adjusting its padding (s1) and

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.import.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.import.scss
@@ -14,14 +14,14 @@ $govuk-button-background-colour: govuk-colour("green") !default;
 /// @type Colour
 /// @access public
 
-$govuk-button-text-colour: govuk-colour("white") !default;
+$govuk-button-text-colour: govuk-functional-colour(inverse-text) !default;
 
 /// Inverted button component background colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-inverse-button-background-colour: govuk-colour("white") !default;
+$govuk-inverse-button-background-colour: govuk-functional-colour(inverse-text) !default;
 
 /// Inverted button component text colour
 ///

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.scss
@@ -16,14 +16,14 @@ $govuk-button-background-colour: helpers.govuk-colour("green") !default;
 /// @type Colour
 /// @access public
 
-$govuk-button-text-colour: helpers.govuk-colour("white") !default;
+$govuk-button-text-colour: helpers.govuk-functional-colour(inverse-text) !default;
 
 /// Inverted button component background colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-inverse-button-background-colour: helpers.govuk-functional-colour(brand-inverse) !default;
+$govuk-inverse-button-background-colour: helpers.govuk-functional-colour(inverse-text) !default;
 
 /// Inverted button component text colour
 ///

--- a/packages/govuk-frontend/src/govuk/components/button/_settings.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_settings.scss
@@ -23,7 +23,7 @@ $govuk-button-text-colour: helpers.govuk-colour("white") !default;
 /// @type Colour
 /// @access public
 
-$govuk-inverse-button-background-colour: helpers.govuk-colour("white") !default;
+$govuk-inverse-button-background-colour: helpers.govuk-functional-colour(brand-inverse) !default;
 
 /// Inverted button component text colour
 ///

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -4,7 +4,7 @@
 @mixin styles {
   $file-upload-border-width: 2px;
   $component-padding: base.govuk-spacing(1);
-  $empty-button-background-colour: base.govuk-colour("white");
+  $empty-button-background-colour: base.govuk-functional-colour(body-background);
   $empty-pseudo-button-background-colour: base.govuk-colour("black", $variant: "tint-95");
   $empty-status-background-colour: base.govuk-colour("blue", $variant: "tint-80");
 
@@ -86,8 +86,8 @@
     display: block;
     margin-bottom: base.govuk-spacing(2);
     padding: base.govuk-spacing(3) base.govuk-spacing(2);
-    color: base.govuk-colour("white");
-    background-color: base.govuk-colour("blue");
+    color: base.govuk-functional-colour(inverse-text);
+    background-color: base.govuk-colour("blue"); // Informative or brand?
     text-align: left;
     @include base.govuk-text-break-word;
   }

--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -9,7 +9,7 @@
 
     // Add a transparent bottom border for forced-colour modes
     border-bottom: 1px solid transparent;
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(inverse-text);
     background: base.govuk-functional-colour(brand);
   }
 

--- a/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
@@ -124,7 +124,7 @@
     padding: base.govuk-spacing(1);
     border: base.$govuk-border-width-form-element solid;
     border-color: base.govuk-functional-colour(input-border);
-    background-color: base.govuk-colour("black", $variant: "tint-95");
+    background-color: base.govuk-functional-colour(emphasis-background);
     text-align: center;
     white-space: nowrap;
     // Emphasise non-editable status of prefixes and suffixes

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -38,7 +38,7 @@
     @include base.govuk-typography-weight-bold;
     margin: 0;
     padding: 0;
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(inverse-text);
   }
 
   .govuk-notification-banner__content {

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -2,4 +2,3 @@
 @use "mixin";
 
 @include mixin.styles;
-

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -2,3 +2,4 @@
 @use "mixin";
 
 @include mixin.styles;
+

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -33,17 +33,17 @@
       // it but the the text remains legible.
       overflow-wrap: break-word;
     }
-  }
-
-  .govuk-panel--confirmation {
-    color: base.govuk-colour("white");
-    background: base.govuk-colour("green");
 
     @media print {
       border-color: currentcolor;
       color: base.govuk-functional-colour(text);
       background: none;
     }
+  }
+
+  .govuk-panel--confirmation {
+    color: base.govuk-colour("white");
+    background: base.govuk-colour("green");
   }
 
   .govuk-panel__title {
@@ -55,5 +55,13 @@
 
   .govuk-panel__title:last-child {
     margin-bottom: 0;
+  }
+
+  .govuk-panel--interruption {
+    color: govuk-colour("white");
+    background-color: $govuk-brand-colour;
+    text-align: left;
+
+    @include govuk-font($size: 19);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -58,7 +58,7 @@
   }
 
   .govuk-panel--interruption {
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(brand-inverse);
     background-color: base.govuk-functional-colour(brand);
     text-align: left;
 

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -58,10 +58,10 @@
   }
 
   .govuk-panel--interruption {
-    color: govuk-colour("white");
-    background-color: $govuk-brand-colour;
+    color: base.govuk-colour("white");
+    background-color: base.govuk-functional-colour(brand);
     text-align: left;
 
-    @include govuk-font($size: 19);
+    @include base.govuk-font($size: 19);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -42,8 +42,8 @@
   }
 
   .govuk-panel--confirmation {
-    color: base.govuk-colour("white");
-    background: base.govuk-colour("green");
+    color: base.govuk-functional-colour(inverse-text);
+    background: base.govuk-functional-colour(success);
   }
 
   .govuk-panel__title {

--- a/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
@@ -2,13 +2,25 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/panel', () => {
+  let axeRules
+
+  beforeAll(() => {
+    axeRules = {
+      /**
+       * Ignore 'Element has insufficient color contrast' for WCAG Level AAA
+       *
+       * Affects regular size text on the green and blue panels
+       */
+      'color-contrast-enhanced': { enabled: false }
+    }
+  })
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('panel')
 
       for (const exampleName in examples) {
         await render(page, 'panel', examples[exampleName])
-        await expect(axe(page)).resolves.toHaveNoViolations()
+        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -45,7 +45,7 @@ examples:
       text: 'Your reference number: HDJ2123F'
   - name: interruption
     options:
-      titleText: Is your weight correct?
+      titleText: Is your age correct?
       html: |
         <p>You entered your age as <strong>109</strong>.</p>
         <div class="govuk-button-group">

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -38,6 +38,23 @@ examples:
     options:
       titleHtml: Application complete
       text: 'Your reference number: HDJ2123F'
+  - name: custom heading level
+    options:
+      titleText: Application complete
+      headingLevel: 2
+      text: 'Your reference number: HDJ2123F'
+  - name: interruption
+    options:
+      titleText: Is your weight correct?
+      html: |
+        <p>You entered your age as <strong>109</strong>.</p>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Yes, this is correct
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+        </div>
+      classes: govuk-panel--interruption
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: title html as text

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -2,8 +2,17 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
-<div class="govuk-panel govuk-panel--confirmation
-  {%- if params.classes %} {{ params.classes }}{% endif %}"
+{%- set classNames = "govuk-panel" -%}
+
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{%- if (not params.classes) or (not "govuk-panel--interruption" in params.classes) %}
+  {% set classNames = classNames + " govuk-panel--confirmation" -%}
+{% endif %}
+
+<div class="{{ classNames }}"
   {{- govukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}

--- a/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
@@ -21,7 +21,7 @@
     // Default user agent colours for selects can have low contrast,
     // and may look disabled (#2435)
     color: base.govuk-functional-colour(text);
-    background-color: base.govuk-colour("white");
+    background-color: base.govuk-functional-colour(body-background);
 
     &:focus {
       @include base.govuk-focused-form-input;
@@ -37,7 +37,7 @@
   .govuk-select option:active,
   .govuk-select option:checked,
   .govuk-select:focus::-ms-value {
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(inverse-text);
     background-color: base.govuk-colour("blue");
   }
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -202,7 +202,7 @@
 
     // Set colour here so non-link text (service name, slot content) can
     // use it too.
-    color: base.govuk-colour("white");
+    color: base.govuk-functional-colour(inverse-text);
 
     background-color: base.govuk-functional-colour(brand);
 
@@ -220,7 +220,7 @@
     // Override the 'active' border colour
     .govuk-service-navigation__item,
     .govuk-service-navigation__service-name {
-      border-color: base.govuk-colour("white");
+      border-color: base.govuk-functional-colour(inverse-text);
     }
 
     // Override link styles

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
@@ -206,7 +206,7 @@
     // Ensures the card header appears separate to the summary list in forced
     // colours mode
     border-bottom: 1px solid transparent;
-    background-color: base.govuk-colour("black", $variant: "tint-95");
+    background-color: base.govuk-functional-colour(emphasis-background);
 
     @media #{base.govuk-from-breakpoint(tablet)} {
       display: flex;

--- a/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_mixin.scss
@@ -71,7 +71,7 @@
         padding: base.govuk-spacing(2) base.govuk-spacing(4);
 
         float: left;
-        background-color: base.govuk-colour("black", $variant: "tint-95");
+        background-color: base.govuk-functional-colour(emphasis-background);
         text-align: center;
 
         &::before {

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -257,7 +257,7 @@
 @mixin govuk-link-style-inverse {
   &:link,
   &:visited {
-    color: govuk-colour("white");
+    color: govuk-functional-colour(brand-inverse);
   }
 
   &:focus {

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -257,7 +257,7 @@
 @mixin govuk-link-style-inverse {
   &:link,
   &:visited {
-    color: govuk-functional-colour(brand-inverse);
+    color: govuk-functional-colour(inverse-text);
   }
 
   &:focus {

--- a/packages/govuk-frontend/src/govuk/overrides/_color.import.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_color.import.scss
@@ -1,0 +1,7 @@
+@use "color.mixin" as mixin;
+
+@import "../tools/exports";
+
+@include govuk-exports("govuk/overrides/color") {
+  @include mixin.styles;
+}

--- a/packages/govuk-frontend/src/govuk/overrides/_color.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_color.mixin.scss
@@ -1,0 +1,9 @@
+@use "../base";
+
+// stylelint-disable declaration-no-important
+/// @access private
+@mixin styles {
+  .govuk-\!-color-inverse {
+    color: govuk-colour("white") !important;
+  }
+}

--- a/packages/govuk-frontend/src/govuk/overrides/_color.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_color.mixin.scss
@@ -4,6 +4,6 @@
 /// @access private
 @mixin styles {
   .govuk-\!-color-inverse {
-    color: govuk-colour("white") !important;
+    color: base.govuk-functional-colour(brand-inverse) !important;
   }
 }

--- a/packages/govuk-frontend/src/govuk/overrides/_color.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_color.scss
@@ -1,0 +1,3 @@
+@use "color.mixin" as color;
+
+@include color.styles;

--- a/packages/govuk-frontend/src/govuk/overrides/_index.import.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_index.import.scss
@@ -1,3 +1,4 @@
+@import "color";
 @import "display";
 @import "spacing";
 @import "text-align";

--- a/packages/govuk-frontend/src/govuk/overrides/_index.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_index.scss
@@ -1,3 +1,4 @@
+@use "color";
 @use "display";
 @use "spacing";
 @use "text-align";

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -107,6 +107,13 @@ $govuk-default-functional-colours: (
     "surface-border": (
       name: "blue",
       variant: "tint-50"
+    ),
+    "emphasis-background": (
+      name: "black",
+      variant: "tint-95"
+    ),
+    "inverse-text": (
+      name: "white"
     )
   )
 );

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -17,6 +17,9 @@ $govuk-default-functional-colours: (
     "brand": (
       name: "blue"
     ),
+    "brand-inverse": (
+      name: "white"
+    ),
     "text": (
       name: "black"
     ),

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -20,6 +20,14 @@ $govuk-default-functional-colours: (
     "brand-inverse": (
       name: "white"
     ),
+    "brand-inverse-hover": (
+      name: "blue",
+      variant: "tint-95"
+    ),
+    "brand-shadow": (
+      name: "blue",
+      variant: "shade-50"
+    ),
     "text": (
       name: "black"
     ),


### PR DESCRIPTION
On top of #6636, explore how best to have components adapt when inside the interruption panel.

## `govuk-!-color-inverse` override

Buttons and links already offer `--inverse` variant. In a similar direction, @36degrees proposed to add a `govuk-!-color-inverse` to adapt the text inside the panel, which could be applicable to paragraphs and headings alike.

## The need for new functional colours

If the override sets `govuk-colour("white")`, the page will not meet WCAG's 4.5:1 contrast ratio if the brand gets changed to a colour that doesn't meet the ratio. This means that to properly adapt to changes of brand colour, the override class (or whichever system adapts the colour) needs to run based off a functional colour that can be changed at the same time as the brand colour.

Naming to be worked out, but this spike went with `brand-inverse` to highlight the relationship of that colour to the `brand` colour. That naming is more 'palette-y' than functional, though.

Adding this functional colour calls for extra functional colours to be created, as the button's background will use that colour and we need its hover state and bottom shadow to adapt as well. 

## Places the override class cannot reach

If the panel includes forms, the override class cannot reach some of the text, for example when a legend of a fieldset is a heading, as the heading's colour is controlled by the `govuk-fieldset__heading` class. Radios label and hints are in a similar space.

## Going forward...
Two options to explore from there:
- `--inverse` classes for form fields to adapt them when necessary
- Using custom properties to swap the colours (see #7154)

## Questions to answer

### What's the semantic of the panel's `blue`?

Is the panel blue to match the GOV.UK Brand, or is it because it's 'informative' and blue is the colour usually used for informative panels online? If the `brand` colour changes, should the panel adapt or remain blue. To help answer, the spike adds branded panels for departments whose colours may make the panel look like:
- an error message
- a success message

### What are the new functional colours attached to?

Should the colour names be attached to the concept of `brand` or to the concept of surface as explored in #7154?

### Is 'inverse' the right semantic?

The `--inverse` classes are not inverting any colours as we don't have blue on white text outside of the links. 