### PR TITLE
Standardise naming of `aria-label` params across components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ We've changed some of the Nunjucks parameters relating to `aria-label` attribute
 - Breadcrumbs: `labelText` has changed to `ariaLabel`
 - Pagination: `landmarkText` has changed to `ariaLabel`
 - Pagination: `item.visuallyHiddenText` has changed to `item.ariaLabel`
+- Password input: `showPasswordAriaLabelText` has changed to `showPasswordAriaLabel`
+- Password input: `hidePasswordAriaLabelText` has changed to `hidePasswordAriaLabel`
 
 Update any references to these parameters to use the new names. The old names have been deprecated and will be removed in the next major version of GOV.UK Frontend.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ We've changed some of the Nunjucks parameters relating to `aria-label` attribute
 - Pagination: `item.visuallyHiddenText` has changed to `item.ariaLabel`
 - Password input: `showPasswordAriaLabelText` has changed to `showPasswordAriaLabel`
 - Password input: `hidePasswordAriaLabelText` has changed to `hidePasswordAriaLabel`
+- Service navigation: `menuButtonLabel` has changed to `menuButtonAriaLabel`
+- Service navigation: `navigationLabel` has changed to `ariaLabel`
 
 Update any references to these parameters to use the new names. The old names have been deprecated and will be removed in the next major version of GOV.UK Frontend.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This was added in [pull request #7232: Add Feedback component](https://github.co
 
 We've changed some of the Nunjucks parameters relating to `aria-label` attributes so that they're named consistently across our components.
 
+- Breadcrumbs: `labelText` has changed to `ariaLabel`
 - Pagination: `landmarkText` has changed to `ariaLabel`
 - Pagination: `item.visuallyHiddenText` has changed to `item.ariaLabel`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ We've added the [Feedback component](https://design-system.service.gov.uk/compon
 
 This was added in [pull request #7232: Add Feedback component](https://github.com/alphagov/govuk-frontend/pull/7232).
 
+### Recommended changes
+
+#### Update the Nunjucks parameter name for ARIA labels
+
+We've changed some of the Nunjucks parameters relating to `aria-label` attributes so that they're named consistently across our components.
+
+- Pagination: `landmarkText` has changed to `ariaLabel`
+- Pagination: `item.visuallyHiddenText` has changed to `item.ariaLabel`
+
+Update any references to these parameters to use the new names. The old names have been deprecated and will be removed in the next major version of GOV.UK Frontend.
+
 ## v6.4.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.4.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This was added in [pull request #7232: Add Feedback component](https://github.co
 
 We've changed some of the Nunjucks parameters relating to `aria-label` attributes so that they're named consistently across our components.
 
+- Accordion: `showSectionAriaLabelText` has changed to `showSectionAriaLabel`
+- Accordion: `hideSectionAriaLabelText` has changed to `hideSectionAriaLabel`
 - Breadcrumbs: `labelText` has changed to `ariaLabel`
 - Pagination: `landmarkText` has changed to `ariaLabel`
 - Pagination: `item.visuallyHiddenText` has changed to `item.ariaLabel`

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
@@ -70,8 +70,8 @@ scenario: |
             value: values["password"],
             errorMessage: errors["password"],
             autocomplete: "new-password",
-            showPasswordAriaLabelText: "Show new password",
-            hidePasswordAriaLabelText: "Hide new password",
+            showPasswordAriaLabel: "Show new password",
+            hidePasswordAriaLabel: "Hide new password",
             passwordShownAnnouncementText: "New password is visible",
             passwordHiddenAnnouncementText: "New password is hidden"
           }) }}
@@ -85,8 +85,8 @@ scenario: |
             value: values["confirm-password"],
             errorMessage: errors["confirm-password"],
             autocomplete: "new-password",
-            showPasswordAriaLabelText: "Show confirmed password",
-            hidePasswordAriaLabelText: "Hide confirmed password",
+            showPasswordAriaLabel: "Show confirmed password",
+            hidePasswordAriaLabel: "Hide confirmed password",
             passwordShownAnnouncementText: "Confirmed password is visible",
             passwordHiddenAnnouncementText: "Confirmed password is hidden"
           }) }}

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -27,10 +27,14 @@ params:
     type: string
     required: false
     description: The text content of the 'Hide' button within each section of the accordion, which is visible when the section is expanded.
-  - name: hideSectionAriaLabelText
+  - name: hideSectionAriaLabel
     type: string
     required: false
     description: Text made available to assistive technologies, like screen-readers, as the final part of the toggle's accessible name when the section is expanded. Defaults to `"Hide this section"`.
+  - name: hideSectionAriaLabelText
+    type: string
+    required: false
+    description: Deprecated. Use `hideSectionAriaLabel` instead.
   - name: showAllSectionsText
     type: string
     required: false
@@ -39,10 +43,14 @@ params:
     type: string
     required: false
     description: The text content of the 'Show' button within each section of the accordion, which is visible when the section is collapsed.
-  - name: showSectionAriaLabelText
+  - name: showSectionAriaLabel
     type: string
     required: false
     description: Text made available to assistive technologies, like screen-readers, as the final part of the toggle's accessible name when the section is collapsed. Defaults to `"Show this section"`.
+  - name: showSectionAriaLabelText
+    type: string
+    required: false
+    description: Deprecated. Use `showSectionAriaLabel` instead.
   - name: items
     type: array
     required: true
@@ -290,8 +298,26 @@ examples:
       hideAllSectionsText: Collapse all sections
       showAllSectionsText: Expand all sections
       hideSectionText: Collapse
-      hideSectionAriaLabelText: Collapse this section
+      hideSectionAriaLabel: Collapse this section
       showSectionText: Expand
+      showSectionAriaLabel: Expand this section
+      items:
+        - heading:
+            text: Section A
+          content:
+            text: We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
+        - heading:
+            text: Section B
+          content:
+            html: |
+              <ul class="govuk-list govuk-list--bullet">
+                <li>Example item 2</li>
+              </ul>
+  - name: with deprecated aria-label parameters
+    hidden: true
+    options:
+      id: with-deprecations
+      hideSectionAriaLabelText: Collapse this section
       showSectionAriaLabelText: Expand this section
       items:
         - heading:

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.jsdom.test.js
@@ -152,6 +152,24 @@ describe('Accordion', () => {
       )
     })
 
+    it('renders with deprecated `aria-label` parameters', () => {
+      document.body.innerHTML = render(
+        'accordion',
+        examples['with deprecated aria-label parameters']
+      )
+      const $component = document.querySelector('.govuk-accordion')
+
+      expect($component).toHaveAttribute(
+        'data-i18n.hide-section-aria-label',
+        'Collapse this section'
+      )
+
+      expect($component).toHaveAttribute(
+        'data-i18n.show-section-aria-label',
+        'Expand this section'
+      )
+    })
+
     it('renders with remember expanded data attribute', () => {
       document.body.innerHTML = render(
         'accordion',

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.njk
@@ -41,7 +41,7 @@
 
   {{- govukI18nAttributes({
     key: 'hide-section-aria-label',
-    message: params.hideSectionAriaLabelText
+    message: params.hideSectionAriaLabel if params.hideSectionAriaLabel else params.hideSectionAriaLabelText
   }) -}}
 
   {{- govukI18nAttributes({
@@ -56,7 +56,7 @@
 
   {{- govukI18nAttributes({
     key: 'show-section-aria-label',
-    message: params.showSectionAriaLabelText
+    message: params.showSectionAriaLabel if params.showSectionAriaLabel else params.showSectionAriaLabelText
   }) -}}
 
   {%- if params.rememberExpanded !== undefined %} data-remember-expanded="{{ params.rememberExpanded | escape }}"{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -35,7 +35,11 @@ params:
   - name: labelText
     type: string
     required: false
-    description: Plain text label identifying the landmark to screen readers. Defaults to "Breadcrumb".
+    description: Accessible name identifying the landmark to screen readers. Defaults to "Breadcrumb".
+  - name: labelText
+    type: string
+    required: false
+    description: Deprecated. Use `ariaLabel` instead.
 
 examples:
   - name: default
@@ -135,6 +139,15 @@ examples:
         - html: <em>Section 2</em>
           href: /section-2
   - name: custom label
+    hidden: true
+    options:
+      ariaLabel: Briwsion bara
+      items:
+        - text: Hafan
+          href: '/'
+        - text: Sefydliadau
+          href: '/organisations'
+  - name: custom label (labelText)
     hidden: true
     options:
       labelText: Briwsion bara

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.jsdom.test.js
@@ -169,8 +169,18 @@ describe('Breadcrumbs', () => {
       expect($component).toHaveAttribute('data-foo', 'bar')
     })
 
-    it('renders with a custom aria-label', () => {
+    it('renders with a custom aria-label (`ariaLabel`)', () => {
       document.body.innerHTML = render('breadcrumbs', examples['custom label'])
+
+      const $component = document.querySelector('.govuk-breadcrumbs')
+      expect($component).toHaveAttribute('aria-label', 'Briwsion bara')
+    })
+
+    it('renders with a custom aria-label (`labelText`)', () => {
+      document.body.innerHTML = render(
+        'breadcrumbs',
+        examples['custom label (labelText)']
+      )
 
       const $component = document.querySelector('.govuk-breadcrumbs')
       expect($component).toHaveAttribute('aria-label', 'Briwsion bara')

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.njk
@@ -3,6 +3,8 @@
 {#- Set classes for this component #}
 {%- set classNames = "govuk-breadcrumbs" -%}
 
+{%- set ariaLabel = params.ariaLabel if params.ariaLabel else (params.labelText | default("Breadcrumb", true)) -%}
+
 {% if params.classes %}
   {% set classNames = classNames + " " + params.classes %}
 {% endif -%}
@@ -11,7 +13,8 @@
   {% set classNames = classNames + " govuk-breadcrumbs--collapse-on-mobile" %}
 {% endif -%}
 
-<nav class="{{ classNames }}" {{- govukAttributes(params.attributes) }} aria-label="{{ params.labelText | default("Breadcrumb") }}">
+
+<nav class="{{ classNames }}" {{- govukAttributes(params.attributes) }} aria-label="{{ ariaLabel }}">
   <ol class="govuk-breadcrumbs__list">
 {% for item in params.items %}
   {% if item.href %}

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -4,7 +4,7 @@
 {% set logoContent -%}
   {{ govukLogo({
     classes: "govuk-header__logotype",
-    ariaLabelText: "GOV.UK"
+    ariaLabel: "GOV.UK"
   }) | trim }}
   {% if (params.productName) -%}
     <span class="govuk-header__product-name">

--- a/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
+++ b/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
@@ -8,10 +8,14 @@ params:
         type: string
         required: false
         description: The pagination item text – usually a page number.  Required unless the item is an ellipsis.
-      - name: visuallyHiddenText
+      - name: ariaLabel
         type: string
         required: false
         description: The visually hidden label for the pagination item, which will be applied to an `aria-label` and announced by screen readers on the pagination item link. Should include page number. Defaults to, for example "Page 1".
+      - name: visuallyHiddenText
+        type: string
+        required: false
+        description: Deprecated. Use `ariaLabel` instead.
       - name: href
         type: string
         required: false
@@ -78,10 +82,14 @@ params:
         type: object
         required: false
         description: The HTML attributes (for example, data attributes) you want to add to the anchor.
+  - name: ariaLabel
+    type: string
+    required: false
+    description: The accessible name for the navigation landmark that wraps the pagination. Defaults to `"Pagination"`.
   - name: landmarkLabel
     type: string
     required: false
-    description: The label for the navigation landmark that wraps the pagination. Defaults to `"Pagination"`.
+    description: Deprecated. Use `ariaLabel` instead.
   - name: classes
     type: string
     required: false
@@ -249,6 +257,22 @@ examples:
         href: '/previous'
       next:
         href: '/next'
+      ariaLabel: 'search'
+      items:
+        - number: 1
+          href: '/page/1'
+        - number: 2
+          href: '/page/2'
+          current: true
+        - number: 3
+          href: '/page/3'
+  - name: with custom navigation landmark (landmarkLabel)
+    hidden: true
+    options:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
       landmarkLabel: 'search'
       items:
         - number: 1
@@ -259,6 +283,24 @@ examples:
         - number: 3
           href: '/page/3'
   - name: with custom accessible labels on item links
+    hidden: true
+    options:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
+      items:
+        - number: 1
+          href: '/page/1'
+          ariaLabel: '1st page'
+        - number: 2
+          href: '/page/2'
+          current: true
+          ariaLabel: '2nd page (you are currently on this page)'
+        - number: 3
+          href: '/page/3'
+          ariaLabel: '3rd page'
+  - name: with custom accessible labels on item links (visuallyHiddenText)
     hidden: true
     options:
       previous:

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -1,6 +1,7 @@
 {% from "../../macros/attributes.njk" import govukAttributes -%}
 
 {% set blockLevel = not params.items and (params.next or params.previous) -%}
+{% set ariaLabel = params.ariaLabel if params.ariaLabel else (params.landmarkLabel | default("Pagination", true)) -%}
 
 {%- set arrowPrevious -%}
   <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
@@ -41,7 +42,8 @@
   {% if item.ellipsis %}
     &ctdot;
   {% else %}
-    <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}"
+    {%- set itemAriaLabel = item.ariaLabel if item.ariaLabel else (item.visuallyHiddenText | default("Page " + item.number)) %}
+    <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ itemAriaLabel }}"
       {%- if item.current %} aria-current="page"{% endif %}
       {{- govukAttributes(item.attributes) }}>
       {{ item.number }}
@@ -50,7 +52,7 @@
   </li>
 {%- endmacro -%}
 
-<nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}"
+<nav class="govuk-pagination {%- if blockLevel %} govuk-pagination--block{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" aria-label="{{ ariaLabel }}"
   {{- govukAttributes(params.attributes) }}>
   {% set previous = params.previous %}
   {% set next = params.next %}

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
@@ -71,11 +71,21 @@ describe('Pagination', () => {
     })
   })
 
-  describe('with custom text, labels and landmarks', () => {
+  describe('with custom text, labels and landmarks (`ariaLabel`)', () => {
     it('renders a custom navigation landmark', () => {
       const $ = render(
         'pagination',
         examples['with custom navigation landmark']
+      )
+      const $nav = $('.govuk-pagination')
+
+      expect($nav.attr('aria-label')).toBe('search')
+    })
+
+    it('renders a custom navigation landmark (`landmarkLabel`)', () => {
+      const $ = render(
+        'pagination',
+        examples['with custom navigation landmark (landmarkLabel)']
       )
       const $nav = $('.govuk-pagination')
 
@@ -97,10 +107,34 @@ describe('Pagination', () => {
       expect($thirdNumber.text().trim()).toBe('three')
     })
 
-    it('renders custom accessible labels for pagination items', () => {
+    it('renders custom accessible labels for pagination items (`ariaLabel`)', () => {
       const $ = render(
         'pagination',
         examples['with custom accessible labels on item links']
+      )
+      const $firstNumber = $(
+        '.govuk-pagination__item:first-child .govuk-pagination__link'
+      )
+      const $secondNumber = $(
+        '.govuk-pagination__item:nth-child(2) .govuk-pagination__link'
+      )
+      const $thirdNumber = $(
+        '.govuk-pagination__item:last-child .govuk-pagination__link'
+      )
+
+      expect($firstNumber.attr('aria-label')).toBe('1st page')
+      expect($secondNumber.attr('aria-label')).toBe(
+        '2nd page (you are currently on this page)'
+      )
+      expect($thirdNumber.attr('aria-label')).toBe('3rd page')
+    })
+
+    it('renders custom accessible labels for pagination items (`visuallyHiddenText`)', () => {
+      const $ = render(
+        'pagination',
+        examples[
+          'with custom accessible labels on item links (visuallyHiddenText)'
+        ]
       )
       const $firstNumber = $(
         '.govuk-pagination__item:first-child .govuk-pagination__link'

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.yaml
@@ -96,8 +96,16 @@ params:
   - name: showPasswordAriaLabelText
     type: string
     required: false
-    description: Button text exposed to assistive technologies, like screen readers, when the password is hidden. Defaults to `"Show password"`.
+    description: Deprecated. Use `showPasswordAriaLabel` instead.
   - name: hidePasswordAriaLabelText
+    type: string
+    required: false
+    description: Deprecated. Use `hidePasswordAriaLabel` instead.
+  - name: showPasswordAriaLabel
+    type: string
+    required: false
+    description: Button text exposed to assistive technologies, like screen readers, when the password is hidden. Defaults to `"Show password"`.
+  - name: hidePasswordAriaLabel
     type: string
     required: false
     description: Button text exposed to assistive technologies, like screen readers, when the password is visible. Defaults to `"Hide password"`.
@@ -223,7 +231,16 @@ examples:
       name: password-translated
       showPasswordText: Datguddia
       hidePasswordText: Cuddio
-      showPasswordAriaLabelText: Datgelu cyfrinair
-      hidePasswordAriaLabelText: Cuddio cyfrinair
+      showPasswordAriaLabel: Datgelu cyfrinair
+      hidePasswordAriaLabel: Cuddio cyfrinair
       passwordShownAnnouncementText: Mae eich cyfrinair yn weladwy.
       passwordHiddenAnnouncementText: Mae eich cyfrinair wedi'i guddio.
+  - name: with deprecated aria-label parameters
+    hidden: true
+    options:
+      label:
+        text: Deprecated
+      id: password-deprecated
+      name: password-deprecated
+      showPasswordAriaLabelText: Reveal
+      hidePasswordAriaLabelText: Conceal

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.njk
@@ -21,12 +21,12 @@
 
   {{- govukI18nAttributes({
     key: 'show-password-aria-label',
-    message: params.showPasswordAriaLabelText
+    message: params.showPasswordAriaLabel if params.showPasswordAriaLabel else params.showPasswordAriaLabelText
   }) -}}
 
   {{- govukI18nAttributes({
     key: 'hide-password-aria-label',
-    message: params.hidePasswordAriaLabelText
+    message: params.hidePasswordAriaLabel if params.hidePasswordAriaLabel else params.hidePasswordAriaLabelText
   }) -}}
 
   {{- govukI18nAttributes({
@@ -52,7 +52,7 @@
   text: params.showPasswordText | default("Show"),
   attributes: {
     "aria-controls": id,
-    "aria-label": params.showPasswordAriaLabelText | default("Show password"),
+    "aria-label": params.showPasswordAriaLabel if params.showPasswordAriaLabel else (params.showPasswordAriaLabelText | default("Show password")),
     "hidden": {
       value: true,
       optional: true

--- a/packages/govuk-frontend/src/govuk/components/password-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/template.test.js
@@ -182,5 +182,20 @@ describe('Password input', () => {
         "Mae eich cyfrinair wedi'i guddio."
       )
     })
+
+    it('renders with deprecated `aria-label` parameters', () => {
+      const $ = render(
+        'password-input',
+        examples['with deprecated aria-label parameters']
+      )
+      const $component = $('[data-module]')
+
+      expect($component.attr('data-i18n.show-password-aria-label')).toBe(
+        'Reveal'
+      )
+      expect($component.attr('data-i18n.hide-password-aria-label')).toBe(
+        'Conceal'
+      )
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -15,14 +15,22 @@ params:
     type: string
     required: false
     description: The text of the mobile navigation menu toggle.
+  - name: menuButtonAriaLabel
+    type: string
+    required: false
+    description: The accessible name for the mobile navigation menu toggle. Assistive software will use the text of the button (`menuButtonText`) if an accessible name isn't specified.
   - name: menuButtonLabel
     type: string
     required: false
-    description: The screen reader label for the mobile navigation menu toggle. Defaults to the same value as `menuButtonText` if not specified.
+    description: Deprecated. Use `menuButtonAriaLabel` instead.
+  - name: ariaLabel
+    type: string
+    required: false
+    description: The accessible name for the navigation menu. Defaults to the same value as `menuButtonText` if not specified.
   - name: navigationLabel
     type: string
     required: false
-    description: The screen reader label for the mobile navigation menu. Defaults to the same value as `menuButtonText` if not specified.
+    description: Deprecated. Use `ariaLabel` instead.
   - name: navigationId
     type: string
     required: false
@@ -287,7 +295,7 @@ examples:
   - name: with custom navigation toggle label
     hidden: true
     options:
-      menuButtonLabel: Enter the NavZone
+      menuButtonAriaLabel: Enter the NavZone
       navigation:
         - href: '#/1'
           text: Navigation item 1
@@ -297,7 +305,7 @@ examples:
     hidden: true
     options:
       menuButtonText: Enter the NavZone
-      menuButtonLabel: Enter the NavZone
+      menuButtonAriaLabel: Enter the NavZone
       navigation:
         - href: '#/1'
           text: Navigation item 1
@@ -306,7 +314,7 @@ examples:
   - name: with custom navigation label
     hidden: true
     options:
-      navigationLabel: Main navigation
+      ariaLabel: Main navigation
       navigation:
         - href: '#/1'
           text: Navigation item 1
@@ -316,7 +324,7 @@ examples:
     hidden: true
     options:
       menuButtonText: Enter the NavZone
-      navigationLabel: The NavZone
+      ariaLabel: The NavZone
       navigation:
         - href: '#/1'
           text: Navigation item 1
@@ -386,3 +394,13 @@ examples:
         end: '<div>[end]</div>'
         navigationStart: '<li>[navigation start]</li>'
         navigationEnd: '<li>[navigation end]</li>'
+  - name: with deprecated aria-label parameters
+    hidden: true
+    options:
+      navigationLabel: Deprecated navigation
+      menuButtonLabel: Enter the deprecated NavZone
+      navigation:
+        - href: '#/1'
+          text: Navigation item 1
+        - href: '#/2'
+          text: Navigation item 2

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
@@ -35,9 +35,10 @@ data-module="govuk-service-navigation"
       {% set navigationItems = params.navigation | default([]) | select("truthy") %}
       {% set collapseNavigationOnMobile = params.collapseNavigationOnMobile | default(navigationItems.length > 1) %}
       {% if navigationItems | length or params.slots.navigationStart or params.slots.navigationEnd %}
-        <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-service-navigation__wrapper {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
+        <nav aria-label="{{ params.ariaLabel if params.ariaLabel else (params.navigationLabel | default(menuButtonText, true)) }}" class="govuk-service-navigation__wrapper {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
           {% if collapseNavigationOnMobile %}
-          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="{{ navigationId }}" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden aria-hidden="true">
+          {%- set menuButtonAriaLabel = params.menuButtonAriaLabel if params.menuButtonAriaLabel else params.menuButtonLabel %}
+          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="{{ navigationId }}" {%- if menuButtonAriaLabel and menuButtonAriaLabel != menuButtonText %} aria-label="{{ menuButtonAriaLabel }}"{% endif %} hidden aria-hidden="true">
             {{ menuButtonText }}
           </button>
           {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
@@ -160,6 +160,22 @@ describe('Service Navigation', () => {
         expect(navId).toBe('main-nav')
         expect($navToggle.attr('aria-controls')).toBe(navId)
       })
+
+      it('renders deprecated `aria-label` parameters', () => {
+        const $ = render(
+          'service-navigation',
+          examples['with deprecated aria-label parameters']
+        )
+        const $component = $('.govuk-service-navigation')
+
+        const $nav = $component.find('nav.govuk-service-navigation__wrapper')
+        const $navToggle = $component.find('.govuk-service-navigation__toggle')
+
+        expect($nav.attr('aria-label')).toBe('Deprecated navigation')
+        expect($navToggle.attr('aria-label')).toBe(
+          'Enter the deprecated NavZone'
+        )
+      })
     })
 
     describe('toggle button', () => {

--- a/packages/govuk-frontend/src/govuk/macros/logo.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/macros/logo.jsdom.test.js
@@ -72,7 +72,7 @@ describe('logo.njk', () => {
       expect($svg.classList).toContain('app-logo--custom-modifier')
     })
 
-    describe('if `ariaLabelText` is set', () => {
+    describe('if `ariaLabel` is set', () => {
       let $svg
 
       beforeAll(() => {
@@ -81,7 +81,7 @@ describe('logo.njk', () => {
           './govuk/macros/logo.njk',
           {
             context: {
-              ariaLabelText: 'test string'
+              ariaLabel: 'test string'
             }
           }
         )

--- a/packages/govuk-frontend/src/govuk/macros/logo.njk
+++ b/packages/govuk-frontend/src/govuk/macros/logo.njk
@@ -36,7 +36,7 @@ releases of Frontend. #}
   the keyboard to navigate. #}
   <svg
     focusable="false"
-    role="{{ "img" if params.ariaLabelText else "presentation" }}"
+    role="{{ "img" if params.ariaLabel else "presentation" }}"
     xmlns="http://www.w3.org/2000/svg"
     {#- The viewbox is 2x the actual display dimensions #}
     viewBox="0 0 {{ svgWidth * 2 }} 60"
@@ -44,10 +44,10 @@ releases of Frontend. #}
     width="{{ svgWidth }}"
     fill="currentcolor"
     {%- if params.classes %} class="{{ params.classes }}"{% endif %}
-    {%- if params.ariaLabelText %} aria-label="{{ params.ariaLabelText }}"{% endif %}
+    {%- if params.ariaLabel %} aria-label="{{ params.ariaLabel }}"{% endif %}
     {{- govukAttributes(params.attributes) }}
   >
-    {%- if params.ariaLabelText %}<title>{{ params.ariaLabelText }}</title>{% endif %}
+    {%- if params.ariaLabel %}<title>{{ params.ariaLabel }}</title>{% endif %}
     {{ _tudorCrown | safe | trim | indent(2) }}
     {% if useLogotype %}
       {{ _logotype | safe | trim | indent(2) }}


### PR DESCRIPTION
Standardises how Nunjucks parameters relating to `aria-label` attributes are named across components.

A bit of unsexy consistency busywork to resolve #5277.

## Changes
- Updated templates, fixtures, parameter docs, tests, and examples for the following components and parameters:
	- Accordion: `showSectionAriaLabelText` → `showSectionAriaLabel`
	- Accordion: `hideSectionAriaLabelText` → `hideSectionAriaLabel`
	- Breadcrumbs: `labelText` → `ariaLabel`
	- Pagination: `landmarkText` → `ariaLabel`
	- Pagination: `item.visuallyHiddenText` → `item.ariaLabel`
	- Password input: `showPasswordAriaLabelText` → `showPasswordAriaLabel`
	- Password input: `hidePasswordAriaLabelText` → `hidePasswordAriaLabel`
	- Service navigation: `menuButtonLabel` → `menuButtonAriaLabel`
	- Service navigation: `navigationLabel` → `ariaLabel`
- Updated the internal logo macro and places where it's referenced: `ariaLabelText` → `ariaLabel`. 

## Thoughts
The Cookie banner component already named this parameters as `ariaLabel`, so have been unchanged.

It could be argued that naming them simply `ariaLabel` may lack flexibility for future changes, but I think it's likely to be fine. We already have established examples in places where we need multiple multiple labels, where they're disambiguated according to use (as in Accordion and Password input) or by hierarchy (as in Pagination). 

I'm additionally comfortable with the `ariaLabel` naming because other parameters that directly manipulate ARIA attributes follow a similar convention (`describedBy` for `aria-describedby`, `current` for `aria-current`). The prefixing of `aria` feels appropriate for avoiding confusion with HTML `<label>` elements and other small runs of text, which are referred to using the term `label` throughout Frontend's code. 