### PR TITLE
Remove outdated params from header across the review app

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/headers/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/headers/index.njk
@@ -109,7 +109,6 @@
     <div class="govuk-grid-column-full-width">
       <h2 class="govuk-heading-l">Header and Exit this page</h2>
         {{ govukHeader({
-        navigationClasses: "govuk-header__navigation--end",
         productName: "Product Name"
         }) }}
         <div class="govuk-width-container">
@@ -130,7 +129,6 @@
     <div class="govuk-grid-column-full-width">
       <h2 class="govuk-heading-l">Header and Notification banner</h2>
         {{ govukHeader({
-        navigationClasses: "govuk-header__navigation--end",
         productName: "Product Name"
         }) }}
         <div class="govuk-width-container">
@@ -157,7 +155,6 @@
     <div class="govuk-grid-column-full-width">
       <h2 class="govuk-heading-l">Header and Panel</h2>
         {{ govukHeader({
-        navigationClasses: "govuk-header__navigation--end",
         productName: "Product Name"
         }) }}
         <div class="govuk-width-container">
@@ -180,7 +177,6 @@
     <div class="govuk-grid-column-full-width">
       <h2 class="govuk-heading-l">Header and Phase banner</h2>
         {{ govukHeader({
-        navigationClasses: "govuk-header__navigation--end",
         productName: "Product Name"
         }) }}
         <div class="govuk-phase-banner">
@@ -233,36 +229,14 @@
         }
       ]
     }) }}
-      {{ govukHeader({
-      serviceName: "Service Name",
-      serviceUrl: "/components/header",
-      navigation: [
-        {
-          href: "#1",
-          text: "Navigation item 1",
-          active: true
-        },
-        {
-          href: "#2",
-          text: "Navigation item 2"
-        },
-        {
-          href: "#3",
-          text: "Navigation item 3"
-        },
-        {
-          href: "#4",
-          text: "Navigation item 4"
-        }
-      ]
-    }) }}
+      {{ govukHeader() }}
 
-        {{ govukPhaseBanner({
-          tag: {
-            text: "Alpha"
-          },
-          html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
-        }) }}
+      {{ govukPhaseBanner({
+        tag: {
+          text: "Alpha"
+        },
+        html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
+      }) }}
 
         {{ govukBreadcrumbs({
           items: [

--- a/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
@@ -58,23 +58,7 @@
 {% block govukHeader %}
   <!-- block:header -->
   {{ govukHeader({
-    serviceName: "Nom du service",
-    containerClasses: containerClasses,
-    navigation: [
-      {
-        href: '#1',
-        text: 'Élément de navigation 1',
-        active: true
-      },
-      {
-        href: '#2',
-        text: 'Élément de navigation 2'
-      },
-      {
-        href: '#3',
-        text: 'Élément de navigation 3'
-      }
-    ]
+    containerClasses: containerClasses
   }) }}
   <!-- endblock:header -->
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -427,29 +427,7 @@
 
   {{ govukHeader({
     homepageUrl: "#",
-    serviceName: "Enw gwasanaeth",
-    serviceUrl: "#",
-    menuButtonLabel: "Dangos neu guddio'r ddewislen",
-    menuButtonText: "Dewislen",
-    navigation: [
-      {
-        href: "#1",
-        text: "Eitem llywio 1",
-        active: true
-      },
-      {
-        href: "#2",
-        text: "Eitem llywio 2"
-      },
-      {
-        href: "#3",
-        text: "Eitem llywio 3"
-      },
-      {
-        href: "#4",
-        text: "Eitem llywio 4"
-      }
-    ]
+    productName: "enw'r cynnyrch"
   }) }}
 
   {{ govukInsetText({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
@@ -12,10 +12,6 @@ notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausage
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
-{% block govukHeader %}
-  {{ govukHeader({}) }}
-{% endblock %}
-
 {% block govukServiceNavigation %}
 {{ govukServiceNavigation({
   navigation: [

--- a/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
@@ -21,11 +21,7 @@ notes: The links to change your answers are not functional.
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
-{% block govukHeader %}
-  {{ govukHeader({
-    serviceName: "Temporary events notice"
-  }) }}
-{% endblock %}
+{% set serviceName = "Temporary events notice" %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow-slot/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/companies-you-follow-slot/index.njk
@@ -11,7 +11,6 @@ notes: Based on Companies House "Find an update company information" service
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
@@ -42,16 +41,9 @@ notes: Based on Companies House "Find an update company information" service
   </li>
 {% endset %}
 
-{% block govukHeader %}
-  {{ govukHeader({
-    classes: "govuk-header--full-width-border",
-    serviceName: "Find and update company information",
-    serviceUrl: "#0"
-  }) }}
-{% endblock %}
-
 {% block govukServiceNavigation %}
   {{ govukServiceNavigation({
+    serviceName: "Find and update company information",
     navigation: [
       {
         href: '#1',

--- a/packages/govuk-frontend-review/src/views/full-page-examples/header-kitchen-sink/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/header-kitchen-sink/index.njk
@@ -54,7 +54,6 @@ scenario: |
 
 {% block govukHeader %}
   {{ govukHeader({
-    navigationClasses: "govuk-header__navigation--end",
     productName: "Product Name"
   }) }}
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -21,11 +21,7 @@ scenario: |
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
-{% block govukHeader %}
-  {{ govukHeader({
-    serviceName: "Apply for a passport"
-  }) }}
-{% endblock %}
+{% set serviceName = "Apply for a passport" %}
 
 {% block headerEnd %}
   {{ govukPhaseBanner({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/confirm.njk
@@ -1,23 +1,24 @@
 {% extends "layouts/full-page-example.njk" %}
 
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Photo submitted" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
-{% block govukHeader %}
-  {{ govukHeader({
+{% block govukServiceNavigation %}
+  {{ govukServiceNavigation({
     serviceName: "Apply for a passport",
     navigation: [
-        {
-            href: "/",
-            text: "Home"
-        },
-        {
-            href: "#upload-a-photo",
-            text: "Upload a photo",
-            active: true
-        }
+      {
+        href: "/",
+        text: "Home"
+      },
+      {
+        href: "#upload-a-photo",
+        text: "Upload a photo",
+        active: true
+      }
     ]
   }) }}
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -23,11 +23,7 @@ scenario: |
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ "Error: " if errorSummary | length }}{{ pageTitle }} - GOV.UK{% endblock %}
 
-{% block govukHeader %}
-  {{ govukHeader({
-    serviceName: "Apply for a passport"
-  }) }}
-{% endblock %}
+{% set serviceName = "Apply for a passport" %}
 
 {% block headerEnd %}
   {{ govukPhaseBanner({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
@@ -24,11 +24,7 @@ notes: The links to change your answers are not functional.
 {% set pageTitle = example.title %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
-{% block govukHeader %}
-  {{ govukHeader({
-    serviceName: "Apply for teacher training"
-  }) }}
-{% endblock %}
+{% set serviceName = "Apply for teacher training" %}
 
 {% block containerStart %}
   {{ govukBackLink({


### PR DESCRIPTION
Removes any headers in our example using `serviceName`, `serviceUrl`, `navigation` and `navigationClasses`.

Where appropriate I've tried to replaces instances of headers with navigation or service names with service navigation and also tried to use our page template to load it automatically eg: `set`ing `serviceName` rather than calling the whole service nav macro.