### PR TITLE
Improve release workflow labels

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,5 @@
-name: 'RELEASE: Build release'
-run-name: "RELEASE: Build release (${{ join(inputs.*, ', ') }})"
+name: '[Release] Build release for review'
+run-name: "[Release] Build release for review (${{ join(inputs.*, ', ') }})"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -1,5 +1,5 @@
-name: 'RELEASE: GitHub release'
-run-name: 'RELEASE: GitHub release to ${{inputs.environment}}'
+name: '[Release] Publish to GitHub releases'
+run-name: '[Release] Publish to GitHub releases (${{inputs.environment}})'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,5 +1,5 @@
-name: 'RELEASE: npm publish'
-run-name: 'RELEASE: npm publish to ${{inputs.environment}}'
+name: '[Release] Publish package to npm'
+run-name: '[Release] Publish package to npm (${{inputs.environment}})'
 
 on:
   workflow_dispatch:

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -16,11 +16,11 @@ Developers must pair on releases, so do not publish on your own. You should crea
 
 ## Build the release
 
-1. Before running the build release workflow, make sure the [changelog](/CHANGELOG.md) is up to date with the latest release notes under the **Unreleased** heading - if it is not up to date, update it in a separate pull request before proceeding.
+1. Before running the "[Release] Build release for review" workflow, make sure the [changelog](/CHANGELOG.md) is up to date with the latest release notes under the **Unreleased** heading - if it is not up to date, update it in a separate pull request before proceeding.
 
 2. Open the [**Actions** tab](https://github.com/alphagov/govuk-frontend/actions) on the `alphagov/govuk-frontend` repo.
 
-3. Select the [RELEASE: Build release workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/build-release.yml) and run the workflow:
+3. Select the ["[Release] Build release for review" workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/build-release.yml) and run the workflow:
    1. Set the **Use workflow from** select field to `main` or the `support/*` branch you're releasing from.
    2. Set the **Release Type** select field to the version change, for example `major`.
    3. For pre-releases, set the **Prerelease label** input field, for example `beta`.
@@ -34,7 +34,7 @@ Developers must pair on releases, so do not publish on your own. You should crea
 
 1. Once you’ve merged the release pull request, open the **Actions** tab on the `alphagov/govuk-frontend` repo.
 
-2. Select the [RELEASE: npm publish workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/publish-to-npm.yaml) and run the workflow:
+2. Select the ["[Release] Publish package to npm" workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/publish-to-npm.yaml) and run the workflow:
    1. Set the **Use workflow from** select field to `main` or the `support/*` branch you're releasing from.
    2. Set the **Environment** select field to `production`.
    3. Select **Run workflow**.
@@ -51,7 +51,7 @@ Developers must pair on releases, so do not publish on your own. You should crea
 
 ## Create a release on GitHub
 
-1. Open the [RELEASE: GitHub release workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/publish-release-to-github.yaml) and run the workflow:
+1. Open the ["[Release] Publish to GitHub releases" workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/publish-release-to-github.yaml) and run the workflow:
    1. Set the **Use workflow from** select field to `main` or the `support/*` branch you're releasing from.
    2. Set the **Environment** select field to `production`.
    3. Select **Run workflow**.


### PR DESCRIPTION
Change from uppercaps to lowercase to lower intensity - tiny bit less stressful.

Re-word the labels so it's clearer what the difference between e.g. `Build release` and `GitHub release` is so it's clearer which steps are publishing and which are the initial review step.

| Before | After | 
| - | - |
| RELEASE: Build release | [Release] Build release for review |
| RELEASE: GitHub release | [Release] Publish to GitHub releases |
| RELEASE: npm publish | [Release] Publish package to npm |

Then for dynamic run-time labels, more consistency:

| Before | After | 
| - | - |
| RELEASE: Build release (major) | [Release] Build release for review (major)  |
| RELEASE: GitHub release to production | [Release] Publish to GitHub releases (production) |
| RELEASE: npm publish to production | [Release] Publish package to npm (production) |