### PR TITLE
Drop "GOV.UK Frontend" from GitHub release titles

### DIFF
--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -94,7 +94,6 @@ jobs:
         if: inputs.environment == 'production'
         run: |
           GH_TAG=${{ steps.create-github-tag.outputs.GH_TAG }}
-          RELEASE_NAME="GOV.UK Frontend $GH_TAG"
           RELEASE_BODY=$(cat release-notes-body)
           ARCHIVE_FILE_PATH="${{steps.archive.outputs.ARCHIVE_FILE_PATH}}"
 
@@ -102,5 +101,5 @@ jobs:
             echo "::error::Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
             exit 1
           else
-            gh release create "$GH_TAG" "$ARCHIVE_FILE_PATH" --title "${RELEASE_NAME}" --notes "$RELEASE_BODY"
+            gh release create "$GH_TAG" "$ARCHIVE_FILE_PATH" --title "${GH_TAG}" --notes "$RELEASE_BODY"
           fi


### PR DESCRIPTION
A [recent change to the GitHub releases page][1] introduced a sidebar to make it easier to navigate between versions.

Unfortunately, because all of our release titles prefix the version number with "GOV.UK Frontend", the actual version number was being truncated, making the list useless.

<img width="218" height="258" alt="Releases page with list of releases in the sidebar, all truncated to just 'GOV.UK Frontend v…'" src="https://github.com/user-attachments/assets/7f1b51cc-9ce3-43a9-88fd-c825757243e7" />

We've already updated the names of existing releases to drop the prefix.

<img width="234" height="396" alt="Releases page with releases listed without the prefix" src="https://github.com/user-attachments/assets/52d95361-eb9c-4803-a9c4-7abfeb855212" />

Update the Release to GitHub workflow to just use the tag for the release title, thus dropping the prefix.

[1]: https://github.blog/changelog/2026-06-30-releases-sidebar-navigation-and-per-asset-download-counts/