### PR TITLE
SPIKE: static title

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -1,4 +1,16 @@
+@use "sass:map";
+
 @use "../../base";
+@use "../../helpers/typography--internal";
+
+/// @access private
+@mixin _title-size($size) {
+  $font-map: map.get(base.$govuk-typography-scale, $size);
+  @include typography--internal.font-size-and-line-height("tablet", $font-map);
+  @media print {
+    @include typography--internal.font-size-and-line-height("print", $font-map);
+  }
+}
 
 /// @access private
 @mixin styles {
@@ -37,8 +49,8 @@
   }
 
   .govuk-panel__title {
-    @include base.govuk-font-size($size: 48);
-    @include base.govuk-typography-weight-bold;
+    @include base.govuk-font($size: 48, $weight: bold);
+
     margin-top: 0;
     margin-bottom: base.govuk-spacing(6);
   }
@@ -78,7 +90,7 @@
 
     // Smaller title to go alongside smaller body text.
     .govuk-panel__title {
-      @include base.govuk-font-size($size: 36);
+      @include _title-size($size: 36);
       margin-bottom: base.govuk-spacing(3);
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -78,7 +78,7 @@
 
     // Smaller title to go alongside smaller body text.
     .govuk-panel__title {
-      @include base.govuk-font-size($size: 36, $fixed-breakpoint: "tablet");
+      @include base.govuk-font-size($size: 36);
       margin-bottom: base.govuk-spacing(3);
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_mixin.scss
@@ -78,7 +78,7 @@
 
     // Smaller title to go alongside smaller body text.
     .govuk-panel__title {
-      @include base.govuk-font-size($size: 36);
+      @include base.govuk-font-size($size: 36, $fixed-breakpoint: "tablet");
       margin-bottom: base.govuk-spacing(3);
     }
   }

--- a/packages/govuk-frontend/src/govuk/helpers/_typography--internal.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography--internal.scss
@@ -3,6 +3,9 @@
 ////
 
 @use "sass:math";
+@use "sass:map";
+
+@use "../tools/if" as *;
 
 /// Convert line-heights specified in pixels into a relative value, unless
 /// they are already unit-less (and thus already treated as relative values)
@@ -20,4 +23,48 @@
   }
 
   @return $line-height;
+}
+
+/// TODO
+///
+/// @param {Number} TODO
+///
+/// @access private
+
+@mixin font-size-and-line-height($breakpoint: false, $font-map: false, $line-height: false, $important: false) {
+  $breakpoint-map: map.get($font-map, $breakpoint);
+  $font-size: map.get($breakpoint-map, "font-size");
+
+  // $calculated-line-height is a separate variable from $line-height,
+  // as otherwise the value would get redefined with each loop and
+  // eventually break typography--internal.line-height.
+  // 1. See if the function was called with a specific line-height
+  $calculated-line-height: $line-height;
+  // 2. Default to the breakpoint-map if no specific value was given
+  @if not $calculated-line-height {
+    $calculated-line-height: map.get($breakpoint-map, "line-height");
+  }
+
+  // 3. Turn the value into a unitless line-height if possible
+  // We continue to call the param $line-height to stay consistent with the
+  // naming with govuk-font.
+  $calculated-line-height: line-height(
+    $line-height: $calculated-line-height,
+    $font-size: $font-size
+  );
+
+  // Print styles do not need converting to rem as they're pt
+  $calculated-font-size: $font-size;
+  @if not $breakpoint == "print" {
+    $calculated-font-size: govuk-px-to-rem($font-size);
+  }
+
+  // Mark rules as !important if $important is true - this will result in
+  // these variables becoming strings, so this needs to happen *after* they
+  // are used in calculations
+  $calculated-font-size: $calculated-font-size govuk-if($important, !important);
+  $calculated-line-height: $calculated-line-height govuk-if($important, !important);
+
+  font-size: $calculated-font-size;
+  line-height: $calculated-line-height;
 }

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -219,12 +219,7 @@
     $font-size-rem: $font-size-rem govuk-if($important, !important);
     $calculated-line-height: $calculated-line-height govuk-if($important, !important);
 
-    @if $breakpoint == "print" {
-      @media print {
-        font-size: $font-size;
-        line-height: $calculated-line-height;
-      }
-    } @else if $fixed-breakpoint {
+    @if $fixed-breakpoint {
       @if $fixed-breakpoint == $breakpoint {
         font-size: $font-size-rem;
         line-height: $calculated-line-height;
@@ -233,6 +228,11 @@
       @if not $breakpoint {
         font-size: $font-size-rem;
         line-height: $calculated-line-height;
+      } @else if $breakpoint == "print" {
+        @media print {
+          font-size: $font-size;
+          line-height: $calculated-line-height;
+        }
       } @else {
         @media #{govuk-from-breakpoint($breakpoint)} {
           font-size: $font-size-rem;

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -190,46 +190,15 @@
   }
 
   @each $breakpoint, $breakpoint-map in $font-map {
-    $font-size: map.get($breakpoint-map, "font-size");
-    $font-size-rem: govuk-px-to-rem($font-size);
-
-    // $calculated-line-height is a separate variable from $line-height,
-    // as otherwise the value would get redefined with each loop and
-    // eventually break typography--internal.line-height.
-    // 1. See if the function was called with a specific line-height
-    $calculated-line-height: $line-height;
-    // 2. Default to the breakpoint-map if no specific value was given
-    @if not $calculated-line-height {
-      $calculated-line-height: map.get($breakpoint-map, "line-height");
-    }
-
-    // 3. Turn the value into a unitless line-height if possible
-    // We continue to call the param $line-height to stay consistent with the
-    // naming with govuk-font.
-    $calculated-line-height: typography--internal.line-height(
-      $line-height: $calculated-line-height,
-      $font-size: $font-size
-    );
-
-    // Mark rules as !important if $important is true - this will result in
-    // these variables becoming strings, so this needs to happen *after* they
-    // are used in calculations
-    $font-size: $font-size govuk-if($important, !important);
-    $font-size-rem: $font-size-rem govuk-if($important, !important);
-    $calculated-line-height: $calculated-line-height govuk-if($important, !important);
-
     @if not $breakpoint {
-      font-size: $font-size-rem;
-      line-height: $calculated-line-height;
+      @include typography--internal.font-size-and-line-height($breakpoint, $font-map);
     } @else if $breakpoint == "print" {
       @media print {
-        font-size: $font-size;
-        line-height: $calculated-line-height;
+        @include typography--internal.font-size-and-line-height("print", $font-map);
       }
     } @else {
       @media #{govuk-from-breakpoint($breakpoint)} {
-        font-size: $font-size-rem;
-        line-height: $calculated-line-height;
+        @include typography--internal.font-size-and-line-height($breakpoint, $font-map);
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -144,12 +144,13 @@
 ///   height. Omit to use the line height from the font map.
 /// @param {Boolean} $important [false] - Whether to mark declarations as
 ///   `!important`.
+/// @param {Boolean} $fixed-breakpoint [false] - Force a fixed breakpoint from the responsive type scale
 ///
 /// @throw if `$size` is not a valid point from the type scale
 ///
 /// @access public
 
-@mixin govuk-font-size($size, $line-height: false, $important: false) {
+@mixin govuk-font-size($size, $line-height: false, $important: false, $fixed-breakpoint: false) {
   // Flag font sizes that start with underscores so we can suppress warnings on
   // deprecated sizes used internally, for example `govuk-font($size: "_14")`
   $size-internal-use-only: string.slice(#{$size}, 1, 1) == "_";
@@ -218,18 +219,25 @@
     $font-size-rem: $font-size-rem govuk-if($important, !important);
     $calculated-line-height: $calculated-line-height govuk-if($important, !important);
 
-    @if not $breakpoint {
-      font-size: $font-size-rem;
-      line-height: $calculated-line-height;
-    } @else if $breakpoint == "print" {
-      @media print {
-        font-size: $font-size;
+    @if $fixed-breakpoint {
+      @if $fixed-breakpoint == $breakpoint {
+        font-size: $font-size-rem;
         line-height: $calculated-line-height;
       }
     } @else {
-      @media #{govuk-from-breakpoint($breakpoint)} {
+      @if not $breakpoint {
         font-size: $font-size-rem;
         line-height: $calculated-line-height;
+      } @else if $breakpoint == "print" {
+        @media print {
+          font-size: $font-size;
+          line-height: $calculated-line-height;
+        }
+      } @else {
+        @media #{govuk-from-breakpoint($breakpoint)} {
+          font-size: $font-size-rem;
+          line-height: $calculated-line-height;
+        }
       }
     }
   }

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -219,7 +219,12 @@
     $font-size-rem: $font-size-rem govuk-if($important, !important);
     $calculated-line-height: $calculated-line-height govuk-if($important, !important);
 
-    @if $fixed-breakpoint {
+    @if $breakpoint == "print" {
+      @media print {
+        font-size: $font-size;
+        line-height: $calculated-line-height;
+      }
+    } @else if $fixed-breakpoint {
       @if $fixed-breakpoint == $breakpoint {
         font-size: $font-size-rem;
         line-height: $calculated-line-height;
@@ -228,11 +233,6 @@
       @if not $breakpoint {
         font-size: $font-size-rem;
         line-height: $calculated-line-height;
-      } @else if $breakpoint == "print" {
-        @media print {
-          font-size: $font-size;
-          line-height: $calculated-line-height;
-        }
       } @else {
         @media #{govuk-from-breakpoint($breakpoint)} {
           font-size: $font-size-rem;

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -144,13 +144,12 @@
 ///   height. Omit to use the line height from the font map.
 /// @param {Boolean} $important [false] - Whether to mark declarations as
 ///   `!important`.
-/// @param {Boolean} $fixed-breakpoint [false] - Force a fixed breakpoint from the responsive type scale
 ///
 /// @throw if `$size` is not a valid point from the type scale
 ///
 /// @access public
 
-@mixin govuk-font-size($size, $line-height: false, $important: false, $fixed-breakpoint: false) {
+@mixin govuk-font-size($size, $line-height: false, $important: false) {
   // Flag font sizes that start with underscores so we can suppress warnings on
   // deprecated sizes used internally, for example `govuk-font($size: "_14")`
   $size-internal-use-only: string.slice(#{$size}, 1, 1) == "_";
@@ -219,25 +218,18 @@
     $font-size-rem: $font-size-rem govuk-if($important, !important);
     $calculated-line-height: $calculated-line-height govuk-if($important, !important);
 
-    @if $fixed-breakpoint {
-      @if $fixed-breakpoint == $breakpoint {
-        font-size: $font-size-rem;
+    @if not $breakpoint {
+      font-size: $font-size-rem;
+      line-height: $calculated-line-height;
+    } @else if $breakpoint == "print" {
+      @media print {
+        font-size: $font-size;
         line-height: $calculated-line-height;
       }
     } @else {
-      @if not $breakpoint {
+      @media #{govuk-from-breakpoint($breakpoint)} {
         font-size: $font-size-rem;
         line-height: $calculated-line-height;
-      } @else if $breakpoint == "print" {
-        @media print {
-          font-size: $font-size;
-          line-height: $calculated-line-height;
-        }
-      } @else {
-        @media #{govuk-from-breakpoint($breakpoint)} {
-          font-size: $font-size-rem;
-          line-height: $calculated-line-height;
-        }
       }
     }
   }


### PR DESCRIPTION
## Why?

We think that having a bigger title on smaller screens makes the Interruption panel more readable

## What's the issue at the moment?

Our font mixin assumes you always want to use the responsive typography scale

## Open questions
- Should this be as part of `govuk-font-size`?
- If it is, is `$fixed-breakpoint` a good name for such a feature?
- Does specifying a `breakpoint` to tie to make sense or some other concept make more sense?
e.g. we have an idea of `from-desktop` https://design-system.service.gov.uk/styles/layout/#desktop-specific-grid-classes