### PR TITLE
Make sure GitHub Actions uses correct version of npm

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -1,5 +1,7 @@
 name: Build
 
+description: Build the project
+
 runs:
   using: composite
 

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -32,6 +32,10 @@ runs:
         # Restore global `~/.npm` cache (unless packages change)
         use-cache: ${{ steps.npm-install-cache.outputs.cache-hit != 'true' }}
 
+    - name: Setup npm
+      shell: bash
+      run: corepack install
+
     - name: Install dependencies
       id: install-node
 

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -1,5 +1,7 @@
 name: Install dependencies
 
+description: Install Node.js dependencies
+
 runs:
   using: composite
 

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -32,10 +32,6 @@ runs:
         # Restore global `~/.npm` cache (unless packages change)
         use-cache: ${{ steps.npm-install-cache.outputs.cache-hit != 'true' }}
 
-    - name: Setup npm
-      shell: bash
-      run: corepack install
-
     - name: Install dependencies
       id: install-node
 

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -17,8 +17,17 @@ runs:
       id: setup-node
 
       with:
+        cache: false
+        node-version-file: .nvmrc
+
+    - name: Setup npm using corepack
+      shell: bash
+      run: corepack enable npm
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6.4.0
+      id: setup-node
+
+      with:
         cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}
         node-version-file: .nvmrc
-    - name: Setup npm
-      shell: bash
-      run: corepack install

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Setup Node.js
       uses: actions/setup-node@v6.4.0
-      id: setup-node
+      id: setup-npm
 
       with:
         cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -17,7 +17,8 @@ runs:
       id: setup-node
 
       with:
-        cache: false
+        cache: ''
+        package-manager-cache: false
         node-version-file: .nvmrc
 
     - name: Setup npm using corepack

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -1,5 +1,7 @@
 name: Setup
 
+description: Setup Node.js and npm to use the correct versions
+
 inputs:
   use-cache:
     description: Restore global `~/.npm` cache

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -17,3 +17,5 @@ runs:
       with:
         cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}
         node-version-file: .nvmrc
+    - name: Setup npm
+      run: corepack install

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -20,4 +20,5 @@ runs:
         cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}
         node-version-file: .nvmrc
     - name: Setup npm
+      shell: bash
       run: corepack install

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "^24.11.0",
     "npm": "^11.16.0"
   },
+  "packageManager": "npm@11.16.0+sha512.03be172fc3b199c7a06433163e459be5b110a6983c1dd6305b7ac10f6b0fa12e1440755a8df6b1064ab2ccb789df0474919fb9c684e322dc57685ede21752ccb",
   "license": "MIT",
   "workspaces": [
     "packages/govuk-frontend",


### PR DESCRIPTION
Set the packageManager field which is used by `corepack` which in turn is used by the GitHub action `actions/setup-node`.

This field was created by running `corepack use npm@11.16.0`

We may want to make more use of `corepack` in the future e.g. recommend it as part of developers setting up their machines, for now, people can do it however they like.

Also the VSCode GitHub Actions workflows plugin was complaining about lack of descriptions so I have fixed that.

Closes #7193 