### PR TITLE
Ensure focus outline appears in browsers that don't support custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ We've added the [Feedback component](https://design-system.service.gov.uk/compon
 
 This was added in [pull request #7232: Add Feedback component](https://github.com/alphagov/govuk-frontend/pull/7232).
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#7304: Ensure focus outline appears in browsers that don't support custom properties](https://github.com/alphagov/govuk-frontend/pull/7304)
+
 ## v6.4.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.4.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend-review/src/stylesheets/partials/_code.scss
+++ b/packages/govuk-frontend-review/src/stylesheets/partials/_code.scss
@@ -12,14 +12,14 @@
   padding: govuk-spacing(4);
   overflow-x: auto;
   border: $govuk-focus-width solid transparent;
-  outline: 1px solid transparent;
+  @include govuk-focus-outline(transparent);
+  outline-width: 1px;
   background-color: govuk-colour("black", $variant: "tint-95");
   @include govuk-responsive-margin(4, "bottom");
 
   &:focus {
     border: $govuk-focus-width solid;
     border-color: govuk-functional-colour(input-border);
-    outline: $govuk-focus-width solid;
-    outline-color: govuk-functional-colour(focus);
+    @include govuk-focus-outline;
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -87,7 +87,7 @@
 
     &:focus {
       border-color: base.govuk-functional-colour(focus);
-      outline: base.$govuk-focus-width solid transparent;
+      @include base.govuk-focus-outline(transparent);
       box-shadow: inset 0 0 0 1px base.govuk-functional-colour(focus);
     }
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
@@ -108,7 +108,7 @@
     // which means the focus state is less obvious. By adding a transparent
     // outline, which becomes solid (text-coloured) in that context, we ensure
     // the focus remains clearly visible.
-    outline: base.$govuk-focus-width solid transparent;
+    @include base.govuk-focus-outline(transparent);
     outline-offset: 1px;
 
     // When in an explicit forced-color mode, we can use the Highlight system
@@ -274,10 +274,9 @@
     // feedback to the user as to which checkbox they will select when their
     // cursor is outside of the visible area.
     .govuk-checkboxes__input:not(:disabled):hover + .govuk-checkboxes__label::before {
-      // Forced colours modes tend to ignore box-shadow.
-      // Apply an outline for those modes to use instead.
-      outline: base.$govuk-focus-width dashed transparent;
+      @include base.govuk-focus-outline(transparent);
       outline-offset: 1px;
+      outline-style: dashed;
       box-shadow: 0 0 0 base.$govuk-hover-width base.govuk-functional-colour(hover);
     }
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/_mixin.scss
@@ -12,8 +12,7 @@
     color: base.govuk-functional-colour(text);
 
     &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      @include base.govuk-focus-outline;
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -27,8 +27,7 @@
     }
 
     &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      @include base.govuk-focus-outline;
       // Use `box-shadow` to add border instead of changing `border-width`
       // (which changes element size) and since `outline` is already used for
       // the yellow focus state.
@@ -41,8 +40,7 @@
     // to recognise `focus-within` and don't set any styles from the block
     // when it's a selector.
     &:focus-within {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      @include base.govuk-focus-outline;
 
       box-shadow: inset 0 0 0 4px base.govuk-functional-colour(input-border);
     }
@@ -138,8 +136,7 @@
     &:active,
     &:focus {
       border: $file-upload-border-width solid base.govuk-colour("black");
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      @include base.govuk-focus-outline;
       // Ensure outline appears outside of the element
       outline-offset: 0;
       background-color: base.govuk-colour("black", $variant: "tint-95");
@@ -157,7 +154,8 @@
 
       &:hover .govuk-file-upload-button__pseudo-button {
         border-color: base.govuk-functional-colour(focus);
-        outline: 3px solid transparent;
+        @include base.govuk-focus-outline;
+        outline-width: 3px;
         background-color: base.govuk-colour("black", $variant: "tint-80");
         box-shadow: inset 0 0 0 1px base.govuk-functional-colour(focus);
       }

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -15,8 +15,7 @@
     border-color: var(--_govuk-notification-banner-colour);
 
     &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      @include base.govuk-focus-outline;
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_mixin.scss
@@ -83,7 +83,8 @@
 
   .govuk-pagination__item--current {
     @include base.govuk-typography-weight-bold;
-    outline: 1px solid transparent;
+    @include base.govuk-focus-outline(transparent);
+    outline-width: 1px;
     background-color: base.govuk-functional-colour(link);
 
     &:hover {

--- a/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
@@ -112,7 +112,7 @@
     // which means the focus state is less obvious. By adding a transparent
     // outline, which becomes solid (text-coloured) in that context, we ensure
     // the focus remains clearly visible.
-    outline: base.$govuk-focus-width solid transparent;
+    @include base.govuk-focus-outline(transparent);
     outline-offset: 1px;
 
     // When in an explicit forced-color mode, we can use the Highlight system
@@ -295,8 +295,10 @@
     .govuk-radios__input:not(:disabled):hover + .govuk-radios__label::before {
       // Forced colours modes tend to ignore box-shadow.
       // Apply an outline for those modes to use instead.
-      outline: $govuk-radios-focus-width dashed transparent;
+      @include base.govuk-focus-outline(transparent);
       outline-offset: 1px;
+      outline-style: dashed;
+      outline-width: $govuk-radios-focus-width;
       box-shadow: 0 0 0 base.$govuk-hover-width base.govuk-functional-colour(hover);
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_mixin.scss
@@ -25,8 +25,7 @@
     }
 
     &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      @include base.govuk-focus-outline;
       outline-offset: 0;
       background-color: base.govuk-functional-colour(focus);
 

--- a/packages/govuk-frontend/src/govuk/helpers/_focused.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_focused.scss
@@ -3,7 +3,41 @@
 ////
 
 @use "../settings/measurements" as *;
+@use "../tools/if" as *;
 @use "colour" as *;
+
+/// Focus outline
+///
+/// Provides an outline to clearly indicate when the target element is focused.
+/// The outline can be `visible` (by default) to be shown in all situations,
+/// or `transparent` to show only in High contrast/Forced colours mode
+/// when other visible cues are used when not in High contrast/Forced colours mode
+/// (see `govuk-focused-text` and `govuk-focused-box`).
+///
+/// @example scss - Default outline, uses the `focus` functional colour
+///   .govuk-notification-banner:focus {
+///     @include govuk-focus-outline;
+///   }
+///
+/// @example scss - Transparent outline, revealed in High contrast mode
+///   .govuk-button:focus {
+///     @include govuk-focus-outline(transparent)
+///   }
+///
+/// @param {String} [$appearance] - The appearance of the outline, use `transparent` for a transparent outline
+/// @access public
+@mixin govuk-focus-outline($appearance: visible) {
+  outline: $govuk-focus-width solid;
+
+  // Separate `outline-color` from `outline`
+  // so the presence of a custom property
+  // does not invalidate the whole `outline` declaration.
+  @if $appearance == transparent {
+    outline-color: transparent;
+  } @else {
+    outline-color: govuk-functional-colour(focus);
+  }
+}
 
 /// Focused text
 ///
@@ -21,8 +55,8 @@
   // When colours are overridden, for example when users have a dark mode,
   // backgrounds and box-shadows disappear, so we need to ensure there's a
   // transparent outline which will be set to a visible colour.
+  @include govuk-focus-outline(transparent);
 
-  outline: $govuk-focus-width solid transparent;
   color: govuk-functional-colour(focus-text);
   background-color: govuk-functional-colour(focus);
   box-shadow:
@@ -62,7 +96,7 @@
 /// @access public
 
 @mixin govuk-focused-box {
-  outline: $govuk-focus-width solid transparent;
+  @include govuk-focus-outline(transparent);
   box-shadow:
     0 0 0 4px govuk-functional-colour(focus),
     0 0 0 8px govuk-functional-colour(focus-text);
@@ -81,8 +115,7 @@
 /// @access public
 
 @mixin govuk-focused-form-input {
-  outline: $govuk-focus-width solid;
-  outline-color: govuk-functional-colour(focus);
+  @include govuk-focus-outline;
   // Ensure outline appears outside of the element
   outline-offset: 0;
   // Double the border by adding its width again. Use `box-shadow` for this

--- a/packages/govuk-frontend/src/govuk/helpers/_focused.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_focused.scss
@@ -2,6 +2,8 @@
 /// @group helpers/accessibility
 ////
 
+@use "sass:string";
+
 @use "../settings/measurements" as *;
 @use "../tools/if" as *;
 @use "colour" as *;
@@ -33,7 +35,11 @@
   // so the presence of a custom property
   // does not invalidate the whole `outline` declaration.
   @if $appearance == transparent {
-    outline-color: transparent;
+    // Use a custom property to set the transparent outline
+    // so that browsers not supporting custom property
+    // will see an outline
+    --_govuk-outline-colour: transparent;
+    outline-color: var(--_govuk-outline-colour);
   } @else {
     outline-color: govuk-functional-colour(focus);
   }

--- a/packages/govuk-frontend/src/govuk/helpers/focused.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/focused.unit.test.js
@@ -1,0 +1,44 @@
+const { compileSassString } = require('@govuk-frontend/helpers/tests')
+const { outdent } = require('outdent')
+
+describe('focus styles', () => {
+  describe('@mixin govuk-focus-outline', () => {
+    it('defaults to the `focus` functional colour', async () => {
+      const sass = `
+        @use 'helpers/focused' as *;
+
+        .app-component:focus {
+          @include govuk-focus-outline;
+        }
+      `
+
+      const { css } = await compileSassString(sass);
+
+      expect(css).toContain(outdent`
+        .app-component:focus {
+          outline: 3px solid;
+          outline-color: var(--govuk-focus-colour, #ffdd00);
+        }
+      `)
+    })
+    it('uses a custom property to set the transparent style', async () =>{
+      const sass = `
+        @use 'helpers/focused' as *;
+
+        .app-component:focus {
+          @include govuk-focus-outline(transparent);
+        }
+      `
+
+      const { css } = await compileSassString(sass);
+
+      expect(css).toContain(outdent`
+        .app-component:focus {
+          outline: 3px solid;
+          --_govuk-outline-colour: transparent;
+          outline-color: var(--_govuk-outline-colour);
+        }
+      `)
+    })
+  })
+})


### PR DESCRIPTION
Encapsulates the creation of focus outlines in a mixin (handy anyways to set a sensible default, I think) and use the mixin to ensure that:
- the `outline-color` is applied separately from the `outline` property, so that an outline is rendered even if the browser does not support custom properties ([with an `auto` value](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/outline-color#formal_definition))
- the `outline-color` is applied through a custom property so that when we set a transparent outline because we apply a visible change through `box-shadow` or some other mean, the lack of support for custom property which makes the `box-shadow` not render also invalidates the `outline-color`, making it visible.

This ensures that when we were sett

**Before**

Tabbing through the page shows no visible focus in browsers that do not support custom properties (IE11, for ex.)

https://github.com/user-attachments/assets/0c9dbe93-583c-40b2-9cff-5533444626d5


**After**

Tabbing through the page shows a visible outline in browsers that do not support custom properties (IE11, for ex.)

https://github.com/user-attachments/assets/ca9aa840-8248-497d-bade-2975bd36841d

Closes #7294