### PR TITLE
Update non-GOV.UK example to use Helvetica

### DIFF
--- a/packages/govuk-frontend-review/src/stylesheets/app-unbranded.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app-unbranded.scss
@@ -1,0 +1,13 @@
+@use "pkg:govuk-frontend" with (
+  $govuk-font-family: (
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif
+  ),
+  $govuk-functional-colours: (
+    brand: #388e3c
+  )
+);
+
+@use "partials/banner";

--- a/packages/govuk-frontend-review/src/stylesheets/app.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/app.scss
@@ -6,6 +6,5 @@
 @use "partials/component-preview";
 @use "partials/feature-flag-banner";
 @use "partials/links";
-@use "partials/non-govuk-service";
 @use "partials/organisation-swatch";
 @use "partials/prose";

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_non-govuk-service.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_non-govuk-service.scss
@@ -1,7 +1,0 @@
-@use "pkg:govuk-frontend/base" as *;
-
-// Resets the brand colour to our palette red.
-// Used by the "non-GOV.UK service" full page example.
-.app-template--hmpf {
-  --govuk-brand-colour: #{govuk-colour("red")};
-}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/non-govuk-service/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/non-govuk-service/index.njk
@@ -10,9 +10,13 @@ scenario: You want to sign in to the HM Pizza Finder service
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set htmlClasses = "app-template--hmpf" %}
+{% set themeColor = "#388E3C" %}
 
 {% block pageTitle %}HM Pizza Finder{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="/stylesheets/app-unbranded.min.css">
+{% endblock %}
 
 {% set logoContent %}
 <svg width="28" height="30" viewBox="0 0 28 30" fill="currentColor" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Generate an entire stylesheet like we are asking users to do, set the brand here while we're at it.

Ensures that the font is display as Helvetica not GDS Transport.