### PR TITLE
Stop file upload component from throwing errors when hidden inputs are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7183: Update exit this page overlay colour to use system colours](https://github.com/alphagov/govuk-frontend/pull/7183)
 - [#7197: Improve source spacing for header](https://github.com/alphagov/govuk-frontend/pull/7197)
+- [#7268: Stop file upload component from throwing errors when hidden inputs are present](https://github.com/alphagov/govuk-frontend/pull/7268)
 
 ## v6.3.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,6 +1,5 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { ConfigurableComponent } from '../../common/configuration.mjs'
-import { formatErrorMessage } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -57,22 +56,13 @@ export class FileUpload extends ConfigurableComponent {
   constructor($root, config = {}) {
     super($root, config)
 
-    const $input = this.$root.querySelector('input')
+    const $input = this.$root.querySelector('input[type="file"]')
 
     if ($input === null) {
       throw new ElementError({
         component: FileUpload,
         identifier: 'File inputs (`<input type="file">`)'
       })
-    }
-
-    if ($input.type !== 'file') {
-      throw new ElementError(
-        formatErrorMessage(
-          FileUpload,
-          'File input (`<input type="file">`) attribute (`type`) is not `file`'
-        )
-      )
     }
 
     this.$input = /** @type {HTMLFileInputElement} */ ($input)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -682,7 +682,24 @@ describe('/components/file-upload', () => {
             })
           })
 
-          it('throws if the input type is not "file"', async () => {
+          it('does not throw when there are additional non-file inputs present', async () => {
+            await render(page, 'file-upload', examples.enhanced, {
+              beforeInitialisation() {
+                const fileInput = document.querySelector('[type="file"]')
+
+                fileInput.insertAdjacentHTML(
+                  'beforebegin',
+                  `<input type="hidden" name="${fileInput.getAttribute('name')}">`
+                )
+              }
+            })
+
+            const $buttonElement = await page.$(buttonSelector)
+
+            expect($buttonElement).not.toBeNull()
+          })
+
+          it('throws when only an input of type "file" is present', async () => {
             await expect(
               render(page, 'file-upload', examples.enhanced, {
                 beforeInitialisation() {
@@ -695,7 +712,7 @@ describe('/components/file-upload', () => {
               cause: {
                 name: 'ElementError',
                 message:
-                  'govuk-file-upload: File input (`<input type="file">`) attribute (`type`) is not `file`'
+                  'govuk-file-upload: File inputs (`<input type="file">`) not found'
               }
             })
           })


### PR DESCRIPTION
This change fixes a problem we encountered with Rails apps where the JS-enhanced version of the file upload component would raise an error when initialising if the `multiple` attribute was present, because Rails adds an extra `hidden` input before the `file` input.

Now, instead of finding any input and failing if its type isn't "file", it finds inputs with type "file" and fails if nothing is found.

## Background

Since Rails version 7.0, when the `multiple` attribute is set on a file input, Rails also renders a hidden input just before the file input, e.g.,

```html
<input name="profile[profile_photo][]" type="hidden" value="">
<input id="profile-profile-photo-field" class="govuk-file-upload" multiple="multiple" type="file" name="profile[profile_photo][]">
```

The hidden field ensures that when a user submits a form with no files selected, the form submission includes an entry for the file field (here, `profile[profile_photo][]`), and Rails can delete any files that are attached.

The more general selector that was used previously selected the `hidden` input instead of the `file` input and raised an error that the input is the wrong type. 

See [the Slack discussion for more info](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1783503757548579).