### PR TITLE
Fix text on small inline radios wrapping unnecessarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7168: Fix lack of explicit colour on input prefix and suffixes](https://github.com/alphagov/govuk-frontend/pull/7168)
+- [#7169: Fix text on small inline radios wrapping unnecessarily](https://github.com/alphagov/govuk-frontend/pull/7169)
 
 ## v6.2.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
@@ -41,7 +41,7 @@
     // __item using flex-wrap because we want hints on a separate line.
     max-width: calc(100% - #{(($govuk-checkboxes-label-padding-left-right * 2) + $govuk-touch-target-size)});
     margin-bottom: 0;
-    padding: (base.govuk-spacing(1) + base.$govuk-border-width-form-element) base.govuk-spacing(3);
+    padding: (base.govuk-spacing(1) + base.$govuk-border-width-form-element) $govuk-checkboxes-label-padding-left-right;
     cursor: pointer;
     // remove 300ms pause on mobile
     touch-action: manipulation;
@@ -206,6 +206,12 @@
     }
 
     .govuk-checkboxes__label {
+      // Recalculate max-width to account for the smaller checkbox size
+      // 1px comes from padding-left (defined below)
+      max-width: calc(
+        100% - #{($govuk-touch-target-size - $input-offset) + $govuk-checkboxes-label-padding-left-right + 1px}
+      );
+
       // Create a tiny space between the small checkbox hover state so that it
       // doesn't clash with the label
       padding-left: 1px;

--- a/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
@@ -46,7 +46,7 @@
       100% - #{($govuk-radios-label-padding-left-right + $govuk-touch-target-size + base.govuk-spacing(3))}
     );
     margin-bottom: 0;
-    padding: (base.govuk-spacing(1) + base.$govuk-border-width-form-element) base.govuk-spacing(3);
+    padding: (base.govuk-spacing(1) + base.$govuk-border-width-form-element) $govuk-radios-label-padding-left-right;
     cursor: pointer;
     // remove 300ms pause on mobile
     touch-action: manipulation;
@@ -227,6 +227,12 @@
     }
 
     .govuk-radios__label {
+      // Recalculate max-width to account for the smaller radio size
+      // 1px comes from padding-left (defined below)
+      max-width: calc(
+        100% - #{($govuk-touch-target-size - $input-offset) + $govuk-radios-label-padding-left-right + 1px}
+      );
+
       // Create a tiny space between the small radio hover state so that it
       // doesn't clash with the label
       padding-left: 1px;

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -528,9 +528,9 @@ examples:
         - value: relevance
           text: relevance
         - value: title
-          text: title
+          text: A to Z
         - value: created
-          text: created
+          text: creation date
 
   - name: small with a divider
     options:


### PR DESCRIPTION
Closes #4873. 

Currently, inline radio buttons that feature more than one word has the text wrap. This is because small radio labels inherit their `max-width` from the full sized radio button, which accounts for both the larger radio input and additional padding present on those labels, creating an unnecessarily narrow `max-width`. 

## Changes
- Add new calculation for `max-width` to the labels for small radio buttons that properly accounts for the smaller input size and reduced left padding. 
  - Duplicated this change to labels on small checkboxes for consistency, even though this issue was never noticeable on checkboxes as we don't support displaying them inline. 
- Updated the left/right padding label padding definition on normal sized radios and checkboxes to use the `$govuk-*-label-padding-left-right` variable. It seems like they were supposed to have been using this already and just weren't for some reason.
- Updated the review app example for small, inline radios to include labels with multiple words, so we can catch any regression to this down the line. 