### PR TITLE
Apply `classes` option to active item

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/language-navigation/language-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/language-navigation.yaml
@@ -274,6 +274,17 @@ examples:
           lang: cy
           href: '#/cy'
           classes: 'app-language-navigation__link--modifier'
+  - name: active item classes
+    hidden: true
+    options:
+      items:
+        - text: English
+          lang: en
+          current: true
+          classes: 'app-language-navigation__link--modifier'
+        - text: Cymraeg
+          lang: cy
+          href: '#/cy'
   - name: item attributes
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/template.jsdom.test.js
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/template.jsdom.test.js
@@ -155,6 +155,17 @@ describe('Language navigation', () => {
       expect($link).toHaveClass('app-language-navigation__link--modifier')
     })
 
+    it('sets item classes on the active item', () => {
+      document.body.innerHTML = render(
+        'language-navigation',
+        examples['active item classes']
+      )
+
+      const $link = document.querySelector('.govuk-language-navigation__text')
+
+      expect($link).toHaveClass('app-language-navigation__link--modifier')
+    })
+
     it('sets item attributes on the link', () => {
       document.body.innerHTML = render(
         'language-navigation',

--- a/packages/govuk-frontend/src/govuk/components/language-navigation/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/language-navigation/template.njk
@@ -6,7 +6,8 @@
   {% set isCurrent = item.current or (not item.href) %}
   {% if isCurrent %}
     <li class="govuk-language-navigation__list-item">
-      <span class="govuk-language-navigation__text" aria-current="true"
+      <span class="govuk-language-navigation__text {%- if item.classes %} {{ item.classes }}{% endif %}"
+        aria-current="true"
         {%- if item.lang %} lang="{{ item.lang }}"{% endif %}
         {%- if item.dir %} dir="{{ item.dir }}"{% endif %}
         {{- govukAttributes(item.attributes) }}>


### PR DESCRIPTION
Make the `classes` option render not only when the item is a link, but also when it's the active item. This makes the API consistently apply the `classes` option, removing the need for users to understand when the option is applied.

Rendering the `classes` on the item whether the item is active or not also lets users target the item with CSS in both situations, with the ability to distinguish if the item is active thanks to our own `.govuk-language-navigation__text` and `.govuk-language-navigation__link` classes.