### PR TITLE
Print style updates for various components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ We made these changes in the following pull requests:
 - [#7306: Update organisation colours following July 2026 MoG changes](https://github.com/alphagov/govuk-frontend/pull/7306)
 - [#7354: Update organisation colour for BIST](https://github.com/alphagov/govuk-frontend/pull/7354)
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#7364: Print style updates for various components](https://github.com/alphagov/govuk-frontend/pull/7364)
+
 ## v6.4.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.4.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/_mixin.scss
@@ -16,6 +16,12 @@
 
     color: base.govuk-functional-colour(surface-text);
     background-color: base.govuk-functional-colour(surface-background);
+
+    @media print {
+      border-bottom-color: currentcolor;
+      color: base.govuk-functional-colour(print-text);
+      background-color: transparent;
+    }
   }
 
   // Support older browsers which don't hide elements with the `hidden` attribute

--- a/packages/govuk-frontend/src/govuk/components/feedback/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/feedback/_mixin.scss
@@ -22,6 +22,11 @@
       margin-right: 0;
       margin-left: 0;
     }
+
+    @media print {
+      border-color: currentcolor;
+      background-color: transparent;
+    }
   }
 
   .govuk-feedback__title {

--- a/packages/govuk-frontend/src/govuk/components/footer/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_mixin.scss
@@ -19,6 +19,12 @@
     border-top-color: base.govuk-functional-colour(brand);
     color: $govuk-footer-text;
     background: base.govuk-functional-colour(template-background);
+
+    @media print {
+      border-top-color: currentcolor;
+      color: base.govuk-functional-colour(text);
+      background-color: transparent;
+    }
   }
 
   .govuk-footer__crown {

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -20,6 +20,11 @@
     --govuk-text-colour: #{$govuk-service-navigation-text-colour};
     color: base.govuk-functional-colour(text);
     background-color: $govuk-service-navigation-background;
+
+    @media print {
+      border-bottom-color: currentcolor;
+      background-color: transparent;
+    }
   }
 
   .govuk-service-navigation__container {
@@ -64,6 +69,10 @@
       &:not(:last-child) {
         @include base.govuk-responsive-margin(6, $direction: right);
       }
+    }
+
+    @media print {
+      border-color: currentcolor;
     }
   }
 
@@ -207,10 +216,19 @@
     --govuk-text-colour: #{base.govuk-functional-colour(inverse-text)};
     background-color: base.govuk-functional-colour(brand);
 
+    @media print {
+      --govuk-text-colour: #{base.govuk-functional-colour(print-text)};
+      background-color: transparent;
+    }
+
     .govuk-width-container {
       border-width: 1px 0;
       border-style: solid;
       border-color: $govuk-service-navigation-border-colour;
+
+      @media print {
+        border-color: currentcolor;
+      }
     }
 
     // Subtract 1px of space to account for the extra border-top
@@ -224,9 +242,12 @@
       border-color: currentcolor;
     }
 
-    // Override link styles
-    .govuk-service-navigation__link {
-      @include base.govuk-link-style-text;
+    // Override link styles if on screens
+    // In print, we want the normal link styles to still apply
+    @media not print {
+      .govuk-service-navigation__link {
+        @include base.govuk-link-style-text;
+      }
     }
 
     // Override mobile menu toggle colour when not focused

--- a/packages/govuk-frontend/src/govuk/custom-properties/_functional-colours.mixin.scss
+++ b/packages/govuk-frontend/src/govuk/custom-properties/_functional-colours.mixin.scss
@@ -14,6 +14,7 @@
       @media print {
         // Use 'true black' to avoid printers using colour ink to print body text
         --govuk-text-colour: #{govuk-functional-colour("print-text")};
+        --govuk-input-border-colour: #{govuk-functional-colour("print-text")};
       }
     }
   }


### PR DESCRIPTION
I was thinking about print styles again recently, and realised that this area might've been a little overlooked when developing recent components and rolling out the new brand colours.

Historically, we've been proactive in removing any large areas of background colour in print styles, such as on the header and panel components. This served to reduce ink consumption when a page is being printed, but also to anticipate printing features that remove background colours and images, and account for the lack of contrast that removing the background colour may result in.

Some newly added or recently redesigned components didn't follow along with this, reintroducing large regions of background colour when a page is being printed. 

## Changes
The following components have had their print styles updated.

- Cookie banner
  - Removed the background colour.
  - Changed the bottom border (previously only shown in forced colours mode) to render visibly when printing.
- Feedback
  - Removed the background colour.
  - Changed the top border colour to use the current text colour (when printing, this should be pure black `#000000`).
- GOV.UK footer
  - Removed the background colour.
  - Changed the top border colour to use the current text colour.
- Service navigation
  - Removed the background colour of the regular and inverted variants.
  - Changed borders to use the current text colour.
  - Changed the border that highlights the currently selected navigation option to the current text colour.
  - On the inverse variant, made link style overrides conditional so that they're only applied when _not_ printing. 

I've also added an additional custom property override to render input borders in pure black when printing. On screens, these use the same off-black shade that text does. Making them pure black in print as well allows for printers to use black ink, instead of needing to colour mix dark grey. 

### Screenshots

All screenshots are taken using Chrome's 'emulate print styles' developer function. Actual appearance when printing may differ due to a whole bunch of circumstances, some of them documented in #3441. 

These all emulate with the ability to manually disable background colours/images turned **off**. If that option were enabled, some of these would render differently, including the buttons on the Cookie banner lacking background colours, and the GOV.UK footer not rendering the royal arms. 

||Before|After|
|:-|:-:|:-:|
|Cookie banner|<img width="2050" height="358" alt="Cookie banner component looking as it normally does, but with a generic sans-serif font and a link visibly rendering the link path after it." src="https://github.com/user-attachments/assets/081bb128-fd9f-4f0e-af44-d786889f5a03" />|<img width="2050" height="358" alt="Same cookie banner but now with a white background and a thick black border beneath it." src="https://github.com/user-attachments/assets/00a348f8-7917-4736-9546-9ce0da1e101d" />|
|Feedback|<img width="1920" height="200" alt="Feedback component in a generic sans-serif, with a light blue background and darker blue border above it to separate it from prior content." src="https://github.com/user-attachments/assets/577c15f6-c81c-424f-9899-2f4341d63851" />|<img width="1920" height="200" alt="Same feedback component but now lacking a background colour and with a black top border." src="https://github.com/user-attachments/assets/299385fd-bd62-477e-a685-93d93d0767d4" />|
|GOV.UK footer|<img width="2050" height="586" alt="GOV.UK footer in a generic sans-serif, with light blue background and a thick blue border at the top. " src="https://github.com/user-attachments/assets/074a8cb1-028e-4d27-be33-a56ab17c3381" />|<img width="2050" height="586" alt="Same footer but with a white background and a black top border instead." src="https://github.com/user-attachments/assets/3301bdd0-3af9-4950-b34a-b267aeca9978" />|
|Service navigation (regular)|<img width="2050" height="118" alt="Service navigation with a service name and navigation links, one of which is highlighted as the 'current page'. It has a light blue background, blue links, and a blue bottom border. The current link has a thicker blue border beneath it." src="https://github.com/user-attachments/assets/a51b0748-26a0-4398-8a6a-8ebf0a3736c2" />|<img width="2050" height="118" alt="Same service navigation, but the background is white and the border of the component and current link are both black instead. Links are still blue, though." src="https://github.com/user-attachments/assets/076b21ae-3b19-4c68-b312-c6ccbdf89578" />|
|Service navigation (inverse variant)|<img width="2050" height="118" alt="Inverse service navigation, which has a dark blue background, white links, and a light blue border both above and below the component." src="https://github.com/user-attachments/assets/b3796527-ca6f-44a0-8bd2-68aa5c5eecb5" />|<img width="2018" height="118" alt="Same service navigation, but it now has a white background, blue links, and a black border above and below it." src="https://github.com/user-attachments/assets/8b03aa63-32b3-4be4-88c3-c3722802fad6" />|

## Thoughts / What's not changed
I've left Buttons as they are for the time being. These render pretty badly when background colours have been removed by a user prior to printing, often lacking in the contrast department, but it probably needs a more thorough investigation to fix nicely. 

I've also left Tags as they are. These look a little unusual when a user has removed background colours in the print dialog, but are otherwise useable and accessible. Proactively removing colours from these will likely harm their usefulness for users who are printing in colour, as well. 

## Todo
- Open new issue for Button print styles(?)