### PR TITLE
fix(summary-list): summary card title doesn't wrap unbreakable text

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss
@@ -218,6 +218,12 @@
 
   .govuk-summary-card__title {
     @include base.govuk-font($size: 19, $weight: bold);
+    // Flex items default to a min-width based on their content's intrinsic
+    // size, which stops long unbreakable strings (e.g. reference numbers)
+    // from wrapping even when `word-break`/`overflow-wrap` is applied. This
+    // lets the title actually shrink so those properties can take effect.
+    // https://github.com/alphagov/govuk-frontend/issues/6513
+    min-width: 0;
     margin: base.govuk-spacing(1) base.govuk-spacing(4) base.govuk-spacing(2) 0;
     color: base.govuk-functional-colour(text);
 

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -815,6 +815,21 @@ examples:
             text: Date of birth
           value:
             text: 13/08/1980
+  - name: summary card with unbreakable title text
+    hidden: true
+    options:
+      card:
+        title:
+          html: '<span class="govuk-!-text-break-word">REF1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>'
+        actions:
+          items:
+            - text: Change
+              href: '#'
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
   - name: translated
     hidden: true
     options:


### PR DESCRIPTION
## Summary

Fixes #6513.

`.govuk-summary-card__title` is a flex item inside `.govuk-summary-card__title-wrapper` at tablet+ widths (`display: flex`). Flex items default to `min-width: auto`, which stops them shrinking below their content's intrinsic size. That meant applying `word-break`/`overflow-wrap` to long unbreakable text inside the title (e.g. a reference number, via the `govuk-!-text-break-word` utility as in the original report) had no effect — the box just grew to fit the content instead of wrapping, and the text overflowed the card.

This sets `min-width: 0` on `.govuk-summary-card__title` so it can actually shrink to the wrapper's available width, letting `overflow-wrap`/`word-break` do their job. This matches the diagnosis already left on the issue (flexbox + `overflow-wrap` interaction) and is the standard fix for this well-known CSS behaviour.

No other properties, markup, or component behaviour changed.

## Screenshots

I don't have a clean way to attach images from this environment, but I reproduced and verified both states visually via the review app (`npm start`) at the new hidden example's preview URL:

`/components/summary-list/summary-card-with-unbreakable-title-text/preview`

- **Before this fix:** the reference-number-style title text overflows past the right edge of the card, cut off by the container.
- **After this fix:** the same text wraps onto multiple lines and stays within the card, matching the expected behaviour in the issue.

Reviewers can check the same URL locally after checking out this branch, or add the `govuk-!-text-break-word` example from the issue to any summary card title.

## Related Issues

- Fixes #6513

## What's included

- `packages/govuk-frontend/src/govuk/components/summary-list/_mixin.scss` — the one-line fix (`min-width: 0`), with a comment explaining why it's needed.
- `packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml` — a new hidden example (`summary card with unbreakable title text`) reproducing the original bug. None of the existing examples use unbreakable text, so nothing currently exercises this path.

## Testing

- `npm run lint` (stylelint + prettier) passes on the changed files.
- `npm test` (all 6 Jest projects — Nunjucks macro, accessibility, integration, JS unit/component/behaviour) passes: 167 suites, 2969 tests, including the summary-list accessibility test running against the new example with zero axe violations.
- Verified the compiled CSS output contains `min-width: 0` in the right place.
- Verified visually in the review app as described above (before/after).

I did not test in IE11 or other grade X browsers, or with a screen reader — this is a pure layout fix with no ARIA/semantic changes, so I don't expect assistive-tech impact, but flagging since I couldn't verify that myself.