### PR TITLE
Add Feedback as a template block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 We've added the [Feedback component](https://design-system.service.gov.uk/components/feedback/) to help services collect feedback from their users throughout their service.
 
-This was added in [pull request #7232: Add Feedback component](https://github.com/alphagov/govuk-frontend/pull/7232).
+If you are using our nunjucks page template, you can show the Feedback component in your service by setting the `feedbackBody` variable in your service's template:
+
+```nunjucks
+{% set feedbackBody %}
+  <p class="govuk-body">
+    Tell us about your experience using this service. <a href="/link-to-your-feedback-form" class="govuk-link">Give us your feedback</a>
+  </p>
+```
+
+We made this change in the following pull requests:
+
+- [#7232: Add Feedback component](https://github.com/alphagov/govuk-frontend/pull/7232)
+- [#7248: Add Feedback as a template block](https://github.com/alphagov/govuk-frontend/pull/7248)
 
 #### You can now pass `day`, `month`, `year`, `error` and `values` options to the Date input component
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/confirm.njk
@@ -1,10 +1,15 @@
 {% extends "layouts/full-page-example.njk" %}
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/feedback/macro.njk" import govukFeedback %}
 
 {% set pageTitle = "Thank you for confirming if you have changed your name" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% set feedbackBody %}
+  <p class="govuk-body">
+    Tell us about your experience using this service. <a href="#" class="govuk-link">Give us your feedback</a>
+  </p>
+{% endset %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -14,14 +19,4 @@
       }) }}
     </div>
   </div>
-{% endblock %}
-
-{% block footerStart %}
-  {% call govukFeedback({
-    titleText: "Help us improve this service"
-  }) %}
-    <p class="govuk-body">
-      Tell us about your experience using this service. <a href="#" class="govuk-link">Give us your feedback</a>
-    </p>
-  {% endcall %}
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -16,7 +16,12 @@ scenario: |
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/feedback/macro.njk" import govukFeedback %}
+
+{% set feedbackBody %}
+  <p class="govuk-body">
+    Tell us about your experience using this service. <a href="#" class="govuk-link">Give us your feedback</a>
+  </p>
+{% endset %}
 
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errorSummary | length }}{{ pageTitle }} - GOV.UK{% endblock %}
@@ -70,14 +75,4 @@ scenario: |
     }) }}
   </form>
 
-{% endblock %}
-
-{% block footerStart %}
-  {% call govukFeedback({
-    titleText: "Help us improve this service"
-  }) %}
-    <p class="govuk-body">
-      Tell us about your experience using this service. <a href="#" class="govuk-link">Give us your feedback</a>
-    </p>
-  {% endcall %}
 {% endblock %}

--- a/packages/govuk-frontend/src/govuk/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/template.jsdom.test.js
@@ -918,6 +918,106 @@ describe('Template', () => {
         expect(document.querySelector('.govuk-footer')).not.toBeInTheDocument()
       })
 
+      describe('govukFeedback block', () => {
+        it('does not render Feedback by default', () => {
+          replacePageWith(renderTemplate('govuk/template.njk'))
+
+          expect(
+            document.querySelector('.govuk-feedback')
+          ).not.toBeInTheDocument()
+        })
+
+        it('renders Feedback if `feedbackBody` is set', () => {
+          const testBody = 'Feedback body content'
+
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                feedbackBody: testBody
+              }
+            })
+          )
+
+          expect(document.querySelector('.govuk-feedback')).toBeInTheDocument()
+
+          expect(
+            document.querySelector('.govuk-feedback__body').textContent.trim()
+          ).toEqual(testBody)
+        })
+
+        it('renders Feedback with default title from `feedbackTitle`', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                feedbackBody: 'Feedback body content'
+              }
+            })
+          )
+
+          expect(
+            document.querySelector('.govuk-feedback__title').textContent.trim()
+          ).toBe('Help us improve this service')
+        })
+
+        it('renders a different Feedback title text if `feedbackTitle` is set', () => {
+          const testTitle = 'Feedback title'
+
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                feedbackBody: 'Feedback body content',
+                feedbackTitle: testTitle
+              }
+            })
+          )
+
+          expect(
+            document.querySelector('.govuk-feedback__title').textContent.trim()
+          ).toEqual(testTitle)
+        })
+
+        it('renders `feedbackBody` as html', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              context: {
+                feedbackBody: '<mark>Feedback</mark>'
+              }
+            })
+          )
+
+          expect(
+            document.querySelector('.govuk-feedback__body > mark')
+          ).toBeInTheDocument()
+        })
+
+        it('allows content to be inserted using govukFeedback', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              blocks: {
+                govukFeedback: '<mark>Feedback</mark>'
+              }
+            })
+          )
+
+          expect(document.querySelector('mark')).toBeInTheDocument()
+          expect(
+            document.querySelector('.govuk-feedback')
+          ).not.toBeInTheDocument()
+        })
+
+        it('renders Feedback as a descendant of <footer>', () => {
+          replacePageWith(
+            renderTemplate('govuk/template.njk', {
+              blocks: {
+                govukFeedback: '<mark>Feedback</mark>'
+              }
+            })
+          )
+
+          expect(document.querySelector('footer > mark')).toBeInTheDocument()
+        })
+      })
+
       describe('govukFooter block', () => {
         it('allows content to be inserted using govukFooter', () => {
           replacePageWith(

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -2,11 +2,13 @@
 {% from "./components/skip-link/macro.njk" import govukSkipLink -%}
 {% from "./components/header/macro.njk" import govukHeader -%}
 {% from "./components/service-navigation/macro.njk" import govukServiceNavigation -%}
+{% from "./components/feedback/macro.njk" import govukFeedback -%}
 {% from "./components/footer/macro.njk" import govukFooter -%}
 
 {# Hardcoded value is $govuk-brand-blue -#}
 {% set themeColor = themeColor | default("#1d70b8", true) -%}
 {% set assetPath = assetPath | default("/assets", true) -%}
+{% set feedbackTitle = feedbackTitle | default("Help us improve this service") -%}
 
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default("en", true) }}" class="govuk-template {%- if htmlClasses %} {{ htmlClasses }}{% endif %}">
@@ -95,6 +97,15 @@
     {% block footer %}
       {% call _govukTemplateFooter() %}
         {% block footerStart %}{% endblock %}
+        {% block govukFeedback %}
+          {%- if feedbackBody %}
+            {% call govukFeedback({
+              titleText: feedbackTitle
+            }) %}
+              {{ feedbackBody | safe | trim }}
+            {% endcall %}
+          {% endif %}
+        {% endblock %}
         {% block govukFooter %}
           {{ govukFooter() }}
         {% endblock %}


### PR DESCRIPTION
Adds a new `govukFeedback` block to the page template as well as 2 extra template variables:

- `feedbackBody` which, when set, displays Feedback
- `feedbackTitle` which is preset but can be overridden

Resolves https://github.com/alphagov/govuk-frontend/issues/7234

Stacked on top of https://github.com/alphagov/govuk-frontend/pull/7232

## Notes

Interested in opinions on presetting `feedbackTitle`. For this particular component we have quite a clear default we want users to apply and users can reset it anyway.

I've attempted to combine the changelog entries for this and the PR adding the actual component into a single entry. Interested especially in @seaemsi's opinion on this.

Do we also need changelog entries for `feedbackBody` and `feedbackTitle`? Could they go into this entry?