### PR TITLE
Escape special characters in selector lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7375: Fix Service navigation example with right aligned Language navigation](https://github.com/alphagov/govuk-frontend/pull/7375) – thanks to @peteryates for reporting this issue
+- [#7396: Escape special characters in selector lookups for the Error summary and Checkboxes components](https://github.com/alphagov/govuk-frontend/pull/7396)
 
 ## v6.5.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -122,7 +122,7 @@ export class Checkboxes extends Component {
    */
   unCheckAllInputsExcept($input) {
     const allInputsWithSameName = document.querySelectorAll(
-      `input[type="checkbox"][name="${$input.name}"]`
+      `input[type="checkbox"][name="${CSS.escape($input.name)}"]`
     )
 
     allInputsWithSameName.forEach(($inputWithSameName) => {
@@ -147,7 +147,7 @@ export class Checkboxes extends Component {
   unCheckExclusiveInputs($input) {
     const allInputsWithSameNameAndExclusiveBehaviour =
       document.querySelectorAll(
-        `input[data-behaviour="exclusive"][type="checkbox"][name="${$input.name}"]`
+        `input[data-behaviour="exclusive"][type="checkbox"][name="${CSS.escape($input.name)}"]`
       )
 
     allInputsWithSameNameAndExclusiveBehaviour.forEach(($exclusiveInput) => {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -454,4 +454,33 @@ describe('Checkboxes', () => {
       })
     })
   })
+
+  describe('when checkbox names contain special characters', () => {
+    it('unchecks other checkboxes when the "None" checkbox is checked', async () => {
+      // Errors logged to the console will cause this test to fail
+      await render(page, 'checkboxes', examples['with divider and None'], {
+        beforeInitialisation($root) {
+          $root.querySelectorAll('.govuk-checkboxes__input').forEach(($input) => {
+            $input.name = 'contact-"None"'
+          })
+        }
+      })
+
+      const $component = await page.$('.govuk-checkboxes')
+      const $inputs = await $component.$$('.govuk-checkboxes__input')
+
+      // Check the first 3 checkboxes
+      await $inputs[0].click()
+      await $inputs[1].click()
+      await $inputs[2].click()
+
+      // Check the "None" checkbox
+      await $inputs[3].click()
+
+      // Expect first 3 checkboxes to have been unchecked
+      expect(await getProperty($inputs[0], 'checked')).toBe(false)
+      expect(await getProperty($inputs[1], 'checked')).toBe(false)
+      expect(await getProperty($inputs[2], 'checked')).toBe(false)
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -146,8 +146,9 @@ export class ErrorSummary extends ConfigurableComponent {
     }
 
     return (
-      document.querySelector(`label[for='${$input.getAttribute('id')}']`) ??
-      $input.closest('label')
+      document.querySelector(
+        `label[for='${CSS.escape($input.getAttribute('id'))}']`
+      ) ?? $input.closest('label')
     )
   }
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -285,4 +285,32 @@ describe('Error Summary', () => {
       })
     })
   })
+
+  describe('when linking to an input whose id contains special characters', () => {
+    it('focuses the target input without errors', async () => {
+      // Errors logged to the console will cause this test to fail
+      await render(page, 'error-summary', examples.default, {
+        beforeInitialisation($root) {
+          const $link = $root.querySelector('.govuk-error-summary__list a')
+          const $input = document.createElement('input')
+          $input.id = "child's-name"
+          document.body.appendChild($input)
+
+          const $label = document.createElement('label')
+          $label.setAttribute('for', "child's-name")
+          $label.textContent = "Child's name"
+          document.body.appendChild($label)
+
+          $link.href = "#child's-name"
+        }
+      })
+
+      await page.click('.govuk-error-summary__list a')
+
+      const activeElement = await page.evaluate(
+        () => document.activeElement.id
+      )
+      expect(activeElement).toBe("child's-name")
+    })
+  })
 })


### PR DESCRIPTION
Closes #7395.

Clicking an error-summary link (or toggling an exclusive checkbox) threw an uncaught `SyntaxError: Invalid selector` when the target's `id`/`name` contained quote characters, because both components interpolated raw values into `querySelector`/`querySelectorAll`. The interpolated values are now escaped with `CSS.escape()`, which every browser in the support matrix implements.

How to test:

1. Render an error summary linking to `#child's-name` with a matching `<label for="child's-name">` and input — clicking the link focuses the input with no console error (new puppeteer test covers this).
2. Render checkboxes with a `"` in the `name` plus an exclusive ("None") option — checking it unchecks the others with no console error (new puppeteer test covers this).
3. `npm test -- --selectProjects ...` (could not run the puppeteer suite locally, leaving it to CI); the fixed modules were additionally verified under jsdom (red without the fix, green with it).
