### PR TITLE
Remove slash micro dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37791,7 +37791,6 @@
         "sass-color-helpers": "^2.1.1",
         "sass-embedded": "^1.89.2",
         "sassdoc": "^2.7.4",
-        "slash": "^5.1.0",
         "stylelint": "^16.26.1"
       },
       "engines": {
@@ -37818,7 +37817,6 @@
         "marked-smartypants": "^1.1.12",
         "outdent": "^0.8.0",
         "shuffle-seed": "^1.1.6",
-        "slash": "^3.0.0",
         "slug": "^9.1.0"
       },
       "devDependencies": {
@@ -37845,14 +37843,6 @@
       "engines": {
         "node": "^24.11.0",
         "npm": "^11.6.1 <11.6.3 || ^11.6.4"
-      }
-    },
-    "packages/govuk-frontend-review/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "packages/govuk-frontend/node_modules/cssnano": {
@@ -38462,8 +38452,7 @@
         "js-yaml": "^4.2.0",
         "minimatch": "^10.2.5",
         "nunjucks": "^3.2.4",
-        "outdent": "^0.8.0",
-        "slash": "^3.0.0"
+        "outdent": "^0.8.0"
       },
       "engines": {
         "node": "^24.11.0",
@@ -38490,14 +38479,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "shared/lib/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "shared/stats": {
@@ -38538,7 +38519,6 @@
         "puppeteer": "^24.42.0",
         "rollup": "^4.60.4",
         "sass-embedded": "^1.89.2",
-        "slash": "^5.1.0",
         "slug": "^9.1.0"
       },
       "engines": {
@@ -38572,7 +38552,6 @@
         "@govuk-frontend/lib": "*",
         "govuk-frontend": "*",
         "sass-embedded": "^1.89.2",
-        "slash": "^5.1.0",
         "stylelint": "^16.26.1"
       },
       "engines": {

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -39,7 +39,6 @@
     "marked-smartypants": "^1.1.12",
     "outdent": "^0.8.0",
     "shuffle-seed": "^1.1.6",
-    "slash": "^3.0.0",
     "slug": "^9.1.0"
   },
   "devDependencies": {

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -1,9 +1,9 @@
 import { join } from 'path'
 
 import { paths } from '@govuk-frontend/config'
+import { slash } from '@govuk-frontend/lib/files'
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
-import { slash } from '@govuk-frontend/lib/files'
 
 import { scripts, styles } from './index.mjs'
 

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { paths } from '@govuk-frontend/config'
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
-import slash from 'slash'
+import { slash } from '@govuk-frontend/lib/files'
 
 import { scripts, styles } from './index.mjs'
 

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -1,11 +1,11 @@
 const { join, relative } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
+const { slash } = require('@govuk-frontend/lib/files')
 const {
   packageResolveToPath,
   packageNameToPath
 } = require('@govuk-frontend/lib/names')
-const slash = require('slash')
 const typedoc = require('typedoc')
 
 const basePath = join(packageNameToPath('govuk-frontend'), 'src')

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -92,7 +92,6 @@
     "sass-color-helpers": "^2.1.1",
     "sass-embedded": "^1.89.2",
     "sassdoc": "^2.7.4",
-    "slash": "^5.1.0",
     "stylelint": "^16.26.1"
   }
 }

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -7,7 +7,7 @@ import {
   componentNameToMacroName,
   packageNameToPath
 } from '@govuk-frontend/lib/names'
-import slash from 'slash'
+import { slash } from '@govuk-frontend/lib/files'
 
 /**
  * GOV.UK Prototype Kit config builder

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -2,12 +2,11 @@ import { join } from 'path'
 
 import { pkg } from '@govuk-frontend/config'
 import { getComponentNames } from '@govuk-frontend/lib/components'
-import { filterPath, getListing } from '@govuk-frontend/lib/files'
+import { filterPath, getListing, slash } from '@govuk-frontend/lib/files'
 import {
   componentNameToMacroName,
   packageNameToPath
 } from '@govuk-frontend/lib/names'
-import { slash } from '@govuk-frontend/lib/files'
 
 /**
  * GOV.UK Prototype Kit config builder

--- a/packages/govuk-frontend/src/govuk/components/components.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.unit.test.js
@@ -2,8 +2,8 @@ const { globSync } = require('fs')
 const { join, basename } = require('path')
 
 const { compileSassString } = require('@govuk-frontend/helpers/tests')
+const { slash } = require('@govuk-frontend/lib/files')
 const { sassNull } = require('sass-embedded')
-const { default: slash } = require('slash')
 const stylelint = require('stylelint')
 
 // Grab the list of components synchronously so we can create

--- a/packages/govuk-frontend/src/govuk/index.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/index.unit.test.mjs
@@ -1,8 +1,8 @@
 import { paths } from '@govuk-frontend/config'
 import { compileSassString } from '@govuk-frontend/helpers/tests'
+import { slash } from '@govuk-frontend/lib/files'
 import { sassNull } from 'sass-embedded'
 import sassdoc from 'sassdoc'
-import slash from 'slash'
 
 let mockWarnFunction, sassConfig
 

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -2,7 +2,7 @@ import { join } from 'path'
 
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
-import slash from 'slash'
+import { slash } from '@govuk-frontend/lib/files'
 
 import { assets, fixtures, scripts, styles, templates } from './index.mjs'
 

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -1,8 +1,8 @@
 import { join } from 'path'
 
+import { slash } from '@govuk-frontend/lib/files'
 import { npm, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
-import { slash } from '@govuk-frontend/lib/files'
 
 import { assets, fixtures, scripts, styles, templates } from './index.mjs'
 

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -6,7 +6,19 @@ const { filesize } = require('filesize')
 const { glob } = require('glob')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
-const slash = require('slash')
+
+/**
+ * Convert Windows backslash paths to slash paths: foo\\bar ➔ foo/bar
+ *
+ * Only use when using Node.js path utils e.g. `join()` is not appropriate,
+ * which automatically accounts for differences in paths between operating systems.
+ *
+ * @param {string} path - File or directory path
+ * @returns {string} A path with forward slashes.
+ */
+function slash(path) {
+  return path.replace(/\\/g, '/')
+}
 
 /**
  * Check path exists
@@ -227,7 +239,8 @@ module.exports = {
   getListing,
   getReadableFileSizes,
   getYaml,
-  mapPathTo
+  mapPathTo,
+  slash
 }
 
 /**

--- a/shared/lib/files.unit.test.mjs
+++ b/shared/lib/files.unit.test.mjs
@@ -1,0 +1,9 @@
+import { slash } from './files.js'
+
+describe('slash', () => {
+  test('convert backwards-slash paths to forward slash paths', () => {
+    expect(slash('c:/aaaa\\bbbb')).toBe('c:/aaaa/bbbb')
+    expect(slash('c:\\aaaa\\bbbb')).toBe('c:/aaaa/bbbb')
+    expect(slash('c:\\aaaa\\bbbb\\★')).toBe('c:/aaaa/bbbb/★')
+  })
+})

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -19,7 +19,6 @@
     "js-yaml": "^4.2.0",
     "minimatch": "^10.2.5",
     "nunjucks": "^3.2.4",
-    "outdent": "^0.8.0",
-    "slash": "^3.0.0"
+    "outdent": "^0.8.0"
   }
 }

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -1,7 +1,7 @@
 import { dirname, parse, relative } from 'path'
 import { fileURLToPath } from 'url'
 
-import slash from 'slash'
+import { slash } from '@govuk-frontend/lib/files'
 
 import { files } from './index.mjs'
 

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -23,7 +23,6 @@
     "puppeteer": "^24.42.0",
     "rollup": "^4.60.4",
     "sass-embedded": "^1.89.2",
-    "slash": "^5.1.0",
     "slug": "^9.1.0"
   }
 }

--- a/tests/sass-tests/package.json
+++ b/tests/sass-tests/package.json
@@ -12,7 +12,6 @@
     "@govuk-frontend/lib": "*",
     "govuk-frontend": "*",
     "sass-embedded": "^1.89.2",
-    "slash": "^5.1.0",
     "stylelint": "^16.26.1"
   }
 }

--- a/tests/sass-tests/sass-file-compilation.integration.test.mjs
+++ b/tests/sass-tests/sass-file-compilation.integration.test.mjs
@@ -2,7 +2,7 @@ import { globSync } from 'node:fs'
 import { relative } from 'node:path'
 
 import { packageNameToPath } from '@govuk-frontend/lib/names'
-import slash from 'slash'
+import { slash } from '@govuk-frontend/lib/files'
 import stylelint from 'stylelint'
 
 import { compileSassStringLikeUsers } from './helpers/sass.js'

--- a/tests/sass-tests/sass-file-compilation.integration.test.mjs
+++ b/tests/sass-tests/sass-file-compilation.integration.test.mjs
@@ -1,8 +1,8 @@
 import { globSync } from 'node:fs'
 import { relative } from 'node:path'
 
-import { packageNameToPath } from '@govuk-frontend/lib/names'
 import { slash } from '@govuk-frontend/lib/files'
+import { packageNameToPath } from '@govuk-frontend/lib/names'
 import stylelint from 'stylelint'
 
 import { compileSassStringLikeUsers } from './helpers/sass.js'


### PR DESCRIPTION
The newest version of `slash` is ESM only and is a pain to upgrade, since we mix ESM and commonjs across the project.

I had a look at what it's actually doing and noticed it's [three lines of code](https://github.com/sindresorhus/slash/blob/98b618f5a3bfcb5dd374b204868818845b87bb2f/index.js#L1-L9), so to save us having to bump this in the future, bring it inline into the project instead.

Closes https://github.com/alphagov/govuk-frontend/pull/7134