### PR TITLE
Remove unnecessary 'navigation' from Language navigation default `aria-label`

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/language-navigation/language-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/language-navigation.yaml
@@ -43,7 +43,7 @@ params:
   - name: ariaLabel
     type: string
     required: false
-    description: Plain text label identifying the navigation landmark to screen readers. Write it in the language of the current page. Defaults to "Language navigation".
+    description: Plain text label identifying the navigation landmark to screen readers. Write it in the language of the current page. Defaults to "Language".
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/template.jsdom.test.js
@@ -25,7 +25,7 @@ describe('Language navigation', () => {
     })
 
     it('renders with default aria-label', () => {
-      expect($component).toHaveAttribute('aria-label', 'Language navigation')
+      expect($component).toHaveAttribute('aria-label', 'Language')
     })
 
     it('includes an unordered list', () => {

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/template.njk
@@ -1,6 +1,6 @@
 {% from "../../macros/attributes.njk" import govukAttributes %}
 
-<nav class="govuk-language-navigation {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }} aria-label="{{ params.ariaLabel | default("Language navigation") }}">
+<nav class="govuk-language-navigation {%- if params.classes %} {{ params.classes }}{% endif %}" {{- govukAttributes(params.attributes) }} aria-label="{{ params.ariaLabel | default("Language") }}">
   <ul class="govuk-language-navigation__list">
 {% for item in params.items %}
   {% set isCurrent = item.current or (not item.href) %}


### PR DESCRIPTION
Screenreaders will already announce "navigation" because the `aria-label` is on a `<nav>` elements, so the word doesn't need to be in the `aria-label`'s content.

This:
- removes the word from the default value
- updates the tests 
- updates the YAML documenting the `ariaLabel` option
- updates the YAML examples for the Service Navigation with a Language navigation