### PR TITLE
Update how Service Navigation aligns the `end` slot

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/header-kitchen-sink/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/header-kitchen-sink/index.njk
@@ -101,8 +101,10 @@ scenario: |
       }
     ],
     slots: {
-      end: languageNavigationHTML,
-      endRightAligned: true
+      end: {
+        html: languageNavigationHTML,
+        align: 'inline'
+      }
     }
   }) }}
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation-inline/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation-inline/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Companies you follow
-name: Language navigation (in Service navigation)
+name: Language navigation (in Service navigation, inline)
 scenario: |
   You are a user logged into Companies House WebFiling service, looking at a
   list of companies you are following.
@@ -55,20 +55,15 @@ notes: Based on Companies House "Find an update company information" service
       },
       {
         href: '#2',
-        text: 'Your details'
-      },
-      {
-        href: '#3',
-        text: 'Your filings'
-      },
-      {
-        href: '#4',
         text: 'Companies you follow',
         current: true
       }
     ],
     slots: {
-      end: languageNavigationHtml
+      end: {
+        html: languageNavigationHtml,
+        align: 'inline'
+      }
     }
   }) }}
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-in-service-navigation/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Companies you follow
-name: Language navigation (in Service navigation, inline)
+name: Language navigation (in Service navigation)
 scenario: |
   You are a user logged into Companies House WebFiling service, looking at a
   list of companies you are following.
@@ -59,8 +59,7 @@ notes: Based on Companies House "Find an update company information" service
       }
     ],
     slots: {
-      end: languageNavigationHtml,
-      endRightAligned: true
+      end: languageNavigationHtml
     }
   }) }}
 {% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -12,7 +12,7 @@
   .govuk-language-navigation__list {
     display: inline-flex;
     flex-wrap: wrap;
-    row-gap: base.govuk-spacing(1);
+    row-gap: base.govuk-spacing(2);
     margin: 0;
     padding: 0;
     list-style-type: none;

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/_mixin.scss
@@ -52,11 +52,16 @@
     }
   }
 
-  // Ensure the Language navigation sits centred vertically
-  // when inside the Service Navigation and has enough
-  // spacing with the navigation items
+  // Ensure the Language navigation has enough
+  // spacing with the rest of the Service Navigation
   .govuk-service-navigation .govuk-language-navigation {
-    margin-top: base.govuk-spacing(3);
+    // Slightly smaller margin because the Service Navigation's menu toggle
+    // has a little margin underneath it already.
+    margin-top: base.govuk-spacing(1);
     margin-bottom: base.govuk-spacing(3);
+
+    @media #{base.govuk-from-breakpoint(tablet)} {
+      margin-top: base.govuk-spacing(3);
+    }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -22,10 +22,33 @@
     background-color: $govuk-service-navigation-background;
   }
 
+  .govuk-service-navigation__inlining-container {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+
+    .govuk-service-navigation__container {
+      // Expand the container to shift the `end` slot to the right
+      flex-grow: 1;
+
+      // Ensure some space between the `end` slot and the container
+      // when displayed inline
+      &:not(:last-child) {
+        margin-right: base.govuk-spacing(6);
+      }
+    }
+  }
+
   .govuk-service-navigation__container {
     display: flex;
     flex-direction: column;
     align-items: start;
+
+    // Avoid the end slot rendering on the right of the container
+    // in small viewports by ensuring the container is full width
+    @media #{base.govuk-until-breakpoint(tablet)} {
+      width: 100%;
+    }
 
     @media #{base.govuk-from-breakpoint(tablet)} {
       flex-direction: row;

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -85,10 +85,19 @@ params:
         type: string
         required: false
         description: HTML injected at the end of the service header container.
-      - name: endRightAligned
-        type: boolean
+      - name: end
+        type: string
         required: false
-        description: If `true`, renders the `end` slot inline in the service navigation row and right aligns it at tablet and above. Defaults to `false`.
+        description: Options for injecting HTML at the end of the service header container.
+        params:
+          - name: html
+            type: string
+            required: false
+            description: HTML injected at the end of the service header container.
+          - name: align
+            type: string
+            required: false
+            description: By default, the `end` slot renders below the navigation items. Use `inline` to render it on the same line as the navigation items when space is available.
       - name: navigationStart
         type: string
         required: false
@@ -430,7 +439,8 @@ examples:
               </li>
             </ul>
           </nav>
-        endRightAligned: true
+      slotsPreferredPositions:
+        end: same-line
   - name: inverse with language navigation
     description: Service navigation that appears sandwiched between other areas of brand blue, such as the GOV.UK header and a custom page masthead.
     pageTemplateOptions:
@@ -469,12 +479,13 @@ examples:
         end: '<div>[end]</div>'
         navigationStart: '<li>[navigation start]</li>'
         navigationEnd: '<li>[navigation end]</li>'
-  - name: with right-aligned end slot
+  - name: with `inline` end slot
     options:
       serviceName: Service name
       navigation:
         - href: '#/1'
           text: Navigation item 1
       slots:
-        end: '<div>[end]</div>'
-        endRightAligned: true
+        end:
+          html: '<div>[end]</div>'
+          align: 'inline'

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
@@ -13,7 +13,9 @@ data-module="govuk-service-navigation"
 {% endset -%}
 
 {%- set innerContent %}
-  <div class="govuk-width-container">
+  <div class="govuk-width-container
+    {%- if endSlotInline %} govuk-service-navigation__inlining-container{% endif -%}
+    ">
 
     {# Slot: start #}
     {%- if params.slots.start %}{{ params.slots.start | safe }}{% endif -%}
@@ -87,17 +89,10 @@ data-module="govuk-service-navigation"
           </ul>
         </nav>
       {% endif %}
-
-      {# Slot: end (right aligned) #}
-      {% if endSlotHtml and endSlotInline %}
-        <div class="govuk-service-navigation__end">
-          {{ endSlotHtml | safe }}
-        </div>
-      {% endif %}
     </div>
 
     {# Slot: end #}
-    {%- if endSlotHtml and not endSlotInline %}{{ endSlotHtml | safe }}{% endif -%}
+    {%- if endSlotHtml %}{{ endSlotHtml | safe }}{% endif -%}
 
   </div>
 {% endset -%}

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.njk
@@ -2,7 +2,9 @@
 
 {%- set menuButtonText = params.menuButtonText | default("Menu", true) -%}
 {%- set navigationId = params.navigationId | default("navigation", true) %}
-{%- set endSlotRightAligned = params.slots.endRightAligned | default(false) %}
+
+{%- set endSlotHtml = params.slots.end if params.slots.end is string else params.slots.end.html %}
+{%- set endSlotInline = params.slots.end is mapping and params.slots.end.align == 'inline' %}
 
 {%- set commonAttributes %}
 class="govuk-service-navigation {%- if params.classes %} {{ params.classes }}{% endif %}"
@@ -87,15 +89,15 @@ data-module="govuk-service-navigation"
       {% endif %}
 
       {# Slot: end (right aligned) #}
-      {% if params.slots.end and endSlotRightAligned %}
+      {% if endSlotHtml and endSlotInline %}
         <div class="govuk-service-navigation__end">
-          {{ params.slots.end | safe }}
+          {{ endSlotHtml | safe }}
         </div>
       {% endif %}
     </div>
 
     {# Slot: end #}
-    {%- if params.slots.end and not endSlotRightAligned %}{{ params.slots.end | safe }}{% endif -%}
+    {%- if endSlotHtml and not endSlotInline %}{{ endSlotHtml | safe }}{% endif -%}
 
   </div>
 {% endset -%}
@@ -103,7 +105,7 @@ data-module="govuk-service-navigation"
 {# If a service name is included, we use a <section> element with an
   aria-label to create a containing landmark region. Otherwise, the <nav> in
   the innerContent can do the job just fine by itself. #}
-{% if params.serviceName or params.slots.start or params.slots.end %}
+{% if params.serviceName or params.slots.start or endSlotHtml %}
   <section aria-label="{{ params.ariaLabel | default("Service information") }}" {{ commonAttributes | safe }}>
     {{ innerContent | safe }}
   </section>

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
@@ -489,20 +489,15 @@ describe('Service Navigation', () => {
     })
 
     it("inserts HTML from the `end` slot inline when the slot's `align` option is `inline`", () => {
-      const $ = render(
-        'service-navigation',
-        examples['with `inline` end slot']
+      const $ = render('service-navigation', examples['with `inline` end slot'])
+
+      const $widthContainer = $(
+        '.govuk-service-navigation .govuk-width-container'
       )
 
-      const $endSlotInContainer = $('.govuk-service-navigation__end')
-      const $endSlotContent = $endSlotInContainer.find('> :first-child')
-      const $slottedElementAtRoot = $('.govuk-width-container > :last-child')
-
-      expect($endSlotInContainer).toHaveLength(1)
-      expect($endSlotContent.prop('outerHTML')).toBe('<div>[end]</div>')
-      expect(
-        $slottedElementAtRoot.hasClass('govuk-service-navigation__container')
-      ).toBeTruthy()
+      expect($widthContainer.attr('class')).toContain(
+        'govuk-service-navigation__inlining-container'
+      )
     })
 
     it('renders the component as a <section> if `start` or `end` slots are used', () => {

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/template.test.js
@@ -488,10 +488,10 @@ describe('Service Navigation', () => {
       expect($slottedElement.prop('outerHTML')).toBe('<div>[end]</div>')
     })
 
-    it('inserts HTML from the `end` slot inline when `endRightAligned` is enabled', () => {
+    it("inserts HTML from the `end` slot inline when the slot's `align` option is `inline`", () => {
       const $ = render(
         'service-navigation',
-        examples['with right-aligned end slot']
+        examples['with `inline` end slot']
       )
 
       const $endSlotInContainer = $('.govuk-service-navigation__end')


### PR DESCRIPTION
## Update the API for aligning the `end` slot

Instead of the `slots` option mixing slots content and options for aligning the slots content, make `end` accept either a `string` (to avoid breaking changes) or an object with `html` (for the content) and `align` (for the alignment) options.

Using two entries for the `end` params in the component's YAML file allows us to show the documentation for both types of values in the Design System site.

## Render the `end` slot in the same place regardless of the alignement

Always render the `end` slot after the `.govuk-service-navigation__container` rather than inside when `inline` and after when not `inline`. With the addition of a new `.govuk-service-navigation__inlining-container` class when the `end` slot needs to be inlined, we can align the slot purely in CSS.