### PR TITLE
Update organisation colours following July 2026 MoG changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ We've added the [Feedback component](https://design-system.service.gov.uk/compon
 
 This was added in [pull request #7232: Add Feedback component](https://github.com/alphagov/govuk-frontend/pull/7232).
 
+### Recommended changes
+
+#### Update references to deprecated organisation colours
+
+Following the July 2026 machinery of government changes, we've made the following updates to Frontend's list of organisation colours:
+
+- `department-for-science-innovation-technology` has been deprecated
+- `department-for-business-trade` has been renamed to `department-for-business-innovation-science-trade` and the previous name deprecated
+- `department-for-culture-media-sport` has been renamed to `department-for-digital-culture-media-sport` and the previous name deprecated
+
+Deprecated organisation names will be removed in a future major release of GOV.UK Frontend.
+
+We made this change in [pull request #7306: Update organisation colours following July 2026 MoG changes](https://github.com/alphagov/govuk-frontend/pull/7306)
+
 ## v6.4.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.4.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend-review/src/views/examples/organisation-colours/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/organisation-colours/index.njk
@@ -20,12 +20,12 @@
   "civil-service": {
     "name": "Civil Service"
   },
-  "department-for-business-trade": {
-    "name": "Department for Business and Trade",
+  "department-for-business-innovation-science-trade": {
+    "name": "Department for Business, Innovation, Science and Trade",
     "start": 2023
   },
-  "department-for-culture-media-sport": {
-    "name": "Department for Culture, Media and Sport",
+  "department-for-digital-culture-media-sport": {
+    "name": "Department for Digital, Culture, Media and Sport",
     "start": 1997
   },
   "department-for-education": {
@@ -39,10 +39,6 @@
   "department-for-environment-food-rural-affairs": {
     "name": "Department for Environment, Food and Rural Affairs",
     "start": 2001
-  },
-  "department-for-science-innovation-technology": {
-    "name": "Department for Science, Innovation and Technology",
-    "start": 2023
   },
   "department-for-transport": {
     "name": "Department for Transport",

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -29,11 +29,23 @@ $govuk-colours-organisations: (
   "civil-service": (
     colour: #b2292e
   ),
-  "department-for-business-trade": (
+  "department-for-business-innovation-science-trade": (
     colour: #e52d13,
     contrast-safe: #e02c13
   ),
+  "department-for-business-trade": (
+    colour: #e52d13,
+    contrast-safe: #e02c13,
+    deprecation-message:
+      "`department-for-business-trade` was renamed to `department-for-business-innovation-science-trade` in July 2026."
+  ),
   "department-for-culture-media-sport": (
+    colour: #ed1588,
+    contrast-safe: #d6177a,
+    deprecation-message:
+      "`department-for-culture-media-sport` was renamed to `department-for-digital-culture-media-sport` in July 2026."
+  ),
+  "department-for-digital-culture-media-sport": (
     colour: #ed1588,
     contrast-safe: #d6177a
   ),
@@ -49,7 +61,9 @@ $govuk-colours-organisations: (
   ),
   "department-for-science-innovation-technology": (
     colour: #00f8f8,
-    contrast-safe: #008180
+    contrast-safe: #008180,
+    deprecation-message:
+      "`department-for-science-innovation-technology` was dissolved in July 2026. It was split into `department-for-business-innovation-science-trade` and `department-for-digital-culture-media-sport`."
   ),
   "department-for-transport": (
     colour: #006853


### PR DESCRIPTION
Too soon? 🙃

Updates Frontend's list of organisations and brand colours following the 20th July 2026 machinery of government changes.

## Changes

- Updated our provided list of organisation brand colours: 
  - Deprecated `department-for-science-innovation-technology`.
  - Renamed `department-for-business-trade` to `department-for-business-innovation-science-trade` and deprecated the previous name.
  - Renamed `department-for-culture-media-sport` to `department-for-digital-culture-media-sport` and deprecated the previous name.
  - As far as I'm aware, neither of the renamed departments are changing brand colours. This is based on public facing DBIST and DCMS social media continuing to use the same colours with their new names. The HMG brand repository hasn't been updated for the MoG yet. 
- Updated example page in review app.