### PR TITLE
Add tests for pixel unit conversions

### DIFF
--- a/packages/govuk-frontend/src/govuk/tools/px-to-em.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/tools/px-to-em.unit.test.mjs
@@ -1,0 +1,26 @@
+import { compileSassString } from '@govuk-frontend/helpers/tests'
+
+describe('tools/px-to-em', () => {
+  it.each([
+    ['16px', undefined, '1em'],
+    ['16', undefined, '1em'],
+    ['0', undefined, '0em'],
+    ['-8px', undefined, '-0.5em'],
+    ['2.4px', undefined, '0.15em'],
+    ['24px', '12px', '2em'],
+    ['24px', '12', '2em']
+  ])('converts %s with context %s to %s', async (value, context, expected) => {
+    const args = context ? `${value}, ${context}` : value
+    const sass = `
+      @use "tools/px-to-em";
+
+      :root {
+        --result: #{px-to-em.govuk-em(${args})};
+      }
+    `
+
+    const { css } = await compileSassString(sass)
+
+    expect(css).toContain(`--result: ${expected};`)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/tools/px-to-rem.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/tools/px-to-rem.unit.test.mjs
@@ -1,0 +1,23 @@
+import { compileSassString } from '@govuk-frontend/helpers/tests'
+
+describe('tools/px-to-rem', () => {
+  it.each([
+    ['16px', '1rem'],
+    ['16', '1rem'],
+    ['0', '0rem'],
+    ['-8px', '-0.5rem'],
+    ['2.4px', '0.15rem']
+  ])('converts %s to %s', async (value, expected) => {
+    const sass = `
+      @use "tools/px-to-rem";
+
+      :root {
+        --result: #{px-to-rem.govuk-px-to-rem(${value})};
+      }
+    `
+
+    const { css } = await compileSassString(sass)
+
+    expect(css).toContain(`--result: ${expected};`)
+  })
+})


### PR DESCRIPTION
## What

Adds focused unit tests for the Sass pixel conversion functions:

- govuk-px-to-rem with pixel and unitless values
- govuk-em with its default and explicit context font sizes
- zero, negative and fractional values for both functions

## Why

This verifies the existing conversion behaviour and completes #7210.

## Testing

- npm run lint
- npm test (166 suites passed, 2,950 tests passed)