### PR TITLE
Fix dead GDS Way links in contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech-debt.yaml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yaml
@@ -8,7 +8,7 @@ body:
       value: |
         This is a template for creating issues that describe technical debt.
 
-        It is based off the [example in the GDS Way page on tracking technical debt](https://gds-way.cloudapps.digital/standards/technical-debt.html#example).
+        It is based off the [example in the GDS Way page on tracking technical debt](https://gds-way.digital.cabinet-office.gov.uk/standards/technical-debt.html#example).
 
   - type: textarea
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Your contribution needs to work with certain browsers and assistive technology a
 
 ## Commit hygiene
 
-Please see our [Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages), which describes how we prefer Git history and commit messages to read.
+Please see our [Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/working-with-git.html#commit-messages), which describes how we prefer Git history and commit messages to read.
 
 ## Updating Changelog
 

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -179,7 +179,7 @@ For consistent formatting we run [Prettier](https://prettier.io).
 
 The standard docs have a [complete list of rules and some reasoning behind them](https://standardjs.com/rules.html).
 
-Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting).
+Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#linting).
 
 See also [testing and linting](/docs/releasing/testing-and-linting.md).
 


### PR DESCRIPTION
## Upstream target
alphagov/govuk-frontend — no issue, self-found gap (dead links in contributor docs)

## What changed
Update three dead GDS Way links in the contributor docs.
They pointed at `gds-way.cloudapps.digital`, a GOV.UK PaaS domain that has been decommissioned.
Repoint them at the current domain `gds-way.digital.cabinet-office.gov.uk`.

- `CONTRIBUTING.md` — commit hygiene link (Git style guide)
- `docs/contributing/coding-standards/js.md` — JavaScript linting link
- `.github/ISSUE_TEMPLATE/tech-debt.yaml` — technical debt example link

## Why
The old `cloudapps.digital` PaaS domain no longer resolves, so all three links fail with a DNS/connection error (HTTP `000`). A contributor following the "Commit hygiene" or "JavaScript coding style" guidance, or opening a tech-debt issue, hits a dead link.

The GDS Way `source-code` page was also restructured. The commit-messages guidance moved to the `working-with-git` page, so that link's path is updated too (not just the domain).

## How to verify
Old domain is dead, new URLs (and their anchors) resolve:

```bash
# Old — all fail (000)
curl -s -o /dev/null -w "%{http_code}\n" https://gds-way.cloudapps.digital/standards/source-code.html

# New — all 200
curl -s -o /dev/null -w "%{http_code}\n" -L https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/working-with-git.html
curl -s -o /dev/null -w "%{http_code}\n" -L https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html
curl -s -o /dev/null -w "%{http_code}\n" -L https://gds-way.digital.cabinet-office.gov.uk/standards/technical-debt.html

# Anchors exist on the new pages
curl -s https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/working-with-git.html | grep -o 'id="commit-messages"'
curl -s https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html | grep -o 'id="linting"'
curl -s https://gds-way.digital.cabinet-office.gov.uk/standards/technical-debt.html | grep -o 'id="example"'
```

## Coverage
N/A — docs/template only, no code changed.

## Checks run locally
- [x] Tests: N/A (no code changed). Baseline suites green before the change: JavaScript unit 865 passed, JavaScript behaviour (jsdom) 536 passed, Nunjucks macro 609 passed.
- [x] Lint: PASS — repo's own lint-staged hook ran on commit (prettier + eslint markdown + stylelint), all green. `prettier --check` and `editorconfig-checker` also pass on the three files.
- [x] Typecheck: N/A (no `.ts`/`.mjs` changed).
- [x] Build: N/A (docs/template only). `build:package` was run earlier to generate fixtures for the test baseline and succeeded.

Note: browser-based projects (`JavaScript component tests`, `Accessibility tests`) need Puppeteer + a dev server and were not run in this environment. This change touches no runtime code, so they are unaffected.

## Changelog
No entry needed. Per `docs/contributing/versioning.md`, internal changes that are not part of the public API do not need changelog entries. This is docs + an issue template only.

## Style / template compliance
- Repo has no `PULL_REQUEST_TEMPLATE.md`; used a standard structure.
- Commit message follows the GDS Way style (imperative, capitalised summary, no trailing full stop, explanatory body). No `Co-Authored-By` trailer.
- One logical change (dead GDS Way domain migration), 3 lines, no unrelated churn. `CHANGELOG.md` was deliberately left untouched (it is historical and also references an old `cloudapps.digital` domain in a past release note).