### PR TITLE
Use the Generic header in the review app

### DIFF
--- a/packages/govuk-frontend-review/src/views/layouts/layout.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/layout.njk
@@ -1,11 +1,18 @@
 {% extends "layouts/_generic.njk" %}
 
+{% from "govuk/components/generic-header/macro.njk" import govukGenericHeader %}
+
 {% set htmlClasses = ["app-template", htmlClasses] | join(" ") if htmlClasses else "app-template" %}
 
 {% block pageTitle %}GOV.UK Frontend{% endblock %}
 
-{# Turn off the default header and footer components #}
-{% block govukHeader %}{% endblock %}
+{# Replace default header with generic header and turn off footer component #}
+{% block govukHeader %}
+  {{ govukGenericHeader({
+    logoText: "GOV.UK Frontend review app"
+  }) }}
+{% endblock %}
+
 {% block govukFooter %}{% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
Adds the Generic header to the review app as a consistent header

<img width="1002" height="657" alt="The generic header on the review app" src="https://github.com/user-attachments/assets/3dae7457-24c2-4b8b-903a-d3eaa2a9f754" />

I've gone with the text "GOV.UK Frontend review app" on the basis of us just calling it what we normally call it.

This header won't show up on full page examples or component previews but will show up on non-full page examples.

