### PR TITLE
Add interruption panel - Inverse text using typography classes

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/interruption-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/interruption-page/index.njk
@@ -1,0 +1,39 @@
+---
+title: Is your age correct?
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ example.title }} - GOV.UK{% endblock %}
+
+{% block containerStart %}
+  {{ govukBackLink({
+    href: "/",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% call govukPanel({
+        classes: "govuk-panel--interruption",
+        titleText: "Is your age correct?"
+      }) %}
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
+        <div class="govuk-button-group">
+          {{ govukButton({
+            classes: "govuk-button--inverse",
+            text: "Yes, this is correct"
+          }) }}
+          <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
+        </div>
+      {% endcall %}
+    </div>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -62,7 +62,5 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background: base.govuk-functional-colour(brand);
     text-align: left;
-
-    @include base.govuk-font($size: 19);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -11,6 +11,7 @@
     padding: base.govuk-spacing(7) - base.$govuk-border-width;
 
     border: base.$govuk-border-width solid transparent;
+    color: base.govuk-functional-colour(text);
 
     text-align: center;
 
@@ -41,12 +42,6 @@
     }
   }
 
-  .govuk-panel--confirmation {
-    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
-    color: base.govuk-functional-colour(text);
-    background: base.govuk-functional-colour(success);
-  }
-
   .govuk-panel__title {
     @include base.govuk-font-size($size: 48);
     @include base.govuk-typography-weight-bold;
@@ -58,9 +53,14 @@
     margin-bottom: 0;
   }
 
+  .govuk-panel--confirmation {
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
+    background: base.govuk-functional-colour(success);
+  }
+
   .govuk-panel--interruption {
-    color: base.govuk-colour("white");
-    background-color: base.govuk-functional-colour(brand);
+    --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
+    background: base.govuk-functional-colour(brand);
     text-align: left;
 
     @include base.govuk-font($size: 19);

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -37,12 +37,7 @@ examples:
     screenshot: true
     options:
       titleHtml: Application complete
-      text: 'Your reference number: HDJ2123F'
-  - name: custom heading level
-    options:
-      titleText: Application complete
-      headingLevel: 2
-      text: 'Your reference number: HDJ2123F'
+      html: Your reference number<br><strong>HDJ2123F</strong>
   - name: interruption
     options:
       titleText: Is your age correct?

--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -40,16 +40,56 @@ examples:
       html: Your reference number<br><strong>HDJ2123F</strong>
   - name: interruption
     options:
+      classes: govuk-panel--interruption
       titleText: Is your age correct?
       html: |
-        <p>You entered your age as <strong>109</strong>.</p>
+        <p class="govuk-body">You entered your age as <strong>109</strong>.</p>
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
             Yes, this is correct
           </button>
           <a href="#" class="govuk-link govuk-link--inverse">Change my age</a>
         </div>
+  - name: interruption-with-content-with-long-line-length
+    options:
       classes: govuk-panel--interruption
+      titleText: Are you sure you want to change this?
+      html: |
+        <p class="govuk-body">You've changed the person's address from Wales to England. This means that the referral needs to be cancelled.</p>
+        <p class="govuk-body">Previous home address: 1 Willow Lane, Newchurch, Kington, HR5 3QF</p>
+        <p class="govuk-body">New home address: 9 Elm Street, Whitney-on-Wye, Hereford, HR3 6EH</p>
+        <p class="govuk-body">You can go back to undo this change.</p>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Are you sure you want to change this?
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">
+            Go back to application
+          </a>
+        </div>
+  - name: interruption-with-headings-content-and-lists
+    options:
+      classes: govuk-panel--interruption
+      titleText: Your new answer affects other sections of this application
+      html: |
+        <h2 class="govuk-heading-m">Question: Where is Andy Cooke located?</h2>
+        <p class="govuk-body">
+          Previous answer: Custody<br>
+          New answer: Released
+        </p>
+        <p class="govuk-body govuk-!-margin-bottom-2">You need to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>enter their custody information</li>
+          <li>update the licence conditions section</li>
+        </ul>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--inverse" data-module="govuk-button">
+            Continue to other sections
+          </button>
+          <a href="#" class="govuk-link govuk-link--inverse">
+            Go back to application
+          </a>
+        </div>
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: title html as text

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -25,9 +25,11 @@ describe('Panel', () => {
 
     it('renders body text', () => {
       const $ = render('panel', examples.default)
-      const panelBodyText = $('.govuk-panel__body').text().trim()
+      const panelBodyText = $('.govuk-panel__body').html().trim()
 
-      expect(panelBodyText).toBe('Your reference number: HDJ2123F')
+      expect(panelBodyText).toBe(
+        'Your reference number<br><strong>HDJ2123F</strong>'
+      )
     })
 
     it('doesnt render panel body if no body text is passed', () => {


### PR DESCRIPTION
> [!NOTE]
> A final review will be available once we get the contribution branch ready
> I will manually merge this into https://github.com/alphagov/govuk-frontend/pull/6636 once approved since we cant merge into a external repo via GitHub

Moves away from global styling of paragraphs to use `govuk-body` (and other) typography styles instead, the colour is then changed by overriding the `text` functional colour (`--govuk-text-colour` CSS Custom Property).

Also adds examples to flesh out the different variants we've seen in the wild and adds a page to represent the Interruption pattern page.

This is first of a few smaller pull requests, known issues that'll be done in follow up include:
- title sizing
- spacing issues

As part of https://github.com/alphagov/govuk-design-system/issues/5418