### PR TITLE
Fix type of `end` slot documentation

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -86,7 +86,7 @@ params:
         required: false
         description: HTML injected at the end of the service header container.
       - name: end
-        type: string
+        type: object
         required: false
         description: Options for injecting HTML at the end of the service header container.
         params:


### PR DESCRIPTION
The duplicate entry documenting the object version of the option had a type of `string` instead of `object`.