### PR TITLE
Add no-underline class to language navigation

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -41,6 +41,12 @@
     @include base.govuk-link-style-default;
   }
 
+  // Use when placed alongside other links without underlines, for example
+  // within the service navigation
+  .govuk-language-navigation--no-underline .govuk-language-navigation__link {
+    @include base.govuk-link-style-no-underline;
+  }
+
   .govuk-language-navigation--inverse {
     color: base.govuk-colour("white");
 

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -396,7 +396,7 @@ examples:
           text: Navigation item 3
       slots:
         end: |-
-          <nav class="govuk-language-navigation" aria-label="Language navigation">
+          <nav class="govuk-language-navigation govuk-language-navigation--no-underline" aria-label="Language navigation">
             <ul class="govuk-language-navigation__list">
               <li class="govuk-language-navigation__list-item">
                 <span class="govuk-language-navigation__text" lang="en" aria-current="true">English</span>
@@ -420,7 +420,7 @@ examples:
           text: Navigation item 3
       slots:
         end: |-
-          <nav class="govuk-language-navigation" aria-label="Language navigation">
+          <nav class="govuk-language-navigation govuk-language-navigation--no-underline" aria-label="Language navigation">
             <ul class="govuk-language-navigation__list">
               <li class="govuk-language-navigation__list-item">
                 <span class="govuk-language-navigation__text" lang="en" aria-current="true">English</span>
@@ -451,7 +451,7 @@ examples:
           text: Navigation item 4
       slots:
         end: |-
-          <nav class="govuk-language-navigation govuk-language-navigation--inverse" aria-label="Language navigation">
+          <nav class="govuk-language-navigation govuk-language-navigation--inverse govuk-language-navigation--no-underline" aria-label="Language navigation">
             <ul class="govuk-language-navigation__list">
               <li class="govuk-language-navigation__list-item">
                 <span class="govuk-language-navigation__text" lang="en" aria-current="true">English</span>


### PR DESCRIPTION
This allows for matching non-underlined links, eg: in the service navigation component.

At the moment, this causes problems on inverse backgrounds:

<img width="178" height="59" alt="A link and some text with the exact same styles" src="https://github.com/user-attachments/assets/e8880548-3b66-4bc8-917e-9b41a9db4c63" />
