### PR TITLE
Use custom properties to change button colours

### DIFF
--- a/packages/govuk-frontend/src/govuk/_base.import.scss
+++ b/packages/govuk-frontend/src/govuk/_base.import.scss
@@ -3,3 +3,4 @@
 @import "helpers";
 @import "custom-properties";
 @import "components/button/settings";
+@import "components/button/helpers";

--- a/packages/govuk-frontend/src/govuk/_base.scss
+++ b/packages/govuk-frontend/src/govuk/_base.scss
@@ -2,3 +2,4 @@
 @forward "tools";
 @forward "helpers";
 @forward "components/button/settings";
+@forward "components/button/helpers";

--- a/packages/govuk-frontend/src/govuk/components/button/_helpers.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_helpers.scss
@@ -1,0 +1,29 @@
+////
+/// @group components/button
+////
+
+@use "sass:list";
+
+/// List of the button variants available in GOV.UK Frontend
+$_available-variants: (secondary, warning, inverse);
+
+/// Configure colours of the Button component for the given variant
+///
+/// Use:
+/// - to create modifiers of the `.govuk-button` class to apply a specific variant to a single button
+/// - inside a component to update the default style of all buttons with only the `.govuk-button` class
+///
+/// It configures the `--_govuk-button-<COLOUR_NAME>` custom properties that apply colours to the button
+/// with the appropriate `--_govuk-<VARIANT>-button-<COLOUR_NAME>` properties that define colours for a given variant.
+///
+/// @access private
+@mixin govuk-button-style($variant-name) {
+  @if not list.index($_available-variants, $variant-name) {
+    @error "Unknown button variant `#{$variant-name}` (available variants: #{$_available-variants})";
+  }
+
+  --_govuk-button-background-colour: var(--_govuk-#{$variant-name}-button-background-colour);
+  --_govuk-button-shadow-colour: var(--_govuk-#{$variant-name}-button-shadow-colour);
+  --_govuk-button-text-colour: var(--_govuk-#{$variant-name}-button-text-colour);
+  --_govuk-button-hover-background-colour: var(--_govuk-#{$variant-name}-button-hover-background-colour);
+}

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -39,6 +39,10 @@
     --_govuk-button-background-colour: #{$govuk-button-colour};
     --_govuk-button-hover-background-colour: #{$govuk-button-hover-background-colour};
     --_govuk-button-shadow-colour: #{$govuk-button-shadow-colour};
+    --_govuk-inverse-button-background-colour: #{$inverse-background-colour};
+    --_govuk-inverse-button-text-colour: #{$inverse-text-colour};
+    --_govuk-inverse-button-hover-background-colour: #{$govuk-inverse-button-hover-colour};
+    --_govuk-inverse-button-shadow-colour: #{$govuk-inverse-button-shadow-colour};
   }
 
   .govuk-button {
@@ -165,10 +169,10 @@
   }
 
   .govuk-button--inverse {
-    --_govuk-button-background-colour: #{$govuk-inverse-button-colour};
-    --_govuk-button-shadow-colour: #{$govuk-inverse-button-shadow-colour};
-    --_govuk-button-text-colour: #{$govuk-inverse-button-text-colour};
-    --_govuk-button-hover-background-colour: #{$govuk-inverse-button-hover-colour};
+    --_govuk-button-background-colour: var(--_govuk-inverse-button-background-colour);
+    --_govuk-button-shadow-colour: var(--_govuk-inverse-button-shadow-colour);
+    --_govuk-button-text-colour: var(--_govuk-inverse-button-text-colour);
+    --_govuk-button-hover-background-colour: var(--_govuk-inverse-button-hover-background-colour);
   }
 
   .govuk-button--start {

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -39,6 +39,10 @@
     --_govuk-button-background-colour: #{$govuk-button-colour};
     --_govuk-button-hover-background-colour: #{$govuk-button-hover-background-colour};
     --_govuk-button-shadow-colour: #{$govuk-button-shadow-colour};
+    --_govuk-secondary-button-background-colour: #{$govuk-secondary-button-colour};
+    --_govuk-secondary-button-text-colour: #{$govuk-secondary-button-text-colour};
+    --_govuk-secondary-button-hover-background-colour: #{$govuk-secondary-button-hover-colour};
+    --_govuk-secondary-button-shadow-colour: #{$govuk-secondary-button-shadow-colour};
     --_govuk-inverse-button-background-colour: #{$inverse-background-colour};
     --_govuk-inverse-button-text-colour: #{$inverse-text-colour};
     --_govuk-inverse-button-hover-background-colour: #{$govuk-inverse-button-hover-colour};
@@ -155,10 +159,10 @@
   }
 
   .govuk-button--secondary {
-    --_govuk-button-background-colour: #{$govuk-secondary-button-colour};
-    --_govuk-button-shadow-colour: #{$govuk-secondary-button-shadow-colour};
-    --_govuk-button-text-colour: #{$govuk-secondary-button-text-colour};
-    --_govuk-button-hover-background-colour: #{$govuk-secondary-button-hover-colour};
+    --_govuk-button-background-colour: var(--_govuk-secondary-button-background-colour);
+    --_govuk-button-shadow-colour: var(--_govuk-secondary-button-shadow-colour);
+    --_govuk-button-text-colour: var(--_govuk-secondary-button-text-colour);
+    --_govuk-button-hover-background-colour: var(--_govuk-secondary-button-hover-background-colour);
   }
 
   .govuk-button--warning {

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -6,47 +6,35 @@
 
 /// @access private
 @mixin styles($background-colour, $text-colour, $inverse-background-colour, $inverse-text-colour) {
-  $govuk-button-colour: $background-colour;
-  $govuk-button-text-colour: $text-colour;
-  $govuk-button-hover-background-colour: base.govuk-colour("green", $variant: "shade-25");
-  $govuk-button-shadow-colour: base.govuk-colour("green", $variant: "shade-50");
-
-  // Secondary button variables
-  $govuk-secondary-button-colour: base.govuk-colour("black", $variant: "tint-95");
-  $govuk-secondary-button-text-colour: base.govuk-colour("black");
-  $govuk-secondary-button-hover-colour: base.govuk-colour("black", $variant: "tint-80");
-  $govuk-secondary-button-shadow-colour: base.govuk-colour("black", $variant: "tint-50");
-
-  // Warning button variables
-  $govuk-warning-button-colour: base.govuk-colour("red");
-  $govuk-warning-button-text-colour: base.govuk-colour("white");
-  $govuk-warning-button-hover-colour: base.govuk-colour("red", $variant: "shade-25");
-  $govuk-warning-button-shadow-colour: base.govuk-colour("red", $variant: "shade-50");
-
-  // Inverse button variables
-  $govuk-inverse-button-colour: $inverse-background-colour;
-  $govuk-inverse-button-text-colour: $inverse-text-colour;
-  $govuk-inverse-button-hover-colour: base.govuk-colour("blue", $variant: "tint-95");
-  $govuk-inverse-button-shadow-colour: base.govuk-colour("blue", $variant: "shade-50");
-
   // Because the shadow (s0) is visually 'part of' the button, we need to reduce
   // the height of the button to compensate by adjusting its padding (s1) and
   // increase the bottom margin to include it (s2).
   $button-shadow-size: base.$govuk-border-width-form-element;
 
   :root {
-    --_govuk-button-text-colour: #{$govuk-button-text-colour};
-    --_govuk-button-background-colour: #{$govuk-button-colour};
-    --_govuk-button-hover-background-colour: #{$govuk-button-hover-background-colour};
-    --_govuk-button-shadow-colour: #{$govuk-button-shadow-colour};
-    --_govuk-secondary-button-background-colour: #{$govuk-secondary-button-colour};
-    --_govuk-secondary-button-text-colour: #{$govuk-secondary-button-text-colour};
-    --_govuk-secondary-button-hover-background-colour: #{$govuk-secondary-button-hover-colour};
-    --_govuk-secondary-button-shadow-colour: #{$govuk-secondary-button-shadow-colour};
+    // Default button colours
+    --_govuk-button-background-colour: #{$background-colour};
+    --_govuk-button-text-colour: #{$text-colour};
+    --_govuk-button-hover-background-colour: #{base.govuk-colour("green", $variant: "shade-25")};
+    --_govuk-button-shadow-colour: #{base.govuk-colour("green", $variant: "shade-50")};
+
+    // Secondary button colours
+    --_govuk-secondary-button-background-colour: #{base.govuk-colour("black", $variant: "tint-95")};
+    --_govuk-secondary-button-text-colour: #{base.govuk-colour("black")};
+    --_govuk-secondary-button-hover-background-colour: #{base.govuk-colour("black", $variant: "tint-80")};
+    --_govuk-secondary-button-shadow-colour: #{base.govuk-colour("black", $variant: "tint-50")};
+
+    // Warning button colours
+    --_govuk-warning-button-background-colour: #{base.govuk-colour("red")};
+    --_govuk-warning-button-text-colour: #{base.govuk-colour("white")};
+    --_govuk-warning-button-hover-background-colour: #{base.govuk-colour("red", $variant: "shade-25")};
+    --_govuk-warning-button-shadow-colour: #{base.govuk-colour("red", $variant: "shade-50")};
+
+    // Warning button colours
     --_govuk-inverse-button-background-colour: #{$inverse-background-colour};
     --_govuk-inverse-button-text-colour: #{$inverse-text-colour};
-    --_govuk-inverse-button-hover-background-colour: #{$govuk-inverse-button-hover-colour};
-    --_govuk-inverse-button-shadow-colour: #{$govuk-inverse-button-shadow-colour};
+    --_govuk-inverse-button-hover-background-colour: #{base.govuk-colour("blue", $variant: "tint-95")};
+    --_govuk-inverse-button-shadow-colour: #{base.govuk-colour("blue", $variant: "shade-50")};
   }
 
   .govuk-button {
@@ -166,10 +154,10 @@
   }
 
   .govuk-button--warning {
-    --_govuk-button-background-colour: #{$govuk-warning-button-colour};
-    --_govuk-button-shadow-colour: #{$govuk-warning-button-shadow-colour};
-    --_govuk-button-text-colour: #{$govuk-warning-button-text-colour};
-    --_govuk-button-hover-background-colour: #{$govuk-warning-button-hover-colour};
+    --_govuk-button-background-colour: var(--_govuk-warning-button-background-colour);
+    --_govuk-button-shadow-colour: var(--_govuk-warning-button-shadow-colour);
+    --_govuk-button-text-colour: var(--_govuk-warning-button-text-colour);
+    --_govuk-button-hover-background-colour: var(--_govuk-warning-button-hover-background-colour);
   }
 
   .govuk-button--inverse {

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -147,24 +147,15 @@
   }
 
   .govuk-button--secondary {
-    --_govuk-button-background-colour: var(--_govuk-secondary-button-background-colour);
-    --_govuk-button-shadow-colour: var(--_govuk-secondary-button-shadow-colour);
-    --_govuk-button-text-colour: var(--_govuk-secondary-button-text-colour);
-    --_govuk-button-hover-background-colour: var(--_govuk-secondary-button-hover-background-colour);
+    @include base.govuk-button-style(secondary);
   }
 
   .govuk-button--warning {
-    --_govuk-button-background-colour: var(--_govuk-warning-button-background-colour);
-    --_govuk-button-shadow-colour: var(--_govuk-warning-button-shadow-colour);
-    --_govuk-button-text-colour: var(--_govuk-warning-button-text-colour);
-    --_govuk-button-hover-background-colour: var(--_govuk-warning-button-hover-background-colour);
+    @include base.govuk-button-style(warning);
   }
 
   .govuk-button--inverse {
-    --_govuk-button-background-colour: var(--_govuk-inverse-button-background-colour);
-    --_govuk-button-shadow-colour: var(--_govuk-inverse-button-shadow-colour);
-    --_govuk-button-text-colour: var(--_govuk-inverse-button-text-colour);
-    --_govuk-button-hover-background-colour: var(--_govuk-inverse-button-hover-background-colour);
+    @include base.govuk-button-style(inverse);
   }
 
   .govuk-button--start {

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -7,8 +7,8 @@
 /// @access private
 @mixin styles($background-colour, $text-colour, $inverse-background-colour, $inverse-text-colour) {
   $govuk-button-colour: $background-colour;
-  $text-colour: $text-colour;
-  $govuk-button-hover-colour: base.govuk-colour("green", $variant: "shade-25");
+  $govuk-button-text-colour: $text-colour;
+  $govuk-button-hover-background-colour: base.govuk-colour("green", $variant: "shade-25");
   $govuk-button-shadow-colour: base.govuk-colour("green", $variant: "shade-50");
 
   // Secondary button variables
@@ -25,7 +25,7 @@
 
   // Inverse button variables
   $govuk-inverse-button-colour: $inverse-background-colour;
-  $inverse-text-colour: $inverse-text-colour;
+  $govuk-inverse-button-text-colour: $inverse-text-colour;
   $govuk-inverse-button-hover-colour: base.govuk-colour("blue", $variant: "tint-95");
   $govuk-inverse-button-shadow-colour: base.govuk-colour("blue", $variant: "shade-50");
 
@@ -33,6 +33,13 @@
   // the height of the button to compensate by adjusting its padding (s1) and
   // increase the bottom margin to include it (s2).
   $button-shadow-size: base.$govuk-border-width-form-element;
+
+  :root {
+    --_govuk-button-text-colour: #{$govuk-button-text-colour};
+    --_govuk-button-background-colour: #{$govuk-button-colour};
+    --_govuk-button-hover-background-colour: #{$govuk-button-hover-background-colour};
+    --_govuk-button-shadow-colour: #{$govuk-button-shadow-colour};
+  }
 
   .govuk-button {
     @include base.govuk-font($size: 19, $line-height: 19px);
@@ -49,9 +56,9 @@
       (base.govuk-spacing(2) - base.$govuk-border-width-form-element - ($button-shadow-size * 0.5)); // s1
     border: base.$govuk-border-width-form-element solid transparent;
     border-radius: 0;
-    color: $text-colour;
-    background-color: $govuk-button-colour;
-    box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0
+    color: var(--_govuk-button-text-colour);
+    background-color: var(--_govuk-button-background-colour);
+    box-shadow: 0 $button-shadow-size 0 var(--_govuk-button-shadow-colour); // s0
     text-align: center;
     vertical-align: top;
     cursor: pointer;
@@ -66,7 +73,7 @@
     &:visited,
     &:active,
     &:hover {
-      color: $text-colour;
+      color: var(--_govuk-button-text-colour);
       text-decoration: none;
     }
 
@@ -77,7 +84,7 @@
     }
 
     &:hover {
-      background-color: $govuk-button-hover-colour;
+      background-color: var(--_govuk-button-hover-background-colour);
     }
 
     &:active {
@@ -130,80 +137,38 @@
   }
 
   .govuk-button[disabled] {
+    --_govuk-button-hover-background-colour: var(--_govuk-button-background-colour);
+
     opacity: (0.5);
 
     &:hover {
-      background-color: $govuk-button-colour;
       cursor: not-allowed;
     }
 
     &:active {
       top: 0;
-      box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0
     }
   }
 
   .govuk-button--secondary {
-    background-color: $govuk-secondary-button-colour;
-    box-shadow: 0 $button-shadow-size 0 $govuk-secondary-button-shadow-colour;
-
-    &,
-    &:link,
-    &:visited,
-    &:active,
-    &:hover {
-      color: $govuk-secondary-button-text-colour;
-    }
-
-    &:hover {
-      background-color: $govuk-secondary-button-hover-colour;
-
-      &[disabled] {
-        background-color: $govuk-secondary-button-colour;
-      }
-    }
+    --_govuk-button-background-colour: #{$govuk-secondary-button-colour};
+    --_govuk-button-shadow-colour: #{$govuk-secondary-button-shadow-colour};
+    --_govuk-button-text-colour: #{$govuk-secondary-button-text-colour};
+    --_govuk-button-hover-background-colour: #{$govuk-secondary-button-hover-colour};
   }
 
   .govuk-button--warning {
-    background-color: $govuk-warning-button-colour;
-    box-shadow: 0 $button-shadow-size 0 $govuk-warning-button-shadow-colour;
-
-    &,
-    &:link,
-    &:visited,
-    &:active,
-    &:hover {
-      color: $govuk-warning-button-text-colour;
-    }
-
-    &:hover {
-      background-color: $govuk-warning-button-hover-colour;
-
-      &[disabled] {
-        background-color: $govuk-warning-button-colour;
-      }
-    }
+    --_govuk-button-background-colour: #{$govuk-warning-button-colour};
+    --_govuk-button-shadow-colour: #{$govuk-warning-button-shadow-colour};
+    --_govuk-button-text-colour: #{$govuk-warning-button-text-colour};
+    --_govuk-button-hover-background-colour: #{$govuk-warning-button-hover-colour};
   }
 
   .govuk-button--inverse {
-    background-color: $govuk-inverse-button-colour;
-    box-shadow: 0 $button-shadow-size 0 $govuk-inverse-button-shadow-colour;
-
-    &,
-    &:link,
-    &:visited,
-    &:active,
-    &:hover {
-      color: $inverse-text-colour;
-    }
-
-    &:hover {
-      background-color: $govuk-inverse-button-hover-colour;
-
-      &[disabled] {
-        background-color: $govuk-inverse-button-colour;
-      }
-    }
+    --_govuk-button-background-colour: #{$govuk-inverse-button-colour};
+    --_govuk-button-shadow-colour: #{$govuk-inverse-button-shadow-colour};
+    --_govuk-button-text-colour: #{$govuk-inverse-button-text-colour};
+    --_govuk-button-hover-background-colour: #{$govuk-inverse-button-hover-colour};
   }
 
   .govuk-button--start {

--- a/packages/govuk-frontend/src/govuk/components/button/helpers.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/helpers.unit.test.mjs
@@ -1,0 +1,41 @@
+import { compileSassString } from '@govuk-frontend/helpers/tests'
+import { outdent } from 'outdent'
+
+describe('button/_helpers', () => {
+  describe('@mixin govuk-button-style', () => {
+    it('Applies the appropriate variant custom properties to the button custom properties', async () => {
+      const sass = `
+        @use "components/button/helpers" as *;
+
+        .app-component {
+          @include govuk-button-style(warning);
+        }
+      `
+
+      const { css } = await compileSassString(sass)
+
+      expect(css).toEqual(outdent`
+        .app-component {
+          --_govuk-button-background-colour: var(--_govuk-warning-button-background-colour);
+          --_govuk-button-shadow-colour: var(--_govuk-warning-button-shadow-colour);
+          --_govuk-button-text-colour: var(--_govuk-warning-button-text-colour);
+          --_govuk-button-hover-background-colour: var(--_govuk-warning-button-hover-background-colour);
+        }
+      `)
+    })
+
+    it('Throws an error if the variant does not exist', () => {
+      const sass = `
+        @use "components/button/helpers" as *;
+
+        .app-component {
+          @include govuk-button-style(unknown-button-variant);
+        }
+      `
+
+      expect(compileSassString(sass)).rejects.toThrow(
+        'Unknown button variant `unknown-button-variant` (available variants: secondary, warning, inverse)'
+      )
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -118,17 +118,16 @@
       border-color: base.govuk-functional-colour("error");
     }
 
-    .govuk-file-upload-button__pseudo-button {
-      background-color: base.govuk-colour("black", $variant: "tint-95");
-    }
+    --_govuk-button-background-colour: var(--_govuk-secondary-button-background-colour);
+    --_govuk-button-shadow-colour: var(--_govuk-secondary-button-shadow-colour);
+    --_govuk-button-text-colour: var(--_govuk-secondary-button-text-colour);
+    --_govuk-button-hover-background-colour: var(--_govuk-secondary-button-hover-background-colour);
 
     &:hover {
+      --_govuk-button-background-colour: var(--_govuk-button-hover-background-colour);
+
       border-style: dashed;
       border-color: base.govuk-colour("black", $variant: "tint-50");
-
-      .govuk-file-upload-button__pseudo-button {
-        background-color: base.govuk-colour("black", $variant: "tint-80");
-      }
 
       .govuk-file-upload-button__status {
         background-color: base.govuk-colour("blue");
@@ -150,15 +149,13 @@
       // here as it is already used for the yellow focus state.
       box-shadow: inset 0 0 0 base.$govuk-border-width-form-element;
 
-      .govuk-file-upload-button__pseudo-button {
-        background-color: base.govuk-functional-colour(focus);
-        box-shadow: 0 2px 0 base.govuk-colour("black");
-      }
+      --_govuk-button-background-colour: #{base.govuk-functional-colour(focus)};
+      --_govuk-button-shadow-colour: #{base.govuk-functional-colour(focus-text)};
 
       &:hover .govuk-file-upload-button__pseudo-button {
+        --_govuk-button-background-colour: var(--_govuk-button-hover-background-colour);
         border-color: base.govuk-functional-colour(focus);
         outline: 3px solid transparent;
-        background-color: base.govuk-colour("black", $variant: "tint-80");
         box-shadow: inset 0 0 0 1px base.govuk-functional-colour(focus);
       }
     }
@@ -167,10 +164,6 @@
   .govuk-file-upload-button--empty {
     border-style: dashed;
     background-color: $empty-button-background-colour;
-
-    .govuk-file-upload-button__pseudo-button {
-      background-color: $empty-pseudo-button-background-colour;
-    }
 
     .govuk-file-upload-button__status {
       color: base.govuk-colour("black");
@@ -204,10 +197,6 @@
     opacity: 0.5;
 
     background-color: $empty-button-background-colour;
-
-    .govuk-file-upload-button__pseudo-button {
-      background-color: $empty-pseudo-button-background-colour;
-    }
 
     .govuk-file-upload-button__status {
       background-color: $empty-status-background-colour;

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -118,10 +118,7 @@
       border-color: base.govuk-functional-colour("error");
     }
 
-    --_govuk-button-background-colour: var(--_govuk-secondary-button-background-colour);
-    --_govuk-button-shadow-colour: var(--_govuk-secondary-button-shadow-colour);
-    --_govuk-button-text-colour: var(--_govuk-secondary-button-text-colour);
-    --_govuk-button-hover-background-colour: var(--_govuk-secondary-button-hover-background-colour);
+    @include base.govuk-button-style(secondary);
 
     &:hover {
       --_govuk-button-background-colour: var(--_govuk-button-hover-background-colour);

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -186,7 +186,7 @@ export class FileUpload extends ConfigurableComponent {
 
     const buttonSpan = document.createElement('span')
     buttonSpan.className =
-      'govuk-button govuk-button--secondary govuk-file-upload-button__pseudo-button'
+      'govuk-button govuk-file-upload-button__pseudo-button'
     buttonSpan.innerText = this.i18n.t('chooseFilesButton')
 
     containerSpan.appendChild(buttonSpan)

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -15,10 +15,7 @@
 
     text-align: center;
 
-    --_govuk-button-background-colour: var(--_govuk-inverse-button-background-colour);
-    --_govuk-button-shadow-colour: var(--_govuk-inverse-button-shadow-colour);
-    --_govuk-button-text-colour: var(--_govuk-inverse-button-text-colour);
-    --_govuk-button-hover-background-colour: var(--_govuk-inverse-button-hover-background-colour);
+    @include base.govuk-button-style(inverse);
 
     @media #{base.govuk-until-breakpoint(tablet)} {
       padding: base.govuk-spacing(4) - base.$govuk-border-width;

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -15,6 +15,11 @@
 
     text-align: center;
 
+    --_govuk-button-background-colour: var(--_govuk-inverse-button-background-colour);
+    --_govuk-button-shadow-colour: var(--_govuk-inverse-button-shadow-colour);
+    --_govuk-button-text-colour: var(--_govuk-inverse-button-text-colour);
+    --_govuk-button-hover-background-colour: var(--_govuk-inverse-button-hover-background-colour);
+
     @media #{base.govuk-until-breakpoint(tablet)} {
       padding: base.govuk-spacing(4) - base.$govuk-border-width;
 

--- a/packages/govuk-frontend/src/govuk/components/panel/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.njk
@@ -13,7 +13,7 @@
     {{ govukButton({
       "text": action.text,
       "type": action.type if action.type else "button",
-      "classes": "govuk-button--inverse" + (" " + action.classes if action.classes),
+      "classes": action.classes if action.classes,
       "href": action.href,
       "attributes": action.attributes
     }) }}

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -210,7 +210,7 @@ describe('Panel', () => {
           const $ = render('panel', examples.interruption)
 
           const $actions = $(
-            '.govuk-panel__actions .govuk-button-group > button.govuk-button.govuk-button--inverse'
+            '.govuk-panel__actions .govuk-button-group > button.govuk-button'
           )
           expect($actions.text()).toContain('Yes, this is correct')
         })


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was closed by the deletion of the `add-interruption-panel--local` branch. It is replaced by #7274

This PR refactors buttons so they use custom properties to set the button colours for each variant. 

## Reduces selector duplication

This reduces the duplication of pseudo-selectors for each button state, as each variant now only need to assign the correct colour to 4 custom properties:
- `--_govuk-button-background-colour` for the background of the button
- `--_govuk-button-text-colour` for the text of the button
- `--_govuk-button-shadow-colour` for the shadow of the button
- `--_govuk-button-hover-background-colour` for the background when hovered.

> [!NOTE]
> These custom properties are currently considered internal implementation details and not meant to be used by external code. This is hinted by the leading `_` in their name.
> It's likely that we will have to provide them as a public API at some point in the future, at which point we can decide on a final naming for the properties (which could likely be the same as now, without the `_`, but we'll need to check if fits the other components relying on custom properties). As this point as well, the button colours will likely become functional colours.

## Enables change of default button styles inside components

This also enables components to redefine the colours of buttons within them without asking users (or us) to set a `.govuk-button--<VARIANT>` class on the buttons:
- the Interruption panel can make `.govuk-button`s `inverse` without needing to explicitely set `.govuk-button--inverse` on the elements
- the File upload can make its pseudo-button `secondary` without setting it to `.govuk-button--secondary` and adjust its colours with less specific selectors (as well as no longer rely on duplicate calls to `govuk-colour()`).

If a component defines a new default for `.govuk-button`, using `.govuk-button--<VARIANT>` still allows to apply a variant to a specific button inside that component. The `.govuk-button--<VARIANT>` classes set the same custom `--_govuk-button-<COLOUR-NAME>` properties listed abot, and being set on the button itself, will take precedence over those cascading from a parent element. 

> [!NOTE]
> Given applying `.govuk-button--<VARIANT>` to any element would change the styles of the default buttons within it, we may want to consider renaming these classes `.govuk-button-style--<VARIANT>` and widen their use.

## Use custom properties to store the colours of each variant

The PR moves from using Sass variables to using custom properties for storing the colours of each button variants. This was the simplest way to enable reuse of the colours, as some of the colours are set from the variables in the `_settings.scss` file.

This creates two sets of custom properties:
- `--_govuk-button-<COLOUR-NAME>` to apply colours to a button
- `--_govuk-<VARIANT>-button-<COLOUR-NAME>` to define the colours for a specific variant

> [!NOTE]
> Same as earlier, these custom properties are considered internal for now. They may need to become public when looking at dark mode (eg. to adjust the secondary colour) or if we lean into white labelling at some point.

You may notice there's no variables for the "default" button styles. Until there's a clear demand/use for it, there's no reason to introduce extra properties for this where the `--_govuk-button-<COLOUR-NAME>` variables can fulfill that role. If needed this could be worked around with the following (albeit relying on setting internal custom properties):

```scss
:root {
  // Store the initial values of the `--govuk-button-<COLOUR-NAME>` in other variables
  // that can be referred to is a component changes the default button styles
  --_app-default-button-background-colour: var(--_govuk-button-background-colour);
  --_app-default-button-text-colour: var(--_govuk-button-text-colour);
  --_app-default-button-shadow-colour: var(--_govuk-button-shadow-colour);
  --_app-default-button-hover-background-colour: var(--_govuk-button-hover-background-colour);
}

.app-button--default {
  // Apply the stored variables to the button
  --_govuk-button-background-colour: var(--_app-default-button-background-colour);
  --_govuk-button-text-colour: var(--_app-default-button-text-colour);
  --_govuk-button-hover-background-colour: var(--_app-default-button-hover-background-colour);
  --_govuk-button-shadow-colour: var(--_app-default-button-shadow-colour);
}
```

## Consistent application of colours through a new `govuk-button-style` mixin

Because configuring button colours rely on setting a set of 4 properties from consistently named custom properties, this can be encapsulated in a mixin that'll reduce the risks of typos and error if requesting a variant that's not defined.

> [!NOTE]
> Like the variables, that mixin is kept internal for now, but could become part of our public Sass API in the future if there's demand.

Fixes #6483 