### PR TITLE
Escape special characters in File upload selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#7375: Fix Service navigation example with right aligned Language navigation](https://github.com/alphagov/govuk-frontend/pull/7375) – thanks to @peteryates for reporting this issue
+- [#7400: Escape special characters in File upload selector](https://github.com/alphagov/govuk-frontend/pull/7400)
 
 ## v6.5.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -420,7 +420,9 @@ export class FileUpload extends ConfigurableComponent {
    */
   findLabel() {
     // Use `label` in the selector so TypeScript knows the type fo `HTMLElement`
-    const $label = document.querySelector(`label[for="${this.$input.id}"]`)
+    const $label = document.querySelector(
+      `label[for="${CSS.escape(this.$input.id)}"]`
+    )
 
     if (!$label) {
       throw new ElementError({

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.puppeteer.test.js
@@ -91,6 +91,29 @@ describe('/components/file-upload', () => {
 
             expect(label).not.toBeNull()
           })
+
+          it('resolves labels for input ids containing special characters', async () => {
+            // Errors logged to the console will cause this test to fail
+            await render(page, 'file-upload', examples.enhanced, {
+              beforeInitialisation($root) {
+                const $input = $root.querySelector('.govuk-file-upload')
+                const $label = document.querySelector(
+                  `label[for="${$input.id}"]`
+                )
+                $input.id = 'a"b'
+                $label.setAttribute('for', 'a"b')
+              }
+            })
+
+            const labelFor = await page.evaluate(() => {
+              const $found = Array.from(
+                document.querySelectorAll('label')
+              ).find(($el) => $el.getAttribute('for') === 'a"b')
+              return $found ? $found.getAttribute('for') : null
+            })
+
+            expect(labelFor).toBe('a"b')
+          })
         })
 
         describe('choose file button', () => {


### PR DESCRIPTION
Closes #7399.

`findLabel()` interpolated the raw input id into `querySelector`, so an id containing a double quote threw an uncaught `Invalid selector` instead of resolving the label — breaking component init. Now escaped with `CSS.escape()`, same approach as #7396/#7398.

How to test:

1. Render file upload with input id `a"b` and a matching label — init resolves the label with no console error (new puppeteer test).
2. Full suite left to CI (puppeteer needs the built review app); the fixed module was additionally verified under jsdom (throws before, resolves after).
