### PR TITLE
Remove unused selector for the `__end` block

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/_mixin.scss
@@ -151,15 +151,6 @@
   // nav items and use slots.
   .govuk-service-navigation__wrapper {
     flex-grow: 1;
-
-    // If the end slot is right-aligned, add some extra spacing to the right of
-    // the navigation. This ensures that the two elements don't get too close as
-    // viewports shrink but before the end slot content wraps to the next line.
-    &:has(+ .govuk-service-navigation__end) {
-      @media #{base.govuk-from-breakpoint(tablet)} {
-        margin-right: base.govuk-spacing(4);
-      }
-    }
   }
 
   //


### PR DESCRIPTION
The block no longer exists as the `end` slot is no longer injected in different places since https://github.com/alphagov/govuk-frontend/pull/7349. The template does not create a `.govuk-service-navigation__end` element anymore.