### PR TITLE
Adjust the spacing around the Language Navigation

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
@@ -41,7 +41,7 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
 
     <div class="govuk-!-margin-bottom-8">
       <span class="govuk-caption-xl">Foreign travel advice</span>
-      <h1 class="govuk-heading-xl">Narnia entry requirements</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Narnia entry requirements</h1>
       {{ govukLanguageNavigation({
         items: [
           {

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -52,4 +52,12 @@
       border-right-color: currentcolor;
     }
   }
+
+  // Ensure the Language navigation sits centred vertically
+  // when inside the Service Navigation and has enough
+  // spacing with the navigation items
+  .govuk-service-navigation .govuk-language-navigation {
+    margin-top: base.govuk-spacing(3);
+    margin-bottom: base.govuk-spacing(3);
+  }
 }

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -5,7 +5,6 @@
   .govuk-language-navigation {
     @include base.govuk-font($size: 19);
 
-    margin-top: base.govuk-spacing(3);
     margin-bottom: base.govuk-spacing(3);
     color: base.govuk-functional-colour(text);
   }

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -5,7 +5,7 @@
   .govuk-language-navigation {
     @include base.govuk-font($size: 19);
 
-    margin-bottom: base.govuk-spacing(3);
+    @include base.govuk-responsive-margin(6, "bottom");
     color: base.govuk-functional-colour(text);
   }
 


### PR DESCRIPTION
Makes little adjustments to the spacing around the Language Navigation, as discussed during pairing.

## Use specific selector for spacing when inside Service Navigation

When inside the Service Navigation, the component needs both a bottom margin (to not sit flush with the bottom when under the navigation items) and at the top (to not be shifted up when inline with the items). This spacing being specific to being inside the Service Navigation, we'll combine selectors rather than set it as the default spacing

## Remove default top margin

Having a top margin in the component leads to extra space when it's the first visible child of an element, like a sidebar. We also manage spacing using `margin-bottom` rather than `margin-top`, so best to remove that top margin.

## Increase default bottom margin

Aligns the component with most components of the Design System

## Update example where component is under the heading

As headings have responsive margins, use a utility class to set the spacing between the heading and the following Language navigation. We'll have to let users know to set the class on their heading as well.