### PR TITLE
Add full page examples of the Language navigation

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation-inline/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation-inline/index.njk
@@ -1,0 +1,99 @@
+---
+title: Companies you follow
+name: Language navigation (in Service navigation)
+scenario: |
+  You are a user logged into Companies House WebFiling service, looking at a
+  list of companies you are following.
+notes: Based on Companies House "Find an update company information" service
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block govukHeader %}
+  {{ govukHeader({
+    classes: "govuk-header--full-width-border"
+  }) }}
+{% endblock %}
+
+{% set languageNavigationHtml -%}
+  {{ govukLanguageNavigation({
+    items: [
+      {
+        text: "English",
+        lang: "en",
+        href: "#",
+        current: true
+      },
+      {
+        text: "Cymraeg",
+        lang: "cy",
+        href: "#"
+      }
+    ]
+  }) }}
+{%- endset %}
+
+{% block govukServiceNavigation %}
+  {{ govukServiceNavigation({
+    classes: "app-service-navigation",
+    serviceName: "Find company information",
+    serviceUrl: "#0",
+    navigation: [
+      {
+        href: '#1',
+        text: 'Search the register'
+      },
+      {
+        href: '#2',
+        text: 'Your details'
+      },
+      {
+        href: '#3',
+        text: 'Your filings'
+      },
+      {
+        href: '#4',
+        text: 'Companies you follow',
+        current: true
+      }
+    ],
+    slots: {
+      end: languageNavigationHtml
+    }
+  }) }}
+{% endblock %}
+
+{% block headerEnd %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Alpha"
+    },
+    html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
+  }) }}
+{% endblock %}
+
+{% block containerStart %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "#0"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">Companies you follow</h1>
+  <p class="govuk-body">You are not following any companies.</p>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation/index.njk
@@ -1,0 +1,91 @@
+---
+title: Companies you follow
+name: Language navigation (in Service navigation, inline)
+scenario: |
+  You are a user logged into Companies House WebFiling service, looking at a
+  list of companies you are following.
+notes: Based on Companies House "Find an update company information" service
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block govukHeader %}
+  {{ govukHeader({
+    classes: "govuk-header--full-width-border"
+  }) }}
+{% endblock %}
+
+{% set languageNavigationHtml -%}
+  {{ govukLanguageNavigation({
+    items: [
+      {
+        text: "English",
+        lang: "en",
+        href: "#",
+        current: true
+      },
+      {
+        text: "Cymraeg",
+        lang: "cy",
+        href: "#"
+      }
+    ]
+  }) }}
+{%- endset %}
+
+{% block govukServiceNavigation %}
+  {{ govukServiceNavigation({
+    classes: "app-service-navigation",
+    serviceName: "Find company information",
+    serviceUrl: "#0",
+    navigation: [
+      {
+        href: '#1',
+        text: 'Search the register'
+      },
+      {
+        href: '#2',
+        text: 'Your details'
+      }
+    ],
+    slots: {
+      end: languageNavigationHtml,
+      endRightAligned: true
+    }
+  }) }}
+{% endblock %}
+
+{% block headerEnd %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Alpha"
+    },
+    html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
+  }) }}
+{% endblock %}
+
+{% block containerStart %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "#0"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">Companies you follow</h1>
+  <p class="govuk-body">You are not following any companies.</p>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-sidebar/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-sidebar/index.njk
@@ -1,0 +1,256 @@
+---
+title: Entry requirements - Narnia travel advice (Language navigation in sidebar)
+name: Language navigation (in sidebar)
+scenario: You want to read guidance about the entry requirements for travelling to Narnia.
+notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requirements
+---
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block containerStart %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Passports, travel and living abroad",
+        href: "#/browse/abroad"
+      },
+      {
+        text: "Travel abroad",
+        href: "#/browse/abroad/travel-abroad"
+      },
+      {
+        text: "Foreign travel advice",
+        href: "#/foreign-travel-advice"
+      }
+    ]
+  }) }}
+{% endblock %}
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <div class="govuk-!-margin-bottom-8">
+      <span class="govuk-caption-xl">Foreign travel advice</span>
+      <h1 class="govuk-heading-xl">Narnia entry requirements</h1>
+    </div>
+
+    <aside class="govuk-!-padding-bottom-3">
+      <nav aria-label="Travel advice pages">
+        <h2 class="govuk-heading-s">Contents</h2>
+        <ol class="govuk-list govuk-list--bullet govuk-!-font-size-16">
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia">Summary</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/safety-and-security">Safety and security</a></li>
+          <li aria-current="true">Entry requirements</li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/time-dilation">Time dilation</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/archenland-travel">Archenland travel</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/travel-advice-help-support">Travel advice help and support</a></li>
+        </ol>
+      </nav>
+    </aside>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+
+  </div>
+  <div class="govuk-grid-column-one-third-from-desktop">
+    {{ govukLanguageNavigation({
+        items: [
+          {
+            text: "English",
+            lang: "en",
+            href: "#",
+            current: true
+          },
+          {
+            text: "Cymraeg",
+            lang: "cy",
+            href: "#"
+          }
+        ]
+      }) }}
+  </div>
+
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <p class="govuk-body">This page reflects the UK government’s understanding of current rules for people travelling on a full ‘British Citizen’ passport from the UK, for the most common types of travel.</p>
+    <p class="govuk-body">Aslan the Great Lion sets and enforces entry rules. If you’re unsure how Narnia’s entry requirements apply to you, contact <a href="#" class="govuk-link">Narnia’s Embassy in the UK</a>, located in your nearest wardrobe.</p>
+
+    <h2 class="govuk-heading-m" id="children-and-young-people">Children and young people</h2>
+    <p class="govuk-body">There are no specific entry requirements for children and young people.</p>
+
+    <h2 class="govuk-heading-m" id="transiting">If you're transiting through Narnia</h2>
+    <p class="govuk-body">Transiting is when you pass through one country on the way to your final destination.</p>
+    <p class="govuk-body">Check with your wardobe manufacturer before departing.</p>
+
+    <h2 class="govuk-heading-m" id="exemptions">Exemptions</h2>
+    <p class="govuk-body">There are no exemptions to Narnia’s entry requirements.</p>
+
+    <h2 class="govuk-heading-m" id="travel-documents">Check your passport and travel documents before you travel</h2>
+
+    <h3 class="govuk-heading-s" id="passport-validity">Passport validity</h3>
+    <p class="govuk-body">If you are planning to travel to a fantasy country (except Middle Earth), you must follow the <a href="#" class="govuk-link">Phantasia area passport requirements</a>.</p>
+    <p class="govuk-body">Your passport must be:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>issued less than 10 years before the date you enter the country (check the ‘date of issue’)</li>
+      <li>valid for at least 3 months after the day you plan to leave (check the ‘expiry date’), accounting for time dilation</li>
+    </ul>
+    <p class="govuk-body">You must check your passport meets these requirements before you travel. If your passport was issued before 1 October 2018, extra months may have been added to its expiry date.</p>
+    <p class="govuk-body">Contact <a href="#" class="govuk-link">Narnia's Embassy in the UK</a> if you think that your passport does not meet both these requirements. <a href="#" class="govuk-link">Renew your passport if you need to</a>.</p>
+
+    <h3 class="govuk-heading-s" id="visas">Visas</h3>
+    <p class="govuk-body">You can travel to countries in the  <a href="#" class="govuk-link">Phantasia area</a> for up to 90 days in any 180-day period without a visa. This applies if you travel as a tourist, to visit family or friends, to attend business meetings, cultural or sports events, or for short-term studies or training.</p>
+    <p class="govuk-body">If you are travelling to Narnia and other Phantasia countries without a visa, make sure your whole visit is within the 90-day limit. Visits to Phantasia countries within the previous 180 days before you travel count towards your 90 days.</p>
+
+    {{ govukPagination({
+      previous: { href: "#/foreign-travel-advice/narnia/safety-and-security", labelText: "Safety and security" },
+      next: { href: "#/foreign-travel-advice/narnia/time-dilation", labelText: "Time dilation" }
+    }) }}
+  </div>
+</div>
+{% endblock %}
+
+{% block govukFooter %}
+
+{{ govukFooter({
+  navigation: [
+    {
+      title: "Services and information",
+      width: "two-thirds",
+      columns: 2,
+      items: [
+        {
+          href: "#",
+          text: "Benefits"
+        },
+        {
+          href: "#",
+          text: "Births, deaths, marriages and care"
+        },
+        {
+          href: "#",
+          text: "Business and self-employed"
+        },
+        {
+          href: "#",
+          text: "Childcare and parenting"
+        },
+        {
+          href: "#",
+          text: "Citizenship and living in the UK"
+        },
+        {
+          href: "#",
+          text: "Crime, justice and the law"
+        },
+        {
+          href: "#",
+          text: "Disabled people"
+        },
+        {
+          href: "#",
+          text: "Driving and transport"
+        },
+        {
+          href: "#",
+          text: "Education and learning"
+        },
+        {
+          href: "#",
+          text: "Employing people"
+        },
+        {
+          href: "#",
+          text: "Environment and countryside"
+        },
+        {
+          href: "#",
+          text: "Housing and local services"
+        },
+        {
+          href: "#",
+          text: "Money and tax"
+        },
+        {
+          href: "#",
+          text: "Passports, travel and living abroad"
+        },
+        {
+          href: "#",
+          text: "Visas and immigration"
+        },
+        {
+          href: "#",
+          text: "Working, jobs and pensions"
+        }
+      ]
+    },
+    {
+      title: "Departments and policy",
+      width: "one-third",
+      items: [
+        {
+          href: "#",
+          text: "How government works"
+        },
+        {
+          href: "#",
+          text: "Departments"
+        },
+        {
+          href: "#",
+          text: "Worldwide"
+        },
+        {
+          href: "#",
+          text: "Policies"
+        },
+        {
+          href: "#",
+          text: "Publications"
+        },
+        {
+          href: "#",
+          text: "Announcements"
+        }
+      ]
+    }
+  ],
+  meta: {
+    items: [
+      {
+        href: "#",
+        text: "Help"
+      },
+      {
+        href: "#",
+        text: "Cookies"
+      },
+      {
+        href: "#",
+        text: "Contact"
+      },
+      {
+        href: "#",
+        text: "Terms and conditions"
+      },
+      {
+        href: "#",
+        text: "Rhestr o Wasanaethau Cymraeg"
+      }
+    ],
+    html: 'Built by the <a href="#" class="govuk-footer__link">Government Digital Service</a>'
+  }
+}) }}
+
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
@@ -41,7 +41,7 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
 
     <div class="govuk-!-margin-bottom-8">
       <span class="govuk-caption-xl">Foreign travel advice</span>
-      <h1 class="govuk-heading-xl">Narnia entry requirements</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Narnia entry requirements</h1>
       {{ govukLanguageNavigation({
         items: [
           {

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
@@ -1,0 +1,253 @@
+---
+title: Entry requirements - Narnia travel advice (Language navigation under heading)
+name: Language navigation (under heading)
+scenario: You want to read guidance about the entry requirements for travelling to Narnia.
+notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requirements
+---
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/language-navigation/macro.njk" import govukLanguageNavigation %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
+{% set pageTitle = example.title %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block containerStart %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Passports, travel and living abroad",
+        href: "#/browse/abroad"
+      },
+      {
+        text: "Travel abroad",
+        href: "#/browse/abroad/travel-abroad"
+      },
+      {
+        text: "Foreign travel advice",
+        href: "#/foreign-travel-advice"
+      }
+    ]
+  }) }}
+{% endblock %}
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <div class="govuk-!-margin-bottom-8">
+      <span class="govuk-caption-xl">Foreign travel advice</span>
+      <h1 class="govuk-heading-xl">Narnia entry requirements</h1>
+      {{ govukLanguageNavigation({
+        items: [
+          {
+            text: "English",
+            lang: "en",
+            href: "#",
+            current: true
+          },
+          {
+            text: "Cymraeg",
+            lang: "cy",
+            href: "#"
+          }
+        ]
+      }) }}
+    </div>
+
+    <aside class="govuk-!-padding-bottom-3">
+      <nav aria-label="Travel advice pages">
+        <h2 class="govuk-heading-s">Contents</h2>
+        <ol class="govuk-list govuk-list--bullet govuk-!-font-size-16">
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia">Summary</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/safety-and-security">Safety and security</a></li>
+          <li aria-current="true">Entry requirements</li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/time-dilation">Time dilation</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/archenland-travel">Archenland travel</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/travel-advice-help-support">Travel advice help and support</a></li>
+        </ol>
+      </nav>
+    </aside>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <p class="govuk-body">This page reflects the UK government’s understanding of current rules for people travelling on a full ‘British Citizen’ passport from the UK, for the most common types of travel.</p>
+    <p class="govuk-body">Aslan the Great Lion sets and enforces entry rules. If you’re unsure how Narnia’s entry requirements apply to you, contact <a href="#" class="govuk-link">Narnia’s Embassy in the UK</a>, located in your nearest wardrobe.</p>
+
+    <h2 class="govuk-heading-m" id="children-and-young-people">Children and young people</h2>
+    <p class="govuk-body">There are no specific entry requirements for children and young people.</p>
+
+    <h2 class="govuk-heading-m" id="transiting">If you're transiting through Narnia</h2>
+    <p class="govuk-body">Transiting is when you pass through one country on the way to your final destination.</p>
+    <p class="govuk-body">Check with your wardobe manufacturer before departing.</p>
+
+    <h2 class="govuk-heading-m" id="exemptions">Exemptions</h2>
+    <p class="govuk-body">There are no exemptions to Narnia’s entry requirements.</p>
+
+    <h2 class="govuk-heading-m" id="travel-documents">Check your passport and travel documents before you travel</h2>
+
+    <h3 class="govuk-heading-s" id="passport-validity">Passport validity</h3>
+    <p class="govuk-body">If you are planning to travel to a fantasy country (except Middle Earth), you must follow the <a href="#" class="govuk-link">Phantasia area passport requirements</a>.</p>
+    <p class="govuk-body">Your passport must be:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>issued less than 10 years before the date you enter the country (check the ‘date of issue’)</li>
+      <li>valid for at least 3 months after the day you plan to leave (check the ‘expiry date’), accounting for time dilation</li>
+    </ul>
+    <p class="govuk-body">You must check your passport meets these requirements before you travel. If your passport was issued before 1 October 2018, extra months may have been added to its expiry date.</p>
+    <p class="govuk-body">Contact <a href="#" class="govuk-link">Narnia's Embassy in the UK</a> if you think that your passport does not meet both these requirements. <a href="#" class="govuk-link">Renew your passport if you need to</a>.</p>
+
+    <h3 class="govuk-heading-s" id="visas">Visas</h3>
+    <p class="govuk-body">You can travel to countries in the  <a href="#" class="govuk-link">Phantasia area</a> for up to 90 days in any 180-day period without a visa. This applies if you travel as a tourist, to visit family or friends, to attend business meetings, cultural or sports events, or for short-term studies or training.</p>
+    <p class="govuk-body">If you are travelling to Narnia and other Phantasia countries without a visa, make sure your whole visit is within the 90-day limit. Visits to Phantasia countries within the previous 180 days before you travel count towards your 90 days.</p>
+
+    {{ govukPagination({
+      previous: { href: "#/foreign-travel-advice/narnia/safety-and-security", labelText: "Safety and security" },
+      next: { href: "#/foreign-travel-advice/narnia/time-dilation", labelText: "Time dilation" }
+    }) }}
+  </div>
+</div>
+{% endblock %}
+
+{% block govukFooter %}
+
+{{ govukFooter({
+  navigation: [
+    {
+      title: "Services and information",
+      width: "two-thirds",
+      columns: 2,
+      items: [
+        {
+          href: "#",
+          text: "Benefits"
+        },
+        {
+          href: "#",
+          text: "Births, deaths, marriages and care"
+        },
+        {
+          href: "#",
+          text: "Business and self-employed"
+        },
+        {
+          href: "#",
+          text: "Childcare and parenting"
+        },
+        {
+          href: "#",
+          text: "Citizenship and living in the UK"
+        },
+        {
+          href: "#",
+          text: "Crime, justice and the law"
+        },
+        {
+          href: "#",
+          text: "Disabled people"
+        },
+        {
+          href: "#",
+          text: "Driving and transport"
+        },
+        {
+          href: "#",
+          text: "Education and learning"
+        },
+        {
+          href: "#",
+          text: "Employing people"
+        },
+        {
+          href: "#",
+          text: "Environment and countryside"
+        },
+        {
+          href: "#",
+          text: "Housing and local services"
+        },
+        {
+          href: "#",
+          text: "Money and tax"
+        },
+        {
+          href: "#",
+          text: "Passports, travel and living abroad"
+        },
+        {
+          href: "#",
+          text: "Visas and immigration"
+        },
+        {
+          href: "#",
+          text: "Working, jobs and pensions"
+        }
+      ]
+    },
+    {
+      title: "Departments and policy",
+      width: "one-third",
+      items: [
+        {
+          href: "#",
+          text: "How government works"
+        },
+        {
+          href: "#",
+          text: "Departments"
+        },
+        {
+          href: "#",
+          text: "Worldwide"
+        },
+        {
+          href: "#",
+          text: "Policies"
+        },
+        {
+          href: "#",
+          text: "Publications"
+        },
+        {
+          href: "#",
+          text: "Announcements"
+        }
+      ]
+    }
+  ],
+  meta: {
+    items: [
+      {
+        href: "#",
+        text: "Help"
+      },
+      {
+        href: "#",
+        text: "Cookies"
+      },
+      {
+        href: "#",
+        text: "Contact"
+      },
+      {
+        href: "#",
+        text: "Terms and conditions"
+      },
+      {
+        href: "#",
+        text: "Rhestr o Wasanaethau Cymraeg"
+      }
+    ],
+    html: 'Built by the <a href="#" class="govuk-footer__link">Government Digital Service</a>'
+  }
+}) }}
+
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -52,4 +52,12 @@
       border-right-color: currentcolor;
     }
   }
+
+  // Ensure the Language navigation sits centred vertically
+  // when inside the Service Navigation and has enough
+  // spacing with the navigation items
+  .govuk-service-navigation .govuk-language-navigation {
+    margin-top: base.govuk-spacing(3);
+    margin-bottom: base.govuk-spacing(3);
+  }
 }

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -5,7 +5,6 @@
   .govuk-language-navigation {
     @include base.govuk-font($size: 19);
 
-    margin-top: base.govuk-spacing(3);
     margin-bottom: base.govuk-spacing(3);
     color: base.govuk-functional-colour(text);
   }

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -5,7 +5,7 @@
   .govuk-language-navigation {
     @include base.govuk-font($size: 19);
 
-    margin-bottom: base.govuk-spacing(3);
+    @include base.govuk-responsive-margin(6, "bottom");
     color: base.govuk-functional-colour(text);
   }
 


### PR DESCRIPTION
Add four new examples showing the Language navigation in various places:
- [after the page's `<h1>`](https://govuk-frontend-pr-7344.herokuapp.com/full-page-examples/language-navigation-under-heading)
- [in a sidebar](https://govuk-frontend-pr-7344.herokuapp.com/full-page-examples/language-navigation-sidebar)
- [in the Service Navigation (below the items)](https://govuk-frontend-pr-7344.herokuapp.com/full-page-examples/language-navigation-in-service-navigation-inline)
- [in the Service Navigation (right of the items)](https://govuk-frontend-pr-7344.herokuapp.com/full-page-examples/language-navigation-in-service-navigation)

The PR only adds the examples, adjustments to the spacing will be done in a future pull request.

## Thoughts

### Under the heading

When used under the heading, the heading's margin (and current top margin of the Language navigation) push the Language navigation quite far from the heading.

| Narrow viewport | Wide viewport |
|---|---|
| ![Language navigation far under heading in narrow viewport](https://github.com/user-attachments/assets/0215e62e-e1fa-49e1-871d-e6a4b8dca4ff) | ![Language navigation far under heading in wide viewport](https://github.com/user-attachments/assets/1e4056ef-dfca-42b0-aa5e-9a6ae76d30b6) |

Users could use utility classes to make it closer to the heading.

| Narrow viewport | Wide viewport |
|---|---|
| ![Language navigation closer to heading in narrow viewport](https://github.com/user-attachments/assets/2f45dc6b-cbc6-4696-a10f-727aeb1595c6) | ![Language navigation closer heading in wide viewport](https://github.com/user-attachments/assets/19d858df-8dad-4bbf-a8ab-53980c048507) |

This may be better achieved through some kind of `govuk-heading-group` class with the following code:

```scss
.govuk-heading-group > * {
	margin-top: 0;
}

// Remove the bottom margins of any element inside the group
// apart from the last one so the margin of the last element
// correctly spaces it with the content following the heading group 
.govuk-heading-group > :not(:last-child) {
  margin-bottom: 0;
}

.govuk-heading-group > * + * {
	margin-top: govuk-spacing(1)
}
```

### In the sidebar

Inside the sidebar, the current `margin-top` on the Language navigation positions the component awkwardly aligning neither its baseline nor its caps with the content on the left.

<img width="1512" height="777" alt="Language navigation in side bar, baseline or caps not aligned with any other element" src="https://github.com/user-attachments/assets/a791b6fc-504a-4c17-8a8e-101e3abd3ca1" />

Removing the top margin (with an override class for now) at least aligns the top of the capitals between the left and the right.

<img width="1512" height="777" alt="Language navigation in side bar, baseline or caps not aligned with any other element" src="https://github.com/user-attachments/assets/894101c7-e40e-48fb-8bb3-a95d93885aa0" />

It may be preferable to align baselines (@lewisdarlow-gds we'll need your input on that), however it'll be trickier to give users the exact code for that as the alignment will depend on:
- whether a caption precedes the heading
- the size of the heading

<table>
<caption>Baseline alignment examples</caption>
<tr>
<th>With caption
<th>With XL Heading
<th>With L Heading
</tr>
<tr>
<td>
<img width="1512" height="778" alt="Screenshot 2026-08-04 at 16 37 56" src="https://github.com/user-attachments/assets/5aecf772-3900-4e85-b087-1f19663785c6" />
<p>Override class (<code>.govuk-!-margin-top-1</code>)
<td>
<img width="1512" height="776" alt="Screenshot 2026-08-04 at 16 39 05" src="https://github.com/user-attachments/assets/51be1154-5d20-4f02-99f1-f7fa63f27a54" />
<p>Requires a magic number for the margin (<code>23px</code>)
<td>
<img width="1512" height="774" alt="Screenshot 2026-08-04 at 16 39 37" src="https://github.com/user-attachments/assets/3035df82-e236-4ed1-a4c5-f5d25d79c82f" />
<p>Requires a magic number for the margin (<code>13px</code>)
</tr>
</table>
