### PR TITLE
Flesh out sidebar example to include related navigation

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-sidebar/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/language-navigation-sidebar/index.njk
@@ -77,6 +77,10 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
         </ol>
       </nav>
     </aside>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
 
     <p class="govuk-body">This page reflects the UK government’s understanding of current rules for people travelling on a full ‘British Citizen’ passport from the UK, for the most common types of travel.</p>
@@ -112,6 +116,31 @@ notes: Based on https://www.gov.uk/foreign-travel-advice/iceland/entry-requireme
       previous: { href: "#/foreign-travel-advice/narnia/safety-and-security", labelText: "Safety and security" },
       next: { href: "#/foreign-travel-advice/narnia/time-dilation", labelText: "Time dilation" }
     }) }}
+  </div>
+  <div class="govuk-grid-column-one-third-from-desktop">
+    <!-- Based off: https://components.publishing.service.gov.uk/component-guide/related_navigation -->
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4" style="border-width: 2px; border-color: var(--govuk-brand-colour);">
+    <div class="app-related-navigation govuk-!-display-none-print govuk-!-margin-bottom-6">
+      <h2 id="related-navigation-heading" class="govuk-heading-s">
+        Related content
+      </h2>
+      <nav aria-labelledby="related-navigation-heading">
+        <ul class="govuk-list govuk-!-font-size-16">
+          <li class="govuk-!-margin-top-3">
+            <a class="govuk-link govuk-link" href="#">About Foreign, Commonwealth &amp; Development Office travel advice</a>
+          </li>
+          <li class="govuk-!-margin-top-3">
+            <a class="govuk-link govuk-link" href="#">Support for British nationals abroad</a>
+          </li>
+          <li class="govuk-!-margin-top-3">
+            <a class="govuk-link govuk-link" href="#">Foreign travel checklist</a>
+          </li>
+          <li class="govuk-!-margin-top-3">
+            <a class="govuk-link govuk-link" href="#">UK help and services in Narnia</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Include a related navigation like the real pages to demonstrate having the Language navigation at the top and the other side bar content at the bottom of the source order.

URL to check:
https://govuk-frontend-pr-7365.herokuapp.com/full-page-examples/language-navigation-sidebar