### PR TITLE
Fix Service navigation example with right aligned Language navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 ## Unreleased
 
+### Fixes
+
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#7375: Fix Service navigation example with right aligned Language navigation](https://github.com/alphagov/govuk-frontend/pull/7375) – thanks to @peteryates for reporting this issue
+
 ## v6.5.0 (Feature release)
 
 To install this version with npm, run `npm install govuk-frontend@6.5.0`. You can also find more information about [how to stay up to date](https://frontend.design-system.service.gov.uk/staying-up-to-date/#updating-to-the-latest-version) in our documentation.

--- a/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
+++ b/packages/govuk-frontend/src/govuk/components/service-navigation/service-navigation.yaml
@@ -428,19 +428,19 @@ examples:
         - href: '#/3'
           text: Navigation item 3
       slots:
-        end: |-
-          <nav class="govuk-language-navigation" aria-label="Language navigation">
-            <ul class="govuk-language-navigation__list">
-              <li class="govuk-language-navigation__list-item">
-                <span class="govuk-language-navigation__text" lang="en" aria-current="true">English</span>
-              </li>
-              <li class="govuk-language-navigation__list-item">
-                <a class="govuk-language-navigation__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
-              </li>
-            </ul>
-          </nav>
-      slotsPreferredPositions:
-        end: same-line
+        end:
+          align: inline
+          html: |-
+            <nav class="govuk-language-navigation" aria-label="Language navigation">
+              <ul class="govuk-language-navigation__list">
+                <li class="govuk-language-navigation__list-item">
+                  <span class="govuk-language-navigation__text" lang="en" aria-current="true">English</span>
+                </li>
+                <li class="govuk-language-navigation__list-item">
+                  <a class="govuk-language-navigation__link" href="#/cy" lang="cy" hreflang="cy" rel="alternate">Cymraeg</a>
+                </li>
+              </ul>
+            </nav>
   - name: inverse with language navigation
     description: Service navigation that appears sandwiched between other areas of brand blue, such as the GOV.UK header and a custom page masthead.
     pageTemplateOptions:


### PR DESCRIPTION
The YAML was using [outdated options][] that we missed before merging #7349. This led to the example showing the Service navigation with a right aligned Language navigation not rendering as intended. The component's fixtures included in the package were also listing incorrect HTML for that example.

## Screenshots

### [Production](https://govuk-frontend-review.herokuapp.com/components/service-navigation/with-right-aligned-language-navigation/preview)

![Screenshot of the Service navigation example with right aligned Language navigation, Language navigation is under the navigation items](https://github.com/user-attachments/assets/a2507721-c0ea-4cee-b186-d47174caa888)

### [This PR](https://govuk-frontend-pr-7375.herokuapp.com/components/service-navigation/with-right-aligned-language-navigation/preview)

![Screenshot of the Service navigation example with right aligned Language navigation, Language navigation to the right of the navigation items](https://github.com/user-attachments/assets/93ad29ef-7f96-4a50-8ba0-e27e4f675339)  

[outdated options]: https://github.com/alphagov/govuk-frontend/pull/7349/changes#diff-0f0578a78677a67d1ee7773c3cf6e90b45a4827b6ab1792db987fab7bd448755R442-R443