### PR TITLE
Remove unused overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,20 +109,8 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "chokidar@^2": {
-      "glob-parent": "^5"
-    },
-    "glob-stream@^6": {
-      "glob-parent": "^5"
-    },
     "latest-version@^5": {
       "package-json": "^7"
-    },
-    "sass-convert": {
-      "semver-regex": "^3"
-    },
-    "sassdoc-extras@^2": {
-      "marked": "^0.8.2"
     }
   }
 }


### PR DESCRIPTION
- We have no dependencies which used `chokidar` < v3, which uses a non-vulnerable `glob-parent`
- None of the other removed dependencies actually _work_ - sassdoc-extra's `marked` is 0.6.3 in the lock file, glob-stream's `glob-parent` is 3.1.0 and sass-convert's `semver-regex` is 1.0.0.

The non-working overrides are all dependencies of `sassdoc`, which is now basically unmaintained, but is also only a dev dependency, so not a particularly worrisome security vector.

Still, possibly a case for moving away from it and finding another way to document our sass.