### PR TITLE
Add interruption panel - make sure Panel print styles apply to modifiers

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -34,12 +34,6 @@
       // it but the the text remains legible.
       overflow-wrap: break-word;
     }
-
-    @media print {
-      --govuk-text-colour: inherit;
-      border-color: currentcolor;
-      background: none;
-    }
   }
 
   .govuk-panel__title {
@@ -62,5 +56,13 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background: base.govuk-functional-colour(brand);
     text-align: left;
+  }
+
+  @media print {
+    .govuk-panel {
+      --govuk-text-colour: inherit;
+      border-color: currentcolor;
+      background: none;
+    }
   }
 }


### PR DESCRIPTION
> [!NOTE]
> A final review will be available once we get the contribution branch ready
> I will manually merge this into https://github.com/alphagov/govuk-frontend/pull/6636 once approved since we cant merge into a external repo via GitHub

Move to below the modifiers for Confirmation and Interruption so that the print styles have higher precedence.

## Screenshot of Confirmation and Interruption Panel variants in print render mode
![Screenshot showing panel component in print mode](https://github.com/user-attachments/assets/3d789fe4-8938-4d96-9f92-df03ac9453f0)

Note that there are issues with the button in print mode but this is unrelated to the Panel so should be considered separately.
