### PR TITLE
Update exit this page overlay colour to use system colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#7183: Update exit this page overlay colour to use system colours](https://github.com/alphagov/govuk-frontend/pull/7183)
+
 ## v6.3.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.3.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_mixin.scss
@@ -68,7 +68,11 @@
     right: 0;
     bottom: 0;
     left: 0;
-    background-color: base.govuk-colour("white");
+    // The overlay is imitating a default browser window so we can use
+    // system colours ensure it matches the browser's default colours.
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/system-color
+    color: CanvasText;
+    background-color: Canvas;
   }
 
   // This class is added to the body when the Exit This Page button is activated


### PR DESCRIPTION
When you press the 'exit this page' button it'll redirect you to a safe page.

Since loading the new page can take a while an overlay is shown that says
'loading'.

Change the colours displayed on this in-between page so they match the browsers default colours (
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/system-color).

GOV.UK Frontend does not set `color-scheme` with a `dark` value so these colours will not change to dark automatically, aligning with the existing behaviour.

This decision was made to ensure that there is no clear flash between a light colour and dark colour which could arouse suspicion.

If GOV.UK Frontend supports dark mode in the future this overlay will then support dark colours and a dark page will change to a dark overlay automatically.

Motivation behind this change is ensuring we dont use any hardcoded colours where possible
and rely on functional colours, in this case the appropriate colours are system level.

## Browser testing
- [x] IE 11 (and older browsers) does not execute this JavaScript so the behaviour of the exit button is identical to pressing a regular link.
- [x] Edge 149 on Windows 11
- [x] Firefox 151 on Windows 11
- [x] Chrome 149 on Windows 11
- [x] Firefox 151 on OSX Golden Gate
- [x] Chrome 149 on OSX Golden Gate
- [x] Safari 27 on OSX Golden Gate
- [x] Safari on iOS v17.3
- [x] Chrome on iOS v17.3

Older devices
- [x] Google Chrome on Moto G9 Play v10.0
- [x] Samsung Internet on Samsung Galaxy S10 v9.0 
 
Closes #7175