### PR TITLE
Fix remaining ElementError moduleName prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For advice on how to use these release notes, see [our guidance on staying up to
 
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
+- Use `moduleName` in Password input and Skip link `ElementError` messages – thanks to @colinrotherham for reporting this issue
 - [#7375: Fix Service navigation example with right aligned Language navigation](https://github.com/alphagov/govuk-frontend/pull/7375) – thanks to @peteryates for reporting this issue
 
 ## v6.5.0 (Feature release)

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.jsdom.test.mjs
@@ -1,0 +1,54 @@
+import { ElementError } from '../../errors/index.mjs'
+
+import { PasswordInput } from './password-input.mjs'
+
+describe('PasswordInput', () => {
+  beforeEach(() => {
+    // Jest does not tidy the JSDOM document between tests
+    // so we need to take care of that ourselves
+    document.documentElement.innerHTML = ''
+    document.body.classList.add('govuk-frontend-supported')
+  })
+
+  describe('errors at instantiation', () => {
+    it('throws when the input is not a `password` type', () => {
+      document.body.innerHTML = `
+        <div data-module="govuk-password-input">
+          <input class="govuk-js-password-input-input" type="number">
+          <button class="govuk-js-password-input-toggle" type="button">Show</button>
+        </div>
+      `
+
+      expect(
+        () =>
+          new PasswordInput(
+            document.querySelector('[data-module="govuk-password-input"]')
+          )
+      ).toThrow(
+        new ElementError(
+          'govuk-password-input: Form field (`.govuk-js-password-input-input`) must be of type `password`.'
+        )
+      )
+    })
+
+    it('throws when the button is not a `button` type', () => {
+      document.body.innerHTML = `
+        <div data-module="govuk-password-input">
+          <input class="govuk-js-password-input-input" type="password">
+          <button class="govuk-js-password-input-toggle" type="submit">Show</button>
+        </div>
+      `
+
+      expect(
+        () =>
+          new PasswordInput(
+            document.querySelector('[data-module="govuk-password-input"]')
+          )
+      ).toThrow(
+        new ElementError(
+          'govuk-password-input: Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
+        )
+      )
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.mjs
@@ -1,5 +1,6 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { ConfigurableComponent } from '../../common/configuration.mjs'
+import { formatErrorMessage } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -47,7 +48,10 @@ export class PasswordInput extends ConfigurableComponent {
 
     if ($input.type !== 'password') {
       throw new ElementError(
-        'Password input: Form field (`.govuk-js-password-input-input`) must be of type `password`.'
+        formatErrorMessage(
+          PasswordInput,
+          'Form field (`.govuk-js-password-input-input`) must be of type `password`.'
+        )
       )
     }
 
@@ -65,7 +69,10 @@ export class PasswordInput extends ConfigurableComponent {
 
     if ($showHideButton.type !== 'button') {
       throw new ElementError(
-        'Password input: Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
+        formatErrorMessage(
+          PasswordInput,
+          'Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
+        )
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/password-input/password-input.puppeteer.test.js
@@ -289,7 +289,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Form field (`.govuk-js-password-input-input`) must be of type `password`.'
+                'govuk-password-input: Form field (`.govuk-js-password-input-input`) must be of type `password`.'
             }
           })
         })
@@ -349,7 +349,7 @@ describe('/components/password-input', () => {
             cause: {
               name: 'ElementError',
               message:
-                'Password input: Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
+                'govuk-password-input: Button (`.govuk-js-password-input-toggle`) must be of type `button`.'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.jsdom.test.mjs
@@ -1,0 +1,27 @@
+import { ElementError } from '../../errors/index.mjs'
+
+import { SkipLink } from './skip-link.mjs'
+
+describe('SkipLink', () => {
+  beforeEach(() => {
+    // Jest does not tidy the JSDOM document between tests
+    // so we need to take care of that ourselves
+    document.documentElement.innerHTML = ''
+    document.body.classList.add('govuk-frontend-supported')
+  })
+
+  describe('errors at instantiation', () => {
+    it('throws when the href does not contain a hash', () => {
+      const href = window.location.pathname
+      document.body.innerHTML = `<a class="govuk-skip-link" href="${href}">Skip to main content</a>`
+
+      expect(
+        () => new SkipLink(document.querySelector('.govuk-skip-link'))
+      ).toThrow(
+        new ElementError(
+          `govuk-skip-link: Target link (\`href="${href}"\`) hash fragment not found`
+        )
+      )
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -35,9 +35,10 @@ export class SkipLink extends Component {
 
     // Check link path matching current page
     if (!linkedElementId) {
-      throw new ElementError(
-        `Skip link: Target link (\`href="${href}"\`) has no hash fragment`
-      )
+      throw new ElementError({
+        component: SkipLink,
+        identifier: `Target link (\`href="${href}"\`) hash fragment`
+      })
     }
 
     const $linkedElement = document.getElementById(linkedElementId)

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -204,7 +204,7 @@ describe('Skip Link', () => {
         cause: {
           name: 'ElementError',
           message:
-            'Skip link: Target link (`href="/components/skip-link/preview"`) has no hash fragment'
+            'govuk-skip-link: Target link (`href="/components/skip-link/preview"`) hash fragment not found'
         }
       })
     })


### PR DESCRIPTION
## What

Prefix the remaining Password input and Skip link `ElementError` messages with `moduleName` (`govuk-password-input:`, `govuk-skip-link:`). Those three messages were missed when other component errors were updated in #5338.

## Why these two shapes

Skip link uses the standard `ElementError` options object, so a missing hash is reported as `hash fragment not found`. Same shape as the skip-link "target content not found" throw. The issue body patched only the prefix and kept `has no hash fragment`; the follow-up on #6177 gave the options-object patch.

Password input keeps `must be of type \`password\`.` / `must be of type \`button\`.` and prefixes with `formatErrorMessage`, the same helper Character count uses for `ConfigError`. Putting `expectedType: 'password'` on the options object would log `is not of type password`. The options object describes DOM types (`HTMLInputElement`), not HTML `type` attributes, and the issue's expected strings keep `must be of type`.

Can switch the skip-link suffix to keep the original wording, or put every throw on the object form.

## Tests

JSDOM tests import the source modules and assert the three messages, so they do not depend on a dist build. Existing puppeteer assertions were updated to the same strings.

## Changelog

Unreleased → Fixes includes a bullet thanking @colinrotherham. Replace the bullet with the usual `[#NNNN: title](url)` once this PR has a number.

## Checklist

- [x] JavaScript follows the repo style (ESLint / Prettier on the edited files)
- [x] Tests updated / added for the changed constructor errors
- [ ] Puppeteer component tests not run locally (they need a dist build, Chrome, and the review app); jsdom tests cover the same messages against source
- [x] Changelog entry under Unreleased → Fixes (PR number still needed)
- [ ] Browser / assistive-technology pass: not applicable; constructor error strings only

Fixes #6177
