### PR TITLE
Adjust in-page examples to be consistent with each other

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-sidebar/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-sidebar/index.njk
@@ -38,30 +38,12 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-
-    <div class="govuk-!-margin-bottom-8">
-      <span class="govuk-caption-xl">Foreign travel advice</span>
-      <h1 class="govuk-heading-xl">Narnia entry requirements</h1>
-    </div>
-
-    <aside class="govuk-!-padding-bottom-3">
-      <nav aria-label="Travel advice pages">
-        <h2 class="govuk-heading-s">Contents</h2>
-        <ol class="govuk-list govuk-list--bullet govuk-!-font-size-16">
-          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia">Summary</a></li>
-          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/safety-and-security">Safety and security</a></li>
-          <li aria-current="true">Entry requirements</li>
-          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/time-dilation">Time dilation</a></li>
-          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/archenland-travel">Archenland travel</a></li>
-          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/travel-advice-help-support">Travel advice help and support</a></li>
-        </ol>
-      </nav>
-    </aside>
-    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
-
+    <span class="govuk-caption-xl">Foreign travel advice</span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Narnia entry requirements</h1>
   </div>
   <div class="govuk-grid-column-one-third-from-desktop">
     {{ govukLanguageNavigation({
+        classes: "govuk-!-margin-bottom-8",
         items: [
           {
             text: "English",
@@ -82,6 +64,20 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
+    <aside class="govuk-!-margin-top-7 govuk-!-padding-bottom-3">
+      <nav aria-label="Travel advice pages">
+        <h2 class="govuk-heading-s">Contents</h2>
+        <ol class="govuk-list govuk-list--bullet govuk-!-font-size-16">
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia">Summary</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/safety-and-security">Safety and security</a></li>
+          <li aria-current="true">Entry requirements</li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/time-dilation">Time dilation</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/archenland-travel">Archenland travel</a></li>
+          <li><a class="govuk-link" href="#/foreign-travel-advice/narnia/travel-advice-help-support">Travel advice help and support</a></li>
+        </ol>
+      </nav>
+    </aside>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
 
     <p class="govuk-body">This page reflects the UK government’s understanding of current rules for people travelling on a full ‘British Citizen’ passport from the UK, for the most common types of travel.</p>
     <p class="govuk-body">Aslan the Great Lion sets and enforces entry rules. If you’re unsure how Narnia’s entry requirements apply to you, contact <a href="#" class="govuk-link">Narnia’s Embassy in the UK</a>, located in your nearest wardrobe.</p>

--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-under-heading/index.njk
@@ -39,25 +39,24 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <div class="govuk-!-margin-bottom-8">
-      <span class="govuk-caption-xl">Foreign travel advice</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Narnia entry requirements</h1>
-      {{ govukLanguageNavigation({
-        items: [
-          {
-            text: "English",
-            lang: "en",
-            href: "#",
-            current: true
-          },
-          {
-            text: "Cymraeg",
-            lang: "cy",
-            href: "#"
-          }
-        ]
-      }) }}
-    </div>
+    <span class="govuk-caption-xl">Foreign travel advice</span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Narnia entry requirements</h1>
+    {{ govukLanguageNavigation({
+      classes: "govuk-!-margin-bottom-8",
+      items: [
+        {
+          text: "English",
+          lang: "en",
+          href: "#",
+          current: true
+        },
+        {
+          text: "Cymraeg",
+          lang: "cy",
+          href: "#"
+        }
+      ]
+    }) }}
 
     <aside class="govuk-!-padding-bottom-3">
       <nav aria-label="Travel advice pages">


### PR DESCRIPTION
Ensures that in both examples the Language navigation ends up in the same space on smaller screens