### PR TITLE
[SPIKE] Link variants through custom properties (selectors in `govuk-link-common`)

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/generic-header/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/generic-header/_mixin.scss
@@ -25,6 +25,7 @@ $header-forced-colour-border-width: 1px;
   --govuk-text-colour: #{$text-colour};
   color: base.govuk-functional-colour(text);
   background: $background-colour;
+  @include base.govuk-link-style-text;
 
   @media print {
     border-bottom-width: 0;
@@ -77,7 +78,7 @@ $header-forced-colour-border-width: 1px;
   font-size: 30px; // We don't have a mixin that produces 30px font size
   text-decoration: none;
 
-  @include base.govuk-link-style-text;
+  @include base.govuk-link-style-default;
 
   &:link,
   &:visited {
@@ -96,16 +97,9 @@ $header-forced-colour-border-width: 1px;
     // Remove any borders that show when focused and hovered.
     margin-bottom: 0;
     border-bottom: 0;
-
-    @include base.govuk-focused-text;
   }
 
   @media print {
-    &:link,
-    &:visited {
-      color: base.govuk-functional-colour(text);
-    }
-
     // Do not append link href to GOV.UK link when printing (e.g. '(/)')
     &::after {
       content: "";

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -97,6 +97,7 @@
   .govuk-service-navigation__link {
     @include base.govuk-link-common;
     @include base.govuk-link-style-no-underline;
+    @include base.govuk-link-style-default;
     @include base.govuk-link-style-no-visited-state;
   }
 
@@ -106,11 +107,6 @@
 
   .govuk-service-navigation__service-name {
     @include base.govuk-typography-weight-bold;
-  }
-
-  // Annoyingly this requires a compound selector in order to overcome the
-  // specificity of the other link colour override we're doing
-  .govuk-service-navigation__service-name .govuk-service-navigation__link {
     @include base.govuk-link-style-text;
   }
 
@@ -226,6 +222,11 @@
 
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background-color: base.govuk-functional-colour(brand);
+    // Avoid defining specific link styles when inverted and just use the text colours
+    @include base.govuk-link-style-text;
+
+    // Similarly to the Breadcrumbs, switch the secondary text colour to `currentcolor`
+    --govuk-secondary-text-colour: currentcolor;
 
     .govuk-width-container {
       border-width: 1px 0;
@@ -242,11 +243,6 @@
     .govuk-service-navigation__item,
     .govuk-service-navigation__service-name {
       border-color: currentcolor;
-    }
-
-    // Override link styles
-    .govuk-service-navigation__link {
-      @include base.govuk-link-style-text;
     }
 
     // Override mobile menu toggle colour when not focused

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -431,6 +431,34 @@ examples:
             </ul>
           </nav>
         endRightAligned: true
+  - name: with language switcher, inverse
+    description: HTML rendered by the language switcher component can be injected into the `end` slot of the service header.
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      classes: govuk-service-navigation--inverse
+      serviceName: Service name
+      serviceUrl: '#/'
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+          active: true
+        - href: '#/2'
+          text: Navigation item 2
+        - href: '#/3'
+          text: Navigation item 3
+      slots:
+        end: |-
+          <nav class="govuk-language-switcher" aria-label="Language switcher">
+            <ul class="govuk-language-switcher__list">
+              <li class="govuk-language-switcher__list-item">
+                <span class="govuk-language-switcher__text" lang="en" aria-current="true">English</span>
+              </li>
+              <li class="govuk-language-switcher__list-item">
+                <a class="govuk-language-switcher__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
+              </li>
+            </ul>
+          </nav>
   - name: with slotted content
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -194,6 +194,7 @@
   @include govuk-link-style-no-visited-state;
 
   --govuk-link-colour: #{govuk-functional-colour(text)};
+  --govuk-link-hover-colour: var(--govuk-link-colour);
   --govuk-link-active-colour: var(--govuk-link-colour);
 }
 

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -119,24 +119,11 @@
 /// @access public
 
 @mixin govuk-link-style-error {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(error);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:hover {
-    color: govuk-colour("red", $variant: "shade-50");
-  }
-
-  &:active {
-    color: govuk-functional-colour(error);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(error)};
+  --govuk-link-hover-colour: #{govuk-colour("red", $variant: "shade-50")};
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Success link styles
@@ -156,24 +143,11 @@
 /// @access public
 
 @mixin govuk-link-style-success {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(success);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:hover {
-    color: govuk-colour("green", $variant: "shade-50");
-  }
-
-  &:active {
-    color: govuk-functional-colour(success);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(success)};
+  --govuk-link-hover-colour: #{govuk-colour("green", $variant: "shade-50")};
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Muted link styles
@@ -193,21 +167,11 @@
 /// @access public
 
 @mixin govuk-link-style-muted {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(secondary-text);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:hover,
-  &:active {
-    color: govuk-functional-colour(text);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(secondary-text)};
+  --govuk-link-hover-colour: #{govuk-functional-colour(text)};
+  --govuk-link-active-colour: var(--govuk-link-hover-colour);
 }
 
 /// Text link styles
@@ -227,15 +191,10 @@
 /// @access public
 
 @mixin govuk-link-style-text {
-  &:link,
-  &:visited,
-  &:active {
-    color: govuk-functional-colour(text);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(text)};
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Inverse link styles
@@ -255,14 +214,11 @@
 /// @access public
 
 @mixin govuk-link-style-inverse {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(inverse-text);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(inverse-text)};
+  --govuk-link-hover-colour: var(--govuk-link-colour);
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Default link styles, without a visited state
@@ -286,27 +242,7 @@
 /// @access public
 
 @mixin govuk-link-style-no-visited-state {
-  &:link {
-    color: govuk-functional-colour(link);
-  }
-
-  &:visited {
-    color: govuk-functional-colour(link);
-  }
-
-  &:hover {
-    color: govuk-functional-colour(link-hover);
-  }
-
-  &:active {
-    color: govuk-functional-colour(link-active);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-visited-colour: var(--govuk-link-colour);
 }
 
 /// Remove underline from links

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -22,9 +22,7 @@
     @include govuk-link-hover-decoration;
   }
 
-  &:focus {
-    @include govuk-focused-text;
-  }
+  @include govuk-link-style-default;
 }
 
 /// Link decoration
@@ -95,10 +93,8 @@
     color: govuk-functional-colour(link-active);
   }
 
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
   &:focus {
-    color: govuk-functional-colour(focus-text);
+    @include govuk-focused-text;
   }
 }
 


### PR DESCRIPTION
This spike is [one of two](https://github.com/alphagov/govuk-frontend/pull/7238) exploring the use of custom properties to change the colours of the link variants, particularly to allow a parent element to configure the colours of all the links inside it, which is useful for the Service Navigation.

Ideally, links across the markup would use `.govuk-link` and the variants would only have to set the relevant `--govuk-link(-<STATE>)-colour` custom properties (see first commit). This is great, but only affects markup actually using `.govuk-link`.

In the couple of instances where links are styles using mixins attached to a completely different class (for example the header's homepage link or the error summary). These instances need both:
- to 'theme' the links by applying the right colours to the `--govuk-link(-<STATE>)-colour`
- to 'style' the links attaching the relevant `--govuk-link-<STATE>-colour` to the `:<STATE>` selector.

Otherwise the `<a>` element get the browser's default styles:

<img width="992" height="414" alt="Error summary showing the default link styles" src="https://github.com/user-attachments/assets/e591bea6-cf9f-4a64-8dde-e47b5bb7d269" />
<img width="1497" height="277" alt="Generic header showing the default link styles" src="https://github.com/user-attachments/assets/f21b8d0c-bc7b-4a45-9303-67f99cdf52f9" />

The documentation of our `govuk-link-style-<STYLE>` mixins states that:

> /// If you use this mixin in a component, you must also include the
> /// `govuk-link-common` mixin to get the correct focus and hover states.

This opens the door to having `govuk-link-common` call `govuk-link-style-default` and generate the rules that attach the relevant `--govuk-link-<STATE>-colour` to the `:<STATE>` selector. 

This allows to re-purpose the `govuk-link-style-<STYLE>` mixins to only changing the custom properties, which can be used either on links themselves or a parent.

See second commit

This then enables the Service Navigation to style the links in its inverse variant from the `.govuk-service-navigation--inverse` selector, reducing the need for extra selectors to affect:
- the link of the service name
- the links of the navigation
- any `.govuk-link` or class using `govuk-link-style-default` injected in its slot.

See third commit

Finally we need to tweak the header's style to apply `govuk-link-style-default` explicitly as the component does not use `govuk-link-common`. Cascading the link colours from the component allows both to centralise how colours are configured and shave a couple of declarations down the line.

See fourth commit

## Thoughts

Moving to custom properties enables to let the link styles cascade to descendants of components, which facilitate creating `--inverse` variants or styling links inside components.

Having `govuk-link-common` output selectors to keep things working is a bit sad, as we don't get as much gain on the CSS output. Down the line, I'd be keen to rework our components to use `.govuk-link` whenever they need a link, which would allow the custom classes to only set custom properties to change the colour of the link. 

Having `govuk-link-common` should be a reasonably non-breaking change:
- if users use one of our `govuk-link-style-<STYLE>` mixins, things will carry on working
- if they weren't it's highly likely they'd be overriding browser's style with custom selectors of their own... which will now override our default link styles

Having `govuk-link-style-<STYLE>` mixins no longer output pseudo selectors is only breaking if the mixins are not used alongside `govuk-link-common`, which is not how they're meant to be used. I think we can consider this non-breaking as well.

