### PR TITLE
Add `inverse-text` functional colour for white text on solid colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,18 @@ We made this change in [pull request #6971: Add date input `day`, `month`, `year
 
 ### Recommended changes
 
+#### Use `inverse-text` instead of `govuk-colour("white")` for text on dark backgrounds that use functional colours
+
+We've introduced a new `inverse-text` functional colour to use on dark backgrounds that use functional colours such as `brand`, `success` and `error`.
+
+If you're using `govuk-colour("white")` as a text colour on dark backgrounds that use functional colours, replace `govuk-colour("white")` with `govuk-functional-colour(inverse-text)`.
+
+However, if you're using a dark background that does not use a functional colour, keep using `govuk-colour("white")`.
+
+In both cases, make sure your text has a minimum contrast of 4.5:1 with the background to meet the ['Contrast (minimum)' criterion of the Web Content Accessibility Guidelines](https://www.w3.org/WAI/WCAG22/quickref/#contrast-minimum).
+
+We made this change in [pull request #7178: Add `inverse-text` functional colour for white text on solid colour](https://github.com/alphagov/govuk-frontend/pull/7178).
+
 #### Add a `<span>` element to start buttons containing HTML
 
 We've updated the Button component's Nunjucks macro to add a `<span>` element around HTML content within start buttons.

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -79,6 +79,12 @@ export default async () => {
     ({ path }) => path
   )
 
+  app.locals.componentFixtures = Object.fromEntries(
+    componentsFixtures.map(({ component, fixtures }) => {
+      return [component, Object.groupBy(fixtures, ({ name }) => name)]
+    })
+  )
+
   // Configure nunjucks
   const env = nunjucks.renderer(app)
 

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_app.scss
@@ -6,7 +6,7 @@
 
 // Darken page background for previewing inversely coloured components
 .app-template__body--inverse {
-  background-color: govuk-colour("blue");
+  background-color: govuk-functional-colour(brand);
 }
 
 .app-template__body--component-preview.app-template__body--inverse {

--- a/packages/govuk-frontend-review/src/views/examples/components-with-inverse-text/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/components-with-inverse-text/index.njk
@@ -1,0 +1,187 @@
+{% extends "layouts/examples.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/generic-header/macro.njk" import govukGenericHeader %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+
+
+
+{% block head %}
+  {{super()}}
+  <style>
+    /*
+      Slight adjustment to let the colour form be accessible throughout the page
+      as you scroll
+    */
+    .govuk-grid-column-one-third {
+      position: sticky;
+      top: 1rem;
+    }
+
+    /*
+     * Minimal styling of the colour inputs
+     */
+    .app-colour-input {
+      min-width: 0;
+      width: 2rem;
+      height: 2rem;
+      vertical-align: top;
+    }
+
+    .app-colour-input-label {
+      display: inline;
+      line-height: 2rem;
+      margin-bottom: 0;
+      word-break: break-all;
+    }
+  </style>
+{% endblock %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    href: "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">Components with solid surfaces</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" data-module="app-examples">
+      <h2 class="govuk-heading-m">Examples</h2>
+      <h3 class="govuk-heading-s">Header</h3>
+      {{ govukHeader(componentFixtures['header']['with product name'][0].options) }}
+
+      <h3 class="govuk-heading-s">Generic header</h3>
+      {{ govukGenericHeader(componentFixtures['generic-header']['with text and image logo'][0].options) }}
+
+      <h3 class="govuk-heading-s">Breadcrumbs (inverse)</h3>
+      <div class="app-template__body--inverse govuk-!-padding-2">
+      {{ govukBreadcrumbs(componentFixtures['breadcrumbs']['inverse'][0].options) }}
+      </div>
+
+      <h3 class="govuk-heading-s">Service navigation (inverse)</h3>
+      {{ govukServiceNavigation(componentFixtures['service-navigation'].inverse[0].options) }}
+
+      <h3 class="govuk-heading-s">Panel</h3>
+      {{ govukPanel(componentFixtures['panel']['default'][0].options) }}
+
+      <h3 class="govuk-heading-s">Pagination</h3>
+      {{ govukPagination(componentFixtures['pagination']['default'][0].options) }}
+
+      <h3 class="govuk-heading-s">Notification banner</h3>
+      {{ govukNotificationBanner(componentFixtures['notification-banner']['default'][0].options) }}
+
+      <h3 class="govuk-heading-s">Notification banner (success)</h3>
+      {{ govukNotificationBanner(componentFixtures['notification-banner']['with type as success'][0].options) }}
+
+      <h3 class="govuk-heading-s">Link (inverse)</h3>
+      <div class="app-template__body--inverse govuk-!-padding-2">
+        <a class="govuk-link govuk-link--inverse" href="">Contact</a>
+      </div>
+
+      <h3 class="govuk-heading-s">File upload (with selected file)</h3>
+      {{ govukFileUpload(componentFixtures['file-upload']['enhanced'][0].options) }}
+
+      <h3 class="govuk-heading-s">Button</h3>
+      {{govukButton(componentFixtures['button']['default'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (start)</h3>
+      {{govukButton(componentFixtures['button']['start'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (warning)</h3>
+      {{govukButton(componentFixtures['button']['warning'][0].options)}}
+
+      <h3 class="govuk-heading-s">Button (inverse)</h3>
+      <div class="app-template__body--inverse govuk-!-padding-2">
+        {{govukButton(componentFixtures['button']['inverse'][0].options)}}
+      </div>
+
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <h2 class="govuk-heading-m">Colours</h2>
+        <template
+          data-module="app-colour-form"
+          data-colours="brand,success,inverse-text,link">
+          <div class="govuk-form-group">
+            <input type="color" class="app-colour-input">
+            <label class="govuk-label govuk-label--s app-colour-input-label"></label>
+          </div>
+        </template>
+    </div>
+  </div>
+{% endblock %}
+
+{% block bodyEnd %}
+  {{super()}}
+  <script type="module">
+    const template = document.querySelector('[data-module="app-colour-form"]');
+    const examples = document.querySelector('[data-module="app-examples"]');
+
+    const relevantProperties = template.dataset.colours.split(',')
+      .map(propertyName => `--govuk-${propertyName.trim()}-colour`)
+
+    const colourProperties = getCustomProperties(document.documentElement).filter(({propertyName}) => {
+      return relevantProperties.includes(propertyName)
+    })
+
+    for (const property of colourProperties) {
+      template.insertAdjacentElement('afterEnd', createField(property))
+    }
+
+    document.addEventListener('input', (event) => {
+      const propertyName = event.target.name;
+      const value = event.target.value;
+      examples.style.setProperty(propertyName, value);
+    })
+
+    //////
+    ///. Supporting functions .
+    //////
+
+    function createField({propertyName, propertyValue}) {
+      const id = propertyName.replace('--','')
+
+      const field = template.content.cloneNode(true)
+      const label = field.querySelector('label')
+      const input = field.querySelector('input')
+
+      label.for = id
+      label.textContent = propertyName
+      input.id = id
+      input.name = propertyName
+      input.value = propertyValue
+
+      return field.children[0];
+    }
+
+    /**
+     * Creates a generator to iterate on all the custom properties styling an element
+     *
+     * @param {Element} element - The element whose custom properties to iterate on
+     * @return {Generator<{propertyName: string, propertyValue: string}>}
+     */
+    function* getCustomProperties(element) {
+      const computedStyles = getComputedStyle(element);
+      for (const property in computedStyles) {
+        // For some reason custom properties are not listed as direct JavaScript properties
+        // of the computed styles. Instead, they're listed as values for number indices of the computed styles
+        if (!Number.isNaN(parseInt(property))) {
+          const propertyName = computedStyles[property];
+          if (propertyName.startsWith('--')) {
+            const propertyValue = computedStyles.getPropertyValue(propertyName);
+            yield {propertyName, propertyValue}
+          }
+        }
+      }
+    }
+
+  </script>
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/_mixin.scss
@@ -124,11 +124,7 @@
   }
 
   .govuk-breadcrumbs--inverse {
-    color: base.govuk-colour("white");
-
-    .govuk-breadcrumbs__link {
-      @include base.govuk-link-style-inverse;
-    }
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
 
     .govuk-breadcrumbs__list-item::before {
       border-color: currentcolor;

--- a/packages/govuk-frontend/src/govuk/components/generic-header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/_mixin.scss
@@ -13,19 +13,23 @@ $header-forced-colour-border-width: 1px;
 
 /// Shared block header styles, with automatic background setting
 ///
-/// @param {String} $background - background colour of header
+/// @param {String} $background-colour - background colour of the header
+/// @param {String} $text-colour - text colour of the header
 /// @access private
-@mixin block-styles($background: base.govuk-colour("black")) {
+@mixin block-styles($background-colour: base.govuk-colour("black"), $text-colour: base.govuk-colour("white")) {
   @include base.govuk-font($size: 16, $line-height: 1);
 
   // Add a transparent bottom border for forced-colour modes
   border-bottom: $header-forced-colour-border-width solid transparent;
-  color: base.govuk-colour("white");
-  background: $background;
+
+  --govuk-text-colour: #{$text-colour};
+  color: base.govuk-functional-colour(text);
+  background: $background-colour;
 
   @media print {
     border-bottom-width: 0;
-    color: base.govuk-functional-colour(text);
+
+    --govuk-text-colour: inherit;
     background: transparent;
   }
 }
@@ -73,7 +77,7 @@ $header-forced-colour-border-width: 1px;
   font-size: 30px; // We don't have a mixin that produces 30px font size
   text-decoration: none;
 
-  @include base.govuk-link-style-inverse;
+  @include base.govuk-link-style-text;
 
   &:link,
   &:visited {

--- a/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_mixin.scss
@@ -6,7 +6,10 @@
   $logo-bottom-margin: 2px;
 
   .govuk-header {
-    @include genericHeader.block-styles($background: base.govuk-functional-colour("brand"));
+    @include genericHeader.block-styles(
+      $background-colour: base.govuk-functional-colour("brand"),
+      $text-colour: base.govuk-functional-colour("inverse-text")
+    );
   }
 
   .govuk-header__container--full-width {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -5,13 +5,14 @@
 /// @access private
 @mixin styles {
   .govuk-notification-banner {
+    --_govuk-notification-banner-colour: #{base.govuk-functional-colour(brand)};
+    --_govuk-notification-banner-title-text-colour: #{base.govuk-functional-colour(inverse-text)};
+
     @include base.govuk-font($size: 19);
     @include base.govuk-responsive-margin(8, "bottom");
 
     border: base.$govuk-border-width solid;
-    border-color: base.govuk-functional-colour(brand);
-
-    background-color: base.govuk-functional-colour(brand);
+    border-color: var(--_govuk-notification-banner-colour);
 
     &:focus {
       outline: base.$govuk-focus-width solid;
@@ -26,6 +27,9 @@
     // text in high contrast mode
     border-bottom: 1px solid transparent;
 
+    color: var(--_govuk-notification-banner-title-text-colour);
+    background-color: var(--_govuk-notification-banner-colour);
+
     @media #{base.govuk-from-breakpoint(tablet)} {
       padding: 2px base.govuk-spacing(4) base.govuk-spacing(1);
     }
@@ -38,7 +42,6 @@
     @include base.govuk-typography-weight-bold;
     margin: 0;
     padding: 0;
-    color: base.govuk-colour("white");
   }
 
   .govuk-notification-banner__content {
@@ -87,9 +90,7 @@
   }
 
   .govuk-notification-banner--success {
-    border-color: base.govuk-functional-colour(success);
-
-    background-color: base.govuk-functional-colour(success);
+    --_govuk-notification-banner-colour: #{base.govuk-functional-colour(success)};
 
     .govuk-notification-banner__link {
       @include base.govuk-link-style-success;

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -36,12 +36,13 @@
   }
 
   .govuk-panel--confirmation {
-    color: base.govuk-colour("white");
-    background: base.govuk-colour("green");
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
+    color: base.govuk-functional-colour(text);
+    background: base.govuk-functional-colour(success);
 
     @media print {
+      --govuk-text-colour: inherit;
       border-color: currentcolor;
-      color: base.govuk-functional-colour(text);
       background: none;
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/select/_mixin.scss
@@ -34,13 +34,6 @@
     }
   }
 
-  .govuk-select option:active,
-  .govuk-select option:checked,
-  .govuk-select:focus::-ms-value {
-    color: base.govuk-colour("white");
-    background-color: base.govuk-colour("blue");
-  }
-
   .govuk-select--error {
     border-color: base.govuk-functional-colour(error);
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -14,7 +14,11 @@
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: $govuk-service-navigation-border-colour;
-    color: $govuk-service-navigation-text-colour;
+    // Ensure that both raw content and content with typography classes
+    // will pick up the correct colour by setting both `--govuk-text-colour`
+    // and `color`.
+    --govuk-text-colour: #{$govuk-service-navigation-text-colour};
+    color: base.govuk-functional-colour(text);
     background-color: $govuk-service-navigation-background;
   }
 
@@ -200,10 +204,7 @@
     // Remove bottom border to add width-container ones
     border-bottom: none;
 
-    // Set colour here so non-link text (service name, slot content) can
-    // use it too.
-    color: base.govuk-colour("white");
-
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background-color: base.govuk-functional-colour(brand);
 
     .govuk-width-container {
@@ -220,12 +221,12 @@
     // Override the 'active' border colour
     .govuk-service-navigation__item,
     .govuk-service-navigation__service-name {
-      border-color: base.govuk-colour("white");
+      border-color: currentcolor;
     }
 
     // Override link styles
     .govuk-service-navigation__link {
-      @include base.govuk-link-style-inverse;
+      @include base.govuk-link-style-text;
     }
 
     // Override mobile menu toggle colour when not focused

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -257,7 +257,7 @@
 @mixin govuk-link-style-inverse {
   &:link,
   &:visited {
-    color: govuk-colour("white");
+    color: govuk-functional-colour(inverse-text);
   }
 
   &:focus {

--- a/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-functional.scss
@@ -20,6 +20,9 @@ $govuk-default-functional-colours: (
     "text": (
       name: "black"
     ),
+    "inverse-text": (
+      name: "white"
+    ),
     // The background colour of the template. This is intended to be the same
     // as `surface-background` for the purposes of making the Footer and Cookie
     // banner components merge seamlessly with the template.

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -48,6 +48,13 @@ module.exports = {
   ],
   plugins: ['stylelint-order'],
   rules: {
+    'custom-property-pattern': [
+      '^_?([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
+      {
+        message: (name) =>
+          `Expected custom property name "${name}" to be kebab-case, possibly starting with an \`_\` if it is private`
+      }
+    ],
     /**
      * GOV.UK Frontend has a specific ordering pattern
      * that should be applied to rules


### PR DESCRIPTION
Add a new `inverse-text` functional colour to represent the white text used on solid colour background and use it in the following instances:

- the inverse variant of the links (which trickles down to the Pagination's current link as well)
- the inverse Breadcrumbs
- the inverse Service Navigation
- the Panel (taking the liberty to set its background to the `success` functional colour
- the Notification Banner
- the GOV.UK Header (however not the Generic Header, as its black background is not a functional colour)

It also removes the styles for the selected option in the Select component as those styles are no longer applied by browsers and were purely presentational.

The PR does not affect:
- the Button component and its `--inverse` variant. This is best addressed as part of #6483.
- the File upload, as the background of the status when a file is selected is not a functional colour and the component could benefit from a reorganisation of its colours anyways. 

You can see the results on the new ['Components with inverse text' page of the review app](https://govuk-frontend-pr-7178.herokuapp.com/examples/solid-surface-components).

## TODO

- [x] As the colour for the header is enclosed in the mixin, it applies to both the branded and unbranded header. However the unbranded header does not use a functional colour as its background. Until it does, we should use `govuk-colour("white")` rather than `govuk-functional-colour(inverse-text)`. Amend the mixin to accept both a background and text colour.
- [x] Use a `--govuk-notification-banner-title-text-colour` variable to assign the colour of the notification banner's title closer to where the `--govuk-notification-banner-background-colour` is set.
- [x] ~As decided when reviewing the spike, avoid assigning `--govuk-text-colour` in the components to have it style elements automatically inside components, to avoid having parts where colour cascades, and others no.~ Not a thing for the confirmation panel, this was only for the new interruption panel.