### PR TITLE
Add interruption panel - Add test coverage and resolve minor ordering issue

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
+++ b/packages/govuk-frontend/src/govuk/components/panel/panel.yaml
@@ -136,3 +136,9 @@ examples:
       titleText: Application complete
       headingLevel: 2
       text: 'Your reference number: HDJ2123F'
+  - name: interruption with custom classes
+    hidden: true
+    options:
+      classes: govuk-panel--interruption extra-class one-more-class
+      titleText: Are you sure you want to change this?
+      html: <p class="govuk-body">You've changed the person's address from Wales to England. This means that the referral needs to be cancelled.</p>

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -2,17 +2,14 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
-{%- set classNames = "govuk-panel" -%}
+{%- set isInterruption = params.classes and ("govuk-panel--interruption" in params.classes) -%}
 
-{%- if params.classes %}
-  {% set classNames = classNames + " " + params.classes %}
-{% endif %}
+{#- The Panel component defaults to the Confirmation variant -#}
+{%- set defaultModifierClassName = "govuk-panel--confirmation" if not isInterruption -%}
 
-{%- if (not params.classes) or (not "govuk-panel--interruption" in params.classes) %}
-  {% set classNames = classNames + " govuk-panel--confirmation" -%}
-{% endif %}
-
-<div class="{{ classNames }}"
+<div class="govuk-panel
+  {%- if defaultModifierClassName %} {{ defaultModifierClassName }}{% endif %}
+  {%- if params.classes %} {{ params.classes }}{% endif -%}"
   {{- govukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -105,4 +105,39 @@ describe('Panel', () => {
       expect($component.attr('second-attribute')).toBe('bar')
     })
   })
+
+  describe('classes', () => {
+    it('has confirmation modifier class by default', () => {
+      const $ = render('panel')
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel govuk-panel--confirmation'
+      )
+    })
+    it('keeps confirmation modifier class if additional classes used', () => {
+      const $ = render('panel', examples.classes)
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel extra-class one-more-class govuk-panel--confirmation'
+      )
+    })
+    it('has no confirmation modifier class if interruption modifier class is used', () => {
+      const $ = render('panel', examples.interruption)
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel govuk-panel--interruption'
+      )
+    })
+    it('keeps interruption modifier class if additional classes used', () => {
+      const $ = render('panel', examples['interruption with custom classes'])
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('class')).toBe(
+        'govuk-panel govuk-panel--interruption extra-class one-more-class'
+      )
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -120,7 +120,7 @@ describe('Panel', () => {
 
       const $component = $('.govuk-panel')
       expect($component.attr('class')).toBe(
-        'govuk-panel extra-class one-more-class govuk-panel--confirmation'
+        'govuk-panel govuk-panel--confirmation extra-class one-more-class'
       )
     })
     it('has no confirmation modifier class if interruption modifier class is used', () => {


### PR DESCRIPTION
> [!NOTE]
> I will manually merge this into https://github.com/alphagov/govuk-frontend/pull/6636 once merged into our local branch since we cant merge into a external repo via GitHub

When adding test coverage for the classes logic noticed the ordering of the classes were a bit odd so refactored the code to be more similar to how we do things in other places.

