### PR TITLE
Try removing uses of slash

### DIFF
--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -3,7 +3,6 @@ import { join } from 'path'
 import { paths } from '@govuk-frontend/config'
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
-import slash from 'slash'
 
 import { scripts, styles } from './index.mjs'
 
@@ -36,9 +35,7 @@ function getTasks(options) {
         { cwd: options.srcPath },
 
         // Run Stylelint checks
-        npm.script('lint:scss:cli', [
-          slash(join(options.workspace, '**/*.scss'))
-        ])
+        npm.script('lint:scss:cli', [join(options.workspace, '**', '*.scss')])
       )
     ),
     'compile:scss watch': () =>
@@ -66,7 +63,7 @@ function getTasks(options) {
 
           // Run ESLint checks
           npm.script('lint:js:cli', [
-            slash(join(options.workspace, '**/*.{cjs,js,mjs}'))
+            join(options.workspace, '**', '*.{cjs,js,mjs}')
           ])
         )
       )

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -5,11 +5,10 @@ const {
   packageResolveToPath,
   packageNameToPath
 } = require('@govuk-frontend/lib/names')
-const slash = require('slash')
 const typedoc = require('typedoc')
 
 const basePath = join(packageNameToPath('govuk-frontend'), 'src')
-const workspacePath = slash(relative(paths.root, basePath))
+const workspacePath = relative(paths.root, basePath)
 const { HEROKU_APP, HEROKU_BRANCH = 'main' } = process.env
 
 /**
@@ -26,7 +25,7 @@ module.exports = {
   // Configure paths
   basePath,
   entryPoints: [
-    slash(packageResolveToPath('govuk-frontend/src/govuk/all.mjs'))
+    packageResolveToPath(join('govuk-frontend', 'src', 'govuk', 'all.mjs'))
   ],
   tsconfig: packageResolveToPath('govuk-frontend/tsconfig.json'),
   out: './dist/docs/jsdoc',

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -7,7 +7,6 @@ import {
   componentNameToMacroName,
   packageNameToPath
 } from '@govuk-frontend/lib/names'
-import slash from 'slash'
 
 /**
  * GOV.UK Prototype Kit config builder
@@ -30,11 +29,11 @@ export default async () => {
   // Build array of macros
   const nunjucksMacros = componentNames.map((componentName) => {
     const [macroPath = ''] = componentMacros.filter(
-      filterPath([`**/${componentName}/macro.njk`])
+      filterPath([join('**', componentName, 'macro.njk')])
     )
 
     return {
-      importFrom: slash(macroPath),
+      importFrom: macroPath,
       macroName: componentNameToMacroName(componentName)
     }
   })

--- a/packages/govuk-frontend/src/govuk/components/components.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.unit.test.js
@@ -3,13 +3,12 @@ const { join, basename } = require('path')
 
 const { compileSassString } = require('@govuk-frontend/helpers/tests')
 const { sassNull } = require('sass-embedded')
-const { default: slash } = require('slash')
 const stylelint = require('stylelint')
 
 // Grab the list of components synchronously so we can create
 // individual test suites for each of them
-const componentFolders = globSync(`${slash(__dirname)}/*`, {
-  exclude: ['**/*.*']
+const componentFolders = globSync(join(__dirname, '*'), {
+  exclude: [join('**', '*.*')]
 })
 
 describe('Components', () => {
@@ -91,7 +90,7 @@ describe('Components', () => {
 
       describe('_index.scss', () => {
         const sassPath = join(componentFolder, '_index.scss')
-        const sassUrl = `file:${slash(sassPath)}`
+        const sassUrl = `file:${sassPath}`
 
         describe.each([
           [
@@ -141,7 +140,7 @@ describe('Components', () => {
 
       describe(`_${componentName}.scss`, () => {
         const sassPath = join(componentFolder, `_${componentName}.scss`)
-        const sassUrl = `file:${slash(sassPath)}`
+        const sassUrl = `file:${sassPath}`
 
         let css
 

--- a/packages/govuk-frontend/src/govuk/index.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/index.unit.test.mjs
@@ -1,8 +1,9 @@
+import { join } from 'path'
+
 import { paths } from '@govuk-frontend/config'
 import { compileSassString } from '@govuk-frontend/helpers/tests'
 import { sassNull } from 'sass-embedded'
 import sassdoc from 'sassdoc'
-import slash from 'slash'
 
 let mockWarnFunction, sassConfig
 
@@ -173,8 +174,8 @@ describe('GOV.UK Frontend', () => {
     it('associates public Sass members with a group', async () => {
       return sassdoc
         .parse([
-          `${slash(paths.package)}/src/govuk/**/*.scss`,
-          `!${slash(paths.package)}/src/govuk/vendor/*.scss`
+          join(paths.package, 'src', 'govuk', '**', '*.scss'),
+          `!${join(paths.package, 'src', 'govuk', 'vendor', '*.scss')}`
         ])
         .then((docs) =>
           docs

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -2,7 +2,6 @@ import { join } from 'path'
 
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
-import slash from 'slash'
 
 import { assets, fixtures, scripts, styles, templates } from './index.mjs'
 
@@ -40,9 +39,7 @@ function getTasks(options) {
         { cwd: options.srcPath },
 
         // Run Stylelint checks
-        npm.script('lint:scss:cli', [
-          slash(join(options.workspace, '**/*.scss'))
-        ])
+        npm.script('lint:scss:cli', [join(options.workspace, '**', '*.scss')])
       )
     ),
     'compile:scss watch': () =>
@@ -63,7 +60,7 @@ function getTasks(options) {
 
           // Run ESLint checks
           npm.script('lint:js:cli', [
-            slash(join(options.workspace, '**/*.{cjs,js,mjs}'))
+            join(options.workspace, '**', '*.{cjs,js,mjs}')
           ])
         )
       )

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -1,12 +1,11 @@
 const { readFile, stat } = require('fs/promises')
-const { parse, relative, basename } = require('path')
+const { parse, relative, basename, join } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
 const { filesize } = require('filesize')
 const { glob } = require('glob')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
-const slash = require('slash')
 
 /**
  * Check path exists
@@ -31,7 +30,7 @@ async function hasPath(entryPath) {
  * @returns {Promise<string[]>} File paths
  */
 async function getListing(directoryPath, options = {}) {
-  const listing = await glob(slash(directoryPath), {
+  const listing = await glob(directoryPath, {
     absolute: true,
     nodir: true,
     realpath: true,
@@ -53,7 +52,7 @@ async function getListing(directoryPath, options = {}) {
  * @returns {Promise<string[]>} Directory names
  */
 async function getDirectories(directoryPath) {
-  const listing = await getListing(`${slash(directoryPath)}/*/`, {
+  const listing = await getListing(join(directoryPath, '*'), {
     nodir: false
   })
 

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -1,8 +1,6 @@
 import { dirname, parse, relative } from 'path'
 import { fileURLToPath } from 'url'
 
-import slash from 'slash'
-
 import { files } from './index.mjs'
 
 /**
@@ -43,11 +41,9 @@ export async function write(filePath, result) {
        * {@link https://sass-lang.com/documentation/js-api/interfaces/CompileResult#sourceMap}
        */
       .map((path) =>
-        slash(
-          path.startsWith('file://')
-            ? relative(dirname(filePath), fileURLToPath(path))
-            : path
-        )
+        path.startsWith('file://')
+          ? relative(dirname(filePath), fileURLToPath(path))
+          : path
       )
 
     writeTasks.push(

--- a/tests/sass-tests/sass-file-compilation.integration.test.mjs
+++ b/tests/sass-tests/sass-file-compilation.integration.test.mjs
@@ -1,8 +1,7 @@
 import { globSync } from 'node:fs'
-import { relative } from 'node:path'
+import { join, relative } from 'node:path'
 
 import { packageNameToPath } from '@govuk-frontend/lib/names'
-import slash from 'slash'
 import stylelint from 'stylelint'
 
 import { compileSassStringLikeUsers } from './helpers/sass.js'
@@ -13,10 +12,13 @@ import { compileSassStringLikeUsers } from './helpers/sass.js'
 const govukFrontendPath = packageNameToPath('govuk-frontend')
 
 // Grab a list of all Sass files and sort them alphabetically, for consistent output
-const sassFiles = globSync(`${slash(govukFrontendPath)}/src/govuk/**/*.scss`, {
-  exclude: ['**/*.import.scss', '**/*--internal.scss']
-})
-  .map((filePath) => slash(relative(govukFrontendPath, filePath)))
+const sassFiles = globSync(
+  join('govukFrontendPath', 'src', 'govuk', '**', '*.scss'),
+  {
+    exclude: ['**/*.import.scss', '**/*--internal.scss']
+  }
+)
+  .map((filePath) => relative(govukFrontendPath, filePath))
   .sort((a, b) => a.localeCompare(b))
 
 // Compile a Sass file and store any errors


### PR DESCRIPTION
Just wondering, do we even need to use this? When using Node.js' tools like `join` it'll automatically detect if it's in Windows-land or Unix-land and use the appropriate forward or backwards slashes.