### PR TITLE
Reinstate support for colour keywords

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -154,7 +154,7 @@
     @return $colour-reference;
   }
 
-  @if not(meta.type-of($colour-reference) == "map") {
+  @if meta.type-of($colour-reference) != "map" {
     @error 'Colour reference should be a Sass colour or a Sass map';
   }
 

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -154,7 +154,7 @@
     @return $colour-reference;
   }
 
-  @if not meta.type-of($colour-reference) == "map" {
+  @if not(meta.type-of($colour-reference) == "map") {
     @error 'Colour reference should be a Sass colour or a Sass map';
   }
 

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -149,13 +149,18 @@
 /// @throws if the `variant` is present but falsy
 /// @access public
 @function govuk-resolve-colour($colour-reference) {
-  // If the reference is already a colour, return the colour
-  @if meta.type-of($colour-reference) == "color" {
+  $colour-keywords: (currentcolor, inherit, initial, revert, revert-layer, unset);
+
+  // If the reference is already a valid colour value, return the value
+  @if meta.type-of($colour-reference) ==
+    "color" or
+    (meta.type-of($colour-reference) == "string" and list.index($colour-keywords, $colour-reference))
+  {
     @return $colour-reference;
   }
 
   @if meta.type-of($colour-reference) != "map" {
-    @error 'Colour reference should be a Sass colour or a Sass map';
+    @error 'Colour reference should be a colour value or a Sass map';
   }
 
   $name: map.get($colour-reference, "name");

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -451,6 +451,26 @@ describe('@function govuk-resolve-colour', () => {
     })
   })
 
+  describe('when called with a colour keyword', () => {
+    it('returns the keyword as-is', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour(inherit);
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: outdent`
+        .foo {
+          color: inherit;
+        }
+      `
+      })
+    })
+  })
+
   describe('when called with a map referring to the palette', () => {
     it('returns the hex representation of the colour', async () => {
       const sass = `

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -422,6 +422,56 @@ describe('@function govuk-functional-colour', () => {
   })
 })
 
+describe('@function govuk-resolve-colour', () => {
+  let sassBootstrap = ''
+
+  beforeEach(() => {
+    sassBootstrap = `
+      @use "helpers/colour" as *;
+    `
+  })
+
+  describe('when called with a colour', () => {
+    it('returns the colour as-is', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour(blue);
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: outdent`
+        .foo {
+          color: blue;
+        }
+      `
+      })
+    })
+  })
+
+  describe('when called with a map referring to the palette', () => {
+    it('returns the hex representation of the colour', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour((name: 'white'));
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: outdent`
+        .foo {
+          color: #ffffff;
+        }
+      `
+      })
+    })
+  })
+})
+
 describe('@function govuk-organisation-colour', () => {
   const sassBootstrap = `
     @use "settings" with (


### PR DESCRIPTION
(Allows the use of certain CSS keywords (that are valid for colours) to be used in addition to Sass colours.)

It can be useful to override colours to be `inherit` rather than a specific colour. This allows for some colours to be configured at run-time, rather than at build time. (For example setting a test colour on the `body` and then have that cascade down into the components.)

In the past, this could be achieved with code such as the following:
```scss
$govuk-text-colour: inherit;
```

In v6 the natural way to do this would be:
```scss
$govuk-functional-colours: (
  text: inherit
);
```

However, doing this generates a build error:
```
Error: [sass] Error: $map: inherit is not a map.                                                                                                         
    ╷                                                                                                                                                    
161 │   $name: map.get($colour-reference, "name");                                                                                                       
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
node_modules/govuk-frontend@6.4.0/dist/govuk/helpers/_colour.scss 161:10                     govuk-resolve-colour()
```

i.e. The `govuk-resolve-colour` function tries to treat the value as if it is a map.

Interestingly, there appears to be a faulty guard, earlier in the function, on line 157:
```scss
  @if not meta.type-of($colour-reference) == "map" {
    @error 'Colour reference should be a Sass colour or a Sass map';
  }
```

I don't think this guard can work due to operator precedence, with the `not` operator binding more tightly than `==`. It can be fixed with parentheses:
```scss
  @if not (meta.type-of($colour-reference) == "map") {
```
Or even as:
```scss
  @if meta.type-of($colour-reference) != "map" {
```

Fix the guard gives a clearer error message:
```
Error: "Colour reference should be a colour value or a Sass map"                                                                           
    ╷                                                                                                                                                    
136 │     $value: govuk-resolve-colour(map.get($govuk-functional-colours, $colour));                                                                     
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                      
    ╵                                                                                                                                                    
node_modules/govuk-frontend@6.4.0/dist/govuk/helpers/_colour.scss 136:13                     govuk-functional-colour()
```

It seems that there are no unit tests for for the `govuk-resolve-colour` function, so first I've added a couple of tests for the existing functionality. (Sass colours, and maps referencing the pallette.) Running the test suite with the new tests are green.

Then a new test case (for `inherit`) was added, which fails.

Finally one of the `if` clauses within the implementation was expanded to catch certain CSS keywords (including `inherit`) alongside the Sass colours. (Which are then simply returned as-is.) This leads to the entire test suite going green again.