### PR TITLE
Language switcher improvements

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/header-kitchen-sink/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/header-kitchen-sink/index.njk
@@ -16,9 +16,27 @@ scenario: |
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/exit-this-page/macro.njk" import govukExitThisPage %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/language-switcher/macro.njk" import govukLanguageSwitcher %}
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
+
+{% set languageSwitcherHTML %}
+  {{ govukLanguageSwitcher({
+    classes: "govuk-language-switcher--no-top-margin",
+    items: [
+      {
+        text: "English",
+        href: "#",
+        current: true
+      },
+      {
+        text: "Cymraeg",
+        href: "#"
+      }
+    ]
+  }) }}
+{% endset %}
 
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
@@ -81,7 +99,11 @@ scenario: |
         text: 'Companies you follow',
         current: true
       }
-    ]
+    ],
+    slots: {
+      end: languageSwitcherHTML,
+      endRightAligned: true
+    }
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/_mixin.scss
@@ -31,7 +31,7 @@
         margin-right: base.govuk-spacing(2);
         margin-left: base.govuk-spacing(2);
         border-right: 1px solid;
-        border-right-color: base.govuk-functional-colour(secondary-text);
+        border-right-color: base.govuk-functional-colour(border);
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/_mixin.scss
@@ -40,4 +40,16 @@
     @include base.govuk-link-common;
     @include base.govuk-link-style-default;
   }
+
+  .govuk-language-switcher--inverse {
+    color: base.govuk-colour("white");
+
+    .govuk-language-switcher__link {
+      @include base.govuk-link-style-inverse;
+    }
+
+    .govuk-language-switcher__list-item::after {
+      border-right-color: currentcolor;
+    }
+  }
 }

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
@@ -32,6 +32,10 @@ params:
         type: boolean
         required: false
         description: Whether this is the language of the current page. Defaults to `true` when `href` is not provided.
+      - name: languageDescriptionText
+        type: string
+        required: false
+        description: Visually hidden text after a language link to indicate what the link will do. Write it in the language of the link (for example, "Change the language to English").
       - name: attributes
         type: object
         required: false
@@ -105,6 +109,19 @@ examples:
           lang: ar
           dir: rtl
           href: '#/ar'
+  - name: with language description
+    description: Add visually hidden text, written in the language of the link, so screen reader users know that selecting a link leads to a translation of the page".
+    options:
+      attributes:
+        lang: cy
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
+          languageDescriptionText: Newid yr iaith i'r Cymraeg
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
@@ -23,7 +23,7 @@ params:
       - name: dir
         type: string
         required: false
-        description: The text direction for the language item element. Use this on every item when the switcher includes languages that use scripts with different directions.
+        description: The text direction of the script the language name is written in (`ltr` for left-to-right scripts or `rtl` for right-to-left). Set this on every item if the switcher includes scripts written in different directions.
       - name: href
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/language-switcher.yaml
@@ -85,6 +85,20 @@ examples:
         - text: 中文
           lang: zh
           href: '#/zh'
+  - name: inverse
+    screenshot: true
+    description: Language switcher that appears on dark backgrounds
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      classes: govuk-language-switcher--inverse
+      items:
+        - text: English
+          lang: en
+          current: true
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
   - name: with translated navigation label
     description: When the current page is not in English, translate the `ariaLabel` into the language of the current page.
     options:

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.jsdom.test.js
@@ -160,6 +160,37 @@ describe('Language switcher', () => {
       expect($link.innerHTML).toContain('<span>Cymraeg</span>')
     })
 
+    it('renders language link description', () => {
+      document.body.innerHTML = render(
+        'language-switcher',
+        examples['with language description']
+      )
+
+      const $listItem = document.querySelector(
+        'li.govuk-language-switcher__list-item:last-child'
+      )
+      const $link = $listItem.querySelector('.govuk-language-switcher__link')
+      const $hiddenText = $listItem.querySelector('.govuk-visually-hidden')
+
+      expect($hiddenText).not.toBeNull()
+      expect($hiddenText).toHaveTextContent(`Newid yr iaith i'r Cymraeg`)
+
+      // The hidden text sits inside the link but after the visible text,
+      // so it forms part of the link's accessible name
+      expect($link.lastElementChild).toBe($hiddenText)
+    })
+
+    it('does not render a language description when not set', () => {
+      document.body.innerHTML = render('language-switcher', examples.default)
+
+      const $listItem = document.querySelector(
+        'li.govuk-language-switcher__list-item:last-child'
+      )
+      const $hiddenText = $listItem.querySelector('.govuk-visually-hidden')
+
+      expect($hiddenText).toBeNull()
+    })
+
     it('sets dir attributes on language items', () => {
       document.body.innerHTML = render(
         'language-switcher',

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
@@ -14,10 +14,10 @@
     </li>
   {% else %}
     <li class="govuk-language-switcher__list-item">
-      <a class="govuk-language-switcher__link" href="{{ item.href }}"
+      <a class="govuk-language-switcher__link" href="{{ item.href }}" rel="alternate"
         {%- if item.lang %} lang="{{ item.lang }}"{% endif %}
         {%- if item.hrefLang or item.lang %} hreflang="{{ item.hrefLang if item.hrefLang else item.lang }}"{% endif %}
-        {%- if item.dir %} dir="{{ item.dir }}"{% endif %} rel="alternate"
+        {%- if item.dir %} dir="{{ item.dir }}"{% endif %}
         {{- govukAttributes(item.attributes) }}>
         {{- item.html | safe if item.html else item.text -}}
       </a>

--- a/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-switcher/template.njk
@@ -20,6 +20,9 @@
         {%- if item.dir %} dir="{{ item.dir }}"{% endif %}
         {{- govukAttributes(item.attributes) }}>
         {{- item.html | safe if item.html else item.text -}}
+        {%- if item.languageDescriptionText -%}
+        <span class="govuk-visually-hidden"> {{ item.languageDescriptionText }}</span>
+        {%- endif %}
       </a>
     </li>
   {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -431,6 +431,36 @@ examples:
             </ul>
           </nav>
         endRightAligned: true
+  - name: inverse with language switcher
+    description: Service navigation that appears sandwiched between other areas of brand blue, such as the GOV.UK header and a custom page masthead.
+    pageTemplateOptions:
+      bodyClasses: app-template__body--inverse
+    options:
+      classes: govuk-service-navigation--inverse
+      serviceName: Apply for a juggling license
+      serviceUrl: '#/'
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+        - href: '#/2'
+          text: Navigation item 2
+          active: true
+        - href: '#/3'
+          text: Navigation item 3
+        - href: '#/4'
+          text: Navigation item 4
+      slots:
+        end: |-
+          <nav class="govuk-language-switcher govuk-language-switcher--inverse" aria-label="Language switcher">
+            <ul class="govuk-language-switcher__list">
+              <li class="govuk-language-switcher__list-item">
+                <span class="govuk-language-switcher__text" lang="en" aria-current="true">English</span>
+              </li>
+              <li class="govuk-language-switcher__list-item">
+                <a class="govuk-language-switcher__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
+              </li>
+            </ul>
+          </nav>
   - name: with slotted content
     hidden: true
     options:


### PR DESCRIPTION
## What

### Tweaks from tech review

Addresses https://github.com/alphagov/govuk-frontend/pull/7164#discussion_r3499861291 and https://github.com/alphagov/govuk-frontend/pull/7164#discussion_r3500028712

### Lighten separator

#### Before

Use the `border` functional colour for the separator. This aligns with the similar separator in the summary list actions. We previously used `secondary-text`, as the breadcrumbs do, but this was deemed dark enough that it could be confused as text. The separator is a visual nicety, rather than a critical functional piece of the component.

<img width="167" height="44" alt="Separator" src="https://github.com/user-attachments/assets/a0db7740-1c4e-47c6-b48a-43670f06c6a6" />

#### After

<img width="168" height="46" alt="Light separator" src="https://github.com/user-attachments/assets/ff42f542-02d3-429b-bd38-1055fea1f1be" />

### Add language link description

This is visually hidden text placed within a language link, after the visible language span, explaining what clicking on that link does. eg: "Cymraeg. Change language to Cymraeg."

We added this to provide context to screen readers. The wording is a bit awkward, because we decided not to put the description _before_ the language, so screen reader users don't have to sit through a bunch of "Change language to [x]" - they hear the relevant language first.

### Add inverse language switcher styles

<img width="169" height="43" alt="Inverse" src="https://github.com/user-attachments/assets/498e9bb1-2a71-4ba5-ab19-ba08acecdad6" />

The inverse language switcher handles separators the same way as breadcrumbs - sets them to white.

