### PR TITLE
Spike using at-supports for focus

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_mixin.scss
@@ -85,17 +85,19 @@
       top: $button-shadow-size;
     }
 
-    &:focus {
-      border-color: base.govuk-functional-colour(focus);
-      outline: base.$govuk-focus-width solid transparent;
-      box-shadow: inset 0 0 0 1px base.govuk-functional-colour(focus);
-    }
+    @include base.govuk-supports(govuk-functional-colour) {
+      &:focus {
+        border-color: base.govuk-functional-colour(focus);
+        outline: base.$govuk-focus-width solid transparent;
+        box-shadow: inset 0 0 0 1px base.govuk-functional-colour(focus);
+      }
 
-    &:focus:not(:active):not(:hover) {
-      border-color: base.govuk-functional-colour(focus);
-      color: base.govuk-functional-colour(focus-text);
-      background-color: base.govuk-functional-colour(focus);
-      box-shadow: 0 2px 0 base.govuk-functional-colour(focus-text);
+      &:focus:not(:active):not(:hover) {
+        border-color: base.govuk-functional-colour(focus);
+        color: base.govuk-functional-colour(focus-text);
+        background-color: base.govuk-functional-colour(focus);
+        box-shadow: 0 2px 0 base.govuk-functional-colour(focus-text);
+      }
     }
 
     // Use a pseudo element to expand the click target area to include the

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_mixin.scss
@@ -104,20 +104,22 @@
   .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
     border-width: 4px;
 
-    // When colours are overridden, the yellow box-shadow becomes invisible
-    // which means the focus state is less obvious. By adding a transparent
-    // outline, which becomes solid (text-coloured) in that context, we ensure
-    // the focus remains clearly visible.
-    outline: base.$govuk-focus-width solid transparent;
-    outline-offset: 1px;
+    @include base.govuk-supports(govuk-functional-colour) {
+      // When colours are overridden, the yellow box-shadow becomes invisible
+      // which means the focus state is less obvious. By adding a transparent
+      // outline, which becomes solid (text-coloured) in that context, we ensure
+      // the focus remains clearly visible.
+      outline: base.$govuk-focus-width solid transparent;
+      outline-offset: 1px;
 
-    // When in an explicit forced-color mode, we can use the Highlight system
-    // color for the outline to better match focus states of native controls
-    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-      outline-color: Highlight;
+      // When in an explicit forced-color mode, we can use the Highlight system
+      // color for the outline to better match focus states of native controls
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        outline-color: Highlight;
+      }
+
+      box-shadow: 0 0 0 base.$govuk-focus-width base.govuk-functional-colour(focus);
     }
-
-    box-shadow: 0 0 0 base.$govuk-focus-width base.govuk-functional-colour(focus);
   }
 
   // Selected state

--- a/packages/govuk-frontend/src/govuk/components/error-summary/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/_mixin.scss
@@ -11,9 +11,11 @@
     border-color: base.govuk-functional-colour(error);
     color: base.govuk-functional-colour(text);
 
-    &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+    @include base.govuk-supports(govuk-functional-colour) {
+      &:focus {
+        outline: base.$govuk-focus-width solid;
+        outline-color: base.govuk-functional-colour(focus);
+      }
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_mixin.scss
@@ -26,25 +26,27 @@
       -webkit-appearance: button;
     }
 
-    &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
-      // Use `box-shadow` to add border instead of changing `border-width`
-      // (which changes element size) and since `outline` is already used for
-      // the yellow focus state.
-      box-shadow: inset 0 0 0 4px base.govuk-functional-colour(input-border);
-    }
+    @include base.govuk-supports(govuk-functional-colour) {
+      &:focus {
+        outline: base.$govuk-focus-width solid;
+        outline-color: base.govuk-functional-colour(focus);
+        // Use `box-shadow` to add border instead of changing `border-width`
+        // (which changes element size) and since `outline` is already used for
+        // the yellow focus state.
+        box-shadow: inset 0 0 0 4px base.govuk-functional-colour(input-border);
+      }
 
-    // Set "focus-within" to fix https://bugzil.la/1430196 so that component
-    // receives focus in Firefox.
-    // This can't be set together with `:focus` as all versions of IE fail
-    // to recognise `focus-within` and don't set any styles from the block
-    // when it's a selector.
-    &:focus-within {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+      // Set "focus-within" to fix https://bugzil.la/1430196 so that component
+      // receives focus in Firefox.
+      // This can't be set together with `:focus` as all versions of IE fail
+      // to recognise `focus-within` and don't set any styles from the block
+      // when it's a selector.
+      &:focus-within {
+        outline: base.$govuk-focus-width solid;
+        outline-color: base.govuk-functional-colour(focus);
 
-      box-shadow: inset 0 0 0 4px base.govuk-functional-colour(input-border);
+        box-shadow: inset 0 0 0 4px base.govuk-functional-colour(input-border);
+      }
     }
 
     &:disabled {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_mixin.scss
@@ -14,9 +14,11 @@
     border: base.$govuk-border-width solid;
     border-color: var(--_govuk-notification-banner-colour);
 
-    &:focus {
-      outline: base.$govuk-focus-width solid;
-      outline-color: base.govuk-functional-colour(focus);
+    @include base.govuk-supports(govuk-functional-colour) {
+      &:focus {
+        outline: base.$govuk-focus-width solid;
+        outline-color: base.govuk-functional-colour(focus);
+      }
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_mixin.scss
@@ -108,20 +108,22 @@
   .govuk-radios__input:focus + .govuk-radios__label::before {
     border-width: 4px;
 
-    // When colours are overridden, the yellow box-shadow becomes invisible
-    // which means the focus state is less obvious. By adding a transparent
-    // outline, which becomes solid (text-coloured) in that context, we ensure
-    // the focus remains clearly visible.
-    outline: base.$govuk-focus-width solid transparent;
-    outline-offset: 1px;
+    @include base.govuk-supports(govuk-functional-colour) {
+      // When colours are overridden, the yellow box-shadow becomes invisible
+      // which means the focus state is less obvious. By adding a transparent
+      // outline, which becomes solid (text-coloured) in that context, we ensure
+      // the focus remains clearly visible.
+      outline: base.$govuk-focus-width solid transparent;
+      outline-offset: 1px;
 
-    // When in an explicit forced-color mode, we can use the Highlight system
-    // color for the outline to better match focus states of native controls
-    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-      outline-color: Highlight;
+      // When in an explicit forced-color mode, we can use the Highlight system
+      // color for the outline to better match focus states of native controls
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        outline-color: Highlight;
+      }
+
+      box-shadow: 0 0 0 $govuk-radios-focus-width base.govuk-functional-colour(focus);
     }
-
-    box-shadow: 0 0 0 $govuk-radios-focus-width base.govuk-functional-colour(focus);
   }
 
   // Selected state

--- a/packages/govuk-frontend/src/govuk/helpers/_focused.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_focused.scss
@@ -4,6 +4,7 @@
 
 @use "../settings/measurements" as *;
 @use "colour" as *;
+@use "supports" as *;
 
 /// Focused text
 ///
@@ -18,19 +19,21 @@
 /// @access public
 
 @mixin govuk-focused-text {
-  // When colours are overridden, for example when users have a dark mode,
-  // backgrounds and box-shadows disappear, so we need to ensure there's a
-  // transparent outline which will be set to a visible colour.
+  @include govuk-supports(govuk-functional-colour) {
+    // When colours are overridden, for example when users have a dark mode,
+    // backgrounds and box-shadows disappear, so we need to ensure there's a
+    // transparent outline which will be set to a visible colour.
 
-  outline: $govuk-focus-width solid transparent;
-  color: govuk-functional-colour(focus-text);
-  background-color: govuk-functional-colour(focus);
-  box-shadow:
-    0 -2px govuk-functional-colour(focus),
-    0 4px govuk-functional-colour(focus-text);
-  // When link is focussed, hide the default underline since the
-  // box shadow adds the "underline"
-  text-decoration: none;
+    outline: $govuk-focus-width solid transparent;
+    color: govuk-functional-colour(focus-text);
+    background-color: govuk-functional-colour(focus);
+    box-shadow:
+      0 -2px govuk-functional-colour(focus),
+      0 4px govuk-functional-colour(focus-text);
+    // When link is focussed, hide the default underline since the
+    // box shadow adds the "underline"
+    text-decoration: none;
+  }
 
   // Fixes an issue in Chromium 108–111 where the box-shadow on the focus state
   // is missing on links that wrap across multiple lines [1].
@@ -62,10 +65,12 @@
 /// @access public
 
 @mixin govuk-focused-box {
-  outline: $govuk-focus-width solid transparent;
-  box-shadow:
-    0 0 0 4px govuk-functional-colour(focus),
-    0 0 0 8px govuk-functional-colour(focus-text);
+  @include govuk-supports(govuk-functional-colour) {
+    outline: $govuk-focus-width solid transparent;
+    box-shadow:
+      0 0 0 4px govuk-functional-colour(focus),
+      0 0 0 8px govuk-functional-colour(focus-text);
+  }
 }
 
 /// Focused form input
@@ -81,14 +86,16 @@
 /// @access public
 
 @mixin govuk-focused-form-input {
-  outline: $govuk-focus-width solid;
-  outline-color: govuk-functional-colour(focus);
-  // Ensure outline appears outside of the element
-  outline-offset: 0;
-  // Double the border by adding its width again. Use `box-shadow` for this
-  // instead of changing `border-width` - this is for consistency with
-  // components such as textarea where we avoid changing `border-width` as
-  // it will change the element size. Also, `outline` cannot be utilised
-  // here as it is already used for the yellow focus state.
-  box-shadow: inset 0 0 0 $govuk-border-width-form-element govuk-functional-colour(input-border);
+  @include govuk-supports(govuk-functional-colour) {
+    outline: $govuk-focus-width solid;
+    outline-color: govuk-functional-colour(focus);
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+    // Double the border by adding its width again. Use `box-shadow` for this
+    // instead of changing `border-width` - this is for consistency with
+    // components such as textarea where we avoid changing `border-width` as
+    // it will change the element size. Also, `outline` cannot be utilised
+    // here as it is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element govuk-functional-colour(input-border);
+  }
 }

--- a/packages/govuk-frontend/src/govuk/helpers/_index.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_index.scss
@@ -7,6 +7,7 @@
 @forward "media-queries";
 @forward "shape-arrow";
 @forward "spacing";
+@forward "supports";
 @forward "typography";
 @forward "visually-hidden";
 @forward "width-container";

--- a/packages/govuk-frontend/src/govuk/helpers/_supports.import.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_supports.import.scss
@@ -1,0 +1,1 @@
+@forward "supports";

--- a/packages/govuk-frontend/src/govuk/helpers/_supports.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_supports.scss
@@ -1,0 +1,24 @@
+/// Supports
+///
+/// Wrap code with @supports guard applicable to different features.
+///
+/// @example scss - Styling the focus state for a link
+///   .app-link:focus {
+///     @include govuk-supports(govuk-functional-colour) {
+///       outline: 1px solid transparent;
+///     }
+///   }
+///
+/// @access public
+
+@mixin govuk-supports($supports...) {
+  @each $support in $supports {
+    @if $support == govuk-functional-colour {
+      @supports (color: var(--css-custom-property)) {
+        @content;
+      }
+    } @else {
+      @error "Checking for support of '" + $support "' is not... supported";
+    }
+  }
+}


### PR DESCRIPTION
Another spike to try to resolve https://github.com/alphagov/govuk-frontend/issues/7294 that is a different approach than https://github.com/alphagov/govuk-frontend/pull/7304

With this approach since the focuses are not styled at all they fall back to user agent which is then a WCAG pass:
<img width="218" height="83" alt="Screenshot of IE11 with user agent dotted outline styling" src="https://github.com/user-attachments/assets/54ea6164-88bb-432e-bd0d-43f9e086eefc" />
