### PR TITLE
[SPIKE] Link variants through custom properties (selectors in `govuk-link-style-*`)

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -106,12 +106,7 @@
 
   .govuk-service-navigation__service-name {
     @include base.govuk-typography-weight-bold;
-  }
-
-  // Annoyingly this requires a compound selector in order to overcome the
-  // specificity of the other link colour override we're doing
-  .govuk-service-navigation__service-name .govuk-service-navigation__link {
-    @include base.govuk-link-style-text;
+    @include base.govuk-link-theme-text;
   }
 
   // Allow navigation section to always take up maximum available space,
@@ -226,6 +221,11 @@
 
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background-color: base.govuk-functional-colour(brand);
+    // Avoid defining specific link styles when inverted and just use the text colours
+    @include base.govuk-link-theme-text;
+
+    // Similarly to the Breadcrumbs, switch the secondary text colour to `currentcolor`
+    --govuk-secondary-text-colour: currentcolor;
 
     .govuk-width-container {
       border-width: 1px 0;
@@ -242,11 +242,6 @@
     .govuk-service-navigation__item,
     .govuk-service-navigation__service-name {
       border-color: currentcolor;
-    }
-
-    // Override link styles
-    .govuk-service-navigation__link {
-      @include base.govuk-link-style-text;
     }
 
     // Override mobile menu toggle colour when not focused

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -431,6 +431,34 @@ examples:
             </ul>
           </nav>
         endRightAligned: true
+  - name: with language switcher, inverse
+    description: HTML rendered by the language switcher component can be injected into the `end` slot of the service header.
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      classes: govuk-service-navigation--inverse
+      serviceName: Service name
+      serviceUrl: '#/'
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+          active: true
+        - href: '#/2'
+          text: Navigation item 2
+        - href: '#/3'
+          text: Navigation item 3
+      slots:
+        end: |-
+          <nav class="govuk-language-switcher" aria-label="Language switcher">
+            <ul class="govuk-language-switcher__list">
+              <li class="govuk-language-switcher__list-item">
+                <span class="govuk-language-switcher__text" lang="en" aria-current="true">English</span>
+              </li>
+              <li class="govuk-language-switcher__list-item">
+                <a class="govuk-language-switcher__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
+              </li>
+            </ul>
+          </nav>
   - name: with slotted content
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -119,24 +119,11 @@
 /// @access public
 
 @mixin govuk-link-style-error {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(error);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:hover {
-    color: govuk-colour("red", $variant: "shade-50");
-  }
-
-  &:active {
-    color: govuk-functional-colour(error);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(error)};
+  --govuk-link-hover-colour: #{govuk-colour("red", $variant: "shade-50")};
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Success link styles
@@ -156,24 +143,11 @@
 /// @access public
 
 @mixin govuk-link-style-success {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(success);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:hover {
-    color: govuk-colour("green", $variant: "shade-50");
-  }
-
-  &:active {
-    color: govuk-functional-colour(success);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(success)};
+  --govuk-link-hover-colour: #{govuk-colour("green", $variant: "shade-50")};
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Muted link styles
@@ -193,21 +167,11 @@
 /// @access public
 
 @mixin govuk-link-style-muted {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(secondary-text);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:hover,
-  &:active {
-    color: govuk-functional-colour(text);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(secondary-text)};
+  --govuk-link-hover-colour: #{govuk-functional-colour(text)};
+  --govuk-link-active-colour: var(--govuk-link-hover-colour);
 }
 
 /// Text link styles
@@ -227,15 +191,10 @@
 /// @access public
 
 @mixin govuk-link-style-text {
-  &:link,
-  &:visited,
-  &:active {
-    color: govuk-functional-colour(text);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(text)};
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Inverse link styles
@@ -255,14 +214,11 @@
 /// @access public
 
 @mixin govuk-link-style-inverse {
-  &:link,
-  &:visited {
-    color: govuk-functional-colour(inverse-text);
-  }
+  @include govuk-link-style-no-visited-state;
 
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-colour: #{govuk-functional-colour(inverse-text)};
+  --govuk-link-hover-colour: var(--govuk-link-colour);
+  --govuk-link-active-colour: var(--govuk-link-colour);
 }
 
 /// Default link styles, without a visited state
@@ -286,27 +242,7 @@
 /// @access public
 
 @mixin govuk-link-style-no-visited-state {
-  &:link {
-    color: govuk-functional-colour(link);
-  }
-
-  &:visited {
-    color: govuk-functional-colour(link);
-  }
-
-  &:hover {
-    color: govuk-functional-colour(link-hover);
-  }
-
-  &:active {
-    color: govuk-functional-colour(link-active);
-  }
-
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable
-  &:focus {
-    color: govuk-functional-colour(focus-text);
-  }
+  --govuk-link-visited-colour: var(--govuk-link-colour);
 }
 
 /// Remove underline from links

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -143,7 +143,11 @@
 /// @access public
 
 @mixin govuk-link-style-success {
-  @include govuk-link-style-no-visited-state;
+  // In order to avoid a breaking change, we need the selectors
+  // to be output by the mixin, as sometimes the mixins are used on their own
+  // and not all instances use `govuk-link-common`
+  @include govuk-link-style-default;
+  @include govuk-link-theme-no-visited-state;
 
   --govuk-link-colour: #{govuk-functional-colour(success)};
   --govuk-link-hover-colour: #{govuk-colour("green", $variant: "shade-50")};
@@ -167,7 +171,11 @@
 /// @access public
 
 @mixin govuk-link-style-muted {
-  @include govuk-link-style-no-visited-state;
+  // In order to avoid a breaking change, we need the selectors
+  // to be output by the mixin, as sometimes the mixins are used on their own
+  // and not all instances use `govuk-link-common`
+  @include govuk-link-style-default;
+  @include govuk-link-theme-no-visited-state;
 
   --govuk-link-colour: #{govuk-functional-colour(secondary-text)};
   --govuk-link-hover-colour: #{govuk-functional-colour(text)};
@@ -191,7 +199,11 @@
 /// @access public
 
 @mixin govuk-link-style-text {
-  @include govuk-link-style-no-visited-state;
+  // In order to avoid a breaking change, we need the selectors
+  // to be output by the mixin, as sometimes the mixins are used on their own
+  // and not all instances use `govuk-link-common`
+  @include govuk-link-style-default;
+  @include govuk-link-theme-no-visited-state;
 
   --govuk-link-colour: #{govuk-functional-colour(text)};
   --govuk-link-active-colour: var(--govuk-link-colour);
@@ -214,7 +226,11 @@
 /// @access public
 
 @mixin govuk-link-style-inverse {
-  @include govuk-link-style-no-visited-state;
+  // In order to avoid a breaking change, we need the selectors
+  // to be output by the mixin, as sometimes the mixins are used on their own
+  // and not all instances use `govuk-link-common`
+  @include govuk-link-style-default;
+  @include govuk-link-theme-no-visited-state;
 
   --govuk-link-colour: #{govuk-functional-colour(inverse-text)};
   --govuk-link-hover-colour: var(--govuk-link-colour);
@@ -242,6 +258,22 @@
 /// @access public
 
 @mixin govuk-link-style-no-visited-state {
+  // In order to avoid a breaking change, we need the selectors
+  // to be output by the mixin, as sometimes the mixins are used on their own
+  // and not all instances use `govuk-link-common`
+  @include govuk-link-style-default;
+
+  @include govuk-link-theme-no-visited-state;
+}
+
+/// Themes links to have no visited states
+///
+/// Applies the appropriate `--govuk-link-...` custom properties
+/// so that the styled element or links inside the style elements
+/// have no visited states
+///
+/// @access private
+@mixin govuk-link-theme-no-visited-state {
   --govuk-link-visited-colour: var(--govuk-link-colour);
 }
 

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -203,9 +203,21 @@
   // to be output by the mixin, as sometimes the mixins are used on their own
   // and not all instances use `govuk-link-common`
   @include govuk-link-style-default;
+  @include govuk-link-theme-text;
+}
+
+/// Themes links to look like the text
+///
+/// Applies the appropriate `--govuk-link-...` custom properties
+/// so that the styled element or links inside the style elements
+/// look like the text
+///
+/// @access private
+@mixin govuk-link-theme-text {
   @include govuk-link-theme-no-visited-state;
 
   --govuk-link-colour: #{govuk-functional-colour(text)};
+  --govuk-link-hover-colour: var(--govuk-link-colour);
   --govuk-link-active-colour: var(--govuk-link-colour);
 }
 


### PR DESCRIPTION
This spike is [one of two](https://github.com/alphagov/govuk-frontend/pull/7238) exploring the use of custom properties to change the colours of the link variants, particularly to allow a parent element to configure the colours of all the links inside it, which is useful for the Service Navigation.

Ideally, links across the markup would use `.govuk-link` and the variants would only have to set the relevant `--govuk-link(-<STATE>)-colour` custom properties (see first commit). This is great, but only affects markup actually using `.govuk-link`.

In the couple of instances where links are styles using mixins attached to a completely different class (for example the header's homepage link or the error summary). These instances need both:
- to 'theme' the links by applying the right colours to the `--govuk-link(-<STATE>)-colour`
- to 'style' the links attaching the relevant `--govuk-link-<STATE>-colour` to the `:<STATE>` selector 

Otherwise the `<a>` element get the browser's default styles:

<img width="992" height="414" alt="Error summary showing the default link styles" src="https://github.com/user-attachments/assets/e591bea6-cf9f-4a64-8dde-e47b5bb7d269" />
<img width="1497" height="277" alt="Generic header showing the default link styles" src="https://github.com/user-attachments/assets/f21b8d0c-bc7b-4a45-9303-67f99cdf52f9" />

To avoid breaking changes, the simplest route is to keep our `govuk-link-style-<STYLE>` mixins output both selectors and changes of custom properties. To facilitate reuse of which variables need changing for a given style, we can extract the variable changes in their own `govuk-link-theme-<STYLE>` mixin, starting with the `-no-visited-state` one that all the other styles use. (see second commit).

This reduces the gains in CSS output, but still opens the path to parents styling links through case. By extracting a theme for text links, the Service Navigation is able to style the links in its inverse variant from the `.govuk-service-navigation--inverse` selector, reducing the need for extra selectors to affect:
- the link of the service name
- the links of the navigation
- any `.govuk-link` or class using `govuk-link-style-default` injected in its slot.

See third commit.

## Thoughts

Moving to custom properties enables to let the link styles cascade to descendants of components, which facilitate creating `--inverse` variants.

Keeping selectors output by each of the `--govuk-link-style-<STYLE>` mixins to avoid a breaking change is a bit sad, as we don't get as much gain on the CSS output. Down the line, I'd be keen to rework our components to use `.govuk-link` whenever they need a link, which would allow the custom classes to only set custom properties to change the colour of the link. 

Having the output of selectors in each `--govuk-link-style-<STYLE>` mixin also requires us to have separate `--govuk-link-theme-<STYLE>` mixins for components to set the colours. This doubles the number of mixins to manage, and creates a nuance between 'style' and 'theme' which may be tricky to grasp. 