### PR TITLE
Fix i18n expression warning

### DIFF
--- a/packages/govuk-frontend/src/govuk/i18n.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.jsdom.test.mjs
@@ -158,19 +158,6 @@ describe('I18n', () => {
         )
       })
 
-      it('nested placeholder only resolves with a matching key', () => {
-        const i18n = new I18n({
-          nameString: 'Their name is %{name%{age}}'
-        })
-        expect(
-          i18n.t('nameString', {
-            name: 'Andrew',
-            age: 55,
-            'name%{age}': 'Testing'
-          })
-        ).toBe('Their name is Testing')
-      })
-
       it('handles placeholder-style text within options values', () => {
         const i18n = new I18n(translations)
         expect(i18n.t('nameString', { name: '%{name}' })).toBe(

--- a/packages/govuk-frontend/src/govuk/i18n.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.jsdom.test.mjs
@@ -72,6 +72,17 @@ describe('I18n', () => {
         )
       })
 
+      it('throws an error if placeholder contains whitespace', () => {
+        expect(() => {
+          const i18n = new I18n({
+            person: '%{cat }'
+          })
+          i18n.t('person', { cat: 'Larry' })
+        }).toThrow(
+          'i18n: placeholder "%{cat }" has invalid key with whitespace'
+        )
+      })
+
       it('only matches %{} as a placeholder', () => {
         const i18n = new I18n({
           price: '%{name}, this } item %{ costs $5.00'

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -33,7 +33,7 @@ export class I18n {
    * @param {{ [key: string]: unknown }} [options] - Any options passed with the translation string, e.g: for string interpolation.
    * @returns {string} The appropriate translation string.
    * @throws {Error} Lookup key required
-   * @throws {Error} Options required for `${}` placeholders
+   * @throws {Error} Options required for `%{}` placeholders
    */
   t(lookupKey, options) {
     if (!lookupKey) {
@@ -58,7 +58,7 @@ export class I18n {
     }
 
     if (typeof translation === 'string') {
-      // Check for ${} placeholders in the translation string
+      // Check for %{} placeholders in the translation string
       // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
       if (translation.match(/%{(.\S+)}/)) {
         if (!options) {

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -59,8 +59,7 @@ export class I18n {
 
     if (typeof translation === 'string') {
       // Check for %{} placeholders in the translation string
-      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-      if (translation.match(/%{(\S+)}/)) {
+      if (/%{(\S+)}/.test(translation)) {
         if (!options) {
           throw new Error(
             'i18n: cannot replace placeholders in string if no option data provided'

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -60,7 +60,7 @@ export class I18n {
     if (typeof translation === 'string') {
       // Check for %{} placeholders in the translation string
       // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-      if (translation.match(/%{(.\S+)}/)) {
+      if (translation.match(/%{(\S+)}/)) {
         if (!options) {
           throw new Error(
             'i18n: cannot replace placeholders in string if no option data provided'
@@ -93,7 +93,7 @@ export class I18n {
       : undefined
 
     return translationString.replace(
-      /%{(.\S+)}/g,
+      /%{(\S+)}/g,
 
       /**
        * Replace translation string placeholders

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -9,6 +9,7 @@ import { isObject } from './common/index.mjs'
 export class I18n {
   translations
   locale
+  placeholderRegex
 
   /**
    * @internal
@@ -22,6 +23,14 @@ export class I18n {
 
     // The locale to use for PluralRules and NumberFormat
     this.locale = config.locale ?? (document.documentElement.lang || 'en')
+
+    /**
+     * Capture anything inside %{} but not if it contains a closing bracket }
+     * e.g "You have %{count} characters remaining" -> 'count'
+     * Set the regex to 'g' for global so it matches multiple placeholders
+     * e.g "You have %{count} characters remaining out of %{total}" -> 'count', 'total'
+     */
+    this.placeholderRegex = /%{([^}]+)}/g
   }
 
   /**
@@ -59,7 +68,7 @@ export class I18n {
 
     if (typeof translation === 'string') {
       // Check for %{} placeholders in the translation string
-      if (/%{(\S+)}/.test(translation)) {
+      if (this.placeholderRegex.test(translation)) {
         if (!options) {
           throw new Error(
             'i18n: cannot replace placeholders in string if no option data provided'
@@ -92,7 +101,7 @@ export class I18n {
       : undefined
 
     return translationString.replace(
-      /%{(\S+)}/g,
+      this.placeholderRegex,
 
       /**
        * Replace translation string placeholders
@@ -124,6 +133,13 @@ export class I18n {
           }
 
           return placeholderValue
+        }
+
+        // When a placeholder has whitespace, e.g. %{name }, throw a more useful error
+        if (/\s/.test(placeholderKey)) {
+          throw new Error(
+            `i18n: placeholder "${placeholderWithBraces}" has invalid key with whitespace`
+          )
         }
 
         throw new Error(


### PR DESCRIPTION
Continues the work at https://github.com/alphagov/govuk-frontend/pull/6350

The change in intention on the logic is to go from finding anything that isnt whitespace inside `%{}` to finding anything that isnt a trailing bracket `}` inside `%{}`.

We then add explicit tests for any whitespace within the placeholder and throw a more meaningful error.

In order to resolve the underlying issue by checking for a trailing bracket `}` we need to remove the test for nested placeholders, this doesnt seem to be functionality we actually want to support.