### PR TITLE
Add interruption panel - adjust spacing and typography

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -43,7 +43,10 @@
     margin-bottom: base.govuk-spacing(6);
   }
 
-  .govuk-panel__title:last-child {
+  // Remove bottom spacing from anything at the end of the Panel's body
+  // to stop the Panel's padding spacing from becoming too large.
+  .govuk-panel__title:last-child,
+  .govuk-panel__body > :last-child {
     margin-bottom: 0;
   }
 
@@ -56,6 +59,27 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background: base.govuk-functional-colour(brand);
     text-align: left;
+
+    // Smaller title to go alongside smaller body text.
+    .govuk-panel__title {
+      @include base.govuk-font-size($size: 36);
+      margin-bottom: base.govuk-spacing(3);
+    }
+
+    // When the Button group is at the end of the Panel's body then,
+    // make sure it has some spacing away from the other body content.
+    .govuk-panel__body > .govuk-button-group:last-child {
+      margin-top: base.govuk-spacing(7);
+    }
+
+    // On larger screens if the Interruption panel has a Button group at the end of the Panel's body,
+    // then we want to adjust the spacing a bit to avoid the Button group
+    // making the Panel's padding spacing being too large.
+    @media #{base.govuk-from-breakpoint(tablet)} {
+      &:has(.govuk-panel__body > .govuk-button-group:last-child) {
+        padding-bottom: base.govuk-spacing(5);
+      }
+    }
   }
 
   @media print {


### PR DESCRIPTION
> [!NOTE]
> A final review will be available once we get the contribution branch ready
> I will manually merge this into https://github.com/alphagov/govuk-frontend/pull/6636 once approved since we cant merge into a external repo via GitHub

- adjust the title size to better balance with smaller text (e.g. `govuk-body`).
- adjust the spacing of the panel and Button group so it is better balanced

## Why not use `.govuk-panel__title--l` like NHS's implementation?
We decided by adding this it implies the heading scale and we dont have a clear need for the other sizes, so for now we'll just apply a smaller title by default and see if a need arises for something more involved.

Paired on with @mia-allers-gds 