### PR TITLE
Add Nunjucks logic to insert `<span>` element around HTML in start buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,26 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
+### Recommended changes
+
+#### Add a `<span>` element to start buttons containing HTML
+
+We've updated the Button component's Nunjucks macro to add a `<span>` element around HTML content within start buttons.
+
+This prevents whitespace around inline HTML elements from collapsing and prevents button content from wrapping incorrectly on narrow screens.
+
+If you're not using our Nunjucks macros, or have fixed this bug in a different way, you may want to update your code to add a `<span>` element instead.
+
+This change is only needed for start buttons containing HTML content. Other Button component styles and start buttons containing plain text were unaffected by the issue.
+
+We made this change in [pull request #7188: Add Nunjucks logic to insert `<span>` element around HTML in start buttons](https://github.com/alphagov/govuk-frontend/pull/7188).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7168: Fix lack of explicit colour on input prefix and suffixes](https://github.com/alphagov/govuk-frontend/pull/7168)
 - [#7169: Fix text on small inline radios wrapping unnecessarily](https://github.com/alphagov/govuk-frontend/pull/7169)
-- [#7188: Add Nunjucks logic to insert `<span>` element around HTML in start buttons](https://github.com/alphagov/govuk-frontend/pull/7188)
 
 ## v6.2.0 (Feature release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7168: Fix lack of explicit colour on input prefix and suffixes](https://github.com/alphagov/govuk-frontend/pull/7168)
 - [#7169: Fix text on small inline radios wrapping unnecessarily](https://github.com/alphagov/govuk-frontend/pull/7169)
+- [#7188: Add Nunjucks logic to insert `<span>` element around HTML in start buttons](https://github.com/alphagov/govuk-frontend/pull/7188)
 
 ## v6.2.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -247,6 +247,12 @@ examples:
       href: '/'
       text: Start now link button
       isStartButton: true
+  - name: start link with html
+    hidden: true
+    options:
+      href: '/'
+      html: Start <em>now</em>
+      isStartButton: true
   - name: prevent double click
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/button/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/button/template.njk
@@ -24,11 +24,23 @@
 
 {%- set commonAttributes %} class="{{ classNames }}" data-module="govuk-button" {{- govukAttributes(params.attributes) -}} {% if params.id %} id="{{ params.id }}"{% endif %}{% endset %}
 
+{#- Wrap content of the button in a <span> if it's a start button with HTML.
+Start buttons use flexbox, which removes whitespace from between HTML elements
+inside of them. -#}
+
+{%- set buttonText %}
+  {%- if params.html and params.isStartButton -%}
+    <span>{{ params.html | safe | trim }}</span>
+  {%- else -%}
+    {{- (params.html | safe | trim) if params.html else params.text -}}
+  {%- endif %}
+{%- endset %}
+
 {#- Actually create a button... or a link! #}
 
 {%- if params.href %}
 <a href="{{ params.href if params.href else '#' }}" role="button" draggable="false" {{- commonAttributes | safe }}>
-  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
+  {{ buttonText | safe | indent(2) }}
   {{- _startIcon() | safe if params.isStartButton }}
 </a>
 
@@ -39,7 +51,7 @@
   {%- if params.disabled %} disabled aria-disabled="true"{% endif %}
   {%- if params.preventDoubleClick !== undefined %} data-prevent-double-click="{{ params.preventDoubleClick }}"{% endif %}
   {{- commonAttributes | safe }}>
-  {{ params.html | safe | trim | indent(2) if params.html else params.text }}
+  {{ buttonText | safe | indent(2) }}
   {{- _startIcon() | safe if params.isStartButton }}
 </button>
 


### PR DESCRIPTION
Start buttons use flexbox for layout and alignment. Part of how flexbox works involves it ignoring whitespace between adjacent flex children (elements and text nodes), causing them to render 'squashed' together.

For example, HTML in a start button like this:
> `Apply for <abbr>PIP</abbr> now`

Would render like this:
> Apply forPIPnow

By wrapping the entire HTML string in an element, we remove the elements and text nodes from being flex children, and whitespace renders as expected.

Fixes #3406.

## Changes
- Added Nunjucks logic to check if `isStartButton` is true and the content is being provided by `html` parameter. 
  - If so, it renders the button HTML with a `<span>` element surrounding it. 
  - Otherwise, it renders the button content the same as previous.
  - To avoid duplication across the link and `<button>` variants of the component, this has been abstracted into a `buttonText` variable set in the Nunjucks template. 
- Added hidden review app example of a start button with HTML content.

## Thoughts
Making the insertion of the `<span>` element highly conditional is in aid of reducing the footprint of additional code generated by the macro. There's no point including it for text-only inner content or on non-start buttons, as the issue is not present there. A few extra bytes is still a lot of data at scale!
