### PR TITLE
Add tests for nested params and fix date input params

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -119,15 +119,15 @@ params:
     required: false
     description: Specify `value` attributes for the date parts without setting items. You can also use the `name` for the fields as keys, including any `namePrefix`.
     params:
-      day:
+      - name: day
         type: string
         required: false
         description: The `value` attribute for the day input.
-      month:
+      - name: month
         type: string
         required: false
         description: The `value` attribute for the month input.
-      year:
+      - name: year
         type: string
         required: false
         description: The `value` attribute for the year input.

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -276,8 +276,9 @@ describe('packages/govuk-frontend/dist/', () => {
         )
         expect(options).toBeInstanceOf(Array)
 
-        // Component options requirements
-        const optionTasks = options.map(async (option) => {
+        // Options can be nested as many times as required, so recursively
+        // go through options looking for any nested options.
+        async function validateOptions(option) {
           // Required fields
           expect(option).toEqual(
             expect.objectContaining({
@@ -300,10 +301,16 @@ describe('packages/govuk-frontend/dist/', () => {
           if (option.isComponent) {
             expect(option.isComponent).toEqual(expect.any(Boolean))
           }
-        })
+
+          // Handle any nested parameters
+          if (option.params) {
+            expect(option.params).toEqual(expect.any(Array))
+            await Promise.all(option.params.map(validateOptions))
+          }
+        }
 
         // Check all component options
-        return Promise.all(optionTasks)
+        return Promise.all(options.map(validateOptions))
       })
 
       // Check all component files


### PR DESCRIPTION
Bug was introduced here:
https://github.com/alphagov/govuk-frontend/pull/6971

But our checks for options doesnt check nested options, so it didnt get caught...

First commit adds the new test coverage that recursively goes through `params` so that all options are being checked.
This results in a failing test that we would have caught the recent regression with:
https://github.com/alphagov/govuk-frontend/actions/runs/28883366125/job/85677841920?pr=7265#step:5:181

Second commit fixes the issue.