### PR TITLE
Fix lack of explicit colour on input prefix and suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#7168: Fix lack of explicit colour on input prefix and suffixes](https://github.com/alphagov/govuk-frontend/pull/7168)
+
 ## v6.2.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.2.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/input/_mixin.scss
@@ -124,6 +124,7 @@
     padding: base.govuk-spacing(1);
     border: base.$govuk-border-width-form-element solid;
     border-color: base.govuk-functional-colour(input-border);
+    color: base.govuk-functional-colour(text);
     background-color: base.govuk-colour("black", $variant: "tint-95");
     text-align: center;
     white-space: nowrap;


### PR DESCRIPTION
Closes #7106. 

## Changes
- Sets an explicit text colour for input prefixes and suffixes. This prevents them from inheriting their colour from an ancestor element, which can result in a lack of sufficient contrast with the light grey background. 