### PR TITLE
Fix quotes used in HTML inside options docs

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/language-navigation/language-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/language-navigation.yaml
@@ -7,7 +7,7 @@ params:
       - name: text
         type: string
         required: true
-        description: If `html` is set, this is not required. Name of the language, written in that language (for example, <span lang='cy'>"Cymraeg"</span> for Welsh). If `html` is provided, the `text` option will be ignored.
+        description: If `html` is set, this is not required. Name of the language, written in that language (for example, <span lang="cy">"Cymraeg"</span> for Welsh). If `html` is provided, the `text` option will be ignored.
       - name: html
         type: string
         required: true


### PR DESCRIPTION
The Design System site's HTML validator expects double-quotes rather than single ones