### PR TITLE
Escape special characters in Tabs selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7375: Fix Service navigation example with right aligned Language navigation](https://github.com/alphagov/govuk-frontend/pull/7375) – thanks to @peteryates for reporting this issue
+- [#7398: Escape special characters in Tabs selectors](https://github.com/alphagov/govuk-frontend/pull/7398)
 
 ## v6.5.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -246,7 +246,9 @@ export class Tabs extends Component {
    * @returns {HTMLAnchorElement | null} Tab link
    */
   getTab(hash) {
-    return this.$root.querySelector(`a.govuk-tabs__tab[href="${hash}"]`)
+    return this.$root.querySelector(
+      `a.govuk-tabs__tab[href="${CSS.escape(hash)}"]`
+    )
   }
 
   /**
@@ -443,7 +445,7 @@ export class Tabs extends Component {
       return null
     }
 
-    return this.$root.querySelector(`#${panelId}`)
+    return this.$root.querySelector(`#${CSS.escape(panelId)}`)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -363,4 +363,46 @@ describe('/components/tabs', () => {
       })
     })
   })
+
+  describe('when ids contain special characters', () => {
+    it('shows the panel for dotted ids', async () => {
+      // Errors logged to the console will cause this test to fail
+      await render(page, 'tabs', examples.default, {
+        beforeInitialisation($root) {
+          const $link = $root.querySelector('.govuk-tabs__tab')
+          const $panel = $root.querySelector($link.hash)
+          $link.setAttribute('href', '#a.b')
+          $panel.id = 'a.b'
+        }
+      })
+
+      await page.click('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+
+      const tabPanelIsHidden = await page.evaluate(
+        () =>
+          document.body.querySelector('.govuk-tabs > .govuk-tabs__panel')
+            .classList.contains('govuk-tabs__panel--hidden')
+      )
+      expect(tabPanelIsHidden).toBeFalsy()
+    })
+
+    it('ignores hashes that match no tab without errors', async () => {
+      // Errors logged to the console will cause this test to fail
+      await render(page, 'tabs', examples.default)
+
+      await page.evaluate(() => {
+        window.location.hash = 'a\\'
+      })
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      const firstTabAriaSelected = await page.evaluate(() =>
+        document.body
+          .querySelector(
+            '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
+          )
+          .getAttribute('aria-selected')
+      )
+      expect(firstTabAriaSelected).toBe('true')
+    })
+  })
 })


### PR DESCRIPTION
Closes #7397.

`getTab()` interpolated the raw URL hash into `querySelector`, so a hash with a CSS-special character (e.g. a trailing backslash, which fragments keep raw) threw an uncaught `Invalid selector` out of `setup()` and killed the whole component. `getPanel()` interpolated the raw panel id, so ids like `a.b` silently matched nothing and show/hide became no-ops. Both now use `CSS.escape()`, which every browser in the support matrix implements — same approach as #7396.

How to test:

1. Render tabs, rename a tab link/panel to a dotted id, click the tab — the panel shows (new puppeteer test).
2. Set `location.hash` to a value matching no tab (e.g. with a backslash) — nothing breaks and the current tab stays selected (new puppeteer test).
3. Full suite left to CI (puppeteer needs the built review app); the fixed module was additionally verified under jsdom (throws/null before, correct matches after).
