### PR TITLE
Match `@types/node` to version of Node we use (24)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,10 @@ updates:
       # so we need to avoid upgrading to their next major version
       - dependency-name: 'iframe-resizer'
         update-types: ['version-update:semver-major']
+      # Node types should correspond to the version in `.nvmrc`
+      # rather than jump to the latest major release of `@types/node`
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
     schedule:
       interval: monthly

--- a/.nvmrc
+++ b/.nvmrc
@@ -3,3 +3,4 @@
 # - the 'engines' fields in the various `package.json` files of the project
 # - `package-lock.json` by running `npm install`
 # - the `[node]` section of the various `.browserslistrc` files of the project
+# - the version on `@types/node` installed in the project with `npm install @types/node@<MAJOR>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/jest-axe": "^3.5.9",
         "@types/js-yaml": "^4.0.9",
         "@types/mime-types": "^3.0.1",
-        "@types/node": "^26.0.1",
+        "@types/node": "^24.13.3",
         "@types/nunjucks": "^3.2.6",
         "@types/semver": "^7.7.1",
         "@types/slug": "^5.0.9",
@@ -8740,13 +8740,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/nunjucks": {
@@ -36662,9 +36662,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/jest-axe": "^3.5.9",
     "@types/js-yaml": "^4.0.9",
     "@types/mime-types": "^3.0.1",
-    "@types/node": "^26.0.1",
+    "@types/node": "^24.13.3",
     "@types/nunjucks": "^3.2.6",
     "@types/semver": "^7.7.1",
     "@types/slug": "^5.0.9",


### PR DESCRIPTION
Downgrade `@types/node` to match the version we use in the project and prevent Dependabot from doing major bumps.