### PR TITLE
Improve source spacing for header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7183: Update exit this page overlay colour to use system colours](https://github.com/alphagov/govuk-frontend/pull/7183)
+- [#7197: Improve source spacing for header](https://github.com/alphagov/govuk-frontend/pull/7197)
 
 ## v6.3.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -1,21 +1,21 @@
 {% from "../generic-header/macro.njk" import govukGenericHeader -%}
 {% from "../../macros/logo.njk" import govukLogo -%}
 
-{% set logoContent %}
+{% set logoContent -%}
   {{ govukLogo({
     classes: "govuk-header__logotype",
     ariaLabelText: "GOV.UK"
-  }) | trim | indent(8) }}
-  {%- if (params.productName) %}
+  }) | trim }}
+  {% if (params.productName) -%}
     <span class="govuk-header__product-name">
       {{- params.productName -}}
     </span>
-  {% endif -%}
+  {%- endif %}
 {% endset %}
 
 {{ govukGenericHeader({
   _namespace: 'govuk',
-  logoHtml: logoContent,
+  logoHtml: logoContent | indent(8),
   url: params.homepageUrl | default("//gov.uk", true),
   containerClasses: params.containerClasses,
   classes: params.classes,


### PR DESCRIPTION
## Change

Move indenting and nunjucks whitespace removal around so that the rendered html for the header looks nicer. Noticed during the 6.3.0 release when looking at npmdiff.

## Visual changes

Visual changes are from viewing page source of the header with a product name example on the review app.

### Before

Note the product name on the same line as the closing `svg` tag

<img width="744" height="540" alt="Page source of header with product name before" src="https://github.com/user-attachments/assets/d210703f-922b-4cdf-a74b-5d519ecb7dcf" />

### After

<img width="719" height="508" alt="Page source of header with product name after" src="https://github.com/user-attachments/assets/2eb458f2-28e9-4711-aade-c791917504aa" />

## Notes

I wasn't able to move the svg back by one indent to make it more nicely inline with it's parent without undoing nunjucks code indenting, which I think is worth retaining for readability. The main thing IMO is the product name so I think this is an acceptable nice small change.