### PR TITLE
Fix guard in colour helper

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -154,7 +154,7 @@
     @return $colour-reference;
   }
 
-  @if not(meta.type-of($colour-reference) == "map") {
+  @if meta.type-of($colour-reference) != "map" {
     @error 'Colour reference should be a Sass colour or a Sass map';
   }
 

--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -154,7 +154,7 @@
     @return $colour-reference;
   }
 
-  @if not meta.type-of($colour-reference) == "map" {
+  @if not(meta.type-of($colour-reference) == "map") {
     @error 'Colour reference should be a Sass colour or a Sass map';
   }
 

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -422,6 +422,56 @@ describe('@function govuk-functional-colour', () => {
   })
 })
 
+describe('@function govuk-resolve-colour', () => {
+  let sassBootstrap = ''
+
+  beforeEach(() => {
+    sassBootstrap = `
+      @use "helpers/colour" as *;
+    `
+  })
+
+  describe('when called with a colour', () => {
+    it('returns the colour as-is', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour(blue);
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: outdent`
+        .foo {
+          color: blue;
+        }
+      `
+      })
+    })
+  })
+
+  describe('when called with a map referring to the palette', () => {
+    it('returns the hex representation of the colour', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour((name: 'white'));
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: outdent`
+        .foo {
+          color: #ffffff;
+        }
+      `
+      })
+    })
+  })
+})
+
 describe('@function govuk-organisation-colour', () => {
   const sassBootstrap = `
     @use "settings" with (

--- a/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.unit.test.js
@@ -470,6 +470,74 @@ describe('@function govuk-resolve-colour', () => {
       })
     })
   })
+
+  describe('when called with a map referring to the palette, inc. a variant', () => {
+    it('returns the hex representation of the colour', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour((name: 'black', variant: 'tint-50'));
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: outdent`
+        .foo {
+          color: #858686;
+        }
+      `
+      })
+    })
+  })
+
+  describe('when called with a map with no name', () => {
+    it('throws an appropriate error', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour((name: ''));
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
+        "Colour reference `name` shouldn't be empty."
+      )
+    })
+  })
+
+  describe('when called with a map with a variant that is empty', () => {
+    it('throws an appropriate error', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour((name: 'white', variant: ''));
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
+        "Colour reference `variant` shouldn't be empty."
+      )
+    })
+  })
+
+  describe('when called with an integer', () => {
+    it('throws an appropriate error', async () => {
+      const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-resolve-colour(1);
+      }
+    `
+
+      await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
+        'Colour reference should be a Sass colour or a Sass map'
+      )
+    })
+  })
 })
 
 describe('@function govuk-organisation-colour', () => {


### PR DESCRIPTION
Also adds a unit test for `govuk-resolve-colour()`.

These are the (hopefully) non-controversial commits plucked out of #7315. The relevant parts of the description of that PR are below:

---

[...]
In v6 the natural way to do this would be:
```scss
$govuk-functional-colours: (
  text: inherit
);
```

However, doing this generates a build error:
```
Error: [sass] Error: $map: inherit is not a map.                                                                                                         
    ╷                                                                                                                                                    
161 │   $name: map.get($colour-reference, "name");                                                                                                       
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
node_modules/govuk-frontend@6.4.0/dist/govuk/helpers/_colour.scss 161:10                     govuk-resolve-colour()
```

i.e. The `govuk-resolve-colour` function tries to treat the value as if it is a map.

**_Interestingly, there appears to be a faulty guard,_** earlier in the function, on line 157:
```scss
  @if not meta.type-of($colour-reference) == "map" {
    @error 'Colour reference should be a Sass colour or a Sass map';
  }
```

I don't think this guard can work due to operator precedence, with the `not` operator binding more tightly than `==`. It can be fixed with parentheses:
```scss
  @if not (meta.type-of($colour-reference) == "map") {
```
Or even as:
```scss
  @if meta.type-of($colour-reference) != "map" {
```

**_Fix[ing] the guard gives a clearer error message_**:
```
Error: "Colour reference should be a colour value or a Sass map"                                                                           
    ╷                                                                                                                                                    
136 │     $value: govuk-resolve-colour(map.get($govuk-functional-colours, $colour));                                                                     
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                      
    ╵                                                                                                                                                    
node_modules/govuk-frontend@6.4.0/dist/govuk/helpers/_colour.scss 136:13                     govuk-functional-colour()
```

It seems that there are no unit tests for for the `govuk-resolve-colour` function, so first **_I've added a couple of tests for the existing functionality._** (Sass colours, and maps referencing the pallette.) Running the test suite with the new tests are green.
[...]

---